### PR TITLE
feat: Panesビューのクロスリポジトリ対応

### DIFF
--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -196,7 +196,7 @@ export function MultiPaneLayout({
                 >
                   <div className={`w-1.5 h-1.5 rounded-full ${session.status === 'active' ? 'bg-green-500' : 'bg-muted-foreground'}`} />
                   {repoName && <span className="text-[10px] opacity-70">{repoName}</span>}
-                  <span>{wt?.branch || "Unknown"}</span>
+                  <span>{wt?.branch || getBaseName(session.worktreePath)}</span>
                 </button>
               );
             })}

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -8,7 +8,7 @@
  * - Uses ttyd iframe for terminal rendering
  */
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Columns2,
@@ -60,6 +60,7 @@ export function MultiPaneLayout({
 }: MultiPaneLayoutProps) {
   const isMobile = useIsMobile();
   const [layoutMode, setLayoutMode] = useState<LayoutMode>("grid-4");
+  const [activeMobilePane, setActiveMobilePane] = useState<string | null>(null);
 
   // Force single pane on mobile
   const effectiveLayoutMode = isMobile ? "single" : layoutMode;
@@ -104,6 +105,15 @@ export function MultiPaneLayout({
 
   // Filter to only show panes that have active sessions
   const visiblePanes = activePanes.filter((id) => sessions.has(id));
+
+  // モバイル時: visiblePanesが変わったらactiveMobilePaneを自動更新
+  useEffect(() => {
+    if (isMobile && visiblePanes.length > 0) {
+      if (!activeMobilePane || !visiblePanes.includes(activeMobilePane)) {
+        setActiveMobilePane(visiblePanes[0]);
+      }
+    }
+  }, [isMobile, visiblePanes, activeMobilePane]);
 
   if (visiblePanes.length === 0) {
     return null;
@@ -162,35 +172,94 @@ export function MultiPaneLayout({
         </div>
       </div>
 
-      {/* Panes Grid */}
-      <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-y-auto auto-rows-[minmax(calc(100vh-10rem),1fr)]`}>
-        {visiblePanes.map((sessionId) => {
-          const session = sessions.get(sessionId);
-          if (!session) return null;
+      {/* Mobile: タブ切り替え式 */}
+      {isMobile ? (
+        <>
+          {/* タブバー */}
+          <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border bg-sidebar overflow-x-auto shrink-0">
+            {visiblePanes.map((sessionId) => {
+              const session = sessions.get(sessionId);
+              if (!session) return null;
+              const wt = getWorktreeForSession(session);
+              const repoName = getRepoNameForSession(session);
+              const isActive = (activeMobilePane || visiblePanes[0]) === sessionId;
+              return (
+                <button
+                  key={sessionId}
+                  type="button"
+                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium whitespace-nowrap shrink-0 transition-colors ${
+                    isActive
+                      ? "bg-primary/20 text-primary border border-primary/30"
+                      : "text-muted-foreground hover:bg-sidebar-accent"
+                  }`}
+                  onClick={() => setActiveMobilePane(sessionId)}
+                >
+                  <div className={`w-1.5 h-1.5 rounded-full ${session.status === 'active' ? 'bg-green-500' : 'bg-muted-foreground'}`} />
+                  {repoName && <span className="text-[10px] opacity-70">{repoName}</span>}
+                  <span>{wt?.branch || "Unknown"}</span>
+                </button>
+              );
+            })}
+          </div>
+          {/* 選択中のペイン */}
+          <div className="flex-1 min-h-0 p-2">
+            {(() => {
+              const selectedId = activeMobilePane && visiblePanes.includes(activeMobilePane) ? activeMobilePane : visiblePanes[0];
+              const session = selectedId ? sessions.get(selectedId) : undefined;
+              if (!session || !selectedId) return null;
+              const worktree = getWorktreeForSession(session);
+              return (
+                <TerminalPane
+                  key={selectedId}
+                  session={session}
+                  worktree={worktree}
+                  repoName={getRepoNameForSession(session)}
+                  onSendMessage={(msg) => onSendMessage(selectedId, msg)}
+                  onSendKey={(key) => onSendKey(selectedId, key)}
+                  onStopSession={() => onStopSession(selectedId)}
+                  onClose={() => onClosePane(selectedId)}
+                  isMaximized={false}
+                  onUploadImage={(base64, mimeType) => onUploadImage?.(selectedId, base64, mimeType)}
+                  imageUploadResult={imageUploadResult}
+                  imageUploadError={imageUploadError}
+                  onClearImageUploadState={onClearImageUploadState}
+                  onCopyBuffer={onCopyBuffer ? () => onCopyBuffer(selectedId) : undefined}
+                />
+              );
+            })()}
+          </div>
+        </>
+      ) : (
+        /* Desktop: グリッド表示 */
+        <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-y-auto auto-rows-[minmax(calc(100vh-10rem),1fr)]`}>
+          {visiblePanes.map((sessionId) => {
+            const session = sessions.get(sessionId);
+            if (!session) return null;
 
-          const worktree = getWorktreeForSession(session);
+            const worktree = getWorktreeForSession(session);
 
-          return (
-            <TerminalPane
-              key={sessionId}
-              session={session}
-              worktree={worktree}
-              repoName={getRepoNameForSession(session)}
-              onSendMessage={(msg) => onSendMessage(sessionId, msg)}
-              onSendKey={(key) => onSendKey(sessionId, key)}
-              onStopSession={() => onStopSession(sessionId)}
-              onClose={() => onClosePane(sessionId)}
-              onMaximize={() => onMaximizePane(sessionId)}
-              isMaximized={false}
-              onUploadImage={(base64, mimeType) => onUploadImage?.(sessionId, base64, mimeType)}
-              imageUploadResult={imageUploadResult}
-              imageUploadError={imageUploadError}
-              onClearImageUploadState={onClearImageUploadState}
-              onCopyBuffer={onCopyBuffer ? () => onCopyBuffer(sessionId) : undefined}
-            />
-          );
-        })}
-      </div>
+            return (
+              <TerminalPane
+                key={sessionId}
+                session={session}
+                worktree={worktree}
+                repoName={getRepoNameForSession(session)}
+                onSendMessage={(msg) => onSendMessage(sessionId, msg)}
+                onSendKey={(key) => onSendKey(sessionId, key)}
+                onStopSession={() => onStopSession(sessionId)}
+                onClose={() => onClosePane(sessionId)}
+                onMaximize={() => onMaximizePane(sessionId)}
+                isMaximized={false}
+                onUploadImage={(base64, mimeType) => onUploadImage?.(sessionId, base64, mimeType)}
+                imageUploadResult={imageUploadResult}
+                imageUploadError={imageUploadError}
+                onClearImageUploadState={onClearImageUploadState}
+                onCopyBuffer={onCopyBuffer ? () => onCopyBuffer(sessionId) : undefined}
+              />
+            );
+          })}
+        </div>
+      )}
 
     </div>
   );

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -8,10 +8,9 @@
  * - Uses ttyd iframe for terminal rendering
  */
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
-  Columns2,
   Square,
   Grid2x2,
 } from "lucide-react";
@@ -104,7 +103,10 @@ export function MultiPaneLayout({
   }
 
   // Filter to only show panes that have active sessions
-  const visiblePanes = activePanes.filter((id) => sessions.has(id));
+  const visiblePanes = useMemo(
+    () => activePanes.filter((id) => sessions.has(id)),
+    [activePanes, sessions]
+  );
 
   // モバイル時: visiblePanesが変わったらactiveMobilePaneを自動更新
   useEffect(() => {
@@ -150,15 +152,6 @@ export function MultiPaneLayout({
             title="Single pane"
           >
             <Square className="w-4 h-4" />
-          </Button>
-          <Button
-            variant={layoutMode === "split-2" ? "secondary" : "ghost"}
-            size="icon"
-            className="h-7 w-7"
-            onClick={() => setLayoutMode("split-2")}
-            title="Split view"
-          >
-            <Columns2 className="w-4 h-4" />
           </Button>
           <Button
             variant={layoutMode === "grid-4" ? "secondary" : "ghost"}

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -17,6 +17,8 @@ import {
 } from "lucide-react";
 import { TerminalPane } from "./TerminalPane";
 import { useIsMobile } from "@/hooks/useMobile";
+import { findRepoForSession } from "@/utils/sessionUtils";
+import { getBaseName } from "@/utils/pathUtils";
 import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types";
 
 type LayoutMode = "single" | "split-2" | "grid-4";
@@ -25,6 +27,7 @@ interface MultiPaneLayoutProps {
   activePanes: string[]; // Session IDs
   sessions: Map<string, ManagedSession>;
   worktrees: Worktree[];
+  repoList?: string[];
   onSendMessage: (sessionId: string, message: string) => void;
   onSendKey: (sessionId: string, key: SpecialKey) => void;
   onStopSession: (sessionId: string) => void;
@@ -42,6 +45,7 @@ export function MultiPaneLayout({
   activePanes,
   sessions,
   worktrees,
+  repoList,
   onSendMessage,
   onSendKey,
   onStopSession,
@@ -64,6 +68,12 @@ export function MultiPaneLayout({
     return worktrees.find((w) => w.id === session.worktreeId);
   };
 
+  const getRepoNameForSession = (session: ManagedSession): string | undefined => {
+    if (!repoList) return undefined;
+    const repo = findRepoForSession(session, repoList);
+    return repo ? getBaseName(repo) : undefined;
+  };
+
   // If a pane is maximized, only show that pane
   if (maximizedPane) {
     const session = sessions.get(maximizedPane);
@@ -74,6 +84,7 @@ export function MultiPaneLayout({
           <TerminalPane
             session={session}
             worktree={worktree}
+            repoName={getRepoNameForSession(session)}
             onSendMessage={(msg) => onSendMessage(maximizedPane, msg)}
             onSendKey={(key) => onSendKey(maximizedPane, key)}
             onStopSession={() => onStopSession(maximizedPane)}
@@ -106,18 +117,7 @@ export function MultiPaneLayout({
       return "grid-cols-1";
     }
 
-    if (effectiveLayoutMode === "split-2") {
-      return "grid-cols-1 md:grid-cols-2";
-    }
-
-    // grid-4モード: ペイン数に応じてグリッドを調整
-    if (effectiveLayoutMode === "grid-4") {
-      if (paneCount <= 2) return "grid-cols-1 md:grid-cols-2";
-      if (paneCount <= 4) return "grid-cols-1 md:grid-cols-2";
-      if (paneCount <= 6) return "grid-cols-1 md:grid-cols-2 xl:grid-cols-3";
-      return "grid-cols-1 md:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4";
-    }
-
+    // split-2、grid-4ともに最大2列
     return "grid-cols-1 md:grid-cols-2";
   };
 
@@ -170,7 +170,7 @@ export function MultiPaneLayout({
       </div>
 
       {/* Panes Grid */}
-      <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-auto auto-rows-fr`}>
+      <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-y-auto auto-rows-[minmax(calc(100vh-10rem),1fr)]`}>
         {visiblePanes.slice(0, getMaxPanes()).map((sessionId) => {
           const session = sessions.get(sessionId);
           if (!session) return null;
@@ -182,6 +182,7 @@ export function MultiPaneLayout({
               key={sessionId}
               session={session}
               worktree={worktree}
+              repoName={getRepoNameForSession(session)}
               onSendMessage={(msg) => onSendMessage(sessionId, msg)}
               onSendKey={(key) => onSendKey(sessionId, key)}
               onStopSession={() => onStopSession(sessionId)}

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -224,7 +224,7 @@ export function MultiPaneLayout({
         </>
       ) : (
         /* Desktop: グリッド表示 */
-        <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-y-auto auto-rows-[minmax(calc(100vh-10rem),1fr)]`}>
+        <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-y-auto auto-rows-[minmax(calc(100vh_-_10rem),1fr)]`}>
           {visiblePanes.map((sessionId) => {
             const session = sessions.get(sessionId);
             if (!session) return null;

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -121,13 +121,6 @@ export function MultiPaneLayout({
     return "grid-cols-1 md:grid-cols-2";
   };
 
-  // 表示するペイン数を決定
-  const getMaxPanes = () => {
-    if (effectiveLayoutMode === "single") return 1;
-    if (effectiveLayoutMode === "split-2") return 2;
-    return visiblePanes.length; // grid-4モードでは全て表示
-  };
-
   return (
     <div className="h-full flex flex-col">
       {/* Layout Controls */}
@@ -171,7 +164,7 @@ export function MultiPaneLayout({
 
       {/* Panes Grid */}
       <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-y-auto auto-rows-[minmax(calc(100vh-10rem),1fr)]`}>
