### PR TITLE
fix: ttydセッション復元とWebSocket接続の問題を修正

### DIFF
--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -92,7 +92,10 @@ export function TerminalPane({
   };
 
   // Construct ttyd iframe URL
-  const ttydIframeSrc = session.ttydUrl || `/ttyd/${session.id}/`;
+  // ttydPortがある場合は直接接続（viteプロキシ経由だとWebSocket接続に問題がある）
+  const ttydIframeSrc = session.ttydPort
+    ? `http://127.0.0.1:${session.ttydPort}/`
+    : session.ttydUrl || `/ttyd/${session.id}/`;
 
   // Quick commands for mobile
   const quickCommands = [

--- a/server/index.ts
+++ b/server/index.ts
@@ -239,9 +239,10 @@ async function startServer() {
       }
     });
 
-    socket.on("session:restore", (worktreePath) => {
+    socket.on("session:restore", async (worktreePath) => {
       try {
-        const session = sessionOrchestrator.getSessionByWorktree(worktreePath);
+        // 既存セッションを復元（ttydが起動していなければ起動）
+        const session = await sessionOrchestrator.restoreSession(worktreePath);
         if (session) {
           socket.emit("session:restored", session);
         } else {

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -90,8 +90,8 @@ export class TtydManager extends EventEmitter {
         "-W", // Writable
         "-p",
         port.toString(),
-        "-b",
-        "127.0.0.1", // ローカルのみ（プロキシ経由でアクセス）
+        "-i",
+        "lo0", // macOS loopback interface
         "-t",
         "fontSize=14",
         "-t",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -48,6 +48,11 @@ export default defineConfig({
         ws: true,
         changeOrigin: true,
       },
+      "/ttyd": {
+        target: "http://localhost:3001",
+        ws: true,
+        changeOrigin: true,
+      },
     },
     fs: {
       strict: true,


### PR DESCRIPTION
## Summary
- セッション復元時にttydが自動起動しない問題を修正
- viteプロキシ経由でのWebSocket接続問題を回避するため、ttydに直接接続するよう変更

## Changes
- `session:restore`ハンドラを非同期化し、ttydが起動していない場合は自動起動
- `SessionOrchestrator`に`restoreSession`メソッドを追加
- `TerminalPane`でttydPortがある場合は直接接続するよう変更
- `ttyd-manager`のバインドオプションをmacOS用に修正（`-i lo0`）
- `vite.config.ts`にttydプロキシ設定を追加（フォールバック用）

## Test plan
- [x] セッション復元後にターミナルが表示されることを確認
- [x] ttydに直接接続できることを確認