### PR TITLE
feat: GitHub Actions CIを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup mise
+        uses: jdx/mise-action@v2
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Type check
+        run: pnpm check
+
+      - name: Build
+        run: pnpm build


### PR DESCRIPTION
## Summary
- PRとmainブランチへのpush時に型チェックとビルドを自動実行するCIを追加
- miseでツールバージョンを統一（Node 22, pnpm 10.4.1）
- macOSランナーを使用（node-pty, better-sqlite3等のネイティブモジュール対応）

## Test plan
- [ ] PRマージ時にCIが実行されることを確認
- [ ] 型チェック（`pnpm check`）が成功することを確認
- [ ] ビルド（`pnpm build`）が成功することを確認