-        {visiblePanes.slice(0, getMaxPanes()).map((sessionId) => {
+        {visiblePanes.map((sessionId) => {
           const session = sessions.get(sessionId);
           if (!session) return null;
 
@@ -199,12 +192,6 @@ export function MultiPaneLayout({
         })}
       </div>
 
-      {/* Hidden Panes Indicator */}
-      {visiblePanes.length > getMaxPanes() && (
-        <div className="h-10 md:h-8 border-t border-border flex items-center justify-center text-sm md:text-xs text-muted-foreground shrink-0">
-          +{visiblePanes.length - getMaxPanes()} more session(s) hidden
-        </div>
-      )}
     </div>
   );
 }

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -232,7 +232,7 @@ export function TerminalPane({
           )}
           <GitBranch className="w-4 h-4 md:w-3 md:h-3 text-muted-foreground shrink-0" />
           <span className="font-mono text-sm md:text-xs truncate text-sidebar-foreground">
-            {worktree?.branch || "Unknown"}
+            {worktree?.branch || session.worktreePath.substring(session.worktreePath.lastIndexOf("/") + 1)}
           </span>
         </div>
         <div className="flex items-center gap-1">

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -35,6 +35,7 @@ import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types
 interface TerminalPaneProps {
   session: ManagedSession;
   worktree: Worktree | undefined;
+  repoName?: string;
   onSendMessage: (message: string) => void;
   onSendKey: (key: SpecialKey) => void;
   onStopSession: () => void;
@@ -51,6 +52,7 @@ interface TerminalPaneProps {
 export function TerminalPane({
   session,
   worktree,
+  repoName,
   onSendMessage,
   onSendKey,
   onStopSession,
@@ -223,6 +225,11 @@ export function TerminalPane({
       <header className="h-14 md:h-10 border-b border-border flex items-center justify-between px-4 md:px-3 bg-sidebar shrink-0">
         <div className="flex items-center gap-2 min-w-0">
           <div className={`status-indicator ${session.status}`} />
+          {repoName && (
+            <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/20 text-primary font-medium shrink-0">
+              {repoName}
+            </span>
+          )}
           <GitBranch className="w-4 h-4 md:w-3 md:h-3 text-muted-foreground shrink-0" />
           <span className="font-mono text-sm md:text-xs truncate text-sidebar-foreground">
             {worktree?.branch || "Unknown"}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -269,21 +269,31 @@ export default function Dashboard() {
     toast.success("Session started");
   };
 
+  // セッションIDをペインリストから削除するヘルパー
+  // targetRepoが指定されていればそのリポのみ、nullならフォールバックで全リポから削除
+  const removeSessionFromPanes = (sessionId: string, targetRepo?: string | null) => {
+    setActivePanesPerRepo((prev) => {
+      const newMap = new Map(prev);
+      if (targetRepo) {
+        const currentPanes = newMap.get(targetRepo) || [];
+        newMap.set(targetRepo, currentPanes.filter((id) => id !== sessionId));
+        return newMap;
+      }
+      // フォールバック: 全リポから削除
+      Array.from(newMap.entries()).forEach(([repo, panes]) => {
+        if (panes.includes(sessionId)) {
+          newMap.set(repo, panes.filter((id: string) => id !== sessionId));
+        }
+      });
+      return newMap;
+    });
+  };
+
   const handleStopSession = (sessionId: string) => {
     stopSession(sessionId);
-    // セッションの所属リポを特定して該当リポのペインリストから削除
     const session = sessions.get(sessionId);
-    if (session) {
-      const targetRepo = findRepoForSession(session, repoList);
-      if (targetRepo) {
-        setActivePanesPerRepo((prev) => {
-          const newMap = new Map(prev);
-          const currentPanes = newMap.get(targetRepo) || [];
-          newMap.set(targetRepo, currentPanes.filter((id) => id !== sessionId));
-          return newMap;
-        });
-      }
-    }
+    const targetRepo = session ? findRepoForSession(session, repoList) : null;
+    removeSessionFromPanes(sessionId, targetRepo);
     if (maximizedPane === sessionId) {
       setMaximizedPane(null);
     }
@@ -323,19 +333,9 @@ export default function Dashboard() {
   const handleClosePane = (sessionId: string) => {
     // ユーザーが意図的に閉じたペインとして記録
     closedPanesRef.current.add(sessionId);
-    // セッションの所属リポを特定して該当リポのペインリストから削除
     const session = sessions.get(sessionId);
-    if (session) {
-      const targetRepo = findRepoForSession(session, repoList);
-      if (targetRepo) {
-        setActivePanesPerRepo((prev) => {
-          const newMap = new Map(prev);
-          const currentPanes = newMap.get(targetRepo) || [];
-          newMap.set(targetRepo, currentPanes.filter((id) => id !== sessionId));
-          return newMap;
-        });
-      }
-    }
+    const targetRepo = session ? findRepoForSession(session, repoList) : null;
+    removeSessionFromPanes(sessionId, targetRepo);
     if (maximizedPane === sessionId) {
       setMaximizedPane(null);
     }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -175,6 +175,13 @@ export default function Dashboard() {
   // 現在のリポジトリのactivePanesを取得
   const activePanes = repoPath ? (activePanesPerRepo.get(repoPath) || []) : [];
 
+  // 全リポジトリ横断のactivePanes（Panesタブ用）
+  const allActivePanes = useMemo(() => {
+    const all: string[] = [];
+    activePanesPerRepo.forEach((panes) => all.push(...panes));
+    return all;
+  }, [activePanesPerRepo]);
+
   // activePanesを更新するヘルパー関数
   const setActivePanes = (updater: string[] | ((prev: string[]) => string[])) => {
     if (!repoPath) return;
@@ -216,8 +223,9 @@ export default function Dashboard() {
   useEffect(() => {
     setMaximizedPane(null);
     setSelectedWorktreeId(null);
-    const currentPanes = repoPath ? (activePanesPerRepo.get(repoPath) || []) : [];
-    setViewMode(currentPanes.length > 0 ? "panes" : "dashboard");
+    let totalPanes = 0;
+    activePanesPerRepo.forEach((panes) => { totalPanes += panes.length; });
+    setViewMode(totalPanes > 0 ? "panes" : "dashboard");
   }, [repoPath, activePanesPerRepo]);
 
   const getSessionForWorktree = (worktreeId: string): ManagedSession | undefined => {
@@ -263,7 +271,19 @@ export default function Dashboard() {
 
   const handleStopSession = (sessionId: string) => {
     stopSession(sessionId);
-    setActivePanes((prev) => prev.filter((id) => id !== sessionId));
+    // セッションの所属リポを特定して該当リポのペインリストから削除
+    const session = sessions.get(sessionId);
+    if (session) {
+      const targetRepo = findRepoForSession(session, repoList);
+      if (targetRepo) {
+        setActivePanesPerRepo((prev) => {
+          const newMap = new Map(prev);
+          const currentPanes = newMap.get(targetRepo) || [];
+          newMap.set(targetRepo, currentPanes.filter((id) => id !== sessionId));
+          return newMap;
+        });
+      }
+    }
     if (maximizedPane === sessionId) {
       setMaximizedPane(null);
     }
@@ -303,7 +323,19 @@ export default function Dashboard() {
   const handleClosePane = (sessionId: string) => {
     // ユーザーが意図的に閉じたペインとして記録
     closedPanesRef.current.add(sessionId);
-    setActivePanes((prev) => prev.filter((id) => id !== sessionId));
+    // セッションの所属リポを特定して該当リポのペインリストから削除
+    const session = sessions.get(sessionId);
+    if (session) {
+      const targetRepo = findRepoForSession(session, repoList);
+      if (targetRepo) {
+        setActivePanesPerRepo((prev) => {
+          const newMap = new Map(prev);
+          const currentPanes = newMap.get(targetRepo) || [];
+          newMap.set(targetRepo, currentPanes.filter((id) => id !== sessionId));
+          return newMap;
+        });
+      }
+    }
     if (maximizedPane === sessionId) {
       setMaximizedPane(null);
     }
@@ -315,30 +347,34 @@ export default function Dashboard() {
 
 
   useEffect(() => {
-    if (!repoPath) return;
+    if (repoList.length === 0) return;
     sessions.forEach((session, sessionId) => {
       // ユーザーが意図的に閉じたペインは再追加しない
       if (closedPanesRef.current.has(sessionId)) return;
-      if (isSessionBelongsToRepo(session, repoPath)) {
-        setActivePanes((prev) => {
-          if (prev.includes(sessionId)) return prev;
-          return [...prev, sessionId];
+      const targetRepo = findRepoForSession(session, repoList);
+      if (targetRepo) {
+        setActivePanesPerRepo((prev) => {
+          const currentPanes = prev.get(targetRepo) || [];
+          if (currentPanes.includes(sessionId)) return prev;
+          const newMap = new Map(prev);
+          newMap.set(targetRepo, [...currentPanes, sessionId]);
+          return newMap;
         });
         setViewMode("panes");
       }
     });
-  }, [sessions, repoPath]);
+  }, [sessions, repoList]);
 
   // 現在のリポジトリに属し、かつ存在するセッションのみをフィルタ
   const { filteredSessions, validActivePanes } = useMemo(() => {
     const filtered = new Map(
-      Array.from(sessions.entries()).filter(([sessionId, session]) =>
-        repoPath && isSessionBelongsToRepo(session, repoPath) && activePanes.includes(sessionId)
+      Array.from(sessions.entries()).filter(([sessionId]) =>
+        allActivePanes.includes(sessionId)
       )
     );
-    const valid = activePanes.filter((id) => filtered.has(id));
+    const valid = allActivePanes.filter((id) => filtered.has(id));
     return { filteredSessions: filtered, validActivePanes: valid };
-  }, [sessions, repoPath, activePanes]);
+  }, [sessions, allActivePanes]);
 
   const SidebarContent = () => (
     <div className="flex-1 flex flex-col overflow-hidden">
@@ -725,6 +761,7 @@ export default function Dashboard() {
               activePanes={validActivePanes}
               sessions={filteredSessions}
               worktrees={worktrees}
+              repoList={repoList}
               onSendMessage={sendMessage}
               onSendKey={sendKey}
               onStopSession={handleStopSession}


### PR DESCRIPTION
## 概要

Panesタブで全リポジトリのセッションを同時に表示・操作できるように改善。リポジトリを切り替えなくても全セッションにアクセス可能になった。

## 変更内容

- **Dashboard.tsx**: ペイン管理ロジックをクロスリポジトリ対応に変更
  - `allActivePanes` で全リポ横断のペイン一覧を集約
  - セッション自動追加を`repoList`全体走査に変更
  - `handleStopSession` / `handleClosePane` を所属リポ特定で直接更新
  - `filteredSessions` を全リポ横断でフィルタ
  - `viewMode` 判定を全リポのペイン合計数で判定

- **TerminalPane.tsx**: ヘッダーにリポジトリ名バッジを追加
  - `repoName` propを追加し、ステータスインジケータ横にバッジ表示

- **MultiPaneLayout.tsx**: リポ名の受け渡しとレイアウト改善
  - `repoList` propを追加し、各ペインにリポ名を算出して渡す
  - グリッドを常に最大2列に統一
  - 各行の最小高さを `calc(100vh - 10rem)` に設定し、3ペイン以上はスクロール表示

## 影響を受けない箇所

- サイドバーのリポ切り替え・worktree一覧（選択リポのみ表示）
- サイドバーの `isInPane` ハイライト（選択リポのペインのみ）
- `closedPanesRef` によるペイン再表示防止ロジック

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal panes show an optional repository-name badge in the header.
  * Dashboard and layout support multiple repositories, aggregating panes across repos.

* **Improvements**
  * Terminal panes fall back to the repository folder name for branch display when branch info is missing.
  * Simplified desktop grid and removed hidden-pane indicators; removed one split layout toggle.
  * Mobile UX: tab-style pane switching with automatic active-pane selection and single-pane view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->