### PR TITLE
feat: トンネル名を環境変数CCM_TUNNEL_NAMEで設定可能にする

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -6,7 +6,7 @@ module.exports = {
       cwd: __dirname,
       node_args: '--env-file=.env.production',
       args: '--remote',
-      instances: 1,
+      exec_mode: 'fork',
       autorestart: true,
       watch: false,
       env: {

--- a/server/index.ts
+++ b/server/index.ts
@@ -631,7 +631,7 @@ async function startServer() {
         localPort: port,
         mode: "named",
         namedTunnelOptions: {
-          tunnelName: "claude-code-manager",
+          tunnelName: process.env.CCM_TUNNEL_NAME || "claude-code-manager",
           publicUrl: `https://${publicDomain}`,
         },
       });


### PR DESCRIPTION
## Summary
- Named Tunnelのトンネル名を環境変数 `CCM_TUNNEL_NAME` で設定可能にした
- デフォルト値は従来通り `claude-code-manager`
- デプロイ環境ごとに異なるトンネル名を使用するケース（例: VM環境）に対応

## Test plan
- [ ] `CCM_TUNNEL_NAME` 未設定時にデフォルト `claude-code-manager` で起動すること
- [ ] `CCM_TUNNEL_NAME=ccm-vm-tunnel` 設定時にそのトンネル名で起動すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tunnel name can now be customized via environment configuration while keeping the previous default when not set.
  * Application startup execution mode adjusted to an explicit fork-based run configuration (no functional change to startup arguments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->