### PR TITLE
fix: ローカルアクセス時のttyd 404エラーを修正

### DIFF
--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -96,7 +96,7 @@ export function TerminalPane({
   const isLocalAccess = typeof window !== 'undefined' &&
     (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
   const ttydIframeSrc = isLocalAccess && session.ttydPort
-    ? `http://127.0.0.1:${session.ttydPort}/`
+    ? `http://127.0.0.1:${session.ttydPort}/ttyd/${session.id}/`
     : `/ttyd/${session.id}/`;
 
   // Quick commands for mobile

--- a/server/index.ts
+++ b/server/index.ts
@@ -107,7 +107,11 @@ async function startServer() {
       return;
     }
 
-    // Expressのapp.useはマウントパスを削除するので、originalUrlを使用
+    // ttydは--base-path=/ttyd/{sessionId}で起動しており、
+    // /ttyd/{sessionId}/以下のパスでリクエストを待ち受ける。
+    // Expressのapp.useはマウントパス(/ttyd/:sessionId)を削除するため、
+    // req.urlは/index.htmlのようにプレフィックスが削除された状態になる。
+    // ttydにはフルパスで転送する必要があるため、originalUrlを使用する。
     req.url = req.originalUrl;
 
     ttydProxy.web(req, res, {
@@ -140,7 +144,9 @@ async function startServer() {
       const session = sessionOrchestrator.getSession(sessionId);
 
       if (session?.ttydPort) {
-        // ttydの--base-pathと一致させるため、パスはそのまま転送
+        // ttydは--base-path=/ttyd/{sessionId}で起動しており、
+        // /ttyd/{sessionId}/wsでWebSocket接続を待ち受ける。
+        // req.urlはそのまま転送する（パスの変更不要）。
         ttydProxy.ws(req, socket, head, {
           target: `ws://127.0.0.1:${session.ttydPort}`,
         });


### PR DESCRIPTION
## 概要

ローカルアクセス時にttyd iframeが404エラーを表示する問題を修正。

## 原因

ttydは`--base-path=/ttyd/{sessionId}`で起動しているが、ローカルアクセス時のiframe URLが`http://127.0.0.1:{port}/`（ルート）を指していたため404になっていた。

## 修正内容

- **TerminalPane.tsx**: ローカルアクセス時のURLに`/ttyd/{sessionId}/`パスを追加
- **server/index.ts**: プロキシ処理のコメントを改善

## 動作確認

| アクセス方法 | 修正前 | 修正後 |
|------------|-------|-------|
| ローカル (`localhost`) | 404 | ✅ 正常 |
| リモート (Cloudflare) | ✅ 正常 | ✅ 正常 (変更なし) |