### PR TITLE
Convert UI to mobile-first design

### DIFF
--- a/client/src/components/ChatPane.tsx
+++ b/client/src/components/ChatPane.tsx
@@ -72,11 +72,11 @@ export function ChatPane({
   return (
     <div className="h-full flex flex-col bg-card border border-border rounded-lg overflow-hidden">
       {/* Header */}
-      <header className="h-10 border-b border-border flex items-center justify-between px-3 bg-sidebar shrink-0">
+      <header className="h-14 md:h-10 border-b border-border flex items-center justify-between px-4 md:px-3 bg-sidebar shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           <div className={`status-indicator ${session.status}`} />
-          <GitBranch className="w-3 h-3 text-muted-foreground shrink-0" />
-          <span className="font-mono text-xs truncate text-sidebar-foreground">
+          <GitBranch className="w-4 h-4 md:w-3 md:h-3 text-muted-foreground shrink-0" />
+          <span className="font-mono text-sm md:text-xs truncate text-sidebar-foreground">
             {worktree?.branch || "Unknown"}
           </span>
         </div>
@@ -85,43 +85,43 @@ export function ChatPane({
             <Button
               variant="ghost"
               size="icon"
-              className="h-6 w-6"
+              className="h-10 w-10 md:h-6 md:w-6"
               onClick={onMaximize}
             >
               {isMaximized ? (
-                <Minimize2 className="w-3 h-3" />
+                <Minimize2 className="w-5 h-5 md:w-3 md:h-3" />
               ) : (
-                <Maximize2 className="w-3 h-3" />
+                <Maximize2 className="w-5 h-5 md:w-3 md:h-3" />
               )}
             </Button>
           )}
           <Button
             variant="ghost"
             size="icon"
-            className="h-6 w-6 text-destructive hover:text-destructive"
+            className="h-10 w-10 md:h-6 md:w-6 text-destructive hover:text-destructive"
             onClick={onStopSession}
           >
-            <Square className="w-3 h-3" />
+            <Square className="w-5 h-5 md:w-3 md:h-3" />
           </Button>
           <Button
             variant="ghost"
             size="icon"
-            className="h-6 w-6"
+            className="h-10 w-10 md:h-6 md:w-6"
             onClick={onClose}
           >
-            <X className="w-3 h-3" />
+            <X className="w-5 h-5 md:w-3 md:h-3" />
           </Button>
         </div>
       </header>
 
       {/* Messages */}
       <div className="flex-1 min-h-0">
-        <ScrollArea className="h-full p-3">
-          <div className="space-y-3">
+        <ScrollArea className="h-full p-4 md:p-3">
+          <div className="space-y-4 md:space-y-3">
             {messages.length === 0 && !streamingContent ? (
-              <div className="text-center py-8">
-                <Terminal className="w-8 h-8 text-muted-foreground mx-auto mb-2" />
-                <p className="text-xs text-muted-foreground">
+              <div className="text-center py-12 md:py-8">
+                <Terminal className="w-12 h-12 md:w-8 md:h-8 text-muted-foreground mx-auto mb-3 md:mb-2" />
+                <p className="text-base md:text-xs text-muted-foreground">
                   Send a message to start
                 </p>
               </div>
@@ -132,13 +132,13 @@ export function ChatPane({
                 ))}
                 {streamingContent && (
                   <div className="flex gap-2 justify-start">
-                    <div className="max-w-[90%] rounded-md p-2 bg-muted border border-border">
-                      <div className="flex items-center gap-1 mb-1 text-[10px] text-muted-foreground">
-                        <Terminal className="w-2.5 h-2.5" />
+                    <div className="max-w-[95%] md:max-w-[90%] rounded-lg md:rounded-md p-3 md:p-2 bg-muted border border-border">
+                      <div className="flex items-center gap-1.5 md:gap-1 mb-2 md:mb-1 text-xs md:text-[10px] text-muted-foreground">
+                        <Terminal className="w-3.5 h-3.5 md:w-2.5 md:h-2.5" />
                         <span>Claude</span>
-                        <span className="inline-block w-1.5 h-1.5 bg-primary rounded-full animate-pulse" />
+                        <span className="inline-block w-2 h-2 md:w-1.5 md:h-1.5 bg-primary rounded-full animate-pulse" />
                       </div>
-                      <div className="text-xs">
+                      <div className="text-sm md:text-xs">
                         <Streamdown>{streamingContent}</Streamdown>
                       </div>
                     </div>
@@ -152,26 +152,26 @@ export function ChatPane({
       </div>
 
       {/* Input */}
-      <form onSubmit={handleSubmit} className="border-t border-border p-2 shrink-0">
+      <form onSubmit={handleSubmit} className="border-t border-border p-3 md:p-2 shrink-0">
         <div className="flex gap-2">
           <div className="flex-1 relative">
-            <span className="absolute left-2 top-1/2 -translate-y-1/2 text-accent font-mono text-xs">
+            <span className="absolute left-3 md:left-2 top-1/2 -translate-y-1/2 text-accent font-mono text-sm md:text-xs">
               {">"}
             </span>
             <Input
               ref={inputRef}
               placeholder="Message..."
               disabled={session.status === "active"}
-              className="h-8 pl-6 text-xs font-mono bg-input border-border"
+              className="h-12 md:h-8 pl-8 md:pl-6 text-base md:text-xs font-mono bg-input border-border"
             />
           </div>
           <Button
             type="submit"
             size="icon"
-            className="h-8 w-8 glow-green"
+            className="h-12 w-12 md:h-8 md:w-8 glow-green"
             disabled={session.status === "active"}
           >
-            <Send className="w-3 h-3" />
+            <Send className="w-5 h-5 md:w-3 md:h-3" />
           </Button>
         </div>
       </form>
@@ -189,7 +189,7 @@ function MessageBubble({ message, compact }: { message: Message; compact?: boole
   return (
     <div className={`flex gap-2 ${isUser ? "justify-end" : "justify-start"}`}>
       <div
-        className={`max-w-[90%] rounded-md p-2 ${
+        className={`max-w-[95%] md:max-w-[90%] rounded-lg md:rounded-md p-3 md:p-2 ${
           isUser
             ? "bg-primary text-primary-foreground"
             : isError
@@ -200,20 +200,20 @@ function MessageBubble({ message, compact }: { message: Message; compact?: boole
         }`}
       >
         {!isUser && (
-          <div className="flex items-center gap-1 mb-1 text-[10px] text-muted-foreground">
+          <div className="flex items-center gap-1.5 md:gap-1 mb-2 md:mb-1 text-xs md:text-[10px] text-muted-foreground">
             {isError ? (
-              <AlertCircle className="w-2.5 h-2.5" />
+              <AlertCircle className="w-3.5 h-3.5 md:w-2.5 md:h-2.5" />
             ) : (
-              <Terminal className="w-2.5 h-2.5" />
+              <Terminal className="w-3.5 h-3.5 md:w-2.5 md:h-2.5" />
             )}
             <span>
               {isError ? "Error" : isToolUse ? "Tool" : isToolResult ? "Result" : "Claude"}
             </span>
           </div>
         )}
-        <div className={`text-xs ${isToolUse || isToolResult ? "font-mono text-[10px]" : ""}`}>
+        <div className={`text-sm md:text-xs ${isToolUse || isToolResult ? "font-mono text-xs md:text-[10px]" : ""}`}>
           {isToolUse || isToolResult ? (
-            <pre className="whitespace-pre-wrap break-words max-h-24 overflow-auto">
+            <pre className="whitespace-pre-wrap break-words max-h-32 md:max-h-24 overflow-auto">
               {message.content}
             </pre>
           ) : (

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -1,10 +1,11 @@
 /**
  * MultiPaneLayout Component - Grid layout for multiple chat panes
- * 
+ *
  * Design: Terminal-Inspired Dark Mode
  * - Flexible grid layout (1x1, 2x1, 2x2, etc.)
  * - Drag and drop pane reordering (future)
  * - Maximize/minimize individual panes
+ * - Mobile-first: single pane on small screens
  */
 
 import { useState } from "react";
@@ -17,6 +18,7 @@ import {
   Maximize2,
 } from "lucide-react";
 import { ChatPane } from "./ChatPane";
+import { useIsMobile } from "@/hooks/useMobile";
 import type { Session, Worktree, Message } from "../../../shared/types";
 
 type LayoutMode = "single" | "split-2" | "grid-4";
@@ -46,7 +48,11 @@ export function MultiPaneLayout({
   onMaximizePane,
   maximizedPane,
 }: MultiPaneLayoutProps) {
+  const isMobile = useIsMobile();
   const [layoutMode, setLayoutMode] = useState<LayoutMode>("split-2");
+
+  // Force single pane on mobile
+  const effectiveLayoutMode = isMobile ? "single" : layoutMode;
 
   const getWorktreeForSession = (session: Session): Worktree | undefined => {
     return worktrees.find((w) => w.id === session.worktreeId);
@@ -85,32 +91,33 @@ export function MultiPaneLayout({
   // Determine grid layout based on mode and number of panes
   const getGridClass = () => {
     const paneCount = visiblePanes.length;
-    
-    if (layoutMode === "single" || paneCount === 1) {
+
+    if (effectiveLayoutMode === "single" || paneCount === 1) {
       return "grid-cols-1";
     }
-    
-    if (layoutMode === "split-2" || paneCount === 2) {
+
+    if (effectiveLayoutMode === "split-2" || paneCount === 2) {
       return "grid-cols-1 md:grid-cols-2";
     }
-    
-    if (layoutMode === "grid-4" || paneCount >= 3) {
+
+    if (effectiveLayoutMode === "grid-4" || paneCount >= 3) {
       return "grid-cols-1 md:grid-cols-2 xl:grid-cols-2";
     }
-    
+
     return "grid-cols-1";
   };
 
   return (
     <div className="h-full flex flex-col">
       {/* Layout Controls */}
-      <div className="h-10 border-b border-border flex items-center justify-between px-4 shrink-0 bg-sidebar">
+      <div className="h-12 md:h-10 border-b border-border flex items-center justify-between px-4 shrink-0 bg-sidebar">
         <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">
+          <span className="text-base md:text-sm text-muted-foreground">
             {visiblePanes.length} active pane{visiblePanes.length !== 1 ? "s" : ""}
           </span>
         </div>
-        <div className="flex items-center gap-1">
+        {/* Hide layout selector on mobile - always single pane */}
+        <div className="hidden md:flex items-center gap-1">
           <Button
             variant={layoutMode === "single" ? "secondary" : "ghost"}
             size="icon"
@@ -142,8 +149,8 @@ export function MultiPaneLayout({
       </div>
 
       {/* Panes Grid */}
-      <div className={`flex-1 grid ${getGridClass()} gap-2 p-2 overflow-hidden auto-rows-fr`}>
-        {visiblePanes.slice(0, layoutMode === "grid-4" ? 4 : layoutMode === "split-2" ? 2 : 1).map((sessionId) => {
+      <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-hidden auto-rows-fr`}>
+        {visiblePanes.slice(0, effectiveLayoutMode === "grid-4" ? 4 : effectiveLayoutMode === "split-2" ? 2 : 1).map((sessionId) => {
           const session = sessions.get(sessionId);
           if (!session) return null;
 
@@ -167,9 +174,9 @@ export function MultiPaneLayout({
       </div>
 
       {/* Hidden Panes Indicator */}
-      {visiblePanes.length > (layoutMode === "grid-4" ? 4 : layoutMode === "split-2" ? 2 : 1) && (
-        <div className="h-8 border-t border-border flex items-center justify-center text-xs text-muted-foreground shrink-0">
-          +{visiblePanes.length - (layoutMode === "grid-4" ? 4 : layoutMode === "split-2" ? 2 : 1)} more session(s) hidden
+      {visiblePanes.length > (effectiveLayoutMode === "grid-4" ? 4 : effectiveLayoutMode === "split-2" ? 2 : 1) && (
+        <div className="h-10 md:h-8 border-t border-border flex items-center justify-center text-sm md:text-xs text-muted-foreground shrink-0">
+          +{visiblePanes.length - (effectiveLayoutMode === "grid-4" ? 4 : effectiveLayoutMode === "split-2" ? 2 : 1)} more session(s) hidden
         </div>
       )}
     </div>

--- a/client/src/components/SessionDashboard.tsx
+++ b/client/src/components/SessionDashboard.tsx
@@ -77,13 +77,13 @@ export function SessionDashboard({
 
   if (sessionsArray.length === 0) {
     return (
-      <div className="h-full flex items-center justify-center">
+      <div className="h-full flex items-center justify-center p-6">
         <div className="text-center max-w-md">
-          <div className="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-6">
-            <Terminal className="w-8 h-8 text-primary" />
+          <div className="w-20 h-20 md:w-16 md:h-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-6">
+            <Terminal className="w-10 h-10 md:w-8 md:h-8 text-primary" />
           </div>
-          <h2 className="text-xl font-semibold mb-2">No Active Sessions</h2>
-          <p className="text-muted-foreground">
+          <h2 className="text-2xl md:text-xl font-semibold mb-3 md:mb-2">No Active Sessions</h2>
+          <p className="text-base md:text-sm text-muted-foreground">
             Start a session from the sidebar to begin working with Claude Code.
           </p>
         </div>
@@ -92,12 +92,12 @@ export function SessionDashboard({
   }
 
   return (
-    <ScrollArea className="h-full p-4">
-      <div className="mb-4">
-        <h2 className="text-lg font-semibold flex items-center gap-2">
-          <Terminal className="w-5 h-5 text-primary" />
+    <ScrollArea className="h-full p-4 md:p-4">
+      <div className="mb-5 md:mb-4">
+        <h2 className="text-xl md:text-lg font-semibold flex items-center gap-2">
+          <Terminal className="w-6 h-6 md:w-5 md:h-5 text-primary" />
           Active Sessions
-          <span className="text-sm font-normal text-muted-foreground">
+          <span className="text-base md:text-sm font-normal text-muted-foreground">
             ({sessionsArray.length})
           </span>
         </h2>
@@ -113,16 +113,16 @@ export function SessionDashboard({
           return (
             <div
               key={session.id}
-              className="group bg-card border border-border rounded-lg overflow-hidden hover:border-primary/50 transition-colors cursor-pointer"
+              className="group bg-card border border-border rounded-lg overflow-hidden hover:border-primary/50 active:border-primary/70 transition-colors cursor-pointer"
               onClick={() => onSelectSession(session.id)}
             >
               {/* Card Header */}
-              <div className="p-3 border-b border-border bg-sidebar">
+              <div className="p-4 md:p-3 border-b border-border bg-sidebar">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2 min-w-0">
                     <div className={`status-indicator ${session.status}`} />
-                    <GitBranch className="w-4 h-4 text-muted-foreground shrink-0" />
-                    <span className="font-mono text-sm truncate">
+                    <GitBranch className="w-5 h-5 md:w-4 md:h-4 text-muted-foreground shrink-0" />
+                    <span className="font-mono text-base md:text-sm truncate">
                       {worktree?.branch || "Unknown"}
                     </span>
                   </div>
@@ -133,63 +133,63 @@ export function SessionDashboard({
               </div>
 
               {/* Card Body */}
-              <div className="p-3">
+              <div className="p-4 md:p-3">
                 {/* Last Message Preview */}
-                <div className="mb-3 min-h-[60px]">
+                <div className="mb-4 md:mb-3 min-h-[70px] md:min-h-[60px]">
                   {isStreaming ? (
                     <div className="flex items-start gap-2">
-                      <Terminal className="w-3 h-3 text-primary mt-0.5 shrink-0" />
-                      <div className="text-xs text-muted-foreground line-clamp-3">
+                      <Terminal className="w-4 h-4 md:w-3 md:h-3 text-primary mt-0.5 shrink-0" />
+                      <div className="text-sm md:text-xs text-muted-foreground line-clamp-3">
                         <span className="text-primary">Processing...</span>
-                        <span className="inline-block w-1.5 h-1.5 bg-primary rounded-full animate-pulse ml-1" />
+                        <span className="inline-block w-2 h-2 md:w-1.5 md:h-1.5 bg-primary rounded-full animate-pulse ml-1" />
                       </div>
                     </div>
                   ) : lastMessage ? (
                     <div className="flex items-start gap-2">
                       {lastMessage.role === "user" ? (
-                        <MessageSquare className="w-3 h-3 text-accent mt-0.5 shrink-0" />
+                        <MessageSquare className="w-4 h-4 md:w-3 md:h-3 text-accent mt-0.5 shrink-0" />
                       ) : (
-                        <Terminal className="w-3 h-3 text-primary mt-0.5 shrink-0" />
+                        <Terminal className="w-4 h-4 md:w-3 md:h-3 text-primary mt-0.5 shrink-0" />
                       )}
-                      <p className="text-xs text-muted-foreground line-clamp-3">
+                      <p className="text-sm md:text-xs text-muted-foreground line-clamp-3">
                         {lastMessage.content}
                       </p>
                     </div>
                   ) : (
-                    <p className="text-xs text-muted-foreground italic">
+                    <p className="text-sm md:text-xs text-muted-foreground italic">
                       No messages yet
                     </p>
                   )}
                 </div>
 
                 {/* Stats */}
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
-                  <div className="flex items-center gap-1">
-                    <MessageSquare className="w-3 h-3" />
+                <div className="flex items-center justify-between text-sm md:text-xs text-muted-foreground">
+                  <div className="flex items-center gap-1.5 md:gap-1">
+                    <MessageSquare className="w-4 h-4 md:w-3 md:h-3" />
                     <span>{messageCount} messages</span>
                   </div>
-                  <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                  <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-6 w-6"
+                      className="h-10 w-10 md:h-6 md:w-6"
                       onClick={(e) => {
                         e.stopPropagation();
                         onSelectSession(session.id);
                       }}
                     >
-                      <Play className="w-3 h-3 text-primary" />
+                      <Play className="w-5 h-5 md:w-3 md:h-3 text-primary" />
                     </Button>
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-6 w-6"
+                      className="h-10 w-10 md:h-6 md:w-6"
                       onClick={(e) => {
                         e.stopPropagation();
                         onStopSession(session.id);
                       }}
                     >
-                      <Square className="w-3 h-3 text-destructive" />
+                      <Square className="w-5 h-5 md:w-3 md:h-3 text-destructive" />
                     </Button>
                   </div>
                 </div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -35,6 +35,13 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import {
   GitBranch,
   Plus,
   FolderOpen,
@@ -51,7 +58,9 @@ import {
   AlertCircle,
   LayoutGrid,
   Columns2,
+  Menu,
 } from "lucide-react";
+import { useIsMobile } from "@/hooks/useMobile";
 import { toast } from "sonner";
 import { useSocket } from "@/hooks/useSocket";
 import { MultiPaneLayout } from "@/components/MultiPaneLayout";
@@ -78,6 +87,8 @@ export default function Dashboard() {
     streamingContent,
   } = useSocket();
 
+  const isMobile = useIsMobile();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   const [viewMode, setViewMode] = useState<ViewMode>("dashboard");
   const [activePanes, setActivePanes] = useState<string[]>([]);
   const [maximizedPane, setMaximizedPane] = useState<string | null>(null);
@@ -186,316 +197,368 @@ export default function Dashboard() {
     });
   }, [sessions]);
 
-  return (
-    <div className="h-screen flex bg-background">
-      {/* Sidebar */}
-      <aside className="w-80 border-r border-border flex flex-col bg-sidebar shrink-0">
-        {/* Header */}
-        <div className="p-4 border-b border-sidebar-border">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-lg bg-primary/20 flex items-center justify-center">
-                <Terminal className="w-5 h-5 text-primary" />
-              </div>
-              <div>
-                <h1 className="font-semibold text-sidebar-foreground">Claude Code Manager</h1>
-                <p className="text-xs text-muted-foreground font-mono">v0.2.0</p>
-              </div>
+  // Sidebar content component for reuse
+  const SidebarContent = () => (
+    <>
+      {/* Repository Path */}
+      <div className="p-4 border-b border-sidebar-border">
+        <Label className="text-xs text-muted-foreground uppercase tracking-wider">Repository</Label>
+        {repoPath ? (
+          <div className="mt-2 flex items-center gap-2">
+            <div className="flex-1 flex items-center gap-2 p-2 md:p-2 rounded-md bg-sidebar-accent">
+              <FolderOpen className="w-4 h-4 md:w-4 md:h-4 text-accent shrink-0" />
+              <span className="text-sm md:text-sm font-mono text-sidebar-foreground truncate">{repoPath}</span>
             </div>
-            <div className="flex items-center gap-1">
-              {isConnected ? (
-                <Wifi className="w-4 h-4 text-primary" />
-              ) : (
-                <WifiOff className="w-4 h-4 text-destructive" />
-              )}
-            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-10 w-10 md:h-8 md:w-8 shrink-0"
+              onClick={refreshWorktrees}
+            >
+              <RefreshCw className="w-5 h-5 md:w-4 md:h-4" />
+            </Button>
           </div>
-        </div>
-
-        {/* Repository Path */}
-        <div className="p-4 border-b border-sidebar-border">
-          <Label className="text-xs text-muted-foreground uppercase tracking-wider">Repository</Label>
-          {repoPath ? (
-            <div className="mt-2 flex items-center gap-2">
-              <div className="flex-1 flex items-center gap-2 p-2 rounded-md bg-sidebar-accent">
-                <FolderOpen className="w-4 h-4 text-accent shrink-0" />
-                <span className="text-sm font-mono text-sidebar-foreground truncate">{repoPath}</span>
+        ) : (
+          <Dialog open={isSelectRepoOpen} onOpenChange={setIsSelectRepoOpen}>
+            <DialogTrigger asChild>
+              <Button variant="outline" className="w-full mt-2 justify-start gap-2 h-12 md:h-10 text-base md:text-sm">
+                <FolderOpen className="w-5 h-5 md:w-4 md:h-4" />
+                Select Repository
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+              <DialogHeader>
+                <DialogTitle>Select Repository</DialogTitle>
+                <DialogDescription>
+                  Enter the path to a local git repository.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4 py-4">
+                <div className="space-y-2">
+                  <Label htmlFor="repoPath">Repository Path</Label>
+                  <Input
+                    id="repoPath"
+                    placeholder="/path/to/your/repository"
+                    value={repoInput}
+                    onChange={(e) => setRepoInput(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        handleSelectRepo();
+                      }
+                    }}
+                    className="font-mono h-12 md:h-10 text-base md:text-sm"
+                  />
+                </div>
               </div>
+              <DialogFooter className="flex-col gap-2 sm:flex-row">
+                <Button variant="outline" onClick={() => setIsSelectRepoOpen(false)} className="h-12 md:h-10">
+                  Cancel
+                </Button>
+                <Button onClick={handleSelectRepo} className="glow-green h-12 md:h-10">
+                  Select
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        )}
+      </div>
+
+      {/* Worktrees Section */}
+      <div className="flex-1 flex flex-col overflow-hidden">
+        <div className="p-4 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <GitBranch className="w-5 h-5 md:w-4 md:h-4 text-muted-foreground" />
+            <span className="text-base md:text-sm font-medium text-sidebar-foreground">Worktrees</span>
+            <span className="text-sm md:text-xs text-muted-foreground">({worktrees.length})</span>
+          </div>
+          <Dialog open={isCreateWorktreeOpen} onOpenChange={setIsCreateWorktreeOpen}>
+            <DialogTrigger asChild>
               <Button
                 variant="ghost"
                 size="icon"
-                className="h-8 w-8 shrink-0"
-                onClick={refreshWorktrees}
+                className="h-10 w-10 md:h-7 md:w-7"
+                disabled={!repoPath}
               >
-                <RefreshCw className="w-4 h-4" />
+                <Plus className="w-5 h-5 md:w-4 md:h-4" />
               </Button>
-            </div>
-          ) : (
-            <Dialog open={isSelectRepoOpen} onOpenChange={setIsSelectRepoOpen}>
-              <DialogTrigger asChild>
-                <Button variant="outline" className="w-full mt-2 justify-start gap-2">
-                  <FolderOpen className="w-4 h-4" />
-                  Select Repository
-                </Button>
-              </DialogTrigger>
-              <DialogContent className="bg-card border-border">
-                <DialogHeader>
-                  <DialogTitle>Select Repository</DialogTitle>
-                  <DialogDescription>
-                    Enter the path to a local git repository.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-4 py-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="repoPath">Repository Path</Label>
-                    <Input
-                      id="repoPath"
-                      placeholder="/path/to/your/repository"
-                      value={repoInput}
-                      onChange={(e) => setRepoInput(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") {
-                          handleSelectRepo();
-                        }
-                      }}
-                      className="font-mono"
-                    />
+            </DialogTrigger>
+            <DialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+              <DialogHeader>
+                <DialogTitle>Create New Worktree</DialogTitle>
+                <DialogDescription>
+                  Create a new git worktree with a new branch.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-4 py-4">
+                <div className="space-y-2">
+                  <Label htmlFor="branch">Branch Name</Label>
+                  <Input
+                    id="branch"
+                    placeholder="feature/new-feature"
+                    value={newBranchName}
+                    onChange={(e) => setNewBranchName(e.target.value)}
+                    className="font-mono h-12 md:h-10 text-base md:text-sm"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="baseBranch">Base Branch (optional)</Label>
+                  <Input
+                    id="baseBranch"
+                    placeholder="main"
+                    value={baseBranch}
+                    onChange={(e) => setBaseBranch(e.target.value)}
+                    className="font-mono h-12 md:h-10 text-base md:text-sm"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-muted-foreground">Worktree Path (auto-generated)</Label>
+                  <div className="p-3 md:p-2 rounded-md bg-muted font-mono text-sm text-muted-foreground">
+                    {repoPath}-{newBranchName.replace(/\//g, "-") || "branch-name"}
                   </div>
                 </div>
-                <DialogFooter>
-                  <Button variant="outline" onClick={() => setIsSelectRepoOpen(false)}>
-                    Cancel
-                  </Button>
-                  <Button onClick={handleSelectRepo} className="glow-green">
-                    Select
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          )}
+              </div>
+              <DialogFooter className="flex-col gap-2 sm:flex-row">
+                <Button variant="outline" onClick={() => setIsCreateWorktreeOpen(false)} className="h-12 md:h-10">
+                  Cancel
+                </Button>
+                <Button onClick={handleCreateWorktree} className="glow-green h-12 md:h-10">
+                  Create Worktree
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </div>
 
-        {/* Worktrees Section */}
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <div className="p-4 flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <GitBranch className="w-4 h-4 text-muted-foreground" />
-              <span className="text-sm font-medium text-sidebar-foreground">Worktrees</span>
-              <span className="text-xs text-muted-foreground">({worktrees.length})</span>
-            </div>
-            <Dialog open={isCreateWorktreeOpen} onOpenChange={setIsCreateWorktreeOpen}>
-              <DialogTrigger asChild>
-                <Button 
-                  variant="ghost" 
-                  size="icon" 
-                  className="h-7 w-7"
-                  disabled={!repoPath}
+        <ScrollArea className="flex-1 px-2">
+          <div className="space-y-1 pb-4">
+            {worktrees.length === 0 && repoPath && (
+              <div className="p-4 text-center text-muted-foreground text-base md:text-sm">
+                No worktrees found
+              </div>
+            )}
+            {!repoPath && (
+              <div className="p-4 text-center text-muted-foreground text-base md:text-sm">
+                Select a repository to view worktrees
+              </div>
+            )}
+            {worktrees.map((worktree) => {
+              const session = getSessionForWorktree(worktree.id);
+              const isSelected = selectedWorktreeId === worktree.id;
+              const isInPane = session && activePanes.includes(session.id);
+
+              return (
+                <div
+                  key={worktree.id}
+                  className={`group p-4 md:p-3 rounded-lg cursor-pointer transition-all ${
+                    isInPane
+                      ? "bg-sidebar-accent border border-primary/30"
+                      : isSelected
+                      ? "bg-sidebar-accent"
+                      : "hover:bg-sidebar-accent/50 active:bg-sidebar-accent/70"
+                  }`}
+                  onClick={() => {
+                    setSelectedWorktreeId(worktree.id);
+                    if (isMobile) setSidebarOpen(false);
+                  }}
                 >
-                  <Plus className="w-4 h-4" />
-                </Button>
-              </DialogTrigger>
-              <DialogContent className="bg-card border-border">
-                <DialogHeader>
-                  <DialogTitle>Create New Worktree</DialogTitle>
-                  <DialogDescription>
-                    Create a new git worktree with a new branch.
-                  </DialogDescription>
-                </DialogHeader>
-                <div className="space-y-4 py-4">
-                  <div className="space-y-2">
-                    <Label htmlFor="branch">Branch Name</Label>
-                    <Input
-                      id="branch"
-                      placeholder="feature/new-feature"
-                      value={newBranchName}
-                      onChange={(e) => setNewBranchName(e.target.value)}
-                      className="font-mono"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label htmlFor="baseBranch">Base Branch (optional)</Label>
-                    <Input
-                      id="baseBranch"
-                      placeholder="main"
-                      value={baseBranch}
-                      onChange={(e) => setBaseBranch(e.target.value)}
-                      className="font-mono"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label className="text-muted-foreground">Worktree Path (auto-generated)</Label>
-                    <div className="p-2 rounded-md bg-muted font-mono text-sm text-muted-foreground">
-                      {repoPath}-{newBranchName.replace(/\//g, "-") || "branch-name"}
-                    </div>
-                  </div>
-                </div>
-                <DialogFooter>
-                  <Button variant="outline" onClick={() => setIsCreateWorktreeOpen(false)}>
-                    Cancel
-                  </Button>
-                  <Button onClick={handleCreateWorktree} className="glow-green">
-                    Create Worktree
-                  </Button>
-                </DialogFooter>
-              </DialogContent>
-            </Dialog>
-          </div>
-
-          <ScrollArea className="flex-1 px-2">
-            <div className="space-y-1 pb-4">
-              {worktrees.length === 0 && repoPath && (
-                <div className="p-4 text-center text-muted-foreground text-sm">
-                  No worktrees found
-                </div>
-              )}
-              {!repoPath && (
-                <div className="p-4 text-center text-muted-foreground text-sm">
-                  Select a repository to view worktrees
-                </div>
-              )}
-              {worktrees.map((worktree) => {
-                const session = getSessionForWorktree(worktree.id);
-                const isSelected = selectedWorktreeId === worktree.id;
-                const isInPane = session && activePanes.includes(session.id);
-
-                return (
-                  <div
-                    key={worktree.id}
-                    className={`group p-3 rounded-lg cursor-pointer transition-all ${
-                      isInPane
-                        ? "bg-sidebar-accent border border-primary/30"
-                        : isSelected
-                        ? "bg-sidebar-accent"
-                        : "hover:bg-sidebar-accent/50"
-                    }`}
-                    onClick={() => setSelectedWorktreeId(worktree.id)}
-                  >
-                    <div className="flex items-center justify-between">
-                      <div className="flex items-center gap-2 min-w-0">
-                        {session && (
-                          <div
-                            className={`status-indicator ${session.status}`}
-                            title={session.status}
-                          />
-                        )}
-                        <GitBranch className="w-4 h-4 text-muted-foreground shrink-0" />
-                        <span className="text-sm font-mono truncate text-sidebar-foreground">
-                          {worktree.branch}
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2 min-w-0">
+                      {session && (
+                        <div
+                          className={`status-indicator ${session.status}`}
+                          title={session.status}
+                        />
+                      )}
+                      <GitBranch className="w-5 h-5 md:w-4 md:h-4 text-muted-foreground shrink-0" />
+                      <span className="text-base md:text-sm font-mono truncate text-sidebar-foreground">
+                        {worktree.branch}
+                      </span>
+                      {worktree.isMain && (
+                        <span className="text-xs md:text-[10px] px-1.5 py-0.5 rounded bg-primary/20 text-primary uppercase">
+                          main
                         </span>
-                        {worktree.isMain && (
-                          <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/20 text-primary uppercase">
-                            main
-                          </span>
-                        )}
-                      </div>
-                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                        {session ? (
-                          <>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-6 w-6"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleSelectSession(session.id);
-                              }}
-                            >
-                              <MessageSquare className="w-3 h-3" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-6 w-6 text-destructive"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleStopSession(session.id);
-                              }}
-                            >
-                              <Square className="w-3 h-3" />
-                            </Button>
-                          </>
-                        ) : (
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+                      {session ? (
+                        <>
                           <Button
                             variant="ghost"
                             size="icon"
-                            className="h-6 w-6 text-primary"
+                            className="h-10 w-10 md:h-6 md:w-6"
                             onClick={(e) => {
                               e.stopPropagation();
-                              handleStartSession(worktree);
+                              handleSelectSession(session.id);
+                              if (isMobile) setSidebarOpen(false);
                             }}
                           >
-                            <Play className="w-3 h-3" />
+                            <MessageSquare className="w-5 h-5 md:w-3 md:h-3" />
                           </Button>
-                        )}
-                        {!worktree.isMain && (
-                          <AlertDialog>
-                            <AlertDialogTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-6 w-6 text-destructive"
-                                onClick={(e) => e.stopPropagation()}
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-10 w-10 md:h-6 md:w-6 text-destructive"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleStopSession(session.id);
+                            }}
+                          >
+                            <Square className="w-5 h-5 md:w-3 md:h-3" />
+                          </Button>
+                        </>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="h-10 w-10 md:h-6 md:w-6 text-primary"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleStartSession(worktree);
+                            if (isMobile) setSidebarOpen(false);
+                          }}
+                        >
+                          <Play className="w-5 h-5 md:w-3 md:h-3" />
+                        </Button>
+                      )}
+                      {!worktree.isMain && (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-10 w-10 md:h-6 md:w-6 text-destructive"
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <Trash2 className="w-5 h-5 md:w-3 md:h-3" />
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>Delete Worktree</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Are you sure you want to delete this worktree? This will also delete the associated branch.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
+                              <AlertDialogCancel className="h-12 md:h-10">Cancel</AlertDialogCancel>
+                              <AlertDialogAction
+                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
+                                onClick={() => handleDeleteWorktree(worktree)}
                               >
-                                <Trash2 className="w-3 h-3" />
-                              </Button>
-                            </AlertDialogTrigger>
-                            <AlertDialogContent className="bg-card border-border">
-                              <AlertDialogHeader>
-                                <AlertDialogTitle>Delete Worktree</AlertDialogTitle>
-                                <AlertDialogDescription>
-                                  Are you sure you want to delete this worktree? This will also delete the associated branch.
-                                </AlertDialogDescription>
-                              </AlertDialogHeader>
-                              <AlertDialogFooter>
-                                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                                <AlertDialogAction
-                                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                                  onClick={() => handleDeleteWorktree(worktree)}
-                                >
-                                  Delete
-                                </AlertDialogAction>
-                              </AlertDialogFooter>
-                            </AlertDialogContent>
-                          </AlertDialog>
-                        )}
-                      </div>
-                    </div>
-                    <div className="mt-1 text-xs text-muted-foreground font-mono truncate pl-6">
-                      {worktree.path}
+                                Delete
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
+                      )}
                     </div>
                   </div>
-                );
-              })}
-            </div>
-          </ScrollArea>
-        </div>
+                  <div className="mt-1 text-sm md:text-xs text-muted-foreground font-mono truncate pl-7 md:pl-6">
+                    {worktree.path}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </ScrollArea>
+      </div>
 
-        {/* Footer */}
-        <div className="p-4 border-t border-sidebar-border">
-          <Button 
-            variant="ghost" 
-            className="w-full justify-start gap-2 text-muted-foreground"
-            onClick={() => toast.info("Settings coming soon")}
-          >
-            <Settings className="w-4 h-4" />
-            Settings
-          </Button>
-        </div>
-      </aside>
+      {/* Footer */}
+      <div className="p-4 border-t border-sidebar-border">
+        <Button
+          variant="ghost"
+          className="w-full justify-start gap-2 text-muted-foreground h-12 md:h-10 text-base md:text-sm"
+          onClick={() => toast.info("Settings coming soon")}
+        >
+          <Settings className="w-5 h-5 md:w-4 md:h-4" />
+          Settings
+        </Button>
+      </div>
+    </>
+  );
+
+  return (
+    <div className="h-screen flex flex-col md:flex-row bg-background">
+      {/* Mobile Header */}
+      {isMobile && (
+        <header className="h-14 border-b border-border flex items-center justify-between px-4 bg-sidebar shrink-0">
+          <div className="flex items-center gap-3">
+            <Sheet open={sidebarOpen} onOpenChange={setSidebarOpen}>
+              <SheetTrigger asChild>
+                <Button variant="ghost" size="icon" className="h-10 w-10">
+                  <Menu className="w-6 h-6" />
+                </Button>
+              </SheetTrigger>
+              <SheetContent side="left" className="w-[85%] max-w-[320px] p-0 flex flex-col bg-sidebar">
+                <SheetHeader className="p-4 border-b border-sidebar-border">
+                  <div className="flex items-center gap-3">
+                    <div className="w-10 h-10 rounded-lg bg-primary/20 flex items-center justify-center">
+                      <Terminal className="w-5 h-5 text-primary" />
+                    </div>
+                    <SheetTitle className="text-sidebar-foreground">Claude Code Manager</SheetTitle>
+                  </div>
+                </SheetHeader>
+                <div className="flex-1 flex flex-col overflow-hidden">
+                  <SidebarContent />
+                </div>
+              </SheetContent>
+            </Sheet>
+            <div className="flex items-center gap-2">
+              <Terminal className="w-5 h-5 text-primary" />
+              <span className="font-semibold text-sidebar-foreground">Claude Code</span>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {isConnected ? (
+              <Wifi className="w-5 h-5 text-primary" />
+            ) : (
+              <WifiOff className="w-5 h-5 text-destructive" />
+            )}
+          </div>
+        </header>
+      )}
+
+      {/* Desktop Sidebar */}
+      {!isMobile && (
+        <aside className="w-80 border-r border-border flex flex-col bg-sidebar shrink-0">
+          {/* Header */}
+          <div className="p-4 border-b border-sidebar-border">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 rounded-lg bg-primary/20 flex items-center justify-center">
+                  <Terminal className="w-5 h-5 text-primary" />
+                </div>
+                <div>
+                  <h1 className="font-semibold text-sidebar-foreground">Claude Code Manager</h1>
+                  <p className="text-xs text-muted-foreground font-mono">v0.2.0</p>
+                </div>
+              </div>
+              <div className="flex items-center gap-1">
+                {isConnected ? (
+                  <Wifi className="w-4 h-4 text-primary" />
+                ) : (
+                  <WifiOff className="w-4 h-4 text-destructive" />
+                )}
+              </div>
+            </div>
+          </div>
+          <SidebarContent />
+        </aside>
+      )}
 
       {/* Main Content */}
       <main className="flex-1 flex flex-col min-w-0">
         {/* View Mode Tabs */}
-        <div className="h-12 border-b border-border flex items-center justify-between px-4 bg-sidebar shrink-0">
+        <div className="h-14 md:h-12 border-b border-border flex items-center justify-between px-4 bg-sidebar shrink-0">
           <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as ViewMode)}>
-            <TabsList className="bg-sidebar-accent">
-              <TabsTrigger value="dashboard" className="gap-2">
-                <LayoutGrid className="w-4 h-4" />
-                Dashboard
+            <TabsList className="bg-sidebar-accent h-10 md:h-9">
+              <TabsTrigger value="dashboard" className="gap-2 h-8 md:h-7 px-3 md:px-2 text-sm md:text-xs">
+                <LayoutGrid className="w-4 h-4 md:w-4 md:h-4" />
+                <span className="hidden sm:inline">Dashboard</span>
               </TabsTrigger>
-              <TabsTrigger value="panes" className="gap-2">
-                <Columns2 className="w-4 h-4" />
-                Panes
+              <TabsTrigger value="panes" className="gap-2 h-8 md:h-7 px-3 md:px-2 text-sm md:text-xs">
+                <Columns2 className="w-4 h-4 md:w-4 md:h-4" />
+                <span className="hidden sm:inline">Panes</span>
                 {activePanes.length > 0 && (
                   <span className="ml-1 text-xs bg-primary/20 text-primary px-1.5 py-0.5 rounded">
                     {activePanes.length}
@@ -507,8 +570,8 @@ export default function Dashboard() {
 
           {!isConnected && (
             <div className="flex items-center gap-2 text-destructive text-sm">
-              <AlertCircle className="w-4 h-4" />
-              <span>Not connected to server</span>
+              <AlertCircle className="w-5 h-5 md:w-4 md:h-4" />
+              <span className="hidden sm:inline">Not connected to server</span>
             </div>
           )}
         </div>
@@ -539,23 +602,23 @@ export default function Dashboard() {
                 maximizedPane={maximizedPane}
               />
             ) : (
-              <div className="h-full flex items-center justify-center">
+              <div className="h-full flex items-center justify-center p-6">
                 <div className="text-center max-w-md">
-                  <div className="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-6">
-                    <Terminal className="w-8 h-8 text-primary" />
+                  <div className="w-20 h-20 md:w-16 md:h-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-6">
+                    <Terminal className="w-10 h-10 md:w-8 md:h-8 text-primary" />
                   </div>
-                  <h2 className="text-xl font-semibold mb-2">No Active Panes</h2>
-                  <p className="text-muted-foreground mb-6">
-                    Start a session from the sidebar to open a chat pane.
+                  <h2 className="text-2xl md:text-xl font-semibold mb-3 md:mb-2">No Active Panes</h2>
+                  <p className="text-base md:text-sm text-muted-foreground mb-6">
+                    {isMobile ? "Tap the menu to select a worktree and start a session." : "Start a session from the sidebar to open a chat pane."}
                   </p>
-                  <div className="flex items-center justify-center gap-4 text-sm text-muted-foreground">
+                  <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-base md:text-sm text-muted-foreground">
                     <div className="flex items-center gap-2">
-                      <Play className="w-4 h-4 text-primary" />
+                      <Play className="w-5 h-5 md:w-4 md:h-4 text-primary" />
                       <span>Start session</span>
                     </div>
-                    <Separator orientation="vertical" className="h-4" />
+                    <Separator orientation="vertical" className="h-4 hidden sm:block" />
                     <div className="flex items-center gap-2">
-                      <Plus className="w-4 h-4 text-accent" />
+                      <Plus className="w-5 h-5 md:w-4 md:h-4 text-accent" />
                       <span>Create worktree</span>
                     </div>
                   </div>


### PR DESCRIPTION
- Dashboard.tsx: モバイルでサイドバーをSheetドロワーとして表示
  - モバイルヘッダーにハンバーガーメニュー追加
  - タッチターゲットを44px以上に拡大
  - ダイアログのモバイル対応（幅・フッターレイアウト）

- ChatPane.tsx: モバイル向けに最適化
  - ヘッダー、入力フォームの高さを拡大
  - テキストサイズをtext-sm/text-baseに変更
  - アイコンサイズを拡大

- MultiPaneLayout.tsx: モバイル対応
  - モバイルではシングルペインを強制
  - レイアウト切り替えボタンをデスクトップのみ表示

- SessionDashboard.tsx: タッチ操作の改善
  - カードのパディングとテキストサイズを拡大
  - ボタンサイズを44px以上に拡大