### PR TITLE
feat: ペイン状態をlocalStorageに永続化してリロード時に復元

### DIFF
--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -60,6 +60,7 @@ export function MultiPaneLayout({
 }: MultiPaneLayoutProps) {
   const [layoutMode, setLayoutMode] = useState<LayoutMode>(() => {
     try {
+      if (typeof window === "undefined") return "grid-4";
       const saved = localStorage.getItem(LAYOUT_MODE_STORAGE_KEY);
       if (saved === "single" || saved === "grid-4") {
         return saved;
@@ -70,6 +71,7 @@ export function MultiPaneLayout({
 
   useEffect(() => {
     try {
+      if (typeof window === "undefined") return;
       localStorage.setItem(LAYOUT_MODE_STORAGE_KEY, layoutMode);
     } catch {}
   }, [layoutMode]);

--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -8,7 +8,7 @@
  * - モバイル表示は MobileLayout が担当
  */
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import {
   Square,
@@ -20,6 +20,8 @@ import { getBaseName } from "@/utils/pathUtils";
 import type { ManagedSession, SpecialKey, Worktree } from "../../../shared/types";
 
 type LayoutMode = "single" | "grid-4";
+
+const LAYOUT_MODE_STORAGE_KEY = "layoutMode";
 
 interface MultiPaneLayoutProps {
   activePanes: string[]; // Session IDs
@@ -56,7 +58,21 @@ export function MultiPaneLayout({
   onClearImageUploadState,
   onCopyBuffer,
 }: MultiPaneLayoutProps) {
-  const [layoutMode, setLayoutMode] = useState<LayoutMode>("grid-4");
+  const [layoutMode, setLayoutMode] = useState<LayoutMode>(() => {
+    try {
+      const saved = localStorage.getItem(LAYOUT_MODE_STORAGE_KEY);
+      if (saved === "single" || saved === "grid-4") {
+        return saved;
+      }
+    } catch {}
+    return "grid-4";
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LAYOUT_MODE_STORAGE_KEY, layoutMode);
+    } catch {}
+  }, [layoutMode]);
 
   const getWorktreeForSession = (session: ManagedSession): Worktree | undefined => {
     return worktrees.find((w) => w.id === session.worktreeId);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -90,7 +90,7 @@ function loadClosedPanes(): Set<string> {
     if (saved) {
       const parsed = JSON.parse(saved);
       if (Array.isArray(parsed)) {
-        return new Set(parsed);
+        return new Set(parsed.filter((v): v is string => typeof v === "string"));
       }
     }
   } catch {}
@@ -218,6 +218,7 @@ export default function Dashboard() {
 
   // ユーザーが意図的に閉じたペインを追跡（useEffectによる再追加を防ぐ）
   const closedPanesRef = useRef<Set<string>>(loadClosedPanes());
+  const viewModeHydratedRef = useRef(true);
 
   const saveClosedPanes = useCallback(() => {
     try {
@@ -292,6 +293,10 @@ export default function Dashboard() {
   }, [tunnelActive, tunnelUrl]);
 
   useEffect(() => {
+    if (viewModeHydratedRef.current) {
+      viewModeHydratedRef.current = false;
+      return;
+    }
     setMaximizedPane(null);
     setSelectedWorktreeId(null);
     let totalPanes = 0;
@@ -458,6 +463,12 @@ export default function Dashboard() {
       }
     });
   }, [sessions, repoList]);
+
+  useEffect(() => {
+    if (maximizedPane && !sessions.has(maximizedPane)) {
+      setMaximizedPane(null);
+    }
+  }, [maximizedPane, sessions]);
 
   // 現在のリポジトリに属し、かつ存在するセッションのみをフィルタ
   const { filteredSessions, validActivePanes } = useMemo(() => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -79,6 +79,23 @@ const SIDEBAR_MIN_WIDTH = 200;
 const SIDEBAR_MAX_WIDTH = 400;
 const SIDEBAR_DEFAULT_WIDTH = 320;
 const SIDEBAR_WIDTH_STORAGE_KEY = "sidebar-width";
+const ACTIVE_PANES_STORAGE_KEY = "activePanesPerRepo";
+const VIEW_MODE_STORAGE_KEY = "viewMode";
+const MAXIMIZED_PANE_STORAGE_KEY = "maximizedPane";
+const CLOSED_PANES_STORAGE_KEY = "closedPanes";
+
+function loadClosedPanes(): Set<string> {
+  try {
+    const saved = localStorage.getItem(CLOSED_PANES_STORAGE_KEY);
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      if (Array.isArray(parsed)) {
+        return new Set(parsed);
+      }
+    }
+  } catch {}
+  return new Set();
+}
 
 export default function Dashboard() {
   const {
@@ -168,12 +185,63 @@ export default function Dashboard() {
     };
   }, [isResizing, sidebarWidth]);
 
-  const [viewMode, setViewMode] = useState<ViewMode>("dashboard");
-  const [activePanesPerRepo, setActivePanesPerRepo] = useState<Map<string, string[]>>(new Map());
-  const [maximizedPane, setMaximizedPane] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    try {
+      const saved = localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+      if (saved === "dashboard" || saved === "panes") {
+        return saved;
+      }
+    } catch {}
+    return "dashboard";
+  });
+  const [activePanesPerRepo, setActivePanesPerRepo] = useState<Map<string, string[]>>(() => {
+    try {
+      const saved = localStorage.getItem(ACTIVE_PANES_STORAGE_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        if (Array.isArray(parsed)) {
+          return new Map(parsed);
+        }
+      }
+    } catch {}
+    return new Map();
+  });
+  const [maximizedPane, setMaximizedPane] = useState<string | null>(() => {
+    try {
+      const saved = localStorage.getItem(MAXIMIZED_PANE_STORAGE_KEY);
+      if (saved) {
+        return JSON.parse(saved);
+      }
+    } catch {}
+    return null;
+  });
 
   // ユーザーが意図的に閉じたペインを追跡（useEffectによる再追加を防ぐ）
-  const closedPanesRef = useRef<Set<string>>(new Set());
+  const closedPanesRef = useRef<Set<string>>(loadClosedPanes());
+
+  const saveClosedPanes = useCallback(() => {
+    try {
+      localStorage.setItem(CLOSED_PANES_STORAGE_KEY, JSON.stringify(Array.from(closedPanesRef.current)));
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(ACTIVE_PANES_STORAGE_KEY, JSON.stringify(Array.from(activePanesPerRepo.entries())));
+    } catch {}
+  }, [activePanesPerRepo]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
+    } catch {}
+  }, [viewMode]);
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(MAXIMIZED_PANE_STORAGE_KEY, JSON.stringify(maximizedPane));
+    } catch {}
+  }, [maximizedPane]);
 
   // 現在のリポジトリのactivePanesを取得
   const activePanes = repoPath ? (activePanesPerRepo.get(repoPath) || []) : [];
@@ -263,6 +331,7 @@ export default function Dashboard() {
     const session = getSessionForWorktree(worktree.id);
     if (session) {
       closedPanesRef.current.add(session.id);
+      saveClosedPanes();
       const targetRepo = findRepoForSession(session, repoList);
       removeSessionFromPanes(session.id, targetRepo);
       if (maximizedPane === session.id) {
@@ -279,6 +348,7 @@ export default function Dashboard() {
     if (existingSession) {
       // ユーザーが明示的に開くので、closedPanesから除外
       closedPanesRef.current.delete(existingSession.id);
+      saveClosedPanes();
       // Add to active panes if not already there
       if (!activePanes.includes(existingSession.id)) {
         setActivePanes((prev) => [...prev, existingSession.id]);
@@ -328,6 +398,7 @@ export default function Dashboard() {
 
     // ユーザーが明示的に開くので、closedPanesから除外
     closedPanesRef.current.delete(sessionId);
+    saveClosedPanes();
 
     // セッションが属するリポジトリを特定
     const targetRepo = findRepoForSession(session, repoList);
@@ -355,6 +426,7 @@ export default function Dashboard() {
   const handleClosePane = (sessionId: string) => {
     // ユーザーが意図的に閉じたペインとして記録
     closedPanesRef.current.add(sessionId);
+    saveClosedPanes();
     const session = sessions.get(sessionId);
     const targetRepo = session ? findRepoForSession(session, repoList) : null;
     removeSessionFromPanes(sessionId, targetRepo);


### PR DESCRIPTION
## 概要

ブラウザリロード時にペイン状態が失われ、毎回worktreeを開き直す必要がある問題を解決します。

## 変更内容

localStorageに以下の状態を保存・復元するようにしました:

| 状態 | localStorageキー | 説明 |
|------|------------------|------|
| `activePanesPerRepo` | `activePanesPerRepo` | リポジトリごとの開いているペイン |
| `viewMode` | `viewMode` | Dashboard/Panesの表示モード |
| `maximizedPane` | `maximizedPane` | 最大化中のペインID |
| `closedPanesRef` | `closedPanes` | ユーザーが閉じたペイン（自動復帰防止用） |
| `layoutMode` | `layoutMode` | single/grid-4のレイアウト |

## 変更ファイル

- `client/src/pages/Dashboard.tsx` - 5つの状態の保存・復元ロジック追加
- `client/src/components/MultiPaneLayout.tsx` - layoutModeの保存・復元ロジック追加

## 設計判断

- 既存の`sidebar-width`と同じlocalStorageパターンを踏襲
- Map/Setはエントリ配列としてJSON変換
- try/catchでlocalStorageエラーを握りつぶし（プライベートブラウジング対策）
- 無効な保存値はデフォルト値にフォールバック
- サーバーに存在しないセッションの除外は既存の`validActivePanes`フィルタリングに委任

## テスト方法

1. ペインを複数開いた状態でリロード → 同じペインが復元される
2. maximizedPaneの状態がリロード後も維持される
3. layoutMode（single/grid-4）がリロード後も維持される
4. 閉じたペインがリロード後に自動復帰しない
5. localStorageが空/不正な値 → デフォルト値にフォールバック

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Layout preferences now persist across page reloads and automatically restore your last selected layout mode; invalid or unreadable settings fall back to a sensible default.
  * Dashboard UI state is now saved and restored, including active panes per repository, view mode, maximized pane selection, and closed panes. State changes are durably persisted so your workspace is retained across sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->