### PR TITLE
fix: ttydポート競合とセッションDB重複エラーを修正

### DIFF
--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -171,7 +171,7 @@ class SessionDatabase {
       session.worktreePath,
       session.status,
       now,
-      now,
+      now
     );
   }
 
@@ -198,7 +198,7 @@ class SessionDatabase {
       session.worktreePath,
       session.status,
       now,
-      now,
+      now
     );
   }
 
@@ -222,7 +222,7 @@ class SessionDatabase {
    */
   getSessionByWorktreePath(worktreePath: string): Session | null {
     const stmt = this.db.prepare(
-      "SELECT * FROM sessions WHERE worktree_path = ?",
+      "SELECT * FROM sessions WHERE worktree_path = ?"
     );
     const row = stmt.get(worktreePath) as SessionRow | undefined;
     return row ? this.rowToSession(row) : null;
@@ -237,7 +237,7 @@ class SessionDatabase {
   updateSessionStatus(id: string, status: SessionStatus): void {
     const now = new Date().toISOString();
     const stmt = this.db.prepare(
-      "UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?",
+      "UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?"
     );
     stmt.run(status, now, id);
   }
@@ -259,10 +259,10 @@ class SessionDatabase {
    */
   getAllSessions(): Session[] {
     const stmt = this.db.prepare(
-      "SELECT * FROM sessions ORDER BY created_at DESC",
+      "SELECT * FROM sessions ORDER BY created_at DESC"
     );
     const rows = stmt.all() as SessionRow[];
-    return rows.map((row) => this.rowToSession(row));
+    return rows.map(row => this.rowToSession(row));
   }
 
   // ============================================================
@@ -286,7 +286,7 @@ class SessionDatabase {
       message.role,
       message.content,
       message.type ?? "text",
-      message.timestamp.toISOString(),
+      message.timestamp.toISOString()
     );
   }
 
@@ -298,10 +298,10 @@ class SessionDatabase {
    */
   getMessagesBySession(sessionId: string): Message[] {
     const stmt = this.db.prepare(
-      "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp ASC",
+      "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp ASC"
     );
     const rows = stmt.all(sessionId) as MessageRow[];
-    return rows.map((row) => this.rowToMessage(row));
+    return rows.map(row => this.rowToMessage(row));
   }
 
   /**

--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -171,14 +171,14 @@ class SessionDatabase {
       session.worktreePath,
       session.status,
       now,
-      now
+      now,
     );
   }
 
   /**
    * セッションをupsert（存在すれば更新、なければ作成）
    *
-   * worktree_pathのUNIQUE制約に基づき、競合時はid, worktree_id, statusを更新する
+   * worktree_pathのUNIQUE制約に基づき、競合時はworktree_id, statusを更新する（idは既存値を維持）
    *
    * @param session - セッション作成データ
    */
@@ -188,7 +188,6 @@ class SessionDatabase {
       INSERT INTO sessions (id, worktree_id, worktree_path, status, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?)
       ON CONFLICT(worktree_path) DO UPDATE SET
-        id = excluded.id,
         worktree_id = excluded.worktree_id,
         status = excluded.status,
         updated_at = excluded.updated_at
@@ -199,7 +198,7 @@ class SessionDatabase {
       session.worktreePath,
       session.status,
       now,
-      now
+      now,
     );
   }
 
@@ -223,7 +222,7 @@ class SessionDatabase {
    */
   getSessionByWorktreePath(worktreePath: string): Session | null {
     const stmt = this.db.prepare(
-      "SELECT * FROM sessions WHERE worktree_path = ?"
+      "SELECT * FROM sessions WHERE worktree_path = ?",
     );
     const row = stmt.get(worktreePath) as SessionRow | undefined;
     return row ? this.rowToSession(row) : null;
@@ -238,7 +237,7 @@ class SessionDatabase {
   updateSessionStatus(id: string, status: SessionStatus): void {
     const now = new Date().toISOString();
     const stmt = this.db.prepare(
-      "UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?"
+      "UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?",
     );
     stmt.run(status, now, id);
   }
@@ -260,10 +259,10 @@ class SessionDatabase {
    */
   getAllSessions(): Session[] {
     const stmt = this.db.prepare(
-      "SELECT * FROM sessions ORDER BY created_at DESC"
+      "SELECT * FROM sessions ORDER BY created_at DESC",
     );
     const rows = stmt.all() as SessionRow[];
-    return rows.map(row => this.rowToSession(row));
+    return rows.map((row) => this.rowToSession(row));
   }
 
   // ============================================================
@@ -287,7 +286,7 @@ class SessionDatabase {
       message.role,
       message.content,
       message.type ?? "text",
-      message.timestamp.toISOString()
+      message.timestamp.toISOString(),
     );
   }
 
@@ -299,10 +298,10 @@ class SessionDatabase {
    */
   getMessagesBySession(sessionId: string): Message[] {
     const stmt = this.db.prepare(
-      "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp ASC"
+      "SELECT * FROM messages WHERE session_id = ? ORDER BY timestamp ASC",
     );
     const rows = stmt.all(sessionId) as MessageRow[];
-    return rows.map(row => this.rowToMessage(row));
+    return rows.map((row) => this.rowToMessage(row));
   }
 
   /**

--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -176,6 +176,34 @@ class SessionDatabase {
   }
 
   /**
+   * セッションをupsert（存在すれば更新、なければ作成）
+   *
+   * worktree_pathのUNIQUE制約に基づき、競合時はid, worktree_id, statusを更新する
+   *
+   * @param session - セッション作成データ
+   */
+  upsertSession(session: CreateSessionInput): void {
+    const now = new Date().toISOString();
+    const stmt = this.db.prepare(`
+      INSERT INTO sessions (id, worktree_id, worktree_path, status, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+      ON CONFLICT(worktree_path) DO UPDATE SET
+        id = excluded.id,
+        worktree_id = excluded.worktree_id,
+        status = excluded.status,
+        updated_at = excluded.updated_at
+    `);
+    stmt.run(
+      session.id,
+      session.worktreeId,
+      session.worktreePath,
+      session.status,
+      now,
+      now
+    );
+  }
+
+  /**
    * IDでセッションを取得
    *
    * @param id - セッションID

--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -178,7 +178,7 @@ class SessionDatabase {
   /**
    * セッションをupsert（存在すれば更新、なければ作成）
    *
-   * worktree_pathのUNIQUE制約に基づき、競合時はworktree_id, statusを更新する（idは既存値を維持）
+   * worktree_pathのUNIQUE制約に基づき、競合時はid, worktree_id, statusを更新する
    *
    * @param session - セッション作成データ
    */
@@ -188,6 +188,7 @@ class SessionDatabase {
       INSERT INTO sessions (id, worktree_id, worktree_path, status, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?)
       ON CONFLICT(worktree_path) DO UPDATE SET
+        id = excluded.id,
         worktree_id = excluded.worktree_id,
         status = excluded.status,
         updated_at = excluded.updated_at

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -58,7 +58,7 @@ export class SessionOrchestrator extends EventEmitter {
         !fs.existsSync(tmuxSession.worktreePath)
       ) {
         console.log(
-          `[Orchestrator] Cleaning up orphaned session (worktree deleted): ${tmuxSession.tmuxSessionName} -> ${tmuxSession.worktreePath}`
+          `[Orchestrator] Cleaning up orphaned session (worktree deleted): ${tmuxSession.tmuxSessionName} -> ${tmuxSession.worktreePath}`,
         );
         tmuxManager.killSession(tmuxSession.id);
         const dbSession = db.getSessionByWorktreePath(tmuxSession.worktreePath);
@@ -72,7 +72,7 @@ export class SessionOrchestrator extends EventEmitter {
       const dbSession = db.getSessionByWorktreePath(tmuxSession.worktreePath);
       if (dbSession) {
         console.log(
-          `[Orchestrator] Restored session: ${tmuxSession.tmuxSessionName} -> ${dbSession.id}`
+          `[Orchestrator] Restored session: ${tmuxSession.tmuxSessionName} -> ${dbSession.id}`,
         );
       }
 
@@ -81,22 +81,22 @@ export class SessionOrchestrator extends EventEmitter {
         .startInstance(tmuxSession.id, tmuxSession.tmuxSessionName)
         .then(() => {
           console.log(
-            `[Orchestrator] Started ttyd for restored session: ${tmuxSession.id}`
+            `[Orchestrator] Started ttyd for restored session: ${tmuxSession.id}`,
           );
           // ttyd起動完了をクライアントに通知（ttydPort/ttydUrlを含む最新情報を送信）
           const dbSession = db.getSessionByWorktreePath(
-            tmuxSession.worktreePath
+            tmuxSession.worktreePath,
           );
           const managed = this.toManagedSession(
             tmuxSession,
-            dbSession?.worktreeId || ""
+            dbSession?.worktreeId || "",
           );
           this.emit("session:updated", managed);
         })
-        .catch(err => {
+        .catch((err) => {
           console.error(
             `[Orchestrator] Failed to start ttyd for ${tmuxSession.id}:`,
-            err.message
+            err.message,
           );
         });
     }
@@ -107,7 +107,7 @@ export class SessionOrchestrator extends EventEmitter {
    */
   private toManagedSession(
     tmuxSession: TmuxSession,
-    worktreeId: string
+    worktreeId: string,
   ): ManagedSession {
     const ttydInstance = ttydManager.getInstance(tmuxSession.id);
     return {
@@ -145,7 +145,7 @@ export class SessionOrchestrator extends EventEmitter {
    */
   async startSession(
     worktreeId: string,
-    worktreePath: string
+    worktreePath: string,
   ): Promise<ManagedSession> {
     // 既存セッションがあれば再利用
     const existingTmux = tmuxManager.getSessionByWorktree(worktreePath);
@@ -155,7 +155,7 @@ export class SessionOrchestrator extends EventEmitter {
       if (!ttydInstance) {
         ttydInstance = await ttydManager.startInstance(
           existingTmux.id,
-          existingTmux.tmuxSessionName
+          existingTmux.tmuxSessionName,
         );
       }
 
@@ -170,10 +170,10 @@ export class SessionOrchestrator extends EventEmitter {
     // ttydインスタンスを起動
     const ttydInstance = await ttydManager.startInstance(
       tmuxSession.id,
-      tmuxSession.tmuxSessionName
+      tmuxSession.tmuxSessionName,
     );
 
-    // DBに保存（既存レコードがあればupsertで更新）
+    // DBに保存（既存レコードがあればupsertで更新、idは既存値を維持）
     db.upsertSession({
       id: tmuxSession.id,
       worktreeId,
@@ -181,8 +181,12 @@ export class SessionOrchestrator extends EventEmitter {
       status: "active",
     });
 
+    // upsertではidが更新されないため、DB上の実際のidを取得して使用する
+    const dbSession = db.getSessionByWorktreePath(worktreePath);
+    const sessionId = dbSession?.id ?? tmuxSession.id;
+
     const managed: ManagedSession = {
-      id: tmuxSession.id,
+      id: sessionId,
       worktreeId,
       worktreePath,
       status: "active",
@@ -256,7 +260,7 @@ export class SessionOrchestrator extends EventEmitter {
    * 既存セッションを復元（ttydが起動していなければ起動）
    */
   async restoreSession(
-    worktreePath: string
+    worktreePath: string,
   ): Promise<ManagedSession | undefined> {
     const tmuxSession = tmuxManager.getSessionByWorktree(worktreePath);
     if (!tmuxSession) return undefined;
@@ -266,7 +270,7 @@ export class SessionOrchestrator extends EventEmitter {
     if (!ttydInstance) {
       ttydInstance = await ttydManager.startInstance(
         tmuxSession.id,
-        tmuxSession.tmuxSessionName
+        tmuxSession.tmuxSessionName,
       );
     }
 
@@ -287,7 +291,7 @@ export class SessionOrchestrator extends EventEmitter {
     for (const s of allSessions) {
       if (s.worktreePath && !fs.existsSync(s.worktreePath)) {
         console.log(
-          `[Orchestrator] Cleaning up orphaned session: ${s.tmuxSessionName} -> ${s.worktreePath}`
+          `[Orchestrator] Cleaning up orphaned session: ${s.tmuxSessionName} -> ${s.worktreePath}`,
         );
         ttydManager.stopInstance(s.id);
         tmuxManager.killSession(s.id);
@@ -298,7 +302,7 @@ export class SessionOrchestrator extends EventEmitter {
         this.emit("session:stopped", s.id);
       }
     }
-    return tmuxManager.getAllSessions().map(s => {
+    return tmuxManager.getAllSessions().map((s) => {
       const dbSession = db.getSessionByWorktreePath(s.worktreePath);
       return this.toManagedSession(s, dbSession?.worktreeId || "");
     });

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -58,7 +58,7 @@ export class SessionOrchestrator extends EventEmitter {
         !fs.existsSync(tmuxSession.worktreePath)
       ) {
         console.log(
-          `[Orchestrator] Cleaning up orphaned session (worktree deleted): ${tmuxSession.tmuxSessionName} -> ${tmuxSession.worktreePath}`,
+          `[Orchestrator] Cleaning up orphaned session (worktree deleted): ${tmuxSession.tmuxSessionName} -> ${tmuxSession.worktreePath}`
         );
         tmuxManager.killSession(tmuxSession.id);
         const dbSession = db.getSessionByWorktreePath(tmuxSession.worktreePath);
@@ -72,7 +72,7 @@ export class SessionOrchestrator extends EventEmitter {
       const dbSession = db.getSessionByWorktreePath(tmuxSession.worktreePath);
       if (dbSession) {
         console.log(
-          `[Orchestrator] Restored session: ${tmuxSession.tmuxSessionName} -> ${dbSession.id}`,
+          `[Orchestrator] Restored session: ${tmuxSession.tmuxSessionName} -> ${dbSession.id}`
         );
       }
 
@@ -81,22 +81,22 @@ export class SessionOrchestrator extends EventEmitter {
         .startInstance(tmuxSession.id, tmuxSession.tmuxSessionName)
         .then(() => {
           console.log(
-            `[Orchestrator] Started ttyd for restored session: ${tmuxSession.id}`,
+            `[Orchestrator] Started ttyd for restored session: ${tmuxSession.id}`
           );
           // ttyd起動完了をクライアントに通知（ttydPort/ttydUrlを含む最新情報を送信）
           const dbSession = db.getSessionByWorktreePath(
-            tmuxSession.worktreePath,
+            tmuxSession.worktreePath
           );
           const managed = this.toManagedSession(
             tmuxSession,
-            dbSession?.worktreeId || "",
+            dbSession?.worktreeId || ""
           );
           this.emit("session:updated", managed);
         })
-        .catch((err) => {
+        .catch(err => {
           console.error(
             `[Orchestrator] Failed to start ttyd for ${tmuxSession.id}:`,
-            err.message,
+            err.message
           );
         });
     }
@@ -107,7 +107,7 @@ export class SessionOrchestrator extends EventEmitter {
    */
   private toManagedSession(
     tmuxSession: TmuxSession,
-    worktreeId: string,
+    worktreeId: string
   ): ManagedSession {
     const ttydInstance = ttydManager.getInstance(tmuxSession.id);
     return {
@@ -145,7 +145,7 @@ export class SessionOrchestrator extends EventEmitter {
    */
   async startSession(
     worktreeId: string,
-    worktreePath: string,
+    worktreePath: string
   ): Promise<ManagedSession> {
     // 既存セッションがあれば再利用
     const existingTmux = tmuxManager.getSessionByWorktree(worktreePath);
@@ -155,7 +155,7 @@ export class SessionOrchestrator extends EventEmitter {
       if (!ttydInstance) {
         ttydInstance = await ttydManager.startInstance(
           existingTmux.id,
-          existingTmux.tmuxSessionName,
+          existingTmux.tmuxSessionName
         );
       }
 
@@ -170,7 +170,7 @@ export class SessionOrchestrator extends EventEmitter {
     // ttydインスタンスを起動
     const ttydInstance = await ttydManager.startInstance(
       tmuxSession.id,
-      tmuxSession.tmuxSessionName,
+      tmuxSession.tmuxSessionName
     );
 
     // DBに保存（既存レコードがあればupsertで更新、idは既存値を維持）
@@ -260,7 +260,7 @@ export class SessionOrchestrator extends EventEmitter {
    * 既存セッションを復元（ttydが起動していなければ起動）
    */
   async restoreSession(
-    worktreePath: string,
+    worktreePath: string
   ): Promise<ManagedSession | undefined> {
     const tmuxSession = tmuxManager.getSessionByWorktree(worktreePath);
     if (!tmuxSession) return undefined;
@@ -270,7 +270,7 @@ export class SessionOrchestrator extends EventEmitter {
     if (!ttydInstance) {
       ttydInstance = await ttydManager.startInstance(
         tmuxSession.id,
-        tmuxSession.tmuxSessionName,
+        tmuxSession.tmuxSessionName
       );
     }
 
@@ -291,7 +291,7 @@ export class SessionOrchestrator extends EventEmitter {
     for (const s of allSessions) {
       if (s.worktreePath && !fs.existsSync(s.worktreePath)) {
         console.log(
-          `[Orchestrator] Cleaning up orphaned session: ${s.tmuxSessionName} -> ${s.worktreePath}`,
+          `[Orchestrator] Cleaning up orphaned session: ${s.tmuxSessionName} -> ${s.worktreePath}`
         );
         ttydManager.stopInstance(s.id);
         tmuxManager.killSession(s.id);
@@ -302,7 +302,7 @@ export class SessionOrchestrator extends EventEmitter {
         this.emit("session:stopped", s.id);
       }
     }
-    return tmuxManager.getAllSessions().map((s) => {
+    return tmuxManager.getAllSessions().map(s => {
       const dbSession = db.getSessionByWorktreePath(s.worktreePath);
       return this.toManagedSession(s, dbSession?.worktreeId || "");
     });

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -173,7 +173,7 @@ export class SessionOrchestrator extends EventEmitter {
       tmuxSession.tmuxSessionName
     );
 
-    // DBに保存（既存レコードがあればupsertで更新、idは既存値を維持）
+    // DBに保存（既存レコードがあればupsertで更新）
     db.upsertSession({
       id: tmuxSession.id,
       worktreeId,
@@ -181,12 +181,8 @@ export class SessionOrchestrator extends EventEmitter {
       status: "active",
     });
 
-    // upsertではidが更新されないため、DB上の実際のidを取得して使用する
-    const dbSession = db.getSessionByWorktreePath(worktreePath);
-    const sessionId = dbSession?.id ?? tmuxSession.id;
-
     const managed: ManagedSession = {
-      id: sessionId,
+      id: tmuxSession.id,
       worktreeId,
       worktreePath,
       status: "active",

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -173,23 +173,13 @@ export class SessionOrchestrator extends EventEmitter {
       tmuxSession.tmuxSessionName
     );
 
-    // DBに保存
-    try {
-      db.createSession({
-        id: tmuxSession.id,
-        worktreeId,
-        worktreePath,
-        status: "active",
-      });
-    } catch (error) {
-      // 重複作成のケースのみフォールバックし、それ以外は握りつぶさない
-      const existing = db.getSessionByWorktreePath(worktreePath);
-      if (existing?.id === tmuxSession.id) {
-        db.updateSessionStatus(tmuxSession.id, "active");
-      } else {
-        throw error;
-      }
-    }
+    // DBに保存（既存レコードがあればupsertで更新）
+    db.upsertSession({
+      id: tmuxSession.id,
+      worktreeId,
+      worktreePath,
+      status: "active",
+    });
 
     const managed: ManagedSession = {
       id: tmuxSession.id,

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -45,7 +45,7 @@ export class TtydManager extends EventEmitter {
         "[TtydManager] ttyd not found. Install it:\n" +
           "  macOS: brew install ttyd\n" +
           "  Ubuntu: apt install ttyd\n" +
-          "  Or from: https://github.com/tsl0922/ttyd",
+          "  Or from: https://github.com/tsl0922/ttyd"
       );
     }
   }
@@ -55,7 +55,7 @@ export class TtydManager extends EventEmitter {
    * 127.0.0.1にbindを試みて確認する（3秒タイムアウト付き）
    */
   private checkPortAvailable(port: number): Promise<boolean> {
-    return new Promise((resolve) => {
+    return new Promise(resolve => {
       const timeout = setTimeout(() => {
         server.close();
         resolve(false);
@@ -80,7 +80,7 @@ export class TtydManager extends EventEmitter {
    */
   private async findAvailablePort(): Promise<number> {
     const usedPorts = new Set(
-      Array.from(this.instances.values()).map((i) => i.port),
+      Array.from(this.instances.values()).map(i => i.port)
     );
 
     // nextPortからMAX_PORTまで探し、見つからなければMIN_PORTからnextPort-1まで探索
@@ -94,7 +94,7 @@ export class TtydManager extends EventEmitter {
       const available = await this.checkPortAvailable(port);
       if (!available) {
         console.log(
-          `[TtydManager] Port ${port} is in use by another process, skipping`,
+          `[TtydManager] Port ${port} is in use by another process, skipping`
         );
         continue;
       }
@@ -113,7 +113,7 @@ export class TtydManager extends EventEmitter {
    */
   async startInstance(
     sessionId: string,
-    tmuxSessionName: string,
+    tmuxSessionName: string
   ): Promise<TtydInstance> {
     // 既に起動済み
     const existing = this.instances.get(sessionId);
@@ -143,7 +143,7 @@ export class TtydManager extends EventEmitter {
    */
   private async _startInstanceInternal(
     sessionId: string,
-    tmuxSessionName: string,
+    tmuxSessionName: string
   ): Promise<TtydInstance> {
     const port = await this.findAvailablePort();
     const basePath = `/ttyd/${sessionId}`;
@@ -180,7 +180,7 @@ export class TtydManager extends EventEmitter {
       {
         stdio: ["ignore", "pipe", "pipe"],
         detached: false,
-      },
+      }
     );
 
     const instance: TtydInstance = {
@@ -208,12 +208,12 @@ export class TtydManager extends EventEmitter {
         }
       });
 
-      ttydProcess.on("error", (error) => {
+      ttydProcess.on("error", error => {
         clearTimeout(timeout);
         reject(error);
       });
 
-      ttydProcess.on("exit", (code) => {
+      ttydProcess.on("exit", code => {
         if (code !== 0 && code !== null) {
           clearTimeout(timeout);
           reject(new Error(`ttyd exited with code ${code}: ${stderr}`));
@@ -225,13 +225,13 @@ export class TtydManager extends EventEmitter {
     this.emit("instance:started", instance);
 
     console.log(
-      `[TtydManager] Started ttyd for ${tmuxSessionName} on port ${port}`,
+      `[TtydManager] Started ttyd for ${tmuxSessionName} on port ${port}`
     );
 
     // プロセス終了時の処理
-    ttydProcess.on("exit", (code) => {
+    ttydProcess.on("exit", code => {
       console.log(
-        `[TtydManager] ttyd for session ${sessionId} exited with code ${code}`,
+        `[TtydManager] ttyd for session ${sessionId} exited with code ${code}`
       );
       this.instances.delete(sessionId);
       this.emit("instance:stopped", sessionId);

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -45,22 +45,29 @@ export class TtydManager extends EventEmitter {
         "[TtydManager] ttyd not found. Install it:\n" +
           "  macOS: brew install ttyd\n" +
           "  Ubuntu: apt install ttyd\n" +
-          "  Or from: https://github.com/tsl0922/ttyd"
+          "  Or from: https://github.com/tsl0922/ttyd",
       );
     }
   }
 
   /**
    * 指定ポートがOSレベルで使用可能かチェック
-   * 127.0.0.1にbindを試みて確認する
+   * 127.0.0.1にbindを試みて確認する（3秒タイムアウト付き）
    */
   private checkPortAvailable(port: number): Promise<boolean> {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
+      const timeout = setTimeout(() => {
+        server.close();
+        resolve(false);
+      }, 3000);
+
       const server = net.createServer();
       server.once("error", () => {
+        clearTimeout(timeout);
         resolve(false);
       });
       server.once("listening", () => {
+        clearTimeout(timeout);
         server.close(() => resolve(true));
       });
       server.listen(port, "127.0.0.1");
@@ -73,23 +80,27 @@ export class TtydManager extends EventEmitter {
    */
   private async findAvailablePort(): Promise<number> {
     const usedPorts = new Set(
-      Array.from(this.instances.values()).map(i => i.port)
+      Array.from(this.instances.values()).map((i) => i.port),
     );
 
-    for (let port = this.nextPort; port <= this.MAX_PORT; port++) {
+    // nextPortからMAX_PORTまで探し、見つからなければMIN_PORTからnextPort-1まで探索
+    const totalPorts = this.MAX_PORT - this.MIN_PORT + 1;
+    for (let i = 0; i < totalPorts; i++) {
+      const port =
+        this.MIN_PORT + ((this.nextPort - this.MIN_PORT + i) % totalPorts);
       if (usedPorts.has(port)) {
         continue;
       }
       const available = await this.checkPortAvailable(port);
       if (!available) {
         console.log(
-          `[TtydManager] Port ${port} is in use by another process, skipping`
+          `[TtydManager] Port ${port} is in use by another process, skipping`,
         );
         continue;
       }
       this.nextPort = port + 1;
       if (this.nextPort > this.MAX_PORT) {
-        this.nextPort = this.MIN_PORT; // ラップアラウンド
+        this.nextPort = this.MIN_PORT;
       }
       return port;
     }
@@ -102,7 +113,7 @@ export class TtydManager extends EventEmitter {
    */
   async startInstance(
     sessionId: string,
-    tmuxSessionName: string
+    tmuxSessionName: string,
   ): Promise<TtydInstance> {
     // 既に起動済み
     const existing = this.instances.get(sessionId);
@@ -132,7 +143,7 @@ export class TtydManager extends EventEmitter {
    */
   private async _startInstanceInternal(
     sessionId: string,
-    tmuxSessionName: string
+    tmuxSessionName: string,
   ): Promise<TtydInstance> {
     const port = await this.findAvailablePort();
     const basePath = `/ttyd/${sessionId}`;
@@ -169,7 +180,7 @@ export class TtydManager extends EventEmitter {
       {
         stdio: ["ignore", "pipe", "pipe"],
         detached: false,
-      }
+      },
     );
 
     const instance: TtydInstance = {
@@ -197,12 +208,12 @@ export class TtydManager extends EventEmitter {
         }
       });
 
-      ttydProcess.on("error", error => {
+      ttydProcess.on("error", (error) => {
         clearTimeout(timeout);
         reject(error);
       });
 
-      ttydProcess.on("exit", code => {
+      ttydProcess.on("exit", (code) => {
         if (code !== 0 && code !== null) {
           clearTimeout(timeout);
           reject(new Error(`ttyd exited with code ${code}: ${stderr}`));
@@ -214,13 +225,13 @@ export class TtydManager extends EventEmitter {
     this.emit("instance:started", instance);
 
     console.log(
-      `[TtydManager] Started ttyd for ${tmuxSessionName} on port ${port}`
+      `[TtydManager] Started ttyd for ${tmuxSessionName} on port ${port}`,
     );
 
     // プロセス終了時の処理
-    ttydProcess.on("exit", code => {
+    ttydProcess.on("exit", (code) => {
       console.log(
-        `[TtydManager] ttyd for session ${sessionId} exited with code ${code}`
+        `[TtydManager] ttyd for session ${sessionId} exited with code ${code}`,
       );
       this.instances.delete(sessionId);
       this.emit("instance:stopped", sessionId);

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -7,6 +7,7 @@
 
 import { type ChildProcess, execSync, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
+import net from "node:net";
 import { TTYD_PORT_END, TTYD_PORT_START } from "./constants.js";
 
 export interface TtydInstance {
@@ -50,21 +51,47 @@ export class TtydManager extends EventEmitter {
   }
 
   /**
-   * 利用可能なポートを探す
+   * 指定ポートがOSレベルで使用可能かチェック
+   * 127.0.0.1にbindを試みて確認する
    */
-  private findAvailablePort(): number {
+  private checkPortAvailable(port: number): Promise<boolean> {
+    return new Promise(resolve => {
+      const server = net.createServer();
+      server.once("error", () => {
+        resolve(false);
+      });
+      server.once("listening", () => {
+        server.close(() => resolve(true));
+      });
+      server.listen(port, "127.0.0.1");
+    });
+  }
+
+  /**
+   * 利用可能なポートを探す
+   * 自身の管理ポートに加え、OSレベルでのバインド可否もチェックする
+   */
+  private async findAvailablePort(): Promise<number> {
     const usedPorts = new Set(
       Array.from(this.instances.values()).map(i => i.port)
     );
 
     for (let port = this.nextPort; port <= this.MAX_PORT; port++) {
-      if (!usedPorts.has(port)) {
-        this.nextPort = port + 1;
-        if (this.nextPort > this.MAX_PORT) {
-          this.nextPort = this.MIN_PORT; // ラップアラウンド
-        }
-        return port;
+      if (usedPorts.has(port)) {
+        continue;
       }
+      const available = await this.checkPortAvailable(port);
+      if (!available) {
+        console.log(
+          `[TtydManager] Port ${port} is in use by another process, skipping`
+        );
+        continue;
+      }
+      this.nextPort = port + 1;
+      if (this.nextPort > this.MAX_PORT) {
+        this.nextPort = this.MIN_PORT; // ラップアラウンド
+      }
+      return port;
     }
     throw new Error("No available ports for ttyd");
   }
@@ -107,7 +134,7 @@ export class TtydManager extends EventEmitter {
     sessionId: string,
     tmuxSessionName: string
   ): Promise<TtydInstance> {
-    const port = this.findAvailablePort();
+    const port = await this.findAvailablePort();
     const basePath = `/ttyd/${sessionId}`;
 
     // ttydオプション:


### PR DESCRIPTION
## Summary

- ttyd起動時にOSレベルのポート使用チェック（`net.createServer`によるbindテスト）を追加し、システムプロセスがポートを占有している場合のEADDRINUSEエラーを回避
- セッションDB保存をUPSERTパターンに変更し、worktree_pathのUNIQUE制約違反でセッション開始が失敗する問題を修正
- ポート探索の全範囲ラップアラウンド対応、タイムアウト追加、FK参照保護

## Test plan

- [ ] ワークツリークリックでセッションが正常に開始されること
- [ ] 既存セッションがある状態でサーバー再起動→セッション復元が正常に動作すること
- [ ] ポート7680がシステムプロセスに占有されていても、次のポートで起動すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal startup reliability by verifying OS-level port bindability before launching instances.
  * Reduced race conditions when selecting ports, with clearer logging for bind failures.

* **Refactor**
  * Consolidated session persistence to create-or-update records and ensure returned session identifiers reflect the persisted database state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->