### PR TITLE
feat: Worktreeアクションを右クリックメニュー/三点メニューに変更

### DIFF
--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -16,6 +16,7 @@ interface MobileLayoutProps {
   repoName: string | null;
   onStartSession: (worktree: Worktree) => void;
   onStopSession: (sessionId: string) => void;
+  onDeleteWorktree: (worktree: Worktree) => void;
   onSendMessage: (sessionId: string, message: string) => void;
   onSendKey: (sessionId: string, key: SpecialKey) => void;
   onSelectSession: (sessionId: string) => void;
@@ -32,6 +33,7 @@ export function MobileLayout({
   repoName,
   onStartSession,
   onStopSession,
+  onDeleteWorktree,
   onSendMessage,
   onSendKey,
   onSelectSession,
@@ -86,6 +88,7 @@ export function MobileLayout({
           onOpenSession={handleOpenSession}
           onStartSession={onStartSession}
           onStopSession={onStopSession}
+          onDeleteWorktree={onDeleteWorktree}
         />
       </div>
 

--- a/client/src/components/MobileSessionList.tsx
+++ b/client/src/components/MobileSessionList.tsx
@@ -95,27 +95,27 @@ export function MobileSessionList({
                 <div className="shrink-0">
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" className="h-10 w-10">
+                      <Button variant="ghost" size="icon" className="h-10 w-10" aria-label="Worktree actions">
                         <MoreVertical className="w-5 h-5" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end" className="w-48">
                       {session ? (
                         <>
-                          <DropdownMenuItem onClick={() => onOpenSession(session.id)}>
+                          <DropdownMenuItem onSelect={() => onOpenSession(session.id)}>
                             <MessageSquare className="w-4 h-4 mr-2" />
                             セッションを開く
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             className="text-destructive focus:text-destructive"
-                            onClick={() => onStopSession(session.id)}
+                            onSelect={() => onStopSession(session.id)}
                           >
                             <Square className="w-4 h-4 mr-2" />
                             セッションを停止
                           </DropdownMenuItem>
                         </>
                       ) : (
-                        <DropdownMenuItem onClick={() => onStartSession(worktree)}>
+                        <DropdownMenuItem onSelect={() => onStartSession(worktree)}>
                           <Play className="w-4 h-4 mr-2" />
                           セッションを開始
                         </DropdownMenuItem>
@@ -125,7 +125,7 @@ export function MobileSessionList({
                           <DropdownMenuSeparator />
                           <DropdownMenuItem
                             className="text-destructive focus:text-destructive"
-                            onClick={() => setDeleteTarget(worktree)}
+                            onSelect={() => setDeleteTarget(worktree)}
                           >
                             <Trash2 className="w-4 h-4 mr-2" />
                             Worktreeを削除

--- a/client/src/components/MobileSessionList.tsx
+++ b/client/src/components/MobileSessionList.tsx
@@ -5,9 +5,26 @@
  * タップターゲットは最低48pxを確保。
  */
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
-import { GitBranch, Play, Square } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { GitBranch, Play, Square, MessageSquare, Trash2, MoreVertical } from "lucide-react";
 import type { ManagedSession, Worktree } from "../../../shared/types";
 
 interface MobileSessionListProps {
@@ -17,6 +34,7 @@ interface MobileSessionListProps {
   onOpenSession: (sessionId: string) => void;
   onStartSession: (worktree: Worktree) => void;
   onStopSession: (sessionId: string) => void;
+  onDeleteWorktree: (worktree: Worktree) => void;
 }
 
 export function MobileSessionList({
@@ -26,7 +44,9 @@ export function MobileSessionList({
   onOpenSession,
   onStartSession,
   onStopSession,
+  onDeleteWorktree,
 }: MobileSessionListProps) {
+  const [deleteTarget, setDeleteTarget] = useState<Worktree | null>(null);
   const sessionByWorktreeId = useMemo(() => {
     const map = new Map<string, ManagedSession>();
     sessions.forEach((session) => {
@@ -72,35 +92,48 @@ export function MobileSessionList({
                     </span>
                   )}
                 </div>
-                <div className="flex items-center gap-2 shrink-0">
-                  {session ? (
-                    <>
-                      <Button
-                        size="sm"
-                        className="h-10 px-4"
-                        onClick={() => onOpenSession(session.id)}
-                      >
-                        Open
+                <div className="shrink-0">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon" className="h-10 w-10">
+                        <MoreVertical className="w-5 h-5" />
                       </Button>
-                      <Button
-                        size="sm"
-                        variant="destructive"
-                        className="h-10 px-3"
-                        onClick={() => onStopSession(session.id)}
-                      >
-                        <Square className="w-4 h-4" />
-                      </Button>
-                    </>
-                  ) : (
-                    <Button
-                      size="sm"
-                      variant="outline"
-                      className="h-10 px-4"
-                      onClick={() => onStartSession(worktree)}
-                    >
-                      <Play className="w-4 h-4 mr-1" /> Start
-                    </Button>
-                  )}
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end" className="w-48">
+                      {session ? (
+                        <>
+                          <DropdownMenuItem onClick={() => onOpenSession(session.id)}>
+                            <MessageSquare className="w-4 h-4 mr-2" />
+                            セッションを開く
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => onStopSession(session.id)}
+                          >
+                            <Square className="w-4 h-4 mr-2" />
+                            セッションを停止
+                          </DropdownMenuItem>
+                        </>
+                      ) : (
+                        <DropdownMenuItem onClick={() => onStartSession(worktree)}>
+                          <Play className="w-4 h-4 mr-2" />
+                          セッションを開始
+                        </DropdownMenuItem>
+                      )}
+                      {!worktree.isMain && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="text-destructive focus:text-destructive"
+                            onClick={() => setDeleteTarget(worktree)}
+                          >
+                            <Trash2 className="w-4 h-4 mr-2" />
+                            Worktreeを削除
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               </div>
             </div>
@@ -112,6 +145,29 @@ export function MobileSessionList({
           </div>
         )}
       </div>
+
+      <AlertDialog open={deleteTarget !== null} onOpenChange={(open) => { if (!open) setDeleteTarget(null); }}>
+        <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Worktreeを削除</AlertDialogTitle>
+            <AlertDialogDescription>
+              このWorktreeを削除しますか？関連するブランチも削除されます。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
+            <AlertDialogCancel className="h-12">キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12"
+              onClick={() => {
+                if (deleteTarget) onDeleteWorktree(deleteTarget);
+                setDeleteTarget(null);
+              }}
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/client/src/components/WorktreeContextMenu.tsx
+++ b/client/src/components/WorktreeContextMenu.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { useIsMobile } from "@/hooks/useMobile";
+import { MessageSquare, Play, Square, Trash2, MoreVertical } from "lucide-react";
+import type { Worktree, ManagedSession } from "../../../shared/types";
+
+interface WorktreeContextMenuProps {
+  children: React.ReactNode;
+  worktree: Worktree;
+  session: ManagedSession | undefined;
+  onStartSession: (worktree: Worktree) => void;
+  onStopSession: (sessionId: string) => void;
+  onSelectSession: (sessionId: string) => void;
+  onDeleteWorktree: (worktree: Worktree) => void;
+}
+
+export function WorktreeContextMenu({
+  children,
+  worktree,
+  session,
+  onStartSession,
+  onStopSession,
+  onSelectSession,
+  onDeleteWorktree,
+}: WorktreeContextMenuProps) {
+  const isMobile = useIsMobile();
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  const deleteDialog = (
+    <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+      <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Worktreeを削除</AlertDialogTitle>
+          <AlertDialogDescription>
+            このWorktreeを削除しますか？関連するブランチも削除されます。
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
+          <AlertDialogCancel className="h-12 md:h-10">キャンセル</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
+            onClick={() => {
+              onDeleteWorktree(worktree);
+              setShowDeleteDialog(false);
+            }}
+          >
+            削除
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="flex items-center">
+        <div className="flex-1 min-w-0">
+          {children}
+        </div>
+        <div className="shrink-0">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-10 w-10"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <MoreVertical className="w-5 h-5" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+              {session ? (
+                <>
+                  <DropdownMenuItem onClick={() => onSelectSession(session.id)}>
+                    <MessageSquare className="w-4 h-4 mr-2" />
+                    セッションを開く
+                  </DropdownMenuItem>
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => onStopSession(session.id)}
+                  >
+                    <Square className="w-4 h-4 mr-2" />
+                    セッションを停止
+                  </DropdownMenuItem>
+                </>
+              ) : (
+                <DropdownMenuItem onClick={() => onStartSession(worktree)}>
+                  <Play className="w-4 h-4 mr-2" />
+                  セッションを開始
+                </DropdownMenuItem>
+              )}
+              {!worktree.isMain && (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => setShowDeleteDialog(true)}
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Worktreeを削除
+                  </DropdownMenuItem>
+                </>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+        {deleteDialog}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          {children}
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-48">
+          {session ? (
+            <>
+              <ContextMenuItem onClick={() => onSelectSession(session.id)}>
+                <MessageSquare className="w-4 h-4 mr-2" />
+                セッションを開く
+              </ContextMenuItem>
+              <ContextMenuItem
+                className="text-destructive focus:text-destructive"
+                onClick={() => onStopSession(session.id)}
+              >
+                <Square className="w-4 h-4 mr-2" />
+                セッションを停止
+              </ContextMenuItem>
+            </>
+          ) : (
+            <ContextMenuItem onClick={() => onStartSession(worktree)}>
+              <Play className="w-4 h-4 mr-2" />
+              セッションを開始
+            </ContextMenuItem>
+          )}
+          {!worktree.isMain && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                className="text-destructive focus:text-destructive"
+                onClick={() => setShowDeleteDialog(true)}
+              >
+                <Trash2 className="w-4 h-4 mr-2" />
+                Worktreeを削除
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+      {deleteDialog}
+    </>
+  );
+}

--- a/client/src/components/WorktreeContextMenu.tsx
+++ b/client/src/components/WorktreeContextMenu.tsx
@@ -88,6 +88,7 @@ export function WorktreeContextMenu({
                 variant="ghost"
                 size="icon"
                 className="h-10 w-10"
+                aria-label="Worktree actions"
                 onClick={(e) => e.stopPropagation()}
               >
                 <MoreVertical className="w-5 h-5" />
@@ -96,20 +97,20 @@ export function WorktreeContextMenu({
             <DropdownMenuContent align="end" className="w-48">
               {session ? (
                 <>
-                  <DropdownMenuItem onClick={() => onSelectSession(session.id)}>
+                  <DropdownMenuItem onSelect={() => onSelectSession(session.id)}>
                     <MessageSquare className="w-4 h-4 mr-2" />
                     セッションを開く
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"
-                    onClick={() => onStopSession(session.id)}
+                    onSelect={() => onStopSession(session.id)}
                   >
                     <Square className="w-4 h-4 mr-2" />
                     セッションを停止
                   </DropdownMenuItem>
                 </>
               ) : (
-                <DropdownMenuItem onClick={() => onStartSession(worktree)}>
+                <DropdownMenuItem onSelect={() => onStartSession(worktree)}>
                   <Play className="w-4 h-4 mr-2" />
                   セッションを開始
                 </DropdownMenuItem>
@@ -119,7 +120,7 @@ export function WorktreeContextMenu({
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"
-                    onClick={() => setShowDeleteDialog(true)}
+                    onSelect={() => setShowDeleteDialog(true)}
                   >
                     <Trash2 className="w-4 h-4 mr-2" />
                     Worktreeを削除
@@ -143,20 +144,20 @@ export function WorktreeContextMenu({
         <ContextMenuContent className="w-48">
           {session ? (
             <>
-              <ContextMenuItem onClick={() => onSelectSession(session.id)}>
+              <ContextMenuItem onSelect={() => onSelectSession(session.id)}>
                 <MessageSquare className="w-4 h-4 mr-2" />
                 セッションを開く
               </ContextMenuItem>
               <ContextMenuItem
                 className="text-destructive focus:text-destructive"
-                onClick={() => onStopSession(session.id)}
+                onSelect={() => onStopSession(session.id)}
               >
                 <Square className="w-4 h-4 mr-2" />
                 セッションを停止
               </ContextMenuItem>
             </>
           ) : (
-            <ContextMenuItem onClick={() => onStartSession(worktree)}>
+            <ContextMenuItem onSelect={() => onStartSession(worktree)}>
               <Play className="w-4 h-4 mr-2" />
               セッションを開始
             </ContextMenuItem>
@@ -166,7 +167,7 @@ export function WorktreeContextMenu({
               <ContextMenuSeparator />
               <ContextMenuItem
                 className="text-destructive focus:text-destructive"
-                onClick={() => setShowDeleteDialog(true)}
+                onSelect={() => setShowDeleteDialog(true)}
               >
                 <Trash2 className="w-4 h-4 mr-2" />
                 Worktreeを削除

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -11,17 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import { WorktreeContextMenu } from "@/components/WorktreeContextMenu";
 import {
   Sheet,
   SheetContent,
@@ -44,9 +34,7 @@ import {
   Plus,
   FolderOpen,
   Play,
-  Square,
   Trash2,
-  MessageSquare,
   Terminal,
   Settings,
   Wifi,
@@ -521,22 +509,35 @@ export default function Dashboard() {
               const isInPane = session && activePanes.includes(session.id);
 
               return (
-                <div
+                <WorktreeContextMenu
                   key={worktree.id}
-                  className={`group p-4 md:p-3 rounded-lg cursor-pointer transition-all ${
-                    isInPane
-                      ? "bg-sidebar-accent border border-primary/30"
-                      : isSelected
-                      ? "bg-sidebar-accent"
-                      : "hover:bg-sidebar-accent/50 active:bg-sidebar-accent/70"
-                  }`}
-                  onClick={() => {
-                    setSelectedWorktreeId(worktree.id);
-                    handleStartSession(worktree);
+                  worktree={worktree}
+                  session={session}
+                  onStartSession={(w) => {
+                    handleStartSession(w);
                     if (isMobile) setSidebarOpen(false);
                   }}
+                  onStopSession={handleStopSession}
+                  onSelectSession={(sessionId) => {
+                    handleSelectSession(sessionId);
+                    if (isMobile) setSidebarOpen(false);
+                  }}
+                  onDeleteWorktree={handleDeleteWorktree}
                 >
-                  <div className="flex items-center justify-between">
+                  <div
+                    className={`group p-4 md:p-3 rounded-lg cursor-pointer transition-all ${
+                      isInPane
+                        ? "bg-sidebar-accent border border-primary/30"
+                        : isSelected
+                        ? "bg-sidebar-accent"
+                        : "hover:bg-sidebar-accent/50 active:bg-sidebar-accent/70"
+                    }`}
+                    onClick={() => {
+                      setSelectedWorktreeId(worktree.id);
+                      handleStartSession(worktree);
+                      if (isMobile) setSidebarOpen(false);
+                    }}
+                  >
                     <div className="flex items-center gap-2 min-w-0">
                       {session && (
                         <div
@@ -554,81 +555,8 @@ export default function Dashboard() {
                         </span>
                       )}
                     </div>
-                    <div className="flex items-center gap-1 shrink-0">
-                      {session ? (
-                        <>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-10 w-10 md:h-6 md:w-6"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleSelectSession(session.id);
-                              if (isMobile) setSidebarOpen(false);
-                            }}
-                          >
-                            <MessageSquare className="w-5 h-5 md:w-3 md:h-3" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-10 w-10 md:h-6 md:w-6 text-destructive"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleStopSession(session.id);
-                            }}
-                          >
-                            <Square className="w-5 h-5 md:w-3 md:h-3" />
-                          </Button>
-                        </>
-                      ) : (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="h-10 w-10 md:h-6 md:w-6 text-primary"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            handleStartSession(worktree);
-                            if (isMobile) setSidebarOpen(false);
-                          }}
-                        >
-                          <Play className="w-5 h-5 md:w-3 md:h-3" />
-                        </Button>
-                      )}
-                      {!worktree.isMain && (
-                        <AlertDialog>
-                          <AlertDialogTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-10 w-10 md:h-6 md:w-6 text-destructive"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <Trash2 className="w-5 h-5 md:w-3 md:h-3" />
-                            </Button>
-                          </AlertDialogTrigger>
-                          <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
-                            <AlertDialogHeader>
-                              <AlertDialogTitle>Delete Worktree</AlertDialogTitle>
-                              <AlertDialogDescription>
-                                Are you sure you want to delete this worktree? This will also delete the associated branch.
-                              </AlertDialogDescription>
-                            </AlertDialogHeader>
-                            <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
-                              <AlertDialogCancel className="h-12 md:h-10">Cancel</AlertDialogCancel>
-                              <AlertDialogAction
-                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
-                                onClick={() => handleDeleteWorktree(worktree)}
-                              >
-                                Delete
-                              </AlertDialogAction>
-                            </AlertDialogFooter>
-                          </AlertDialogContent>
-                        </AlertDialog>
-                      )}
-                    </div>
                   </div>
-                </div>
+                </WorktreeContextMenu>
               );
             })}
           </div>
@@ -751,6 +679,7 @@ export default function Dashboard() {
             repoName={repoPath ? getBaseName(repoPath) : null}
             onStartSession={handleStartSession}
             onStopSession={handleStopSession}
+            onDeleteWorktree={handleDeleteWorktree}
             onSendMessage={sendMessage}
             onSendKey={sendKey}
             onSelectSession={handleSelectSession}


### PR DESCRIPTION
## 概要

Worktreeアイテムのインラインボタン（開始/停止/削除）を、デスクトップでは右クリックコンテキストメニュー、モバイルでは三点ドットメニューに変更し、UIを簡潔にした。

## 変更内容

- **WorktreeContextMenu.tsx（新規）**: `useIsMobile()`でデスクトップ/モバイルを自動切替する統合コンポーネント
  - デスクトップ: 右クリック → ContextMenu
  - モバイル: MoreVerticalボタン → DropdownMenu
  - 削除確認のAlertDialogはstate制御方式に変更
- **Dashboard.tsx**: サイドバーのインラインボタン群を削除し、WorktreeContextMenuでラップ
- **MobileSessionList.tsx**: インラインボタンを三点メニューに変更、削除確認AlertDialog追加
- **MobileLayout.tsx**: onDeleteWorktree propのパススルー追加

## メニュー項目

| 条件 | メニュー項目 |
|------|------------|
| セッション存在時 | セッションを開く / セッションを停止 |
| セッション非存在時 | セッションを開始 |
| mainブランチ以外 | Worktreeを削除（確認ダイアログ付き） |

## テスト方法

- [ ] デスクトップ: worktree行を右クリック → コンテキストメニュー表示
- [ ] デスクトップ: 左クリックが引き続きセッション開始/選択として動作
- [ ] デスクトップ: 「Worktreeを削除」→ AlertDialog表示 → キャンセル/実行
- [ ] モバイル: 三点ボタンタップ → DropdownMenu表示
- [ ] セッション有無でメニュー項目が正しく切り替わること
- [ ] mainブランチでは削除項目が非表示であること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to delete worktrees with confirmation dialog for safety
  * Implemented dropdown menus (mobile) and context menus (desktop) for organizing worktree actions
  * Consolidated worktree operations (open, start, stop, delete) into unified action menus

<!-- end of auto-generated comment: release notes by coderabbit.ai -->