### PR TITLE
fix: Worktree削除時にセッションペインが残留する問題を修正

### DIFF
--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -50,6 +50,10 @@ interface UseSocketReturn {
   deleteWorktree: (worktreePath: string) => void;
   refreshWorktrees: () => void;
 
+  // Worktree deletion notification
+  deletedWorktreeId: string | null;
+  clearDeletedWorktreeId: () => void;
+
   // Sessions
   sessions: Map<string, ManagedSession>;
   startSession: (worktreeId: string, worktreePath: string) => void;
@@ -96,6 +100,7 @@ export function useSocket(): UseSocketReturn {
     return localStorage.getItem("selectedRepoPath");
   });
   const [worktrees, setWorktrees] = useState<Worktree[]>([]);
+  const [deletedWorktreeId, setDeletedWorktreeId] = useState<string | null>(null);
   const [sessions, setSessions] = useState<Map<string, ManagedSession>>(new Map());
 
   // Tunnel state
@@ -204,6 +209,7 @@ export function useSocket(): UseSocketReturn {
 
     socket.on("worktree:deleted", (wtId) => {
       setWorktrees((prev) => prev.filter((w) => w.id !== wtId));
+      setDeletedWorktreeId(wtId);
     });
 
     socket.on("worktree:error", (err) => {
@@ -356,6 +362,10 @@ export function useSocket(): UseSocketReturn {
     socketRef.current?.emit("worktree:list", repoPath);
   }, [repoPath]);
 
+  const clearDeletedWorktreeId = useCallback(() => {
+    setDeletedWorktreeId(null);
+  }, []);
+
   // Session actions
   const startSession = useCallback((worktreeId: string, worktreePath: string) => {
     socketRef.current?.emit("session:start", { worktreeId, worktreePath });
@@ -447,6 +457,8 @@ export function useSocket(): UseSocketReturn {
     createWorktree,
     deleteWorktree,
     refreshWorktrees,
+    deletedWorktreeId,
+    clearDeletedWorktreeId,
     sessions,
     startSession,
     stopSession,

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -113,6 +113,8 @@ export default function Dashboard() {
     imageUploadError,
     clearImageUploadState,
     copyBuffer,
+    deletedWorktreeId,
+    clearDeletedWorktreeId,
   } = useSocket();
 
   const isMobile = useIsMobile();
@@ -243,13 +245,32 @@ export default function Dashboard() {
     toast.success(`Creating worktree: ${branchName}`);
   };
 
+  useEffect(() => {
+    if (deletedWorktreeId) {
+      toast.success("Worktreeを削除しました");
+      clearDeletedWorktreeId();
+    }
+  }, [deletedWorktreeId, clearDeletedWorktreeId]);
+
   const handleDeleteWorktree = (worktree: Worktree) => {
     if (worktree.isMain) {
       toast.error("Cannot delete the main worktree");
       return;
     }
+
+    // 対応するセッションがあればペインを即座に閉じる
+    const session = getSessionForWorktree(worktree.id);
+    if (session) {
+      closedPanesRef.current.add(session.id);
+      const targetRepo = findRepoForSession(session, repoList);
+      removeSessionFromPanes(session.id, targetRepo);
+      if (maximizedPane === session.id) {
+        setMaximizedPane(null);
+      }
+    }
+
     deleteWorktree(worktree.path);
-    toast.success("Worktree deleted");
+    toast.info("Worktreeを削除中...");
   };
 
   const handleStartSession = (worktree: Worktree) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -242,16 +242,15 @@ async function startServer() {
           sessionOrchestrator.stopSession(session.id);
         }
 
-        // 削除前にworktree IDを取得
-        const currentWorktrees = await listWorktrees(repoPath);
-        const target = currentWorktrees.find((w) => w.path === worktreePath);
+        // worktree IDをパスから決定的に導出（listWorktreesと同じロジック）
+        const deletedWorktreeId = Buffer.from(worktreePath)
+          .toString("base64")
+          .replace(/[/+=]/g, "");
 
         await deleteWorktree(repoPath, worktreePath);
 
-        // 削除成功を個別イベントで通知
-        if (target) {
-          socket.emit("worktree:deleted", target.id);
-        }
+        // 削除成功を通知
+        socket.emit("worktree:deleted", deletedWorktreeId);
 
         const worktrees = await listWorktrees(repoPath);
         socket.emit("worktree:list", worktrees);

--- a/server/index.ts
+++ b/server/index.ts
@@ -242,7 +242,16 @@ async function startServer() {
           sessionOrchestrator.stopSession(session.id);
         }
 
+        // 削除前にworktree IDを取得
+        const currentWorktrees = await listWorktrees(repoPath);
+        const target = currentWorktrees.find((w) => w.path === worktreePath);
+
         await deleteWorktree(repoPath, worktreePath);
+
+        // 削除成功を個別イベントで通知
+        if (target) {
+          socket.emit("worktree:deleted", target.id);
+        }
 
         const worktrees = await listWorktrees(repoPath);
         socket.emit("worktree:list", worktrees);


### PR DESCRIPTION
## 概要

Worktree削除時に以下の問題を修正:

- 削除対象のworktreeに紐づくセッションのペインが自動で閉じられない
- 削除完了前に「Worktree deleted」のsuccessトーストが表示される
- サーバーが`worktree:deleted`イベントをemitしていない

## 変更内容

- **server/index.ts**: `worktree:delete`ハンドラーで削除成功時に`worktree:deleted`イベントをemit
- **client/src/hooks/useSocket.ts**: `deletedWorktreeId` state追加、削除通知をDashboardに伝達
- **client/src/pages/Dashboard.tsx**: `handleDeleteWorktree`にペインクリーンアップ処理を追加、トーストをOptimistic UI対応に変更

## 動作

1. Worktree削除 → ペインが即座に消える → 「削除中...」トースト表示
2. サーバーで削除完了 → `worktree:deleted`イベント → 「削除しました」トースト表示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-worktree deletion notifications with clearer progress feedback.
  * UI shows informational "deletion in progress" status for removed worktrees.

* **Bug Fixes**
  * Automatically closes and cleans up session panes for deleted worktrees to avoid orphaned sessions.
  * Pre-deletion cleanup ensures consistent UI state and accurate post-delete updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->