### PR TITLE
fix: Ctrl+Cでclaude終了後もシェルを維持

### DIFF
--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -33,12 +33,14 @@ export class SessionOrchestrator extends EventEmitter {
     });
 
     tmuxManager.on("session:stopped", (sessionId: string) => {
+      // tmuxが停止した場合はttydも停止するが、session:stoppedは発行しない
+      // 明示的にstopSession()が呼ばれた場合のみセッション削除する
       ttydManager.stopInstance(sessionId);
-      this.emit("session:stopped", sessionId);
     });
 
     ttydManager.on("instance:stopped", (sessionId: string) => {
       // ttydが停止してもtmuxセッションは維持
+      // セッション削除もしない（明示的なstopSession呼び出し時のみ削除）
     });
   }
 

--- a/server/lib/tmux-manager.ts
+++ b/server/lib/tmux-manager.ts
@@ -105,9 +105,14 @@ export class TmuxManager extends EventEmitter {
     const tmuxSessionName = `${this.SESSION_PREFIX}${id}`;
 
     try {
-      // tmuxセッションを作成（detached mode）してclaudeを起動
+      // tmuxセッションを作成（detached mode）- シェルだけを起動
       execSync(
-        `tmux new-session -d -s "${tmuxSessionName}" -c "${worktreePath}" "claude --dangerously-skip-permissions"`,
+        `tmux new-session -d -s "${tmuxSessionName}" -c "${worktreePath}"`,
+        { stdio: "pipe" }
+      );
+      // claudeコマンドを送信（終了後もシェルが残るのでvimなども使える）
+      execSync(
+        `tmux send-keys -t "${tmuxSessionName}" "claude --dangerously-skip-permissions" Enter`,
         { stdio: "pipe" }
       );
       // マウスモードを有効にしてスクロールを可能にする


### PR DESCRIPTION
## Summary
- Ctrl+Cでclaude終了後もターミナル（シェル）が維持されるように修正
- tmuxセッション起動方法を変更：シェル起動 → send-keysでclaude実行
- ttyd/tmux終了時のセッション自動削除を停止

## 変更内容

### tmux-manager.ts
- `tmux new-session ... "claude"` → `tmux new-session` + `tmux send-keys "claude" Enter`
- claude終了後もシェルが残り、vimなど他コマンドが使用可能

### session-orchestrator.ts
- `session:stopped`イベントの自動発行を停止
- 明示的な`stopSession()`呼び出し時のみセッション削除

## Test plan
- [ ] 新規セッション開始でclaudeが起動することを確認
- [ ] Ctrl+Cでclaude終了後、シェルプロンプトが表示されることを確認
- [ ] シェルでvimなどのコマンドが実行できることを確認
- [ ] セッションがUIに残り続けることを確認
- [ ] 停止ボタンでセッションが削除されることを確認