### PR TITLE
fix: モバイルでリポジトリ選択ダイアログが意図せず閉じる問題を修正

### DIFF
--- a/client/src/components/RepoSelectDialog.tsx
+++ b/client/src/components/RepoSelectDialog.tsx
@@ -2,16 +2,22 @@ import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { useIsMobile } from "@/hooks/useMobile";
 import { FolderOpen, RefreshCw, Search } from "lucide-react";
 import type { RepoInfo } from "../../../shared/types";
 
@@ -24,21 +30,28 @@ interface RepoSelectDialogProps {
   onSelectRepo: (path: string) => void;
 }
 
-export function RepoSelectDialog({
-  isOpen,
-  onOpenChange,
+// --- 共通コンテンツ ---
+function RepoSelectContent({
+  variant,
   scannedRepos,
   isScanning,
   onScanRepos,
   onSelectRepo,
-}: RepoSelectDialogProps) {
+  onOpenChange,
+}: {
+  variant: "dialog" | "drawer";
+  scannedRepos: RepoInfo[];
+  isScanning: boolean;
+  onScanRepos: (basePath: string) => void;
+  onSelectRepo: (path: string) => void;
+  onOpenChange: (open: boolean) => void;
+}) {
   const [scanBasePath, setScanBasePath] = useState(() => {
     return localStorage.getItem("scanBasePath") || "";
   });
   const [repoInput, setRepoInput] = useState("");
   const [filterQuery, setFilterQuery] = useState("");
 
-  // フィルタリング結果をメモ化
   const filteredRepos = useMemo(() => {
     if (!filterQuery.trim()) {
       return scannedRepos;
@@ -51,7 +64,6 @@ export function RepoSelectDialog({
     );
   }, [scannedRepos, filterQuery]);
 
-  // スキャンパスをlocalStorageに保存
   useEffect(() => {
     if (scanBasePath) {
       localStorage.setItem("scanBasePath", scanBasePath);
@@ -59,22 +71,181 @@ export function RepoSelectDialog({
   }, [scanBasePath]);
 
   const handleScanRepos = () => {
-    if (!scanBasePath.trim()) {
-      return;
-    }
+    if (!scanBasePath.trim()) return;
     onScanRepos(scanBasePath.trim());
   };
 
   const handleSelectRepo = () => {
-    if (!repoInput.trim()) {
-      return;
-    }
+    if (!repoInput.trim()) return;
     onSelectRepo(repoInput.trim());
     onOpenChange(false);
   };
 
+  const isDrawer = variant === "drawer";
+
   return (
-    <Dialog open={isOpen} onOpenChange={onOpenChange} modal={false}>
+    <div className="space-y-4 py-4 flex-1 overflow-hidden flex flex-col">
+      {/* スキャン用入力 */}
+      <div className="space-y-2 px-1">
+        <Label htmlFor="scanPath">スキャンするパス</Label>
+        <div className="flex gap-2">
+          <Input
+            id="scanPath"
+            placeholder="/Users/username/dev"
+            value={scanBasePath}
+            onChange={(e) => setScanBasePath(e.target.value)}
+            autoFocus={!isDrawer}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleScanRepos();
+            }}
+            className="font-mono h-12 md:h-10 text-base md:text-sm flex-1"
+          />
+          <Button
+            type="button"
+            onClick={handleScanRepos}
+            disabled={isScanning}
+            className="h-12 md:h-10 shrink-0"
+          >
+            {isScanning ? (
+              <RefreshCw className="w-4 h-4 animate-spin" />
+            ) : (
+              "スキャン"
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* スキャン結果リスト */}
+      <div className="space-y-2 flex-1 overflow-hidden flex flex-col px-1">
+        <Label>
+          {isScanning
+            ? "スキャン中..."
+            : scannedRepos.length > 0
+              ? `検出されたリポジトリ (${filteredRepos.length}/${scannedRepos.length})`
+              : "検出されたリポジトリ"}
+        </Label>
+        {/* 検索ボックス */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <Input
+            placeholder="リポジトリを検索..."
+            value={filterQuery}
+            onChange={(e) => setFilterQuery(e.target.value)}
+            className="pl-9 h-10"
+            disabled={isScanning || scannedRepos.length === 0}
+          />
+        </div>
+        <div
+          className={`flex-1 border rounded-md overflow-y-auto ${
+            isDrawer ? "min-h-[120px]" : "min-h-[200px] max-h-[300px]"
+          } ${isScanning ? "opacity-50" : ""}`}
+        >
+          <div className="p-2 space-y-1">
+            {filteredRepos.map((repo) => (
+              <div
+                key={repo.path}
+                className={`rounded-md cursor-pointer transition-colors ${
+                  isDrawer
+                    ? "p-4 min-h-[44px] hover:bg-accent active:bg-accent/80"
+                    : "p-3 hover:bg-accent"
+                }`}
+                onClick={() => {
+                  onSelectRepo(repo.path);
+                  onOpenChange(false);
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <FolderOpen className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span className="font-medium text-sm truncate">
+                    {repo.name}
+                  </span>
+                  {repo.branch && (
+                    <span className="text-xs text-muted-foreground">
+                      ({repo.branch})
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-muted-foreground font-mono mt-1 truncate pl-6">
+                  {repo.path}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* 直接パス入力 */}
+      <div className="space-y-2 px-1">
+        <Label htmlFor="repoPath">または直接パスを入力</Label>
+        <Input
+          id="repoPath"
+          placeholder="/path/to/your/repository"
+          value={repoInput}
+          onChange={(e) => setRepoInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSelectRepo();
+          }}
+          className="font-mono h-12 md:h-10 text-base md:text-sm"
+        />
+      </div>
+
+      {/* フッター */}
+      {isDrawer ? (
+        <div className="flex flex-col gap-2 pt-2 px-1">
+          <Button
+            type="button"
+            onClick={handleSelectRepo}
+            disabled={!repoInput.trim()}
+            className="glow-green h-12"
+          >
+            選択
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            className="h-12"
+          >
+            キャンセル
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end pt-2 px-1">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            className="h-12 md:h-10"
+          >
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSelectRepo}
+            disabled={!repoInput.trim()}
+            className="glow-green h-12 md:h-10"
+          >
+            選択
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- デスクトップ版: Dialog ---
+function RepoSelectDialogDesktop({
+  isOpen,
+  onOpenChange,
+  scannedRepos,
+  isScanning,
+  onScanRepos,
+  onSelectRepo,
+}: RepoSelectDialogProps) {
+  return (
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-lg mx-auto max-h-[80vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>リポジトリを選択</DialogTitle>
@@ -82,108 +253,55 @@ export function RepoSelectDialog({
             ディレクトリパスを入力してスキャンするか、直接リポジトリパスを入力してください。
           </DialogDescription>
         </DialogHeader>
-        <div className="space-y-4 py-4 flex-1 overflow-hidden flex flex-col">
-          {/* スキャン用入力 */}
-          <div className="space-y-2">
-            <Label htmlFor="scanPath">スキャンするパス</Label>
-            <div className="flex gap-2">
-              <Input
-                id="scanPath"
-                placeholder="/Users/username/dev"
-                value={scanBasePath}
-                onChange={(e) => setScanBasePath(e.target.value)}
-                autoFocus
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") {
-                    handleScanRepos();
-                  }
-                }}
-                className="font-mono h-12 md:h-10 text-base md:text-sm flex-1"
-              />
-              <Button
-                type="button"
-                onClick={handleScanRepos}
-                disabled={isScanning}
-                className="h-12 md:h-10 shrink-0"
-              >
-                {isScanning ? (
-                  <RefreshCw className="w-4 h-4 animate-spin" />
-                ) : (
-                  "スキャン"
-                )}
-              </Button>
-            </div>
-          </div>
-
-          {/* スキャン結果リスト - 常に表示して高さを固定 */}
-          <div className="space-y-2 flex-1 overflow-hidden flex flex-col">
-            <Label>
-              {isScanning ? "スキャン中..." : scannedRepos.length > 0 ? `検出されたリポジトリ (${filteredRepos.length}/${scannedRepos.length})` : "検出されたリポジトリ"}
-            </Label>
-            {/* 検索ボックス */}
-            <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-              <Input
-                placeholder="リポジトリを検索..."
-                value={filterQuery}
-                onChange={(e) => setFilterQuery(e.target.value)}
-                className="pl-9 h-10"
-                disabled={isScanning || scannedRepos.length === 0}
-              />
-            </div>
-            <div className={`flex-1 border rounded-md overflow-y-auto min-h-[300px] max-h-[300px] ${isScanning ? "opacity-50" : ""}`}>
-                <div className="p-2 space-y-1">
-                  {filteredRepos.map((repo) => (
-                    <div
-                      key={repo.path}
-                      className="p-3 rounded-md hover:bg-accent cursor-pointer transition-colors"
-                      onClick={() => {
-                        onSelectRepo(repo.path);
-                        onOpenChange(false);
-                      }}
-                    >
-                      <div className="flex items-center gap-2">
-                        <FolderOpen className="w-4 h-4 text-muted-foreground shrink-0" />
-                        <span className="font-medium text-sm truncate">{repo.name}</span>
-                        {repo.branch && <span className="text-xs text-muted-foreground">({repo.branch})</span>}
-                      </div>
-                      <div className="text-xs text-muted-foreground font-mono mt-1 truncate pl-6">
-                        {repo.path}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-
-          <Separator />
-
-          {/* 直接パス入力 */}
-          <div className="space-y-2">
-            <Label htmlFor="repoPath">または直接パスを入力</Label>
-            <Input
-              id="repoPath"
-              placeholder="/path/to/your/repository"
-              value={repoInput}
-              onChange={(e) => setRepoInput(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") {
-                  handleSelectRepo();
-                }
-              }}
-              className="font-mono h-12 md:h-10 text-base md:text-sm"
-            />
-          </div>
-        </div>
-        <DialogFooter className="flex-col gap-2 sm:flex-row">
-          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} className="h-12 md:h-10">
-            キャンセル
-          </Button>
-          <Button type="button" onClick={handleSelectRepo} disabled={!repoInput.trim()} className="glow-green h-12 md:h-10">
-            選択
-          </Button>
-        </DialogFooter>
+        <RepoSelectContent
+          variant="dialog"
+          scannedRepos={scannedRepos}
+          isScanning={isScanning}
+          onScanRepos={onScanRepos}
+          onSelectRepo={onSelectRepo}
+          onOpenChange={onOpenChange}
+        />
       </DialogContent>
     </Dialog>
   );
+}
+
+// --- モバイル版: Drawer ---
+function RepoSelectDrawerMobile({
+  isOpen,
+  onOpenChange,
+  scannedRepos,
+  isScanning,
+  onScanRepos,
+  onSelectRepo,
+}: RepoSelectDialogProps) {
+  return (
+    <Drawer open={isOpen} onOpenChange={onOpenChange}>
+      <DrawerContent className="max-h-[85dvh] flex flex-col">
+        <DrawerHeader>
+          <DrawerTitle>リポジトリを選択</DrawerTitle>
+          <DrawerDescription>
+            ディレクトリパスを入力してスキャンするか、直接リポジトリパスを入力してください。
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="flex-1 overflow-hidden flex flex-col px-4">
+          <RepoSelectContent
+            variant="drawer"
+            scannedRepos={scannedRepos}
+            isScanning={isScanning}
+            onScanRepos={onScanRepos}
+            onSelectRepo={onSelectRepo}
+            onOpenChange={onOpenChange}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+// --- エントリーポイント ---
+export function RepoSelectDialog(props: RepoSelectDialogProps) {
+  const isMobile = useIsMobile();
+  if (isMobile) return <RepoSelectDrawerMobile {...props} />;
+  return <RepoSelectDialogDesktop {...props} />;
 }


### PR DESCRIPTION
## 概要

モバイルでリポジトリ選択ダイアログを操作すると、背景タップで意図せず閉じてしまう問題を修正。

`RepoSelectDialog` を3層構造に再設計し、デスクトップではDialog、モバイルではDrawer（ボトムシート）を使い分ける方式に変更。

## 変更内容

- `useIsMobile` でデバイス判定し、Dialog / Drawer を切り替え
- 共通UIロジックを `RepoSelectContent` コンポーネントに抽出
- `modal={false}` を削除し、フォーカストラップ・背景スクロールロックを有効化
- モバイル向け最適化:
  - `vaul` ベースのDrawer（ボトムシート）でスワイプ閉じ対応
  - タッチターゲット 44px（Apple推奨サイズ）
  - `autoFocus` 無効化（キーボード即表示を防止）
  - フッターを縦積みレイアウトに変更
  - リスト領域を `max-h-[85dvh]` で flex 拡張
- 未使用の `ScrollArea` import を削除

## テスト方法

- デスクトップ（768px以上）: Dialog表示、Esc / オーバーレイクリックで閉じる
- モバイル（768px未満）: Drawer表示、スワイプ下で閉じる、リスト内スクロールでDrawerが閉じない