### PR TITLE
fix: ttydプロキシのパス転送とサーバー起動時のttyd自動起動を修正

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -107,9 +107,8 @@ async function startServer() {
       return;
     }
 
-    // Rewrite path to remove /ttyd/:sessionId prefix
-    req.url = req.url?.replace(`/ttyd/${sessionId}`, "") || "/";
-    if (req.url === "") req.url = "/";
+    // Expressのapp.useはマウントパスを削除するので、originalUrlを使用
+    req.url = req.originalUrl;
 
     ttydProxy.web(req, res, {
       target: `http://127.0.0.1:${session.ttydPort}`,
@@ -141,10 +140,7 @@ async function startServer() {
       const session = sessionOrchestrator.getSession(sessionId);
 
       if (session?.ttydPort) {
-        // Rewrite path to remove /ttyd/:sessionId prefix for WebSocket
-        const rewrittenPath = pathname.replace(`/ttyd/${sessionId}`, '') || '/';
-        req.url = rewrittenPath + (url.search || '');
-
+        // ttydの--base-pathと一致させるため、パスはそのまま転送
         ttydProxy.ws(req, socket, head, {
           target: `ws://127.0.0.1:${session.ttydPort}`,
         });

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -45,7 +45,7 @@ export class SessionOrchestrator extends EventEmitter {
   }
 
   /**
-   * 前回の実行から残っているセッションを復元
+   * 前回の実行から残っているセッションを復元（ttydも起動）
    */
   private restoreExistingSessions(): void {
     const tmuxSessions = tmuxManager.getAllSessions();
@@ -58,6 +58,15 @@ export class SessionOrchestrator extends EventEmitter {
           `[Orchestrator] Restored session: ${tmuxSession.tmuxSessionName} -> ${dbSession.id}`
         );
       }
+
+      // ttydも自動起動
+      ttydManager.startInstance(tmuxSession.id, tmuxSession.tmuxSessionName)
+        .then(() => {
+          console.log(`[Orchestrator] Started ttyd for restored session: ${tmuxSession.id}`);
+        })
+        .catch((err) => {
+          console.error(`[Orchestrator] Failed to start ttyd for ${tmuxSession.id}:`, err.message);
+        });
     }
   }
 


### PR DESCRIPTION
## 概要
ttydプロキシの404エラーとサーバー再起動時のttyd自動起動を修正

## 問題
- fix-escで追加された`--base-path`オプションとプロキシのパス書き換えが競合していた
- サーバー再起動時に既存tmuxセッションのttydが自動起動されなかった

## 修正内容
- HTTPプロキシで`req.originalUrl`を使用してttydの`--base-path`と一致させる
- WebSocketプロキシでもパスをそのまま転送
- `restoreExistingSessions()`でttydも自動起動するように修正

## テスト
- ローカルでターミナル表示を確認済み
- リモート（Cloudflare Tunnel経由）でターミナル表示を確認済み