### PR TITLE
fix: 再接続時に「Starting terminal...」で止まる問題を修正

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -312,10 +312,41 @@ async function startServer() {
     // Send allowed repos list to client on connection
     socket.emit("repos:list", allowedRepos);
 
+    // ===== Session Orchestrator Event Handlers =====
+    // sessionOrchestrator のイベントをそのまま Socket.IO クライアントへ転送する
+    // 注意: session:list送信やttyd自動復元より前に登録する必要がある
+    // （自動復元で発行されるsession:restoredイベントを転送するため）
+    const forwardedEvents = ["session:created", "session:restored", "session:stopped", "session:updated"] as const;
+    type ForwardedEvent = (typeof forwardedEvents)[number];
+
+    const forwardHandlers = new Map<ForwardedEvent, (...args: unknown[]) => void>();
+    for (const event of forwardedEvents) {
+      const handler = (...args: unknown[]) => {
+        (socket.emit as (event: string, ...args: unknown[]) => void)(event, ...args);
+      };
+      forwardHandlers.set(event, handler);
+      sessionOrchestrator.on(event, handler);
+    }
+
     // 既存セッション一覧を送信（リロード時のペイン復元用）
     const existingSessions = sessionOrchestrator.getAllSessions();
     if (existingSessions.length > 0) {
       socket.emit("session:list", existingSessions);
+    }
+
+    // ttydが未起動のセッションを自動復元（非同期）
+    // restoreSessionがsession:restoredイベントを発行し、上記の転送ハンドラー経由でクライアントに通知される
+    for (const session of existingSessions) {
+      if (!session.ttydPort && session.worktreePath) {
+        sessionOrchestrator.restoreSession(session.worktreePath)
+          .catch((err) => {
+            console.error(`[Socket] ttyd自動復元失敗 (${session.id}):`, getErrorMessage(err));
+            socket.emit("session:error", {
+              sessionId: session.id,
+              error: `ターミナルの起動に失敗しました: ${getErrorMessage(err)}`,
+            });
+          });
+      }
     }
 
     // ===== Repository Commands =====
@@ -478,20 +509,6 @@ async function startServer() {
         callback({ error: String(error) });
       }
     });
