### PR TITLE
fix: ttydのループバックインターフェース名をプラットフォームに応じて切り替え

### DIFF
--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -120,7 +120,9 @@ export class TtydManager extends EventEmitter {
         "-p",
         port.toString(),
         "-i",
-        "lo0", // macOS loopback interface
+        // ループバックインターフェース名はOSによって異なる
+        // macOS: lo0, Linux: lo
+        process.platform === "darwin" ? "lo0" : "lo",
         "--base-path",
         basePath, // プロキシ経由でのWebSocket接続に必要
         "-t",


### PR DESCRIPTION
## 概要

`server/lib/ttyd-manager.ts` で ttyd の `-i` オプションに `lo0` がハードコードされていたため、Linux環境で動作しない問題を修正。

## 変更内容

- `process.platform` で判定し、macOS (`darwin`) なら `lo0`、それ以外（Linux等）なら `lo` を使用するように修正

## テスト手順

- [ ] macOS環境でttydがループバックインターフェース `lo0` にバインドされることを確認
- [ ] Linux環境でttydがループバックインターフェース `lo` にバインドされることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ttyd network interface binding to properly support macOS and Linux systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->