### PR TITLE
feat: モバイルUIを専用コンポーネントに分離

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ temp/
 *.db
 *.sqlite
 *.sqlite3
+
+# Application data
+data/

--- a/client/index.html
+++ b/client/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1" />
+      content="width=device-width, initial-scale=1.0, maximum-scale=1, viewport-fit=cover" />
     <title>Claude Code Manager</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -5,7 +5,7 @@
  * iframe再マウント防止のため、display:none/blockで表示を切り替える。
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { MobileSessionList } from "@/components/MobileSessionList";
 import { MobileSessionView } from "@/components/MobileSessionView";
 import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types";
@@ -58,6 +58,13 @@ export function MobileLayout({
   const handleBack = useCallback(() => {
     setActiveView("list");
   }, []);
+
+  // 選択中のセッションが削除された場合、一覧画面にフォールバック
+  useEffect(() => {
+    if (activeView === "detail" && selectedSessionId && !sessions.has(selectedSessionId)) {
+      setActiveView("list");
+    }
+  }, [activeView, selectedSessionId, sessions]);
 
   // ワークツリーのIDからWorktreeを取得するヘルパー
   const getWorktreeForSession = (session: ManagedSession): Worktree | undefined => {

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -1,0 +1,119 @@
+/**
+ * MobileLayout - モバイル専用ルートコンポーネント
+ *
+ * 「セッション一覧」と「セッション詳細」を画面遷移で切り替える。
+ * iframe再マウント防止のため、display:none/blockで表示を切り替える。
+ */
+
+import { useState, useCallback } from "react";
+import { MobileSessionList } from "@/components/MobileSessionList";
+import { MobileSessionView } from "@/components/MobileSessionView";
+import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types";
+
+interface MobileLayoutProps {
+  sessions: Map<string, ManagedSession>;
+  worktrees: Worktree[];
+  repoName: string | null;
+  onStartSession: (worktree: Worktree) => void;
+  onStopSession: (sessionId: string) => void;
+  onSendMessage: (sessionId: string, message: string) => void;
+  onSendKey: (sessionId: string, key: SpecialKey) => void;
+  onSelectSession: (sessionId: string) => void;
+  onUploadImage?: (sessionId: string, base64Data: string, mimeType: string) => void;
+  imageUploadResult?: { path: string; filename: string } | null;
+  imageUploadError?: string | null;
+  onClearImageUploadState?: () => void;
+  onCopyBuffer?: (sessionId: string) => Promise<string | null>;
+}
+
+export function MobileLayout({
+  sessions,
+  worktrees,
+  repoName,
+  onStartSession,
+  onStopSession,
+  onSendMessage,
+  onSendKey,
+  onSelectSession,
+  onUploadImage,
+  imageUploadResult,
+  imageUploadError,
+  onClearImageUploadState,
+  onCopyBuffer,
+}: MobileLayoutProps) {
+  const [activeView, setActiveView] = useState<"list" | "detail">("list");
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+
+  // セッションを選択して詳細画面に遷移
+  const handleOpenSession = useCallback(
+    (sessionId: string) => {
+      setSelectedSessionId(sessionId);
+      setActiveView("detail");
+      onSelectSession(sessionId);
+    },
+    [onSelectSession]
+  );
+
+  // 一覧画面に戻る
+  const handleBack = useCallback(() => {
+    setActiveView("list");
+  }, []);
+
+  // ワークツリーのIDからWorktreeを取得するヘルパー
+  const getWorktreeForSession = (session: ManagedSession): Worktree | undefined => {
+    return worktrees.find((w) => w.id === session.worktreeId);
+  };
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* 一覧画面 */}
+      <div
+        className={
+          activeView === "list" ? "flex-1 flex flex-col" : "hidden"
+        }
+      >
+        <MobileSessionList
+          sessions={sessions}
+          worktrees={worktrees}
+          repoName={repoName}
+          onOpenSession={handleOpenSession}
+          onStartSession={onStartSession}
+          onStopSession={onStopSession}
+        />
+      </div>
+
+      {/* 詳細画面 - 各セッションのビューを保持（iframe再マウント防止） */}
+      {Array.from(sessions.entries()).map(([sessionId, session]) => (
+        <div
+          key={sessionId}
+          className={
+            activeView === "detail" && selectedSessionId === sessionId
+              ? "flex-1 flex flex-col"
+              : "hidden"
+          }
+        >
+          <MobileSessionView
+            session={session}
+            worktree={getWorktreeForSession(session)}
+            onBack={handleBack}
+            onSendMessage={(message) => onSendMessage(sessionId, message)}
+            onSendKey={(key) => onSendKey(sessionId, key)}
+            onStopSession={() => onStopSession(sessionId)}
+            onUploadImage={
+              onUploadImage
+                ? (base64Data, mimeType) =>
+                    onUploadImage(sessionId, base64Data, mimeType)
+                : undefined
+            }
+            imageUploadResult={imageUploadResult}
+            imageUploadError={imageUploadError}
+            onClearImageUploadState={onClearImageUploadState}
+            onCopyBuffer={
+              onCopyBuffer ? () => onCopyBuffer(sessionId) : undefined
+            }
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/MobileSessionList.tsx
+++ b/client/src/components/MobileSessionList.tsx
@@ -5,6 +5,7 @@
  * タップターゲットは最低48pxを確保。
  */
 
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { GitBranch, Play, Square } from "lucide-react";
 import type { ManagedSession, Worktree } from "../../../shared/types";
@@ -26,8 +27,16 @@ export function MobileSessionList({
   onStartSession,
   onStopSession,
 }: MobileSessionListProps) {
+  const sessionByWorktreeId = useMemo(() => {
+    const map = new Map<string, ManagedSession>();
+    sessions.forEach((session) => {
+      map.set(session.worktreeId, session);
+    });
+    return map;
+  }, [sessions]);
+
   const getSessionForWorktree = (worktreeId: string) => {
-    return Array.from(sessions.values()).find((s) => s.worktreeId === worktreeId);
+    return sessionByWorktreeId.get(worktreeId);
   };
 
   return (

--- a/client/src/components/MobileSessionList.tsx
+++ b/client/src/components/MobileSessionList.tsx
@@ -1,0 +1,108 @@
+/**
+ * MobileSessionList - モバイル用セッション一覧画面
+ *
+ * ワークツリーをカード形式で表示し、セッションの開始・停止・オープンを操作する。
+ * タップターゲットは最低48pxを確保。
+ */
+
+import { Button } from "@/components/ui/button";
+import { GitBranch, Play, Square } from "lucide-react";
+import type { ManagedSession, Worktree } from "../../../shared/types";
+
+interface MobileSessionListProps {
+  sessions: Map<string, ManagedSession>;
+  worktrees: Worktree[];
+  repoName: string | null;
+  onOpenSession: (sessionId: string) => void;
+  onStartSession: (worktree: Worktree) => void;
+  onStopSession: (sessionId: string) => void;
+}
+
+export function MobileSessionList({
+  sessions,
+  worktrees,
+  repoName,
+  onOpenSession,
+  onStartSession,
+  onStopSession,
+}: MobileSessionListProps) {
+  const getSessionForWorktree = (worktreeId: string) => {
+    return Array.from(sessions.values()).find((s) => s.worktreeId === worktreeId);
+  };
+
+  return (
+    <div className="flex-1 flex flex-col safe-area-x">
+      {/* リポジトリ名表示 */}
+      {repoName && (
+        <div className="px-4 py-2 border-b border-border/50">
+          <span className="text-xs text-muted-foreground font-mono">{repoName}</span>
+        </div>
+      )}
+
+      {/* ワークツリーリスト */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {worktrees.map((worktree) => {
+          const session = getSessionForWorktree(worktree.id);
+          return (
+            <div
+              key={worktree.id}
+              className="bg-card border border-border rounded-lg p-4"
+            >
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2 min-w-0">
+                  {session && (
+                    <div className={`status-indicator ${session.status}`} />
+                  )}
+                  <GitBranch className="w-4 h-4 text-muted-foreground shrink-0" />
+                  <span className="font-mono text-sm truncate">
+                    {worktree.branch}
+                  </span>
+                  {worktree.isMain && (
+                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/20 text-primary uppercase">
+                      main
+                    </span>
+                  )}
+                </div>
+                <div className="flex items-center gap-2 shrink-0">
+                  {session ? (
+                    <>
+                      <Button
+                        size="sm"
+                        className="h-10 px-4"
+                        onClick={() => onOpenSession(session.id)}
+                      >
+                        Open
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        className="h-10 px-3"
+                        onClick={() => onStopSession(session.id)}
+                      >
+                        <Square className="w-4 h-4" />
+                      </Button>
+                    </>
+                  ) : (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="h-10 px-4"
+                      onClick={() => onStartSession(worktree)}
+                    >
+                      <Play className="w-4 h-4 mr-1" /> Start
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+        {worktrees.length === 0 && (
+          <div className="text-center text-muted-foreground py-8">
+            ワークツリーがありません
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -1,0 +1,422 @@
+/**
+ * MobileSessionView - モバイル用セッション詳細画面
+ *
+ * ターミナル全画面表示 + Quick Keys + 入力バー常時表示。
+ * Opsドロップダウンで追加操作（Copy Buffer, Paste Image, Reload, スラッシュコマンド）。
+ */
+
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  ChevronLeft,
+  Square,
+  Send,
+  MoreVertical,
+  GitBranch,
+  Copy,
+  ImageIcon,
+  RefreshCw,
+} from "lucide-react";
+import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types";
+import { useVisualViewport } from "../hooks/useVisualViewport";
+
+interface MobileSessionViewProps {
+  session: ManagedSession;
+  worktree: Worktree | undefined;
+  onBack: () => void;
+  onSendMessage: (message: string) => void;
+  onSendKey: (key: SpecialKey) => void;
+  onStopSession: () => void;
+  onUploadImage?: (base64Data: string, mimeType: string) => void;
+  imageUploadResult?: { path: string; filename: string } | null;
+  imageUploadError?: string | null;
+  onClearImageUploadState?: () => void;
+  onCopyBuffer?: () => Promise<string | null>;
+}
+
+export function MobileSessionView({
+  session,
+  worktree,
+  onBack,
+  onSendMessage,
+  onSendKey,
+  onStopSession,
+  onUploadImage,
+  imageUploadResult,
+  imageUploadError,
+  onClearImageUploadState,
+  onCopyBuffer,
+}: MobileSessionViewProps) {
+  const { height: viewportHeight, isKeyboardVisible } = useVisualViewport();
+  const [inputValue, setInputValue] = useState("");
+  const [iframeKey, setIframeKey] = useState(0);
+  const [pastedImage, setPastedImage] = useState<{
+    base64: string;
+    mimeType: string;
+    preview: string;
+  } | null>(null);
+  const [imageMessage, setImageMessage] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // ttyd iframe URL構築
+  const isLocalAccess =
+    typeof window !== "undefined" &&
+    (window.location.hostname === "localhost" ||
+      window.location.hostname === "127.0.0.1");
+  const ttydIframeSrc =
+    isLocalAccess && session.ttydPort
+      ? `http://127.0.0.1:${session.ttydPort}/ttyd/${session.id}/`
+      : `/ttyd/${session.id}/`;
+
+  // メッセージ送信
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (inputValue.trim()) {
+      onSendMessage(inputValue);
+      setInputValue("");
+    }
+  };
+
+  // Enter送信、Shift+Enter改行
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit(e);
+    }
+  };
+
+  // iframeリロード
+  const handleReloadIframe = () => {
+    setIframeKey((prev) => prev + 1);
+  };
+
+  // クリップボードから画像を読み取り
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent | ClipboardEvent) => {
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      const itemsArray = Array.from(items);
+      for (const item of itemsArray) {
+        if (item.type.startsWith("image/")) {
+          e.preventDefault();
+          const file = item.getAsFile();
+          if (!file) continue;
+
+          const reader = new FileReader();
+          reader.onload = (event) => {
+            const dataUrl = event.target?.result as string;
+            const [header, base64] = dataUrl.split(",");
+            const mimeType =
+              header.match(/data:(.*?);/)?.[1] || "image/png";
+            setPastedImage({ base64, mimeType, preview: dataUrl });
+          };
+          reader.readAsDataURL(file);
+          break;
+        }
+      }
+    },
+    []
+  );
+
+  // ペーストイベントのリスナー
+  useEffect(() => {
+    const handleDocumentPaste = (e: ClipboardEvent) => {
+      if (document.activeElement === textareaRef.current) {
+        handlePaste(e);
+      }
+    };
+    document.addEventListener("paste", handleDocumentPaste);
+    return () => document.removeEventListener("paste", handleDocumentPaste);
+  }, [handlePaste]);
+
+  // クリップボードからの画像ペーストボタン
+  const handlePasteButtonClick = async () => {
+    try {
+      const clipboardItems = await navigator.clipboard.read();
+      for (const item of clipboardItems) {
+        const imageType = item.types.find((type) =>
+          type.startsWith("image/")
+        );
+        if (imageType) {
+          const blob = await item.getType(imageType);
+          const reader = new FileReader();
+          reader.onload = (event) => {
+            const dataUrl = event.target?.result as string;
+            const [header, base64] = dataUrl.split(",");
+            const mimeType =
+              header.match(/data:(.*?);/)?.[1] || "image/png";
+            setPastedImage({ base64, mimeType, preview: dataUrl });
+          };
+          reader.readAsDataURL(blob);
+          break;
+        }
+      }
+    } catch (err) {
+      console.error("Failed to read clipboard:", err);
+    }
+  };
+
+  // 画像アップロード成功時に自動送信
+  useEffect(() => {
+    if (imageUploadResult && pastedImage) {
+      const message = imageMessage.trim()
+        ? `@${imageUploadResult.path} ${imageMessage}`
+        : `@${imageUploadResult.path}`;
+      onSendMessage(message);
+      setPastedImage(null);
+      setImageMessage("");
+      onClearImageUploadState?.();
+    }
+  }, [imageUploadResult, pastedImage, imageMessage, onSendMessage, onClearImageUploadState]);
+
+  // tmuxバッファコピー
+  const handleCopyBuffer = async () => {
+    if (!onCopyBuffer) return;
+    try {
+      const text = await onCopyBuffer();
+      if (text) {
+        await navigator.clipboard.writeText(text);
+      }
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  // スラッシュコマンド
+  const slashCommands = [
+    { label: "/resume", cmd: "/resume" },
+    { label: "/help", cmd: "/help" },
+    { label: "/status", cmd: "/status" },
+    { label: "/clear", cmd: "/clear" },
+    { label: "/compact", cmd: "/compact" },
+  ];
+
+  return (
+    <div
+      className="flex-1 flex flex-col safe-area-x"
+      style={isKeyboardVisible ? { height: `${viewportHeight}px`, maxHeight: `${viewportHeight}px` } : undefined}
+    >
+      {/* ヘッダー: 戻る、ブランチ名、Opsドロップダウン、Stopボタン */}
+      <header className="h-12 border-b border-border flex items-center justify-between px-2 bg-sidebar shrink-0 safe-area-top">
+        <div className="flex items-center gap-1 min-w-0">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-10 w-10 shrink-0"
+            onClick={onBack}
+          >
+            <ChevronLeft className="w-5 h-5" />
+          </Button>
+          <div className={`status-indicator ${session.status} shrink-0`} />
+          <GitBranch className="w-4 h-4 text-muted-foreground shrink-0" />
+          <span className="font-mono text-sm truncate">
+            {worktree?.branch ||
+              session.worktreePath.substring(
+                session.worktreePath.lastIndexOf("/") + 1
+              )}
+          </span>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          {/* Opsドロップダウン */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-10 w-10">
+                <MoreVertical className="w-5 h-5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              <DropdownMenuItem onClick={handleCopyBuffer}>
+                <Copy className="w-4 h-4 mr-2" />
+                Copy Buffer
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handlePasteButtonClick}>
+                <ImageIcon className="w-4 h-4 mr-2" />
+                Paste Image
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleReloadIframe}>
+                <RefreshCw className="w-4 h-4 mr-2" />
+                Reload Terminal
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              {slashCommands.map(({ label, cmd }) => (
+                <DropdownMenuItem
+                  key={cmd}
+                  onClick={() => onSendMessage(cmd)}
+                  className="font-mono text-xs"
+                >
+                  {label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {/* Stopボタン */}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-10 w-10 text-destructive hover:text-destructive"
+            onClick={onStopSession}
+          >
+            <Square className="w-5 h-5" />
+          </Button>
+        </div>
+      </header>
+
+      {/* ttyd iframe（残り全スペース） */}
+      <div className="flex-1 min-h-0 bg-[#1a1b26]">
+        {session.ttydUrl || session.ttydPort ? (
+          <iframe
+            key={iframeKey}
+            src={ttydIframeSrc}
+            className="w-full h-full border-0"
+            title={`Terminal - ${worktree?.branch || session.id}`}
+            allow="clipboard-read; clipboard-write; keyboard-map"
+          />
+        ) : (
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            <div className="text-center">
+              <div className="animate-spin w-8 h-8 border-2 border-primary border-t-transparent rounded-full mx-auto mb-4" />
+              <p>ターミナルを起動中...</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 画像ペーストプレビュー */}
+      {pastedImage && (
+        <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-50">
+          <div className="bg-card border border-border rounded-lg p-4 max-w-md w-full mx-4">
+            <h3 className="text-sm font-semibold mb-3">画像を送信</h3>
+            <div className="mb-3">
+              <img
+                src={pastedImage.preview}
+                alt="Pasted"
+                className="max-h-48 mx-auto rounded border border-border"
+              />
+            </div>
+            <div className="mb-3">
+              <Textarea
+                value={imageMessage}
+                onChange={(e) => setImageMessage(e.target.value)}
+                placeholder="画像についてのメッセージ（任意）"
+                className="min-h-[60px] resize-none text-sm"
+                rows={2}
+              />
+            </div>
+            {imageUploadError && (
+              <p className="text-destructive text-xs mb-3">
+                {imageUploadError}
+              </p>
+            )}
+            <div className="flex gap-2 justify-end">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => {
+                  setPastedImage(null);
+                  setImageMessage("");
+                  onClearImageUploadState?.();
+                }}
+              >
+                キャンセル
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => {
+                  onUploadImage?.(pastedImage.base64, pastedImage.mimeType);
+                }}
+              >
+                送信
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Quick Keys: y/n/Esc/Ctrl+C/S-Tab 常時表示 */}
+      <div className="flex items-center gap-1 px-3 py-1.5 border-t border-border/50 bg-sidebar overflow-x-auto">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 px-3 text-xs shrink-0"
+          onClick={() => onSendKey("y")}
+        >
+          y
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 px-3 text-xs shrink-0"
+          onClick={() => onSendKey("n")}
+        >
+          n
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 px-3 text-xs shrink-0"
+          onClick={() => onSendKey("Escape")}
+        >
+          Esc
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 px-3 text-xs text-destructive hover:text-destructive shrink-0"
+          onClick={() => onSendKey("C-c")}
+        >
+          Ctrl+C
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-8 px-3 text-xs shrink-0"
+          onClick={() => onSendKey("S-Tab")}
+        >
+          S-Tab
+        </Button>
+      </div>
+
+      {/* 入力バー: 常時表示 */}
+      <form
+        onSubmit={handleSubmit}
+        className="p-3 border-t border-border bg-sidebar safe-area-bottom"
+      >
+        <div className="flex gap-2 items-end">
+          <div className="flex-1">
+            <Textarea
+              ref={textareaRef}
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="メッセージを入力... (Enter送信)"
+              className="min-h-[44px] max-h-32 resize-none font-mono text-sm bg-input"
+              rows={1}
+            />
+          </div>
+          <Button
+            type="submit"
+            size="icon"
+            className="h-11 w-11 glow-green shrink-0"
+            disabled={!inputValue.trim()}
+          >
+            <Send className="w-5 h-5" />
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -101,6 +101,7 @@ export function MobileSessionView({
   // クリップボードから画像を読み取り
   const handlePaste = useCallback(
     (e: React.ClipboardEvent | ClipboardEvent) => {
+      if (!onUploadImage) return;
       const items = e.clipboardData?.items;
       if (!items) return;
 
@@ -124,7 +125,7 @@ export function MobileSessionView({
         }
       }
     },
-    []
+    [onUploadImage]
   );
 
   // ペーストイベントのリスナー
@@ -140,6 +141,7 @@ export function MobileSessionView({
 
   // クリップボードからの画像ペーストボタン
   const handlePasteButtonClick = async () => {
+    if (!onUploadImage) return;
     try {
       const clipboardItems = await navigator.clipboard.read();
       for (const item of clipboardItems) {
@@ -234,14 +236,18 @@ export function MobileSessionView({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuItem onClick={handleCopyBuffer}>
-                <Copy className="w-4 h-4 mr-2" />
-                Copy Buffer
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={handlePasteButtonClick}>
-                <ImageIcon className="w-4 h-4 mr-2" />
-                Paste Image
-              </DropdownMenuItem>
+              {onCopyBuffer && (
+                <DropdownMenuItem onClick={handleCopyBuffer}>
+                  <Copy className="w-4 h-4 mr-2" />
+                  Copy Buffer
+                </DropdownMenuItem>
+              )}
+              {onUploadImage && (
+                <DropdownMenuItem onClick={handlePasteButtonClick}>
+                  <ImageIcon className="w-4 h-4 mr-2" />
+                  Paste Image
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem onClick={handleReloadIframe}>
                 <RefreshCw className="w-4 h-4 mr-2" />
                 Reload Terminal

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -1,21 +1,20 @@
 /**
- * MultiPaneLayout Component - Grid layout for multiple terminal panes
+ * MultiPaneLayout Component - PC向けグリッドレイアウト
  *
  * Design: Terminal-Inspired Dark Mode
- * - Flexible grid layout (1x1, 2x1, 2x2, etc.)
+ * - Flexible grid layout (1x1, 2x2)
  * - Maximize/minimize individual panes
- * - Mobile-first: single pane on small screens
  * - Uses ttyd iframe for terminal rendering
+ * - モバイル表示は MobileLayout が担当
  */
 
-import { useState, useEffect, useMemo } from "react";
+import { useState, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Square,
   Grid2x2,
 } from "lucide-react";
 import { TerminalPane } from "./TerminalPane";
-import { useIsMobile } from "@/hooks/useMobile";
 import { findRepoForSession } from "@/utils/sessionUtils";
 import { getBaseName } from "@/utils/pathUtils";
 import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types";
@@ -57,12 +56,7 @@ export function MultiPaneLayout({
   onClearImageUploadState,
   onCopyBuffer,
 }: MultiPaneLayoutProps) {
-  const isMobile = useIsMobile();
   const [layoutMode, setLayoutMode] = useState<LayoutMode>("grid-4");
-  const [activeMobilePane, setActiveMobilePane] = useState<string | null>(null);
-
-  // Force single pane on mobile
-  const effectiveLayoutMode = isMobile ? "single" : layoutMode;
 
   const getWorktreeForSession = (session: ManagedSession): Worktree | undefined => {
     return worktrees.find((w) => w.id === session.worktreeId);
@@ -108,15 +102,6 @@ export function MultiPaneLayout({
     [activePanes, sessions]
   );
 
-  // モバイル時: visiblePanesが変わったらactiveMobilePaneを自動更新
-  useEffect(() => {
-    if (isMobile && visiblePanes.length > 0) {
-      if (!activeMobilePane || !visiblePanes.includes(activeMobilePane)) {
-        setActiveMobilePane(visiblePanes[0]);
-      }
-    }
-  }, [isMobile, visiblePanes, activeMobilePane]);
-
   if (visiblePanes.length === 0) {
     return null;
   }
@@ -125,25 +110,24 @@ export function MultiPaneLayout({
   const getGridClass = () => {
     const paneCount = visiblePanes.length;
 
-    if (effectiveLayoutMode === "single" || paneCount === 1) {
+    if (layoutMode === "single" || paneCount === 1) {
       return "grid-cols-1";
     }
 
     // split-2、grid-4ともに最大2列
-    return "grid-cols-1 md:grid-cols-2";
+    return "grid-cols-2";
   };
 
   return (
     <div className="h-full flex flex-col">
       {/* Layout Controls */}
-      <div className="h-12 md:h-10 border-b border-border flex items-center justify-between px-4 shrink-0 bg-sidebar">
+      <div className="h-10 border-b border-border flex items-center justify-between px-4 shrink-0 bg-sidebar">
         <div className="flex items-center gap-2">
-          <span className="text-base md:text-sm text-muted-foreground">
+          <span className="text-sm text-muted-foreground">
             {visiblePanes.length} active pane{visiblePanes.length !== 1 ? "s" : ""}
           </span>
         </div>
-        {/* Hide layout selector on mobile - always single pane */}
-        <div className="hidden md:flex items-center gap-1">
+        <div className="flex items-center gap-1">
           <Button
             variant={layoutMode === "single" ? "secondary" : "ghost"}
             size="icon"
@@ -165,94 +149,35 @@ export function MultiPaneLayout({
         </div>
       </div>
 
-      {/* Mobile: タブ切り替え式 */}
-      {isMobile ? (
-        <>
-          {/* タブバー */}
-          <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border bg-sidebar overflow-x-auto shrink-0">
-            {visiblePanes.map((sessionId) => {
-              const session = sessions.get(sessionId);
-              if (!session) return null;
-              const wt = getWorktreeForSession(session);
-              const repoName = getRepoNameForSession(session);
-              const isActive = (activeMobilePane || visiblePanes[0]) === sessionId;
-              return (
-                <button
-                  key={sessionId}
-                  type="button"
-                  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium whitespace-nowrap shrink-0 transition-colors ${
-                    isActive
-                      ? "bg-primary/20 text-primary border border-primary/30"
-                      : "text-muted-foreground hover:bg-sidebar-accent"
-                  }`}
-                  onClick={() => setActiveMobilePane(sessionId)}
-                >
-                  <div className={`w-1.5 h-1.5 rounded-full ${session.status === 'active' ? 'bg-green-500' : 'bg-muted-foreground'}`} />
-                  {repoName && <span className="text-[10px] opacity-70">{repoName}</span>}
-                  <span>{wt?.branch || getBaseName(session.worktreePath)}</span>
-                </button>
-              );
-            })}
-          </div>
-          {/* 選択中のペイン */}
-          <div className="flex-1 min-h-0 p-2">
-            {(() => {
-              const selectedId = activeMobilePane && visiblePanes.includes(activeMobilePane) ? activeMobilePane : visiblePanes[0];
-              const session = selectedId ? sessions.get(selectedId) : undefined;
-              if (!session || !selectedId) return null;
-              const worktree = getWorktreeForSession(session);
-              return (
-                <TerminalPane
-                  key={selectedId}
-                  session={session}
-                  worktree={worktree}
-                  repoName={getRepoNameForSession(session)}
-                  onSendMessage={(msg) => onSendMessage(selectedId, msg)}
-                  onSendKey={(key) => onSendKey(selectedId, key)}
-                  onStopSession={() => onStopSession(selectedId)}
-                  onClose={() => onClosePane(selectedId)}
-                  isMaximized={false}
-                  onUploadImage={(base64, mimeType) => onUploadImage?.(selectedId, base64, mimeType)}
-                  imageUploadResult={imageUploadResult}
-                  imageUploadError={imageUploadError}
-                  onClearImageUploadState={onClearImageUploadState}
-                  onCopyBuffer={onCopyBuffer ? () => onCopyBuffer(selectedId) : undefined}
-                />
-              );
-            })()}
-          </div>
-        </>
-      ) : (
-        /* Desktop: グリッド表示 */
-        <div className={`flex-1 grid ${getGridClass()} gap-3 md:gap-2 p-3 md:p-2 overflow-y-auto auto-rows-[minmax(calc(100vh_-_10rem),1fr)]`}>
-          {visiblePanes.map((sessionId) => {
-            const session = sessions.get(sessionId);
-            if (!session) return null;
+      {/* グリッド表示 */}
+      <div className={`flex-1 grid ${getGridClass()} gap-2 p-2 overflow-y-auto auto-rows-[minmax(calc(100vh_-_10rem),1fr)]`}>
+        {visiblePanes.map((sessionId) => {
+          const session = sessions.get(sessionId);
+          if (!session) return null;
 
-            const worktree = getWorktreeForSession(session);
+          const worktree = getWorktreeForSession(session);
 
-            return (
-              <TerminalPane
-                key={sessionId}
-                session={session}
-                worktree={worktree}
-                repoName={getRepoNameForSession(session)}
-                onSendMessage={(msg) => onSendMessage(sessionId, msg)}
-                onSendKey={(key) => onSendKey(sessionId, key)}
-                onStopSession={() => onStopSession(sessionId)}
-                onClose={() => onClosePane(sessionId)}
-                onMaximize={() => onMaximizePane(sessionId)}
-                isMaximized={false}
-                onUploadImage={(base64, mimeType) => onUploadImage?.(sessionId, base64, mimeType)}
-                imageUploadResult={imageUploadResult}
-                imageUploadError={imageUploadError}
-                onClearImageUploadState={onClearImageUploadState}
-                onCopyBuffer={onCopyBuffer ? () => onCopyBuffer(sessionId) : undefined}
-              />
-            );
-          })}
-        </div>
-      )}
+          return (
+            <TerminalPane
+              key={sessionId}
+              session={session}
+              worktree={worktree}
+              repoName={getRepoNameForSession(session)}
+              onSendMessage={(msg) => onSendMessage(sessionId, msg)}
+              onSendKey={(key) => onSendKey(sessionId, key)}
+              onStopSession={() => onStopSession(sessionId)}
+              onClose={() => onClosePane(sessionId)}
+              onMaximize={() => onMaximizePane(sessionId)}
+              isMaximized={false}
+              onUploadImage={(base64, mimeType) => onUploadImage?.(sessionId, base64, mimeType)}
+              imageUploadResult={imageUploadResult}
+              imageUploadError={imageUploadError}
+              onClearImageUploadState={onClearImageUploadState}
+              onCopyBuffer={onCopyBuffer ? () => onCopyBuffer(sessionId) : undefined}
+            />
+          );
+        })}
+      </div>
 
     </div>
   );

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -19,7 +19,7 @@ import { findRepoForSession } from "@/utils/sessionUtils";
 import { getBaseName } from "@/utils/pathUtils";
 import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types";
 
-type LayoutMode = "single" | "split-2" | "grid-4";
+type LayoutMode = "single" | "grid-4";
 
 interface MultiPaneLayoutProps {
   activePanes: string[]; // Session IDs
@@ -114,7 +114,7 @@ export function MultiPaneLayout({
       return "grid-cols-1";
     }
 
-    // split-2、grid-4ともに最大2列
+    // grid-4は最大2列
     return "grid-cols-2";
   };
 

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -71,12 +71,12 @@ export function TerminalPane({
   const [showInput, setShowInput] = useState(true);
   const [showQuickCommands, setShowQuickCommands] = useState(false);
 
-  // PCでは初回マウント時に入力バーを非表示にする
+  // PCでは入力バーをデフォルト非表示にする
   useEffect(() => {
     if (!isMobile) {
       setShowInput(false);
     }
-  }, []);
+  }, [isMobile]);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iframeKey, setIframeKey] = useState(0);

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -31,6 +31,7 @@ import {
   Check,
 } from "lucide-react";
 import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types";
+import { useIsMobile } from "../hooks/useMobile";
 
 interface TerminalPaneProps {
   session: ManagedSession;
@@ -65,9 +66,17 @@ export function TerminalPane({
   onClearImageUploadState,
   onCopyBuffer,
 }: TerminalPaneProps) {
+  const isMobile = useIsMobile();
   const [inputValue, setInputValue] = useState("");
   const [showInput, setShowInput] = useState(true);
   const [showQuickCommands, setShowQuickCommands] = useState(false);
+
+  // PCでは初回マウント時に入力バーを非表示にする
+  useEffect(() => {
+    if (!isMobile) {
+      setShowInput(false);
+    }
+  }, []);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iframeKey, setIframeKey] = useState(0);
@@ -274,7 +283,7 @@ export function TerminalPane({
             onClick={() => setShowInput(!showInput)}
             title={showInput ? "Hide input" : "Show input"}
           >
-            <Keyboard className="w-5 h-5 md:w-3 md:h-3" />
+            <Keyboard className={`w-5 h-5 md:w-3 md:h-3 ${showInput ? "text-primary" : ""}`} />
           </Button>
           {onMaximize && (
             <Button

--- a/client/src/hooks/useVisualViewport.ts
+++ b/client/src/hooks/useVisualViewport.ts
@@ -32,6 +32,7 @@ export function useVisualViewport(): VisualViewportState {
 
     viewport.addEventListener("resize", handleResize);
     viewport.addEventListener("scroll", handleResize);
+    handleResize();
 
     return () => {
       viewport.removeEventListener("resize", handleResize);

--- a/client/src/hooks/useVisualViewport.ts
+++ b/client/src/hooks/useVisualViewport.ts
@@ -1,0 +1,43 @@
+import { useState, useEffect } from "react";
+
+interface VisualViewportState {
+  height: number;
+  offsetTop: number;
+  isKeyboardVisible: boolean;
+}
+
+/**
+ * visualViewport APIでviewport高さとキーボード表示状態を取得するカスタムフック。
+ * Safari 13+でサポート。非対応ブラウザではwindow.innerHeightにフォールバック。
+ */
+export function useVisualViewport(): VisualViewportState {
+  const [state, setState] = useState<VisualViewportState>({
+    height: typeof window !== "undefined" ? window.innerHeight : 0,
+    offsetTop: 0,
+    isKeyboardVisible: false,
+  });
+
+  useEffect(() => {
+    const viewport = window.visualViewport;
+    if (!viewport) return;
+
+    const handleResize = () => {
+      const isKeyboardVisible = viewport.height < window.innerHeight * 0.75;
+      setState({
+        height: viewport.height,
+        offsetTop: viewport.offsetTop,
+        isKeyboardVisible,
+      });
+    };
+
+    viewport.addEventListener("resize", handleResize);
+    viewport.addEventListener("scroll", handleResize);
+
+    return () => {
+      viewport.removeEventListener("resize", handleResize);
+      viewport.removeEventListener("scroll", handleResize);
+    };
+  }, []);
+
+  return state;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -230,3 +230,15 @@
     box-shadow: 0 0 20px oklch(0.8 0.2 200 / 0.3);
   }
 }
+
+/* Safe Area utilities */
+.safe-area-top {
+  padding-top: env(safe-area-inset-top);
+}
+.safe-area-bottom {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.safe-area-x {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -231,14 +231,16 @@
   }
 }
 
-/* Safe Area utilities */
-.safe-area-top {
-  padding-top: env(safe-area-inset-top);
-}
-.safe-area-bottom {
-  padding-bottom: env(safe-area-inset-bottom);
-}
-.safe-area-x {
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
+@layer utilities {
+  /* Safe Area utilities */
+  .safe-area-top {
+    padding-top: env(safe-area-inset-top);
+  }
+  .safe-area-bottom {
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .safe-area-x {
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+  }
 }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -65,6 +65,7 @@ import { toast } from "sonner";
 import { useSocket } from "@/hooks/useSocket";
 import { MultiPaneLayout } from "@/components/MultiPaneLayout";
 import { SessionDashboard } from "@/components/SessionDashboard";
+import { MobileLayout } from "@/components/MobileLayout";
 import { RepoSelectDialog } from "@/components/RepoSelectDialog";
 import { CreateWorktreeDialog } from "@/components/CreateWorktreeDialog";
 import { isSessionBelongsToRepo, findRepoForSession } from "@/utils/sessionUtils";
@@ -668,7 +669,7 @@ export default function Dashboard() {
   );
 
   return (
-    <div className="h-screen flex flex-col md:flex-row bg-background">
+    <div className="h-[100dvh] flex flex-col md:flex-row bg-background">
       {isMobile && (
         <header className="h-14 border-b border-border flex items-center justify-between px-4 bg-sidebar shrink-0">
           <div className="flex items-center gap-3">
@@ -743,83 +744,103 @@ export default function Dashboard() {
       )}
 
       <main className="flex-1 flex flex-col min-w-0">
-        <div className="h-14 md:h-12 border-b border-border flex items-center justify-between px-4 bg-sidebar shrink-0">
-          <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as ViewMode)}>
-            <TabsList className="bg-sidebar-accent h-10 md:h-9">
-              <TabsTrigger value="dashboard" className="gap-2 h-8 md:h-7 px-3 md:px-2 text-sm md:text-xs">
-                <LayoutGrid className="w-4 h-4 md:w-4 md:h-4" />
-                <span className="hidden sm:inline">Dashboard</span>
-              </TabsTrigger>
-              <TabsTrigger value="panes" className="gap-2 h-8 md:h-7 px-3 md:px-2 text-sm md:text-xs">
-                <Columns2 className="w-4 h-4 md:w-4 md:h-4" />
-                <span className="hidden sm:inline">Panes</span>
-                {validActivePanes.length > 0 && (
-                  <span className="ml-1 text-xs bg-primary/20 text-primary px-1.5 py-0.5 rounded">
-                    {validActivePanes.length}
-                  </span>
-                )}
-              </TabsTrigger>
-            </TabsList>
-          </Tabs>
+        {isMobile ? (
+          <MobileLayout
+            sessions={sessions}
+            worktrees={worktrees}
+            repoName={repoPath ? getBaseName(repoPath) : null}
+            onStartSession={handleStartSession}
+            onStopSession={handleStopSession}
+            onSendMessage={sendMessage}
+            onSendKey={sendKey}
+            onSelectSession={handleSelectSession}
+            onUploadImage={uploadImage}
+            imageUploadResult={imageUploadResult}
+            imageUploadError={imageUploadError}
+            onClearImageUploadState={clearImageUploadState}
+            onCopyBuffer={copyBuffer}
+          />
+        ) : (
+          <>
+            <div className="h-14 md:h-12 border-b border-border flex items-center justify-between px-4 bg-sidebar shrink-0">
+              <Tabs value={viewMode} onValueChange={(v) => setViewMode(v as ViewMode)}>
+                <TabsList className="bg-sidebar-accent h-10 md:h-9">
+                  <TabsTrigger value="dashboard" className="gap-2 h-8 md:h-7 px-3 md:px-2 text-sm md:text-xs">
+                    <LayoutGrid className="w-4 h-4 md:w-4 md:h-4" />
+                    <span className="hidden sm:inline">Dashboard</span>
+                  </TabsTrigger>
+                  <TabsTrigger value="panes" className="gap-2 h-8 md:h-7 px-3 md:px-2 text-sm md:text-xs">
+                    <Columns2 className="w-4 h-4 md:w-4 md:h-4" />
+                    <span className="hidden sm:inline">Panes</span>
+                    {validActivePanes.length > 0 && (
+                      <span className="ml-1 text-xs bg-primary/20 text-primary px-1.5 py-0.5 rounded">
+                        {validActivePanes.length}
+                      </span>
+                    )}
+                  </TabsTrigger>
+                </TabsList>
+              </Tabs>
 
-          {!isConnected && (
-            <div className="flex items-center gap-2 text-destructive text-sm">
-              <AlertCircle className="w-5 h-5 md:w-4 md:h-4" />
-              <span className="hidden sm:inline">Not connected to server</span>
-            </div>
-          )}
-        </div>
-
-        <div className="flex-1 overflow-hidden">
-          {viewMode === "dashboard" ? (
-            <SessionDashboard
-              sessions={sessions}
-              onSelectSession={handleSelectSession}
-              onStopSession={handleStopSession}
-            />
-          ) : validActivePanes.length > 0 ? (
-            <MultiPaneLayout
-              activePanes={validActivePanes}
-              sessions={filteredSessions}
-              worktrees={worktrees}
-              repoList={repoList}
-              onSendMessage={sendMessage}
-              onSendKey={sendKey}
-              onStopSession={handleStopSession}
-              onClosePane={handleClosePane}
-              onMaximizePane={handleMaximizePane}
-              maximizedPane={maximizedPane}
-              onUploadImage={uploadImage}
-              imageUploadResult={imageUploadResult}
-              imageUploadError={imageUploadError}
-              onClearImageUploadState={clearImageUploadState}
-              onCopyBuffer={copyBuffer}
-            />
-          ) : (
-              <div className="h-full flex items-center justify-center p-6">
-                <div className="text-center max-w-md">
-                  <div className="w-20 h-20 md:w-16 md:h-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-6">
-                    <Terminal className="w-10 h-10 md:w-8 md:h-8 text-primary" />
-                  </div>
-                  <h2 className="text-2xl md:text-xl font-semibold mb-3 md:mb-2">No Active Panes</h2>
-                  <p className="text-base md:text-sm text-muted-foreground mb-6">
-                    {isMobile ? "Tap the menu to select a worktree and start a session." : "Start a session from the sidebar to open a chat pane."}
-                  </p>
-                  <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-base md:text-sm text-muted-foreground">
-                    <div className="flex items-center gap-2">
-                      <Play className="w-5 h-5 md:w-4 md:h-4 text-primary" />
-                      <span>Start session</span>
-                    </div>
-                    <Separator orientation="vertical" className="h-4 hidden sm:block" />
-                    <div className="flex items-center gap-2">
-                      <Plus className="w-5 h-5 md:w-4 md:h-4 text-accent" />
-                      <span>Create worktree</span>
-                    </div>
-                  </div>
+              {!isConnected && (
+                <div className="flex items-center gap-2 text-destructive text-sm">
+                  <AlertCircle className="w-5 h-5 md:w-4 md:h-4" />
+                  <span className="hidden sm:inline">Not connected to server</span>
                 </div>
-              </div>
-          )}
-        </div>
+              )}
+            </div>
+
+            <div className="flex-1 overflow-hidden">
+              {viewMode === "dashboard" ? (
+                <SessionDashboard
+                  sessions={sessions}
+                  onSelectSession={handleSelectSession}
+                  onStopSession={handleStopSession}
+                />
+              ) : validActivePanes.length > 0 ? (
+                <MultiPaneLayout
+                  activePanes={validActivePanes}
+                  sessions={filteredSessions}
+                  worktrees={worktrees}
+                  repoList={repoList}
+                  onSendMessage={sendMessage}
+                  onSendKey={sendKey}
+                  onStopSession={handleStopSession}
+                  onClosePane={handleClosePane}
+                  onMaximizePane={handleMaximizePane}
+                  maximizedPane={maximizedPane}
+                  onUploadImage={uploadImage}
+                  imageUploadResult={imageUploadResult}
+                  imageUploadError={imageUploadError}
+                  onClearImageUploadState={clearImageUploadState}
+                  onCopyBuffer={copyBuffer}
+                />
+              ) : (
+                  <div className="h-full flex items-center justify-center p-6">
+                    <div className="text-center max-w-md">
+                      <div className="w-20 h-20 md:w-16 md:h-16 rounded-2xl bg-primary/10 flex items-center justify-center mx-auto mb-6">
+                        <Terminal className="w-10 h-10 md:w-8 md:h-8 text-primary" />
+                      </div>
+                      <h2 className="text-2xl md:text-xl font-semibold mb-3 md:mb-2">No Active Panes</h2>
+                      <p className="text-base md:text-sm text-muted-foreground mb-6">
+                        Start a session from the sidebar to open a chat pane.
+                      </p>
+                      <div className="flex flex-col sm:flex-row items-center justify-center gap-4 text-base md:text-sm text-muted-foreground">
+                        <div className="flex items-center gap-2">
+                          <Play className="w-5 h-5 md:w-4 md:h-4 text-primary" />
+                          <span>Start session</span>
+                        </div>
+                        <Separator orientation="vertical" className="h-4 hidden sm:block" />
+                        <div className="flex items-center gap-2">
+                          <Plus className="w-5 h-5 md:w-4 md:h-4 text-accent" />
+                          <span>Create worktree</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+              )}
+            </div>
+          </>
+        )}
       </main>
 
       {/* ポート選択ダイアログ */}

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
     {
       name: 'claude-code-manager',
       script: 'dist/index.js',
+      cwd: '/Users/shoma/dev/github.com/ignission/claude-code-manager',
       args: '--remote',
       instances: 1,
       autorestart: true,

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -3,7 +3,7 @@ module.exports = {
     {
       name: 'claude-code-manager',
       script: 'dist/index.js',
-      cwd: '/Users/shoma/dev/github.com/ignission/claude-code-manager',
+      cwd: __dirname,
       args: '--remote',
       instances: 1,
       autorestart: true,


### PR DESCRIPTION
## 概要
- モバイル向けUIを専用コンポーネント（MobileLayout, MobileSessionList, MobileSessionView）に分離
- MultiPaneLayoutからモバイル固有ロジックを除去し、PC専用のグリッドレイアウトに簡素化
- viewport-fit=coverとSafe Area対応CSSでiPhoneノッチ対応
- PCではTerminalPaneの入力バーをデフォルト非表示に変更
- useVisualViewportフックでモバイルキーボード対応

## 変更ファイル
- `client/index.html` - viewport-fit=cover追加
- `client/src/components/MultiPaneLayout.tsx` - モバイルコード除去、PC専用化
- `client/src/components/TerminalPane.tsx` - PC初期表示で入力バー非表示
- `client/src/components/MobileLayout.tsx` - 新規：モバイル専用レイアウト
- `client/src/components/MobileSessionList.tsx` - 新規：モバイルセッション一覧
- `client/src/components/MobileSessionView.tsx` - 新規：モバイルセッション表示
- `client/src/hooks/useVisualViewport.ts` - 新規：Visual Viewport API対応フック
- `client/src/index.css` - Safe Area CSSユーティリティ追加
- `client/src/pages/Dashboard.tsx` - モバイル/PC条件分岐
- `ecosystem.config.cjs` - cwd追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile-optimized interface: session list and full-screen session view with persistent input, quick-keys, paste-image preview/upload, and improved mobile keyboard handling.
  * Viewport meta updated (viewport-fit=cover) for better safe-area behavior on notched devices.

* **Refactor**
  * Desktop layout simplified to a consistent grid rendering, removing device-specific conditional branches.

* **Style**
  * Added safe-area utility classes for notch/safe-area padding.

* **Chores**
  * Added application data path to ignore list; updated process working directory setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->