### PR TITLE
fix: Beaconブランチ命名規則をスラッシュ区切りに修正

### DIFF
--- a/client/src/components/MultiPaneLayout.tsx
+++ b/client/src/components/MultiPaneLayout.tsx
@@ -71,6 +71,12 @@ export function MultiPaneLayout({
     return repo ? getBaseName(repo) : undefined;
   };
 
+  // Filter to only show panes that have active sessions
+  const visiblePanes = useMemo(
+    () => activePanes.filter(id => sessions.has(id)),
+    [activePanes, sessions]
+  );
+
   // If a pane is maximized, only show that pane
   if (maximizedPane) {
     const session = sessions.get(maximizedPane);
@@ -102,12 +108,6 @@ export function MultiPaneLayout({
       );
     }
   }
-
-  // Filter to only show panes that have active sessions
-  const visiblePanes = useMemo(
-    () => activePanes.filter(id => sessions.has(id)),
-    [activePanes, sessions]
-  );
 
   if (visiblePanes.length === 0) {
     return null;

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -101,8 +101,9 @@ worktreeの作成・削除はMCPツールを使ってください。
 
 #### Phase 3: worktree作成＆タスク着手
 8. Issue/チケットの識別子からブランチ名を構築する
-   - GitHub Issue: feat/123-slug（例: feat/123-add-search）
-   - Jira: feat/PROJ-123-slug（例: feat/PMDEV-325-supplier-password）
+   - チケット番号とslugの区切りはハイフンではなくスラッシュ（/）を使う（slug内のハイフンは可）
+   - GitHub Issue: feat/123/slug（例: feat/123/add-search）
+   - Jira: feat/PROJ-123/slug（例: feat/PMDEV-325/supplier-password）
    - ユーザーに確認: 「このブランチ名でよいですか？」
 9. 確認が取れたら:
    - create_worktreeでworktreeを作成（返り値にworktreeのIDとパスが含まれる）
@@ -237,7 +238,7 @@ class MessageQueue {
       if (this.messages.length > 0) {
         yield this.messages.shift()!;
       } else {
-        const msg = await new Promise<SDKUserMessage>(resolve => {
+        const msg = await new Promise<SDKUserMessage>((resolve) => {
           this.waiting = resolve;
         });
         // close()で解決された場合はyieldせずにループを抜ける
@@ -287,7 +288,7 @@ export interface BeaconDeps {
   createWorktree: (
     repoPath: string,
     branchName: string,
-    baseBranch?: string
+    baseBranch?: string,
   ) => Promise<unknown>;
   deleteWorktree: (repoPath: string, worktreePath: string) => Promise<void>;
   getRepos: () => string[];
@@ -372,7 +373,7 @@ export class BeaconManager extends EventEmitter {
               .optional()
               .describe("リポジトリパス（省略時は全リポジトリ）"),
           },
-          handler: async args => {
+          handler: async (args) => {
             const repoPath = args.repoPath as string | undefined;
             if (repoPath) {
               const worktrees = await deps.listWorktrees(repoPath);
@@ -418,7 +419,7 @@ export class BeaconManager extends EventEmitter {
             worktreeId: z.string().describe("worktreeのID"),
             worktreePath: z.string().describe("worktreeのパス"),
           },
-          handler: async args => {
+          handler: async (args) => {
             const worktreeId = args.worktreeId as string;
             const worktreePath = args.worktreePath as string;
             const session = await deps.startSession(worktreeId, worktreePath);
@@ -438,7 +439,7 @@ export class BeaconManager extends EventEmitter {
           inputSchema: {
             sessionId: z.string().describe("セッションID"),
           },
-          handler: async args => {
+          handler: async (args) => {
             const sessionId = args.sessionId as string;
             deps.stopSession(sessionId);
             return {
@@ -459,7 +460,7 @@ export class BeaconManager extends EventEmitter {
             sessionId: z.string().describe("セッションID"),
             message: z.string().describe("送信するテキスト"),
           },
-          handler: async args => {
+          handler: async (args) => {
             deps.sendMessage(args.sessionId as string, args.message as string);
             return {
               content: [
@@ -481,7 +482,7 @@ export class BeaconManager extends EventEmitter {
               .string()
               .describe("送信するキー（y, n, C-c, Escape, Enter, S-Tab）"),
           },
-          handler: async args => {
+          handler: async (args) => {
             const validKeys = new Set([
               "Enter",
               "C-c",
@@ -528,10 +529,10 @@ export class BeaconManager extends EventEmitter {
               .optional()
               .describe("取得する行数（デフォルト: 100）"),
           },
-          handler: async args => {
+          handler: async (args) => {
             const output = deps.capturePane(
               args.sessionId as string,
-              (args.lines as number | undefined) ?? 100
+              (args.lines as number | undefined) ?? 100,
             );
             if (output === null) {
               return {
@@ -559,12 +560,12 @@ export class BeaconManager extends EventEmitter {
               .optional()
               .describe("ベースブランチ（省略時はHEAD）"),
           },
-          handler: async args => {
+          handler: async (args) => {
             try {
               const worktree = await deps.createWorktree(
                 args.repoPath as string,
                 args.branchName as string,
-                args.baseBranch as string | undefined
+                args.baseBranch as string | undefined,
               );
               return {
                 content: [
@@ -590,11 +591,11 @@ export class BeaconManager extends EventEmitter {
             repoPath: z.string().describe("リポジトリのパス"),
             worktreePath: z.string().describe("削除するworktreeのパス"),
           },
-          handler: async args => {
+          handler: async (args) => {
             try {
               await deps.deleteWorktree(
                 args.repoPath as string,
-                args.worktreePath as string
+                args.worktreePath as string,
               );
               return {
                 content: [
@@ -616,7 +617,7 @@ export class BeaconManager extends EventEmitter {
           inputSchema: {
             worktreePath: z.string().describe("worktreeのパス"),
           },
-          handler: async args => {
+          handler: async (args) => {
             const url = await deps.getPrUrl(args.worktreePath as string);
             if (url) {
               return {
@@ -641,14 +642,14 @@ export class BeaconManager extends EventEmitter {
             args: z
               .array(z.string())
               .describe(
-                'ghサブコマンドと引数（例: ["pr", "view", "--json", "url"]）'
+                'ghサブコマンドと引数（例: ["pr", "view", "--json", "url"]）',
               ),
             cwd: z
               .string()
               .optional()
               .describe("実行ディレクトリ（省略時はHOME）"),
           },
-          handler: async params => {
+          handler: async (params) => {
             const args = params.args as string[];
             // コマンドキーを構築（"pr view", "status" 等）
             const commandKey =
@@ -721,7 +722,7 @@ export class BeaconManager extends EventEmitter {
     const idleMs = now - this.session.lastActivity.getTime();
     if (idleMs > IDLE_TIMEOUT_MS) {
       console.log(
-        `[BeaconManager] セッションがアイドルタイムアウト (${Math.round(idleMs / 60000)}分)`
+        `[BeaconManager] セッションがアイドルタイムアウト (${Math.round(idleMs / 60000)}分)`,
       );
       this.closeSession();
     }

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -238,7 +238,7 @@ class MessageQueue {
       if (this.messages.length > 0) {
         yield this.messages.shift()!;
       } else {
-        const msg = await new Promise<SDKUserMessage>((resolve) => {
+        const msg = await new Promise<SDKUserMessage>(resolve => {
           this.waiting = resolve;
         });
         // close()で解決された場合はyieldせずにループを抜ける
@@ -288,7 +288,7 @@ export interface BeaconDeps {
   createWorktree: (
     repoPath: string,
     branchName: string,
-    baseBranch?: string,
+    baseBranch?: string
   ) => Promise<unknown>;
   deleteWorktree: (repoPath: string, worktreePath: string) => Promise<void>;
   getRepos: () => string[];
@@ -373,7 +373,7 @@ export class BeaconManager extends EventEmitter {
               .optional()
               .describe("リポジトリパス（省略時は全リポジトリ）"),
           },
-          handler: async (args) => {
+          handler: async args => {
             const repoPath = args.repoPath as string | undefined;
             if (repoPath) {
               const worktrees = await deps.listWorktrees(repoPath);
@@ -419,7 +419,7 @@ export class BeaconManager extends EventEmitter {
             worktreeId: z.string().describe("worktreeのID"),
             worktreePath: z.string().describe("worktreeのパス"),
           },
-          handler: async (args) => {
+          handler: async args => {
             const worktreeId = args.worktreeId as string;
             const worktreePath = args.worktreePath as string;
             const session = await deps.startSession(worktreeId, worktreePath);
@@ -439,7 +439,7 @@ export class BeaconManager extends EventEmitter {
           inputSchema: {
             sessionId: z.string().describe("セッションID"),
           },
-          handler: async (args) => {
+          handler: async args => {
             const sessionId = args.sessionId as string;
             deps.stopSession(sessionId);
             return {
@@ -460,7 +460,7 @@ export class BeaconManager extends EventEmitter {
             sessionId: z.string().describe("セッションID"),
             message: z.string().describe("送信するテキスト"),
           },
-          handler: async (args) => {
+          handler: async args => {
             deps.sendMessage(args.sessionId as string, args.message as string);
             return {
               content: [
@@ -482,7 +482,7 @@ export class BeaconManager extends EventEmitter {
               .string()
               .describe("送信するキー（y, n, C-c, Escape, Enter, S-Tab）"),
           },
-          handler: async (args) => {
+          handler: async args => {
             const validKeys = new Set([
               "Enter",
               "C-c",
@@ -529,10 +529,10 @@ export class BeaconManager extends EventEmitter {
               .optional()
               .describe("取得する行数（デフォルト: 100）"),
           },
-          handler: async (args) => {
+          handler: async args => {
             const output = deps.capturePane(
               args.sessionId as string,
-              (args.lines as number | undefined) ?? 100,
+              (args.lines as number | undefined) ?? 100
             );
             if (output === null) {
               return {
@@ -560,12 +560,12 @@ export class BeaconManager extends EventEmitter {
               .optional()
               .describe("ベースブランチ（省略時はHEAD）"),
           },
-          handler: async (args) => {
+          handler: async args => {
             try {
               const worktree = await deps.createWorktree(
                 args.repoPath as string,
                 args.branchName as string,
-                args.baseBranch as string | undefined,
+                args.baseBranch as string | undefined
               );
               return {
                 content: [
@@ -591,11 +591,11 @@ export class BeaconManager extends EventEmitter {
             repoPath: z.string().describe("リポジトリのパス"),
             worktreePath: z.string().describe("削除するworktreeのパス"),
           },
-          handler: async (args) => {
+          handler: async args => {
             try {
               await deps.deleteWorktree(
                 args.repoPath as string,
-                args.worktreePath as string,
+                args.worktreePath as string
               );
               return {
                 content: [
@@ -617,7 +617,7 @@ export class BeaconManager extends EventEmitter {
           inputSchema: {
             worktreePath: z.string().describe("worktreeのパス"),
           },
-          handler: async (args) => {
+          handler: async args => {
             const url = await deps.getPrUrl(args.worktreePath as string);
             if (url) {
               return {
@@ -642,14 +642,14 @@ export class BeaconManager extends EventEmitter {
             args: z
               .array(z.string())
               .describe(
-                'ghサブコマンドと引数（例: ["pr", "view", "--json", "url"]）',
+                'ghサブコマンドと引数（例: ["pr", "view", "--json", "url"]）'
               ),
             cwd: z
               .string()
               .optional()
               .describe("実行ディレクトリ（省略時はHOME）"),
           },
-          handler: async (params) => {
+          handler: async params => {
             const args = params.args as string[];
             // コマンドキーを構築（"pr view", "status" 等）
             const commandKey =
@@ -722,7 +722,7 @@ export class BeaconManager extends EventEmitter {
     const idleMs = now - this.session.lastActivity.getTime();
     if (idleMs > IDLE_TIMEOUT_MS) {
       console.log(
-        `[BeaconManager] セッションがアイドルタイムアウト (${Math.round(idleMs / 60000)}分)`,
+        `[BeaconManager] セッションがアイドルタイムアウト (${Math.round(idleMs / 60000)}分)`
       );
       this.closeSession();
     }


### PR DESCRIPTION
## 概要

Beaconのブランチ命名規則で、チケット番号とslugの区切りをハイフンからスラッシュに変更。

- 変更前: `feat/PMDEV-325-supplier-password`
- 変更後: `feat/PMDEV-325/supplier-password`

## 変更内容

- Beaconシステムプロンプトのブランチ命名規則を修正
- slug内のハイフンは引き続き使用可能であることを明記
- MultiPaneLayout.tsxのuseMemoフック呼び出し順序を修正（biome lint対応）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated branch naming convention format: ticket identifiers and slugs now use slash separators instead of hyphens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->