### PR TITLE
feat: モバイルターミナルのスワイプスクロール対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 .env.local
 .env.development.local
 .env.test.local
+.env.production
 .env.production.local
 
 # IDE and editor files

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -74,7 +74,7 @@ export function MobileLayout({
   };
 
   return (
-    <div className="h-full flex flex-col min-h-0 overflow-clip">
+    <div className="h-full flex flex-col min-h-0 overflow-hidden">
       {/* 一覧画面 */}
       <div
         className={

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -193,6 +193,48 @@ export function MobileSessionView({
     }
   };
 
+  // スワイプスクロールモード
+  const [scrollMode, setScrollMode] = useState(false);
+  const swipeStateRef = useRef<{ startY: number; sentLines: number } | null>(null);
+  const LINE_HEIGHT = 20; // 1行あたりのpx閾値
+
+  // スクロールモードON時にcopy-modeに入り、OFF時にqで抜ける
+  const toggleScrollMode = useCallback(() => {
+    if (scrollMode) {
+      onSendKey("q");
+      setScrollMode(false);
+    } else {
+      onSendKey("copy-mode");
+      setScrollMode(true);
+    }
+  }, [scrollMode, onSendKey]);
+
+  const handleOverlayTouchStart = useCallback((e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    swipeStateRef.current = { startY: touch.clientY, sentLines: 0 };
+  }, []);
+
+  const handleOverlayTouchMove = useCallback((e: React.TouchEvent) => {
+    const state = swipeStateRef.current;
+    if (!state) return;
+    e.preventDefault();
+    const touch = e.touches[0];
+    const deltaY = state.startY - touch.clientY;
+    const totalLines = Math.floor(Math.abs(deltaY) / LINE_HEIGHT);
+    const newLines = totalLines - state.sentLines;
+    if (newLines > 0) {
+      const key: SpecialKey = deltaY > 0 ? "scroll-up" : "scroll-down";
+      for (let i = 0; i < newLines; i++) {
+        onSendKey(key);
+      }
+      state.sentLines = totalLines;
+    }
+  }, [onSendKey]);
+
+  const handleOverlayTouchEnd = useCallback(() => {
+    swipeStateRef.current = null;
+  }, []);
+
   // スラッシュコマンド
   const slashCommands = [
     { label: "/resume", cmd: "/resume" },
@@ -276,16 +318,29 @@ export function MobileSessionView({
         </div>
       </header>
 
-      {/* ttyd iframe（残り全スペース） */}
-      <div className="flex-1 min-h-0 bg-[#1a1b26] overflow-hidden">
+      {/* ttyd iframe + スクロールモード時のオーバーレイ */}
+      <div className="flex-1 min-h-0 bg-[#1a1b26] overflow-hidden relative">
         {session.ttydUrl || session.ttydPort ? (
-          <iframe
-            key={iframeKey}
-            src={ttydIframeSrc}
-            className="w-full h-full border-0"
-            title={`Terminal - ${worktree?.branch || session.id}`}
-            allow="clipboard-read; clipboard-write; keyboard-map"
-          />
+          <>
+            <iframe
+              key={iframeKey}
+              src={ttydIframeSrc}
+              className="w-full h-full border-0"
+              title={`Terminal - ${worktree?.branch || session.id}`}
+              allow="clipboard-read; clipboard-write; keyboard-map"
+            />
+            {/* スクロールモード中のみ表示されるスワイプ検出オーバーレイ */}
+            {scrollMode && (
+              <div
+                className="absolute inset-0 bg-primary/5"
+                style={{ touchAction: "none" }}
+                onTouchStart={handleOverlayTouchStart}
+                onTouchMove={handleOverlayTouchMove}
+                onTouchEnd={handleOverlayTouchEnd}
+                onTouchCancel={handleOverlayTouchEnd}
+              />
+            )}
+          </>
         ) : (
           <div className="flex items-center justify-center h-full text-muted-foreground">
             <div className="text-center">
@@ -347,8 +402,21 @@ export function MobileSessionView({
         </div>
       )}
 
-      {/* Quick Keys: y/n/Esc/Ctrl+C/S-Tab 常時表示 */}
-      <div className="flex items-center gap-1 px-3 py-1.5 border-t border-border/50 bg-sidebar overflow-x-auto">
+      {/* Quick Keys: スクロールモードトグル + y/n/Esc/Ctrl+C/S-Tab 常時表示 */}
+      <div className="flex items-center gap-1 px-3 py-1.5 border-t border-border/50 bg-sidebar overflow-x-auto select-none">
+        {/* スクロールモードトグル: ON=スワイプでスクロール、OFF=通常操作 */}
+        <Button
+          type="button"
+          variant={scrollMode ? "default" : "ghost"}
+          size="sm"
+          className={`h-8 px-3 text-xs shrink-0 ${scrollMode ? "bg-primary text-primary-foreground" : ""}`}
+          onClick={toggleScrollMode}
+        >
+          {scrollMode ? "Scroll ✓" : "Scroll"}
+        </Button>
+        {/* 区切り線 */}
+        <div className="w-px h-5 bg-border/50 mx-1" />
+        {/* 既存のQuick Keys */}
         <Button
           type="button"
           variant="ghost"

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -17,7 +17,6 @@ import {
   Maximize2,
   Minimize2,
   Send,
-  CornerDownLeft,
   StopCircle,
   GitBranch,
   Keyboard,
@@ -320,7 +319,7 @@ export function TerminalPane({
       </header>
 
       {/* ttyd iframe */}
-      <div className="flex-1 min-h-0 bg-[#1a1b26]">
+      <div className="flex-1 min-h-0 bg-[#1a1b26] overflow-hidden">
         {session.ttydUrl || session.ttydPort ? (
           <iframe
             key={iframeKey}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -131,12 +131,12 @@
     @apply bg-background text-foreground;
     font-family: "Inter", system-ui, -apple-system, sans-serif;
     height: 100dvh;
-    overflow: clip;
+    overflow: hidden;
     overscroll-behavior: none;
   }
   #root {
     height: 100%;
-    overflow: clip;
+    overflow: hidden;
   }
   button:not(:disabled),
   [role="button"]:not([aria-disabled="true"]),

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -4,6 +4,7 @@ module.exports = {
       name: 'claude-code-manager',
       script: 'dist/index.js',
       cwd: __dirname,
+      node_args: '--env-file=.env.production',
       args: '--remote',
       instances: 1,
       autorestart: true,
@@ -11,7 +12,6 @@ module.exports = {
       env: {
         NODE_ENV: 'production',
       },
-      env_file: '.env.production',
       out_file: 'logs/out.log',
       error_file: 'logs/error.log',
       log_date_format: 'YYYY-MM-DD HH:mm:ss',

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "license": "MIT",
+  "engines": {
+    "node": ">=20.6.0"
+  },
   "scripts": {
     "dev": "vite --host",
     "dev:server": "tsx watch server/index.ts",

--- a/server/index.ts
+++ b/server/index.ts
@@ -402,7 +402,7 @@ async function startServer() {
 
     // ===== Session Orchestrator Event Handlers =====
     // sessionOrchestrator のイベントをそのまま Socket.IO クライアントへ転送する
-    const forwardedEvents = ["session:created", "session:restored", "session:stopped"] as const;
+    const forwardedEvents = ["session:created", "session:restored", "session:stopped", "session:updated"] as const;
     type ForwardedEvent = (typeof forwardedEvents)[number];
 
     const forwardHandlers = new Map<ForwardedEvent, (...args: unknown[]) => void>();

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -55,10 +55,14 @@ export class SessionOrchestrator extends EventEmitter {
         );
       }
 
-      // ttydも自動起動
+      // ttydも自動起動（起動完了後にクライアントへ通知）
       ttydManager.startInstance(tmuxSession.id, tmuxSession.tmuxSessionName)
         .then(() => {
           console.log(`[Orchestrator] Started ttyd for restored session: ${tmuxSession.id}`);
+          // ttyd起動完了をクライアントに通知（ttydPort/ttydUrlを含む最新情報を送信）
+          const dbSession = db.getSessionByWorktreePath(tmuxSession.worktreePath);
+          const managed = this.toManagedSession(tmuxSession, dbSession?.worktreeId || "");
+          this.emit("session:updated", managed);
         })
         .catch((err) => {
           console.error(`[Orchestrator] Failed to start ttyd for ${tmuxSession.id}:`, err.message);

--- a/server/lib/tmux-manager.ts
+++ b/server/lib/tmux-manager.ts
@@ -11,7 +11,7 @@ import { nanoid } from "nanoid";
 import type { SpecialKey } from "../../shared/types.js";
 
 /** 送信を許可する特殊キーのホワイトリスト */
-const ALLOWED_SPECIAL_KEYS = new Set<SpecialKey>(["Enter", "C-c", "C-d", "y", "n", "S-Tab", "Escape"]);
+const ALLOWED_SPECIAL_KEYS = new Set<SpecialKey>(["Enter", "C-c", "C-d", "y", "n", "S-Tab", "Escape", "scroll-up", "scroll-down", "copy-mode", "q"]);
 
 export interface TmuxSession {
   id: string;
@@ -209,8 +209,23 @@ export class TmuxManager extends EventEmitter {
       throw new Error(`許可されていない特殊キーです: ${key}`);
     }
 
+    // copy-mode はtmuxのcopy-modeコマンドを使用
+    if (key === "copy-mode") {
+      const result = spawnSync("tmux", ["copy-mode", "-t", session.tmuxSessionName], { stdio: "pipe" });
+      if (result.error) throw result.error;
+      if (result.status !== 0) throw new Error(`tmux copy-mode exited with status ${result.status}`);
+      session.lastActivity = new Date();
+      return;
+    }
+
     // S-Tab はtmuxでは "BTab" として送信
-    const tmuxKey = key === "S-Tab" ? "BTab" : key;
+    // scroll-up/scroll-down はcopy-mode内でUp/Downキーとして送信
+    const keyMap: Partial<Record<SpecialKey, string>> = {
+      "S-Tab": "BTab",
+      "scroll-up": "Up",
+      "scroll-down": "Down",
+    };
+    const tmuxKey = keyMap[key] ?? key;
     const result = spawnSync("tmux", ["send-keys", "-t", session.tmuxSessionName, tmuxKey], { stdio: "pipe" });
     if (result.error) throw result.error;
     if (result.status !== 0) throw new Error(`tmux send-keys exited with status ${result.status}`);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -70,7 +70,7 @@ export interface ClaudeStreamEvent {
 }
 
 /** 特殊キー入力の種別 */
-export type SpecialKey = "Enter" | "C-c" | "C-d" | "y" | "n" | "S-Tab" | "Escape";
+export type SpecialKey = "Enter" | "C-c" | "C-d" | "y" | "n" | "S-Tab" | "Escape" | "scroll-up" | "scroll-down" | "copy-mode" | "q";
 
 // WebSocket event types
 export interface ServerToClientEvents {


### PR DESCRIPTION
## Summary

- xterm.jsがモバイルタッチスクロール非対応のため、tmux copy-modeを活用したスワイプスクロール機能を実装
- Quick Keysバーに「Scroll」トグルボタンを追加（ON/OFFでスクロールモード切替）
- `overflow: clip` → `overflow: hidden` に統一（モバイルブラウザ互換性向上）

## 変更内容

| ファイル | 変更 |
|---------|------|
| MobileSessionView.tsx | Scrollトグルボタン、スワイプ検出オーバーレイ追加 |
| shared/types.ts | SpecialKeyに`scroll-up`, `scroll-down`, `copy-mode`, `q`追加 |
| tmux-manager.ts | 新SpecialKeyのtmuxコマンドマッピング追加 |
| index.css, MobileLayout.tsx | `overflow: clip` → `overflow: hidden` |
| session-orchestrator.ts, server/index.ts | ttyd復元時の`session:updated`通知追加 |
| TerminalPane.tsx | 未使用import削除、overflow-hidden追加 |

## 使い方

1. 「Scroll」ボタンをタップ → tmux copy-modeに入る
2. スワイプで上下スクロール（20px移動ごとに1行）
3. もう一度「Scroll ✓」をタップ → 通常操作に戻る

## 背景

- [xterm.js #5377](https://github.com/xtermjs/xterm.js/issues/5377): モバイルタッチスクロール非対応
- [WebKit #149264](https://bugs.webkit.org/show_bug.cgi?id=149264): iOS iframe内タッチスクロール制限

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Swipe-based scrolling for mobile sessions with a toggle in the Quick Keys bar.
  * Added scroll-up, scroll-down, and copy-mode commands for improved terminal navigation.

* **Improvements**
  * Refined overflow handling across layouts for more consistent visual display.
  * Sessions now emit updated notifications so clients receive real-time session state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->