### PR TITLE
fix: リモートアクセス時のttydプロキシを修正

### DIFF
--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -92,10 +92,12 @@ export function TerminalPane({
   };
 
   // Construct ttyd iframe URL
-  // ttydPortがある場合は直接接続（viteプロキシ経由だとWebSocket接続に問題がある）
-  const ttydIframeSrc = session.ttydPort
+  // ローカル開発時のみ直接接続、リモートアクセス時はプロキシ経由
+  const isLocalAccess = typeof window !== 'undefined' &&
+    (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+  const ttydIframeSrc = isLocalAccess && session.ttydPort
     ? `http://127.0.0.1:${session.ttydPort}/`
-    : session.ttydUrl || `/ttyd/${session.id}/`;
+    : `/ttyd/${session.id}/`;
 
   // Quick commands for mobile
   const quickCommands = [

--- a/server/index.ts
+++ b/server/index.ts
@@ -141,6 +141,10 @@ async function startServer() {
       const session = sessionOrchestrator.getSession(sessionId);
 
       if (session?.ttydPort) {
+        // Rewrite path to remove /ttyd/:sessionId prefix for WebSocket
+        const rewrittenPath = pathname.replace(`/ttyd/${sessionId}`, '') || '/';
+        req.url = rewrittenPath + (url.search || '');
+
         ttydProxy.ws(req, socket, head, {
           target: `ws://127.0.0.1:${session.ttydPort}`,
         });


### PR DESCRIPTION
## 概要

リモートアクセス（Cloudflare Tunnel経由）時にttydターミナルが正しく動作しない問題を修正。

## 変更内容

### クライアント側 (`TerminalPane.tsx`)
- ローカル開発時（localhost/127.0.0.1）のみ直接ttydポートに接続
- リモートアクセス時はプロキシ経由で接続するよう変更

### サーバー側 (`index.ts`)
- WebSocket接続時のパスをリライトしてttydプロキシが正しく動作するよう修正
- `/ttyd/:sessionId` プレフィックスを除去してttydに転送

## 背景

Cloudflare Tunnel経由でアクセスした場合、クライアントから直接ttydポートにアクセスできないため、プロキシ経由で接続する必要があった。