### PR TITLE
feat: ダッシュボードを全リポジトリ横断表示に変更

### DIFF
--- a/client/src/components/SessionDashboard.tsx
+++ b/client/src/components/SessionDashboard.tsx
@@ -2,7 +2,7 @@
  * SessionDashboard Component - Overview of all active sessions
  *
  * Design: Terminal-Inspired Dark Mode
- * - Grid layout showing all active sessions
+ * - Grid layout showing all active sessions grouped by repository
  * - Session cards with status and quick actions
  * - Click to expand into full terminal view
  */
@@ -18,28 +18,59 @@ import {
   Zap,
   AlertCircle,
   ExternalLink,
+  FolderOpen,
 } from "lucide-react";
 import type { TtydSession } from "./TerminalPane";
-import type { Worktree } from "../../../shared/types";
 
 interface SessionDashboardProps {
   sessions: Map<string, TtydSession>;
-  worktrees: Worktree[];
   onSelectSession: (sessionId: string) => void;
   onStopSession: (sessionId: string) => void;
 }
 
+/**
+ * セッションをリポジトリごとにグループ化
+ */
+function groupSessionsByRepo(sessions: TtydSession[]): Map<string, TtydSession[]> {
+  const grouped = new Map<string, TtydSession[]>();
+
+  for (const session of sessions) {
+    // worktreePathの親ディレクトリをリポジトリのベースパスとして使用
+    // 例: /Users/xxx/dev/claude-code-manager-feature -> /Users/xxx/dev をベースパスとして
+    // リポジトリ名は claude-code-manager
+    const pathParts = session.worktreePath.split("/");
+    const dirName = pathParts.pop() || "";
+    const basePath = pathParts.join("/");
+
+    // worktreeIdまたはworktreePathからリポジトリ名を推測
+    // worktreeIdは通常 hash 形式なので、worktreePathを使う
+    // tmuxSessionNameから情報を取得することも可能
+
+    // リポジトリのベースパスをキーにする
+    // 同じベースパスを持つセッションは同じリポジトリに属する
+    const repoKey = basePath;
+
+    const existing = grouped.get(repoKey) || [];
+    existing.push(session);
+    grouped.set(repoKey, existing);
+  }
+
+  return grouped;
+}
+
+/**
+ * worktreePathから表示用の名前を取得（ディレクトリ名）
+ */
+function getDisplayName(worktreePath: string): string {
+  return worktreePath.split("/").pop() || worktreePath;
+}
+
 export function SessionDashboard({
   sessions,
-  worktrees,
   onSelectSession,
   onStopSession,
 }: SessionDashboardProps) {
   const sessionsArray = Array.from(sessions.values());
-
-  const getWorktreeForSession = (session: TtydSession): Worktree | undefined => {
-    return worktrees.find((w) => w.id === session.worktreeId);
-  };
 
   const getStatusColor = (status: TtydSession["status"]) => {
     switch (status) {
@@ -83,6 +114,9 @@ export function SessionDashboard({
     );
   }
 
+  // リポジトリごとにセッションをグループ化
+  const groupedSessions = groupSessionsByRepo(sessionsArray);
+
   return (
     <ScrollArea className="h-full p-4 md:p-4">
       <div className="mb-5 md:mb-4">
@@ -95,89 +129,108 @@ export function SessionDashboard({
         </h2>
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
-        {sessionsArray.map((session) => {
-          const worktree = getWorktreeForSession(session);
+      <div className="space-y-6">
+        {Array.from(groupedSessions.entries()).map(([repoPath, repoSessions]) => {
+          // リポジトリのベースパスから表示名を取得
+          const repoDisplayName = repoPath.split("/").pop() || repoPath;
 
           return (
-            <div
-              key={session.id}
-              className="group bg-card border border-border rounded-lg overflow-hidden hover:border-primary/50 active:border-primary/70 transition-colors cursor-pointer"
-              onClick={() => onSelectSession(session.id)}
-            >
-              {/* Card Header */}
-              <div className="p-4 md:p-3 border-b border-border bg-sidebar">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2 min-w-0">
-                    <div className={`status-indicator ${session.status}`} />
-                    <GitBranch className="w-5 h-5 md:w-4 md:h-4 text-muted-foreground shrink-0" />
-                    <span className="font-mono text-base md:text-sm truncate">
-                      {worktree?.branch || "Unknown"}
-                    </span>
-                  </div>
-                  <div className={`flex items-center gap-1 ${getStatusColor(session.status)}`}>
-                    {getStatusIcon(session.status)}
-                  </div>
-                </div>
+            <div key={repoPath} className="space-y-3">
+              {/* リポジトリヘッダー */}
+              <div className="flex items-center gap-2 text-muted-foreground">
+                <FolderOpen className="w-4 h-4" />
+                <span className="text-sm font-medium">{repoDisplayName}</span>
+                <span className="text-xs">({repoSessions.length})</span>
               </div>
 
-              {/* Card Body */}
-              <div className="p-4 md:p-3">
-                {/* Session Info */}
-                <div className="mb-4 md:mb-3 space-y-2">
-                  <div className="flex items-center gap-2 text-sm md:text-xs text-muted-foreground">
-                    <Terminal className="w-4 h-4 md:w-3 md:h-3 shrink-0" />
-                    <span className="font-mono truncate">
-                      tmux: {session.tmuxSessionName || session.id}
-                    </span>
-                  </div>
-                  {session.ttydPort && (
-                    <div className="flex items-center gap-2 text-sm md:text-xs text-muted-foreground">
-                      <ExternalLink className="w-4 h-4 md:w-3 md:h-3 shrink-0" />
-                      <span className="font-mono">
-                        port: {session.ttydPort}
-                      </span>
-                    </div>
-                  )}
-                  <div className="text-sm md:text-xs text-muted-foreground font-mono truncate">
-                    {session.worktreePath}
-                  </div>
-                </div>
+              {/* セッションカードグリッド */}
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+                {repoSessions.map((session) => {
+                  const displayName = getDisplayName(session.worktreePath);
 
-                {/* Actions */}
-                <div className="flex items-center justify-between text-sm md:text-xs text-muted-foreground">
-                  <div className="flex items-center gap-1.5 md:gap-1">
-                    {session.ttydUrl ? (
-                      <span className="text-primary">Terminal ready</span>
-                    ) : (
-                      <span>Starting...</span>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-10 w-10 md:h-6 md:w-6"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onSelectSession(session.id);
-                      }}
+                  return (
+                    <div
+                      key={session.id}
+                      className="group bg-card border border-border rounded-lg overflow-hidden hover:border-primary/50 active:border-primary/70 transition-colors cursor-pointer"
+                      onClick={() => onSelectSession(session.id)}
                     >
-                      <Play className="w-5 h-5 md:w-3 md:h-3 text-primary" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-10 w-10 md:h-6 md:w-6"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onStopSession(session.id);
-                      }}
-                    >
-                      <Square className="w-5 h-5 md:w-3 md:h-3 text-destructive" />
-                    </Button>
-                  </div>
-                </div>
+                      {/* Card Header */}
+                      <div className="p-4 md:p-3 border-b border-border bg-sidebar">
+                        <div className="flex items-center justify-between">
+                          <div className="flex items-center gap-2 min-w-0">
+                            <div className={`status-indicator ${session.status}`} />
+                            <GitBranch className="w-5 h-5 md:w-4 md:h-4 text-muted-foreground shrink-0" />
+                            <span className="font-mono text-base md:text-sm truncate">
+                              {displayName}
+                            </span>
+                          </div>
+                          <div className={`flex items-center gap-1 ${getStatusColor(session.status)}`}>
+                            {getStatusIcon(session.status)}
+                          </div>
+                        </div>
+                      </div>
+
+                      {/* Card Body */}
+                      <div className="p-4 md:p-3">
+                        {/* Session Info */}
+                        <div className="mb-4 md:mb-3 space-y-2">
+                          <div className="flex items-center gap-2 text-sm md:text-xs text-muted-foreground">
+                            <Terminal className="w-4 h-4 md:w-3 md:h-3 shrink-0" />
+                            <span className="font-mono truncate">
+                              tmux: {session.tmuxSessionName || session.id}
+                            </span>
+                          </div>
+                          {session.ttydPort && (
+                            <div className="flex items-center gap-2 text-sm md:text-xs text-muted-foreground">
+                              <ExternalLink className="w-4 h-4 md:w-3 md:h-3 shrink-0" />
+                              <span className="font-mono">
+                                port: {session.ttydPort}
+                              </span>
+                            </div>
+                          )}
+                          <div className="text-sm md:text-xs text-muted-foreground font-mono truncate">
+                            {session.worktreePath}
+                          </div>
+                        </div>
+
+                        {/* Actions */}
+                        <div className="flex items-center justify-between text-sm md:text-xs text-muted-foreground">
+                          <div className="flex items-center gap-1.5 md:gap-1">
+                            {session.ttydUrl ? (
+                              <span className="text-primary">Terminal ready</span>
+                            ) : (
+                              <span>Starting...</span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-10 w-10 md:h-6 md:w-6"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onSelectSession(session.id);
+                              }}
+                            >
+                              <Play className="w-5 h-5 md:w-3 md:h-3 text-primary" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-10 w-10 md:h-6 md:w-6"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                onStopSession(session.id);
+                              }}
+                            >
+                              <Square className="w-5 h-5 md:w-3 md:h-3 text-destructive" />
+                            </Button>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
             </div>
           );

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
@@ -228,6 +228,17 @@ export default function Dashboard() {
         setViewMode("panes");
       }
     });
+  }, [sessions, repoPath, activePanes]);
+
+  // 現在のリポジトリに属し、かつ存在するセッションのみをフィルタ
+  const { filteredSessions, validActivePanes } = useMemo(() => {
+    const filtered = new Map(
+      Array.from(sessions.entries()).filter(([sessionId, session]) =>
+        repoPath && isSessionBelongsToRepo(session, repoPath) && activePanes.includes(sessionId)
+      )
+    );
+    const valid = activePanes.filter((id) => filtered.has(id));
+    return { filteredSessions: filtered, validActivePanes: valid };
   }, [sessions, repoPath, activePanes]);
 
   const SidebarContent = () => (
@@ -611,9 +622,9 @@ export default function Dashboard() {
               <TabsTrigger value="panes" className="gap-2 h-8 md:h-7 px-3 md:px-2 text-sm md:text-xs">
                 <Columns2 className="w-4 h-4 md:w-4 md:h-4" />
                 <span className="hidden sm:inline">Panes</span>
-                {activePanes.length > 0 && (
+                {validActivePanes.length > 0 && (
                   <span className="ml-1 text-xs bg-primary/20 text-primary px-1.5 py-0.5 rounded">
-                    {activePanes.length}
+                    {validActivePanes.length}
                   </span>
                 )}
               </TabsTrigger>
@@ -635,26 +646,19 @@ export default function Dashboard() {
               onSelectSession={handleSelectSession}
               onStopSession={handleStopSession}
             />
-          ) : (() => {
-            const filteredSessions = new Map(
-              Array.from(sessions.entries()).filter(([sessionId, session]) =>
-                repoPath && isSessionBelongsToRepo(session, repoPath) && activePanes.includes(sessionId)
-              )
-            );
-            const validActivePanes = activePanes.filter((id) => filteredSessions.has(id));
-            return validActivePanes.length > 0 ? (
-              <MultiPaneLayout
-                activePanes={validActivePanes}
-                sessions={filteredSessions}
-                worktrees={worktrees}
-                onSendMessage={sendMessage}
-                onSendKey={sendKey}
-                onStopSession={handleStopSession}
-                onClosePane={handleClosePane}
-                onMaximizePane={handleMaximizePane}
-                maximizedPane={maximizedPane}
-              />
-            ) : (
+          ) : validActivePanes.length > 0 ? (
+            <MultiPaneLayout
+              activePanes={validActivePanes}
+              sessions={filteredSessions}
+              worktrees={worktrees}
+              onSendMessage={sendMessage}
+              onSendKey={sendKey}
+              onStopSession={handleStopSession}
+              onClosePane={handleClosePane}
+              onMaximizePane={handleMaximizePane}
+              maximizedPane={maximizedPane}
+            />
+          ) : (
               <div className="h-full flex items-center justify-center p-6">
                 <div className="text-center max-w-md">
                   <div className="w-20 h-20 md:w-16 md:h-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-6">
@@ -677,8 +681,7 @@ export default function Dashboard() {
                   </div>
                 </div>
               </div>
-            );
-          })()}
+          )}
         </div>
       </main>
     </div>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -611,12 +611,7 @@ export default function Dashboard() {
         <div className="flex-1 overflow-hidden">
           {viewMode === "dashboard" ? (
             <SessionDashboard
-              sessions={new Map(
-                Array.from(sessions.entries()).filter(([_, session]) =>
-                  worktrees.some((wt) => wt.id === session.worktreeId)
-                )
-              )}
-              worktrees={worktrees}
+              sessions={sessions}
               onSelectSession={handleSelectSession}
               onStopSession={handleStopSession}
             />

--- a/client/src/utils/sessionUtils.ts
+++ b/client/src/utils/sessionUtils.ts
@@ -27,3 +27,18 @@ export function isSessionBelongsToRepo(
 
   return worktreeParent === repoParent && worktreeName.startsWith(`${repoName}-`);
 }
+
+/**
+ * セッションが属するリポジトリをrepoListから検索する
+ */
+export function findRepoForSession(
+  session: TtydSession,
+  repoList: string[]
+): string | null {
+  for (const repo of repoList) {
+    if (isSessionBelongsToRepo(session, repo)) {
+      return repo;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- ダッシュボードで全リポジトリのセッションを横断表示
- セッションを親ディレクトリでグループ化して表示
- worktreesプロパティを削除し、シンプルな設計に

## 変更内容
| ファイル | 変更内容 |
|---------|---------|
| `SessionDashboard.tsx` | リポジトリごとにグループ化して表示 |
| `Dashboard.tsx` | sessionsをフィルタリングせず全件渡す |

## 表示イメージ
```
Active Sessions (3)

📁 dev (2)
  ├─ claude-code-manager [active]
  └─ claude-code-manager-feature [idle]

📁 projects (1)
  └─ my-app [active]
```

## Test plan
- [ ] 複数リポジトリでセッションを開始
- [ ] ダッシュボードで全セッションが表示されることを確認
- [ ] リポジトリごとにグループ化されていることを確認
- [ ] セッションカードをクリックでペインビューに切り替わることを確認