### PR TITLE
fix: Linuxでポートスキャンが一部のプロセスを検出できない問題を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:full:remote": "concurrently \"pnpm dev\" \"pnpm dev:remote\"",
     "dev:remote": "tsx watch server/index.ts --remote",
     "dev:quick": "tsx watch server/index.ts --quick",
-    "build": "vite build && esbuild server/index.ts server/lib/git.ts server/lib/tmux-manager.ts server/lib/ttyd-manager.ts server/lib/session-orchestrator.ts server/lib/tunnel.ts server/lib/auth.ts server/lib/qrcode.ts server/lib/database.ts server/lib/port-scanner.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts server/lib/git.ts server/lib/tmux-manager.ts server/lib/ttyd-manager.ts server/lib/session-orchestrator.ts server/lib/tunnel.ts server/lib/auth.ts server/lib/qrcode.ts server/lib/database.ts server/lib/port-scanner.ts server/lib/constants.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "start:remote": "NODE_ENV=production node dist/index.js --remote",
     "start:quick": "NODE_ENV=production node dist/index.js --quick",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "dev:full:remote": "concurrently \"pnpm dev\" \"pnpm dev:remote\"",
     "dev:remote": "tsx watch server/index.ts --remote",
     "dev:quick": "tsx watch server/index.ts --quick",
-    "build": "vite build && esbuild server/index.ts server/lib/git.ts server/lib/tmux-manager.ts server/lib/ttyd-manager.ts server/lib/session-orchestrator.ts server/lib/tunnel.ts server/lib/auth.ts server/lib/qrcode.ts server/lib/database.ts server/lib/port-scanner.ts server/lib/constants.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
+    "build": "vite build && esbuild server/index.ts server/lib/*.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "start:remote": "NODE_ENV=production node dist/index.js --remote",
     "start:quick": "NODE_ENV=production node dist/index.js --quick",

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -1,0 +1,5 @@
+/** ttydポート範囲の開始ポート */
+export const TTYD_PORT_START = 7680;
+
+/** ttydポート範囲の終了ポート */
+export const TTYD_PORT_END = 7780;

