### PR TITLE
fix: worktreeビューのUI改善

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -275,9 +275,6 @@ export default function Dashboard() {
                       <div className={`text-sm font-medium truncate ${isSelected ? "text-primary" : "text-sidebar-foreground"}`}>
                         {repoName}
                       </div>
-                      <div className="text-xs text-muted-foreground font-mono truncate">
-                        {repo}
-                      </div>
                     </div>
                     <div className="flex items-center gap-1">
                       {isSelected && (
@@ -383,7 +380,7 @@ export default function Dashboard() {
                         </span>
                       )}
                     </div>
-                    <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
+                    <div className="flex items-center gap-1">
                       {session ? (
                         <>
                           <Button


### PR DESCRIPTION
## 概要
- リポジトリ一覧からフルパス表示を削除
- Worktree削除ボタンを常時表示に変更

## 変更内容
- リポジトリ名のみ表示するようにし、冗長なフルパス表示を削除
- ホバー時のみ表示されていた削除ボタンを常時表示に変更し、操作性を向上