### PR TITLE
feat: ペイン表示をリポジトリ単位で管理

### DIFF
--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -45,7 +45,7 @@ export function MultiPaneLayout({
   maximizedPane,
 }: MultiPaneLayoutProps) {
   const isMobile = useIsMobile();
-  const [layoutMode, setLayoutMode] = useState<LayoutMode>("split-2");
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>("grid-4");
 
   // Force single pane on mobile
   const effectiveLayoutMode = isMobile ? "single" : layoutMode;
@@ -91,15 +91,26 @@ export function MultiPaneLayout({
       return "grid-cols-1";
     }
 
-    if (effectiveLayoutMode === "split-2" || paneCount === 2) {
+    if (effectiveLayoutMode === "split-2") {
       return "grid-cols-1 md:grid-cols-2";
     }
 
-    if (effectiveLayoutMode === "grid-4" || paneCount >= 3) {
-      return "grid-cols-1 md:grid-cols-2 xl:grid-cols-2";
+    // grid-4モード: ペイン数に応じてグリッドを調整
+    if (effectiveLayoutMode === "grid-4") {
+      if (paneCount <= 2) return "grid-cols-1 md:grid-cols-2";
+      if (paneCount <= 4) return "grid-cols-1 md:grid-cols-2";
+      if (paneCount <= 6) return "grid-cols-1 md:grid-cols-2 xl:grid-cols-3";
+      return "grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4";
     }
 
-    return "grid-cols-1";
+    return "grid-cols-1 md:grid-cols-2";
+  };
+
+  // 表示するペイン数を決定
+  const getMaxPanes = () => {
+    if (effectiveLayoutMode === "single") return 1;
+    if (effectiveLayoutMode === "split-2") return 2;
+    return visiblePanes.length; // grid-4モードでは全て表示
   };
 
   return (
@@ -144,8 +155,8 @@ export function MultiPaneLayout({
       </div>
 
       {/* Panes Grid */}
-      <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-hidden auto-rows-fr`}>
-        {visiblePanes.slice(0, effectiveLayoutMode === "grid-4" ? 4 : effectiveLayoutMode === "split-2" ? 2 : 1).map((sessionId) => {
+      <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-auto auto-rows-fr`}>
+        {visiblePanes.slice(0, getMaxPanes()).map((sessionId) => {
           const session = sessions.get(sessionId);
           if (!session) return null;
 
@@ -168,9 +179,9 @@ export function MultiPaneLayout({
       </div>
 
       {/* Hidden Panes Indicator */}
-      {visiblePanes.length > (effectiveLayoutMode === "grid-4" ? 4 : effectiveLayoutMode === "split-2" ? 2 : 1) && (
+      {visiblePanes.length > getMaxPanes() && (
         <div className="h-10 md:h-8 border-t border-border flex items-center justify-center text-sm md:text-xs text-muted-foreground shrink-0">
-          +{visiblePanes.length - (effectiveLayoutMode === "grid-4" ? 4 : effectiveLayoutMode === "split-2" ? 2 : 1)} more session(s) hidden
+          +{visiblePanes.length - getMaxPanes()} more session(s) hidden
         </div>
       )}
     </div>

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -55,8 +55,10 @@ interface UseSocketReturn {
   scanRepos: (basePath: string) => void;
 
   // Repository
+  repoList: string[];
   repoPath: string | null;
   selectRepo: (path: string) => void;
+  removeRepo: (path: string) => void;
 
   // Worktrees
   worktrees: Worktree[];

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -193,22 +193,16 @@ export function useSocket(): UseSocketReturn {
     });
 
     // Session events (ttyd-based)
+    const updateSession = (session: TtydSession): void => {
+      setSessions((prev) => new Map(prev).set(session.id, session));
+    };
+
     socket.on("session:created", (session) => {
       console.log("[Socket] Session created:", session.id, "ttydUrl:", session.ttydUrl);
-      setSessions((prev) => {
-        const next = new Map(prev);
-        next.set(session.id, session);
-        return next;
-      });
+      updateSession(session);
     });
 
-    socket.on("session:updated", (session) => {
-      setSessions((prev) => {
-        const next = new Map(prev);
-        next.set(session.id, session);
-        return next;
-      });
-    });
+    socket.on("session:updated", updateSession);
 
     socket.on("session:stopped", (sessionId) => {
       setSessions((prev) => {
@@ -220,11 +214,7 @@ export function useSocket(): UseSocketReturn {
 
     socket.on("session:restored", (session) => {
       console.log("[Socket] Session restored:", session.id, "ttydUrl:", session.ttydUrl);
-      setSessions((prev) => {
-        const next = new Map(prev);
-        next.set(session.id, session);
-        return next;
-      });
+      updateSession(session);
     });
 
     socket.on("session:restore_failed", ({ worktreePath: _path, error: err }) => {
@@ -307,8 +297,6 @@ export function useSocket(): UseSocketReturn {
   }, []);
 
   const sendMessage = useCallback((sessionId: string, message: string) => {
-    // For ttyd approach, we just send the message to tmux
-    // No local message state management needed (ttyd handles display)
     socketRef.current?.emit("session:send", { sessionId, message });
   }, []);
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,12 +1,3 @@
-/**
- * Dashboard Page - Claude Code Manager
- * 
- * Design: Terminal-Inspired Dark Mode
- * - Left sidebar: Worktree list with status indicators
- * - Right main area: Multi-pane view or dashboard overview
- * - Real-time communication via Socket.IO
- */
-
 import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -58,7 +49,6 @@ import {
   MessageSquare,
   Terminal,
   Settings,
-  Send,
   Wifi,
   WifiOff,
   RefreshCw,
@@ -127,26 +117,19 @@ export default function Dashboard() {
   const [newBranchName, setNewBranchName] = useState("");
   const [baseBranch, setBaseBranch] = useState("");
 
-  // Show error toast when error changes
   useEffect(() => {
-    if (error) {
-      toast.error(error);
-    }
+    if (error) toast.error(error);
   }, [error]);
 
-  // リポジトリ切り替え時にビューを切り替え
   useEffect(() => {
     setMaximizedPane(null);
     setSelectedWorktreeId(null);
-    // activePanesがあればpanesビューに切り替え、なければdashboardに
     const currentPanes = repoPath ? (activePanesPerRepo.get(repoPath) || []) : [];
     setViewMode(currentPanes.length > 0 ? "panes" : "dashboard");
   }, [repoPath, activePanesPerRepo]);
 
-  // Find session for a worktree
   const getSessionForWorktree = (worktreeId: string): TtydSession | undefined => {
-    const sessionsArray = Array.from(sessions.values());
-    return sessionsArray.find((s) => s.worktreeId === worktreeId);
+    return Array.from(sessions.values()).find((s) => s.worktreeId === worktreeId);
   };
 
   const handleSelectRepo = (path: string) => {
@@ -216,15 +199,7 @@ export default function Dashboard() {
     setMaximizedPane(maximizedPane === sessionId ? null : sessionId);
   };
 
-  const handleSendMessage = (sessionId: string, message: string) => {
-    sendMessage(sessionId, message);
-  };
 
-  const handleSendKey = (sessionId: string, key: "Enter" | "C-c" | "C-d" | "y" | "n") => {
-    sendKey(sessionId, key);
-  };
-
-  // Auto-add new sessions to active panes (現在のリポジトリに属するセッションのみ)
   useEffect(() => {
     if (!repoPath) return;
     sessions.forEach((session, sessionId) => {
@@ -235,15 +210,12 @@ export default function Dashboard() {
     });
   }, [sessions, repoPath, activePanes]);
 
-  // Sidebar content component for reuse
   const SidebarContent = () => (
     <>
-      {/* Repository List */}
       <div className="p-4 border-b border-sidebar-border">
         <div className="flex items-center justify-between mb-2">
           <Label className="text-xs text-muted-foreground uppercase tracking-wider">Repositories</Label>
           {allowedRepos.length > 0 ? (
-            /* --repos オプションが指定された場合: Selectドロップダウン */
             <Select onValueChange={selectRepo} value={repoPath || undefined}>
               <SelectTrigger className="w-auto h-8 text-xs gap-1">
                 <Plus className="w-3 h-3" />
@@ -257,7 +229,6 @@ export default function Dashboard() {
               </SelectContent>
             </Select>
           ) : (
-            /* --repos オプションなしの場合: ダイアログで追加 */
             <RepoSelectDialog
               isOpen={isSelectRepoOpen}
               onOpenChange={setIsSelectRepoOpen}
@@ -269,7 +240,6 @@ export default function Dashboard() {
           )}
         </div>
 
-        {/* 登録済みリポジトリ一覧 */}
         {repoList.length > 0 ? (
           <div className="space-y-1">
             {repoList.map((repo) => {
@@ -331,7 +301,6 @@ export default function Dashboard() {
         )}
       </div>
 
-      {/* Worktrees Section */}
       <div className="flex-1 flex flex-col overflow-hidden">
         <div className="p-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
@@ -532,7 +501,6 @@ export default function Dashboard() {
         </ScrollArea>
       </div>
 
-      {/* Footer */}
       <div className="p-4 border-t border-sidebar-border">
         <Button
           variant="ghost"
@@ -548,7 +516,6 @@ export default function Dashboard() {
 
   return (
     <div className="h-screen flex flex-col md:flex-row bg-background">
-      {/* Mobile Header */}
       {isMobile && (
         <header className="h-14 border-b border-border flex items-center justify-between px-4 bg-sidebar shrink-0">
           <div className="flex items-center gap-3">
@@ -587,10 +554,8 @@ export default function Dashboard() {
         </header>
       )}
 
-      {/* Desktop Sidebar */}
       {!isMobile && (
         <aside className="w-80 border-r border-border flex flex-col bg-sidebar shrink-0">
-          {/* Header */}
           <div className="p-4 border-b border-sidebar-border">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
@@ -615,9 +580,7 @@ export default function Dashboard() {
         </aside>
       )}
 
-      {/* Main Content */}
       <main className="flex-1 flex flex-col min-w-0">
-        {/* View Mode Tabs */}
         <div className="h-14 md:h-12 border-b border-border flex items-center justify-between px-4 bg-sidebar shrink-0">
           <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as ViewMode)}>
             <TabsList className="bg-sidebar-accent h-10 md:h-9">
@@ -645,7 +608,6 @@ export default function Dashboard() {
           )}
         </div>
 
-        {/* Content Area */}
         <div className="flex-1 overflow-hidden">
           {viewMode === "dashboard" ? (
             <SessionDashboard
@@ -659,8 +621,6 @@ export default function Dashboard() {
               onStopSession={handleStopSession}
             />
           ) : (() => {
-            // MultiPaneLayoutに渡す前に、現在のリポジトリに属するセッションのみをフィルタ
-            // また、activePanesに存在するセッションのみを表示
             const filteredSessions = new Map(
               Array.from(sessions.entries()).filter(([sessionId, session]) =>
                 repoPath && isSessionBelongsToRepo(session, repoPath) && activePanes.includes(sessionId)
@@ -672,8 +632,8 @@ export default function Dashboard() {
                 activePanes={validActivePanes}
                 sessions={filteredSessions}
                 worktrees={worktrees}
-                onSendMessage={handleSendMessage}
-                onSendKey={handleSendKey}
+                onSendMessage={sendMessage}
+                onSendKey={sendKey}
                 onStopSession={handleStopSession}
                 onClosePane={handleClosePane}
                 onMaximizePane={handleMaximizePane}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -134,15 +134,13 @@ export default function Dashboard() {
     }
   }, [error]);
 
-  // リポジトリ切り替え時にビューをリセット
+  // リポジトリ切り替え時にビューを切り替え
   useEffect(() => {
     setMaximizedPane(null);
     setSelectedWorktreeId(null);
-    // activePanesがあればpanesビューを維持、なければdashboardに
+    // activePanesがあればpanesビューに切り替え、なければdashboardに
     const currentPanes = repoPath ? (activePanesPerRepo.get(repoPath) || []) : [];
-    if (currentPanes.length === 0) {
-      setViewMode("dashboard");
-    }
+    setViewMode(currentPanes.length > 0 ? "panes" : "dashboard");
   }, [repoPath, activePanesPerRepo]);
 
   // Find session for a worktree

--- a/client/src/utils/sessionUtils.ts
+++ b/client/src/utils/sessionUtils.ts
@@ -1,0 +1,31 @@
+import type { TtydSession } from "../hooks/useSocket";
+
+/**
+ * セッションが指定されたリポジトリに属するかどうかを判定する
+ *
+ * @param session - 判定対象のセッション
+ * @param repoPath - リポジトリのパス
+ * @returns セッションがリポジトリに属する場合はtrue
+ */
+export function isSessionBelongsToRepo(
+  session: TtydSession,
+  repoPath: string
+): boolean {
+  const worktreePath = session.worktreePath;
+
+  // メインworktree（パスが完全一致）
+  if (worktreePath === repoPath) return true;
+
+  // 派生worktree（同じ親ディレクトリで、リポジトリ名で始まる）
+  const repoParent = repoPath.substring(0, repoPath.lastIndexOf("/"));
+  const repoName = repoPath.substring(repoPath.lastIndexOf("/") + 1);
+  const worktreeParent = worktreePath.substring(
+    0,
+    worktreePath.lastIndexOf("/")
+  );
+  const worktreeName = worktreePath.substring(
+    worktreePath.lastIndexOf("/") + 1
+  );
+
+  return worktreeParent === repoParent && worktreeName.startsWith(repoName + "-");
+}

--- a/client/src/utils/sessionUtils.ts
+++ b/client/src/utils/sessionUtils.ts
@@ -1,31 +1,29 @@
 import type { TtydSession } from "../hooks/useSocket";
 
+function getParentPath(path: string): string {
+  const lastSlash = path.lastIndexOf("/");
+  return lastSlash >= 0 ? path.substring(0, lastSlash) : "";
+}
+
+function getBaseName(path: string): string {
+  return path.substring(path.lastIndexOf("/") + 1);
+}
+
 /**
  * セッションが指定されたリポジトリに属するかどうかを判定する
- *
- * @param session - 判定対象のセッション
- * @param repoPath - リポジトリのパス
- * @returns セッションがリポジトリに属する場合はtrue
  */
 export function isSessionBelongsToRepo(
   session: TtydSession,
   repoPath: string
 ): boolean {
-  const worktreePath = session.worktreePath;
+  const { worktreePath } = session;
 
-  // メインworktree（パスが完全一致）
   if (worktreePath === repoPath) return true;
 
-  // 派生worktree（同じ親ディレクトリで、リポジトリ名で始まる）
-  const repoParent = repoPath.substring(0, repoPath.lastIndexOf("/"));
-  const repoName = repoPath.substring(repoPath.lastIndexOf("/") + 1);
-  const worktreeParent = worktreePath.substring(
-    0,
-    worktreePath.lastIndexOf("/")
-  );
-  const worktreeName = worktreePath.substring(
-    worktreePath.lastIndexOf("/") + 1
-  );
+  const repoParent = getParentPath(repoPath);
+  const repoName = getBaseName(repoPath);
+  const worktreeParent = getParentPath(worktreePath);
+  const worktreeName = getBaseName(worktreePath);
 
-  return worktreeParent === repoParent && worktreeName.startsWith(repoName + "-");
+  return worktreeParent === repoParent && worktreeName.startsWith(`${repoName}-`);
 }


### PR DESCRIPTION
## Summary
- ペイン状態をリポジトリごとに保持する`Map<repoPath, sessionId[]>`構造に変更
- リポジトリ切り替え時にセッションとペインが正しく保持・復元されるように修正
- `isSessionBelongsToRepo`関数でセッションのリポジトリ所属を判定

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `client/src/utils/sessionUtils.ts` | 新規作成。`isSessionBelongsToRepo`関数を実装 |
| `client/src/pages/Dashboard.tsx` | 状態管理をリポジトリ単位に変更 |
| `client/src/hooks/useSocket.ts` | 型定義に`repoList`と`removeRepo`を追加 |

## Test plan
- [ ] リポジトリAでセッション開始 → ペイン表示確認
- [ ] リポジトリBに切り替え → リポジトリAのペインが非表示になることを確認
- [ ] リポジトリBでセッション開始 → ペイン表示確認
- [ ] リポジトリAに戻る → リポジトリAのペインが復元されることを確認
- [ ] 両方のセッションがバックグラウンドで維持されていることを確認