--- a/server/lib/port-scanner.ts
+++ b/server/lib/port-scanner.ts
@@ -9,10 +9,21 @@ export interface ListeningPort {
 /**
  * システムでリッスン中のポートを取得
  * ttydポート（7680-7780）は除外
+ * macOSではlsof、Linuxではssコマンドを使用
  */
 export function getListeningPorts(): ListeningPort[] {
+  if (process.platform === "darwin") {
+    return getListeningPortsMacOS();
+  }
+  return getListeningPortsLinux();
+}
+
+/**
+ * macOS向け: lsofを使用してリッスン中のポートを取得
+ */
+function getListeningPortsMacOS(): ListeningPort[] {
   try {
-    // macOS: lsof -i -P -n | grep LISTEN
+    // lsofコマンドは固定文字列のため、シェルインジェクションのリスクなし
     const output = execSync("lsof -i -P -n | grep LISTEN", {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
@@ -42,6 +53,80 @@ export function getListeningPorts(): ListeningPort[] {
       // 重複を避ける
       if (!ports.some((p) => p.port === port)) {
         ports.push({ port, process, pid });
+      }
+    }
+
+    // ポート番号でソート
+    return ports.sort((a, b) => a.port - b.port);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Linux向け: ss -tlnpを使用してリッスン中のポートを取得
+ *
+ * ssの出力例:
+ *   State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process
+ *   LISTEN 0      511                *:3001             *:*    users:(("node /home/admi",pid=8325,fd=25))
+ *   LISTEN 0      4096         0.0.0.0:5433       0.0.0.0:*
+ *
+ * Local Addressの形式:
+ *   127.0.0.1:PORT, 0.0.0.0:PORT, *:PORT, [::]:PORT, 127.0.0.53%lo:53 など
+ *
+ * Processカラムがない行もある（権限不足でプロセス情報が取得できない場合）
+ * プロセス名にスペースや括弧を含む場合がある（例: "next-server (v1"）
+ */
+function getListeningPortsLinux(): ListeningPort[] {
+  try {
+    // ssコマンドは固定文字列のため、シェルインジェクションのリスクなし
+    const output = execSync("ss -tlnp", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const ports: ListeningPort[] = [];
+    const lines = output.trim().split("\n");
+
+    // 1行目はヘッダーなのでスキップ
+    for (let i = 1; i < lines.length; i++) {
+      const line = lines[i];
+      if (!line.startsWith("LISTEN")) continue;
+
+      // 空白で分割してカラムを取得
+      // columns: [State, Recv-Q, Send-Q, Local Address:Port, Peer Address:Port, ...]
+      const columns = line.split(/\s+/);
+      if (columns.length < 5) continue;
+
+      const localAddr = columns[3];
+
+      // ポート番号を抽出（最後の:以降の数字）
+      // 形式例: "127.0.0.1:20242", "0.0.0.0:5433", "*:3001", "[::]:3001", "127.0.0.53%lo:53"
+      const portMatch = localAddr.match(/:(\d+)$/);
+      if (!portMatch) continue;
+
+      const port = parseInt(portMatch[1], 10);
+
+      // ttydポート（7680-7780）を除外
+      if (port >= 7680 && port <= 7780) continue;
+
+      // プロセス情報を抽出
+      // 形式: users:(("プロセス名",pid=NNN,fd=NN))
+      // プロセス名にスペースや括弧が含まれる場合があるため、pid=の手前までを名前として取得
+      let processName = "unknown";
+      let pid = 0;
+
+      const usersMatch = line.match(
+        /users:\(\("(.+?)",pid=(\d+),fd=\d+\)\)/,
+      );
+      if (usersMatch) {
+        processName = usersMatch[1];
+        pid = parseInt(usersMatch[2], 10);
+      }
+
+      // 重複を避ける
+      if (!ports.some((p) => p.port === port)) {
+        ports.push({ port, process: processName, pid });
       }
     }
 

--- a/server/lib/port-scanner.ts
+++ b/server/lib/port-scanner.ts
@@ -1,4 +1,5 @@
 import { execSync } from "child_process";
+import { TTYD_PORT_START, TTYD_PORT_END } from "./constants.js";
 
 export interface ListeningPort {
   port: number;
@@ -6,133 +7,114 @@ export interface ListeningPort {
   pid: number;
 }
 
+/** 行パーサーの戻り値型 */
+interface ParsedLine {
+  port: number;
+  processName: string;
+  pid: number;
+}
+
 /**
  * システムでリッスン中のポートを取得
- * ttydポート（7680-7780）は除外
+ * ttydポート（TTYD_PORT_START-TTYD_PORT_END）は除外
  * macOSではlsof、Linuxではssコマンドを使用
  */
 export function getListeningPorts(): ListeningPort[] {
-  if (process.platform === "darwin") {
-    return getListeningPortsMacOS();
-  }
-  return getListeningPortsLinux();
+  const command =
+    process.platform === "darwin" ? "lsof -i -P -n | grep LISTEN" : "ss -tlnp";
+  const parseLine =
+    process.platform === "darwin" ? parseLsofLine : parseSsLine;
+  return collectPorts(command, parseLine);
 }
 
 /**
- * macOS向け: lsofを使用してリッスン中のポートを取得
+ * コマンド出力からポート一覧を収集する共通処理
  */
-function getListeningPortsMacOS(): ListeningPort[] {
+function collectPorts(
+  command: string,
+  parseLine: (line: string) => ParsedLine | null,
+): ListeningPort[] {
   try {
-    // lsofコマンドは固定文字列のため、シェルインジェクションのリスクなし
-    const output = execSync("lsof -i -P -n | grep LISTEN", {
+    const output = execSync(command, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
 
     const ports: ListeningPort[] = [];
-    const lines = output.trim().split("\n");
+    const seen = new Set<number>();
 
-    for (const line of lines) {
-      // 例: "node 83337 user 22u IPv4 ... *:3001 (LISTEN)"
-      const parts = line.split(/\s+/);
-      if (parts.length < 9) continue;
+    for (const line of output.trim().split("\n")) {
+      const parsed = parseLine(line);
+      if (!parsed) continue;
 
-      const process = parts[0];
-      const pid = parseInt(parts[1], 10);
-      const address = parts[8]; // "*:3001" or "127.0.0.1:3001"
+      const { port, processName, pid } = parsed;
 
-      // ポート番号を抽出
-      const portMatch = address.match(/:(\d+)$/);
-      if (!portMatch) continue;
+      // ttydポートを除外
+      if (port >= TTYD_PORT_START && port <= TTYD_PORT_END) continue;
 
-      const port = parseInt(portMatch[1], 10);
-
-      // ttydポート（7680-7780）を除外
-      if (port >= 7680 && port <= 7780) continue;
-
-      // 重複を避ける
-      if (!ports.some((p) => p.port === port)) {
-        ports.push({ port, process, pid });
-      }
-    }
-
-    // ポート番号でソート
-    return ports.sort((a, b) => a.port - b.port);
-  } catch {
-    return [];
-  }
-}
-
-/**
- * Linux向け: ss -tlnpを使用してリッスン中のポートを取得
- *
- * ssの出力例:
- *   State  Recv-Q Send-Q Local Address:Port  Peer Address:Port Process
- *   LISTEN 0      511                *:3001             *:*    users:(("node /home/admi",pid=8325,fd=25))
- *   LISTEN 0      4096         0.0.0.0:5433       0.0.0.0:*
- *
- * Local Addressの形式:
- *   127.0.0.1:PORT, 0.0.0.0:PORT, *:PORT, [::]:PORT, 127.0.0.53%lo:53 など
- *
- * Processカラムがない行もある（権限不足でプロセス情報が取得できない場合）
- * プロセス名にスペースや括弧を含む場合がある（例: "next-server (v1"）
- */
-function getListeningPortsLinux(): ListeningPort[] {
-  try {
-    // ssコマンドは固定文字列のため、シェルインジェクションのリスクなし
-    const output = execSync("ss -tlnp", {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-
-    const ports: ListeningPort[] = [];
-    const lines = output.trim().split("\n");
-
-    // 1行目はヘッダーなのでスキップ
-    for (let i = 1; i < lines.length; i++) {
-      const line = lines[i];
-      if (!line.startsWith("LISTEN")) continue;
-
-      // 空白で分割してカラムを取得
-      // columns: [State, Recv-Q, Send-Q, Local Address:Port, Peer Address:Port, ...]
-      const columns = line.split(/\s+/);
-      if (columns.length < 5) continue;
-
-      const localAddr = columns[3];
-
-      // ポート番号を抽出（最後の:以降の数字）
-      // 形式例: "127.0.0.1:20242", "0.0.0.0:5433", "*:3001", "[::]:3001", "127.0.0.53%lo:53"
-      const portMatch = localAddr.match(/:(\d+)$/);
-      if (!portMatch) continue;
-
-      const port = parseInt(portMatch[1], 10);
-
-      // ttydポート（7680-7780）を除外
-      if (port >= 7680 && port <= 7780) continue;
-
-      // プロセス情報を抽出
-      // 形式: users:(("プロセス名",pid=NNN,fd=NN))
-      // プロセス名にスペースや括弧が含まれる場合があるため、pid=の手前までを名前として取得
-      let processName = "unknown";
-      let pid = 0;
-
-      const usersMatch = line.match(
-        /users:\(\("(.+?)",pid=(\d+),fd=\d+\)\)/,
-      );
-      if (usersMatch) {
-        processName = usersMatch[1];
-        pid = parseInt(usersMatch[2], 10);
-      }
-
-      // 重複を避ける
-      if (!ports.some((p) => p.port === port)) {
+      if (!seen.has(port)) {
+        seen.add(port);
         ports.push({ port, process: processName, pid });
       }
     }
 
-    // ポート番号でソート
     return ports.sort((a, b) => a.port - b.port);
   } catch {
     return [];
   }
+}
+
+/**
+ * macOS lsof出力の1行をパース
+ * 例: "node 83337 user 22u IPv4 ... *:3001 (LISTEN)"
+ */
+function parseLsofLine(line: string): ParsedLine | null {
+  const parts = line.split(/\s+/);
+  if (parts.length < 9) return null;
+
+  const processName = parts[0];
+  const pid = parseInt(parts[1], 10);
+  const address = parts[8]; // "*:3001" or "127.0.0.1:3001"
+
+  const portMatch = address.match(/:(\d+)$/);
+  if (!portMatch) return null;
+
+  return { port: parseInt(portMatch[1], 10), processName, pid };
+}
+
+/**
+ * Linux ss -tlnp出力の1行をパース
+ *
+ * 出力例:
+ *   LISTEN 0 511 *:3001 *:* users:(("node /home/admi",pid=8325,fd=25))
+ *   LISTEN 0 4096 0.0.0.0:5433 0.0.0.0:*
+ *
+ * Processカラムがない行もある（権限不足の場合）
+ * プロセス名にスペースや括弧を含む場合がある（例: "next-server (v1"）
+ */
+function parseSsLine(line: string): ParsedLine | null {
+  if (!line.startsWith("LISTEN")) return null;
+
+  const columns = line.split(/\s+/);
+  if (columns.length < 5) return null;
+
+  const localAddr = columns[3];
+
+  // ポート番号を抽出（最後の:以降の数字）
+  // 形式例: "127.0.0.1:20242", "0.0.0.0:5433", "*:3001", "[::]:3001", "127.0.0.53%lo:53"
+  const portMatch = localAddr.match(/:(\d+)$/);
+  if (!portMatch) return null;
+
+  // プロセス情報を抽出
+  // 形式: users:(("プロセス名",pid=NNN,fd=NN))
+  let processName = "unknown";
+  let pid = 0;
+
+  const usersMatch = line.match(/users:\(\("(.+?)",pid=(\d+),fd=\d+\)\)/);
+  if (usersMatch) {
+    processName = usersMatch[1];
+    pid = parseInt(usersMatch[2], 10);
+  }
+
+  return { port: parseInt(portMatch[1], 10), processName, pid };
 }

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -22,10 +22,12 @@ export class TtydManager extends EventEmitter {
   /** 起動中のPromiseを保持し、同じセッションに対する重複起動を防ぐ */
   private pendingStarts: Map<string, Promise<TtydInstance>> = new Map();
   private nextPort: number;
+  private readonly MIN_PORT: number;
   private readonly MAX_PORT: number;
 
   constructor(startPort = TTYD_PORT_START, maxPort = TTYD_PORT_END) {
     super();
+    this.MIN_PORT = startPort;
     this.nextPort = startPort;
     this.MAX_PORT = maxPort;
     this.checkTtydInstalled();
@@ -59,7 +61,7 @@ export class TtydManager extends EventEmitter {
       if (!usedPorts.has(port)) {
         this.nextPort = port + 1;
         if (this.nextPort > this.MAX_PORT) {
-          this.nextPort = TTYD_PORT_START; // ラップアラウンド
+          this.nextPort = this.MIN_PORT; // ラップアラウンド
         }
         return port;
       }

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -7,6 +7,7 @@
 
 import { spawn, execSync, type ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { TTYD_PORT_START, TTYD_PORT_END } from "./constants.js";
 
 export interface TtydInstance {
   sessionId: string;
@@ -23,7 +24,7 @@ export class TtydManager extends EventEmitter {
   private nextPort: number;
   private readonly MAX_PORT: number;
 
-  constructor(startPort = 7680, maxPort = 7780) {
+  constructor(startPort = TTYD_PORT_START, maxPort = TTYD_PORT_END) {
     super();
     this.nextPort = startPort;
     this.MAX_PORT = maxPort;
@@ -58,7 +59,7 @@ export class TtydManager extends EventEmitter {
       if (!usedPorts.has(port)) {
         this.nextPort = port + 1;
         if (this.nextPort > this.MAX_PORT) {
-          this.nextPort = 7680; // ラップアラウンド
+          this.nextPort = TTYD_PORT_START; // ラップアラウンド
         }
         return port;
       }


### PR DESCRIPTION
## 概要

- Linuxで`lsof`が一部のリッスンポート（Next.jsなど）を検出できない問題を修正
- Linux環境では`ss -tlnp`コマンドを使用するように変更
- macOSでは従来通り`lsof`を使用

## 背景

Ubuntu上でNext.jsを3333ポートで起動した際、Quick Tunnelのポートリストに表示されなかった。
`lsof -i -P -n`では検出できないが、`ss -tlnp`では正しく検出される。

## テスト

サーバー上で動作確認済み。`ss -tlnp`パーサーがNext.js（port 3333）を含む全ポートを正しく検出することを確認。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-platform port discovery with improved macOS and Linux parsing, deduplication, sorting, and resilient failure handling.
* **Bug Fixes**
  * Eliminates duplicate port entries and better handles varied process info formats.
* **Chores**
  * Replaced hard-coded terminal-service port bounds with a defined configurable range; build inputs updated to include the new constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->