### PR TITLE
feat: リポジトリスキャン機能の改善

### DIFF
--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -187,7 +187,7 @@ export function useSocket(): UseSocketReturn {
     socket.on("repos:scanning", ({ status, error: scanError }) => {
       if (status === "start") {
         setIsScanning(true);
-        setScannedRepos([]);
+        // スキャン中も前回のリストを保持（UIの伸縮を防ぐ）
       } else if (status === "complete") {
         setIsScanning(false);
       } else if (status === "error") {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -337,14 +337,14 @@ export default function Dashboard() {
               </SelectContent>
             </Select>
           ) : (
-            <RepoSelectDialog
-              isOpen={isSelectRepoOpen}
-              onOpenChange={setIsSelectRepoOpen}
-              scannedRepos={scannedRepos}
-              isScanning={isScanning}
-              onScanRepos={scanRepos}
-              onSelectRepo={handleSelectRepo}
-            />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => setIsSelectRepoOpen(true)}
+            >
+              <FolderOpen className="w-4 h-4" />
+            </Button>
           )}
         </div>
 
@@ -870,6 +870,16 @@ export default function Dashboard() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* リポジトリ選択ダイアログ - SidebarContentの外に配置して再マウントを防ぐ */}
+      <RepoSelectDialog
+        isOpen={isSelectRepoOpen}
+        onOpenChange={setIsSelectRepoOpen}
+        scannedRepos={scannedRepos}
+        isScanning={isScanning}
+        onScanRepos={scanRepos}
+        onSelectRepo={handleSelectRepo}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 概要

リポジトリスキャン機能を大幅に改善しました。

## 変更内容

### パフォーマンス改善
- `find`コマンドの代わりに`fd`コマンドを使用（約9倍高速化: 18秒→2秒）
- ブランチ情報の取得を省略してスキャン速度を向上
- `fd`がない環境では自動的に`find`にフォールバック

### UI/UX改善
- 検索ボックスを追加してリポジトリをフィルタリング可能に
- リストエリアの高さを固定してダイアログの伸縮を防止
- スキャン中も前回のリストを保持（`setScannedRepos([])`を削除）
- `RepoSelectDialog`をルートレベルに移動して再マウントを防止

### バグ修正
- `github.com`などドットを含むディレクトリ配下のリポジトリが検出されない問題を修正
- スキャン中にダイアログが一瞬消える問題を修正

## 変更ファイル

- `server/lib/git.ts` - fdコマンドによる高速スキャン
- `client/src/components/RepoSelectDialog.tsx` - 検索ボックス、高さ固定
- `client/src/hooks/useSocket.ts` - スキャン開始時のリストクリアを削除
- `client/src/pages/Dashboard.tsx` - ダイアログ配置の修正