-
-    // ===== Session Orchestrator Event Handlers =====
-    // sessionOrchestrator のイベントをそのまま Socket.IO クライアントへ転送する
-    const forwardedEvents = ["session:created", "session:restored", "session:stopped", "session:updated"] as const;
-    type ForwardedEvent = (typeof forwardedEvents)[number];
-
-    const forwardHandlers = new Map<ForwardedEvent, (...args: unknown[]) => void>();
-    for (const event of forwardedEvents) {
-      const handler = (...args: unknown[]) => {
-        (socket.emit as (event: string, ...args: unknown[]) => void)(event, ...args);
-      };
-      forwardHandlers.set(event, handler);
-      sessionOrchestrator.on(event, handler);
-    }
 
     // ===== Port Scan Commands =====
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -306,6 +306,9 @@ async function startServer() {
 
   // ===== Socket.IO Connection Handler =====
 
+  // 複数クライアント同時接続時の重複復元を防ぐ（セッションID → 復元中のPromise）
+  const pendingAutoRestores = new Map<string, Promise<void>>();
+
   io.on("connection", (socket) => {
     console.log(`Client connected: ${socket.id}`);
 
@@ -335,18 +338,28 @@ async function startServer() {
     }
 
     // ttydが未起動のセッションを自動復元（非同期）
-    // restoreSessionがsession:restoredイベントを発行し、上記の転送ハンドラー経由でクライアントに通知される
+    // 複数クライアント同時接続でも同一セッションの復元は1回だけ実行される
     for (const session of existingSessions) {
-      if (!session.ttydPort && session.worktreePath) {
-        sessionOrchestrator.restoreSession(session.worktreePath)
-          .catch((err) => {
-            console.error(`[Socket] ttyd自動復元失敗 (${session.id}):`, getErrorMessage(err));
-            socket.emit("session:error", {
-              sessionId: session.id,
-              error: `ターミナルの起動に失敗しました: ${getErrorMessage(err)}`,
-            });
+      if (session.ttydPort || !session.worktreePath) continue;
+
+      let recovery = pendingAutoRestores.get(session.id);
+      if (!recovery) {
+        recovery = sessionOrchestrator
+          .restoreSession(session.worktreePath)
+          .then(() => undefined)
+          .finally(() => {
+            pendingAutoRestores.delete(session.id);
           });
+        pendingAutoRestores.set(session.id, recovery);
       }
+
+      recovery.catch((err) => {
+        console.error(`[Socket] ttyd自動復元失敗 (${session.id}):`, getErrorMessage(err));
+        socket.emit("session:error", {
+          sessionId: session.id,
+          error: `ターミナルの起動に失敗しました: ${getErrorMessage(err)}`,
+        });
+      });
     }
 
     // ===== Repository Commands =====

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -18,6 +18,8 @@ export interface TtydInstance {
 
 export class TtydManager extends EventEmitter {
   private instances: Map<string, TtydInstance> = new Map();
+  /** 起動中のPromiseを保持し、同じセッションに対する重複起動を防ぐ */
+  private pendingStarts: Map<string, Promise<TtydInstance>> = new Map();
   private nextPort: number;
   private readonly MAX_PORT: number;
 
@@ -66,17 +68,42 @@ export class TtydManager extends EventEmitter {
 
   /**
    * tmuxセッション用のttydインスタンスを起動
+   * 重複起動ガード付き: 同じセッションIDに対する並行起動を防ぐ
    */
   async startInstance(
     sessionId: string,
     tmuxSessionName: string
   ): Promise<TtydInstance> {
-    // 既存インスタンスがあれば返す
+    // 既に起動済み
     const existing = this.instances.get(sessionId);
     if (existing) {
       return existing;
     }
 
+    // 既に起動中（別の呼び出しが進行中）
+    const pending = this.pendingStarts.get(sessionId);
+    if (pending) {
+      return pending;
+    }
+
+    // 新規起動
+    const promise = this._startInstanceInternal(sessionId, tmuxSessionName);
+    this.pendingStarts.set(sessionId, promise);
+
+    try {
+      return await promise;
+    } finally {
+      this.pendingStarts.delete(sessionId);
+    }
+  }
+
+  /**
+   * ttydインスタンスの実際の起動処理（内部用）
+   */
+  private async _startInstanceInternal(
+    sessionId: string,
+    tmuxSessionName: string
+  ): Promise<TtydInstance> {
     const port = this.findAvailablePort();
     const basePath = `/ttyd/${sessionId}`;
 


### PR DESCRIPTION
## 概要

ブラウザリロード/再接続時にターミナルが「Starting terminal...」のまま表示されない問題を修正。

## 原因

- サーバー再起動後、ttydの起動が非同期（fire-and-forget）で行われるため、`session:list`送信時にttydが未起動 → `ttydPort: null`
- イベント転送ハンドラーが`session:list`送信後に登録されており、ttyd復元イベントを取りこぼす可能性があった
- ttyd起動失敗時のリトライ・通知機構がなかった

## 変更内容

### `server/lib/ttyd-manager.ts`
- `pendingStarts` Mapを追加し、同一セッションに対する並行ttyd起動を防止

### `server/index.ts`
- イベント転送ハンドラーの登録を`session:list`送信**前**に移動
- ttyd未起動セッションの自動復元処理を追加（失敗時はクライアントにエラー通知）

## テスト

- サーバー再起動後にブラウザリロードし、ターミナルが正常に表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic session restore across multiple reconnects with deduplication to avoid duplicate restores.
  * Immediate forwarding of session lifecycle events to clients for real-time updates.

* **Bug Fixes**
  * Prevented concurrent startups of the same session to avoid conflicts and race conditions.
  * Per-session error handling added for restore/start operations to avoid blocking other sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->