### PR TITLE
fix: モバイルでスクロールできない問題を修正

### DIFF
--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -74,11 +74,11 @@ export function MobileLayout({
   };
 
   return (
-    <div className="h-full flex flex-col">
+    <div className="h-full flex flex-col min-h-0">
       {/* 一覧画面 */}
       <div
         className={
-          activeView === "list" ? "flex-1 flex flex-col" : "hidden"
+          activeView === "list" ? "flex-1 flex flex-col min-h-0" : "hidden"
         }
       >
         <MobileSessionList
@@ -98,7 +98,7 @@ export function MobileLayout({
           key={sessionId}
           className={
             activeView === "detail" && selectedSessionId === sessionId
-              ? "flex-1 flex flex-col"
+              ? "flex-1 flex flex-col min-h-0"
               : "hidden"
           }
         >

--- a/client/src/components/MobileSessionList.tsx
+++ b/client/src/components/MobileSessionList.tsx
@@ -60,7 +60,7 @@ export function MobileSessionList({
   };
 
   return (
-    <div className="flex-1 flex flex-col safe-area-x">
+    <div className="flex-1 flex flex-col min-h-0 safe-area-x">
       {/* リポジトリ名表示 */}
       {repoName && (
         <div className="px-4 py-2 border-b border-border/50">
@@ -69,7 +69,7 @@ export function MobileSessionList({
       )}
 
       {/* ワークツリーリスト */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+      <div className="flex-1 overflow-y-auto min-h-0 p-4 space-y-3">
         {worktrees.map((worktree) => {
           const session = getSessionForWorktree(worktree.id);
           return (

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -204,7 +204,7 @@ export function MobileSessionView({
 
   return (
     <div
-      className="flex-1 flex flex-col safe-area-x"
+      className="flex-1 flex flex-col min-h-0 safe-area-x"
       style={isKeyboardVisible ? { height: `${viewportHeight}px`, maxHeight: `${viewportHeight}px` } : undefined}
     >
       {/* ヘッダー: 戻る、ブランチ名、Opsドロップダウン、Stopボタン */}


### PR DESCRIPTION
## 概要

モバイルビューでコンテンツのスクロールができない問題を修正しました。

## 原因

フレックスボックスのネスト構造で `flex-1` を使用する際、`min-height` のデフォルト値が `auto`（コンテンツサイズ）になるため、子要素が親の高さを超えても縮小されず `overflow-y-auto` が機能しない状態でした。

## 修正内容

フレックスコンテナに `min-h-0`（`min-height: 0`）を追加し、スクロール領域の高さが正しく確定するようにしました。

| ファイル | 修正箇所数 |
|---------|-----------|
| `MobileLayout.tsx` | 3箇所（ルート要素、一覧/詳細ラッパー） |
| `MobileSessionList.tsx` | 2箇所（ルート要素、ワークツリーリスト） |
| `MobileSessionView.tsx` | 1箇所（ルート要素） |

## テスト

- [ ] モバイルデバイスまたはDevToolsでセッション一覧のスクロール確認
- [ ] チャット画面のメッセージスクロール確認
- [ ] キーボード表示時のスクロール動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile layout rendering issues where flex containers could shrink below their content height, causing improper display of the session list and detail views. Updated layout constraints across multiple mobile components to ensure consistent rendering and proper element sizing when toggling between different views on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->