### PR TITLE
feat: セッションidle状態の色分けとDB永続化

### DIFF
--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -49,13 +49,15 @@ export function SessionCard({
     return () => clearInterval(timer);
   }, []);
 
-  // stopped/error → 赤、idle（サーバーまたはクライアント検出） → 青、active → 緑
+  // stopped/error → 赤、no content(サーバーidle) → 青、変化なし(クライアントidle) → 赤、active → 緑
   const dotColor =
     session.status === "stopped" || session.status === "error"
       ? "bg-red-500"
-      : session.status === "idle" || isIdle
+      : session.status === "idle"
         ? "bg-blue-500"
-        : "bg-green-500";
+        : isIdle
+          ? "bg-red-500"
+          : "bg-green-500";
 
   // アイドル時はactivityText（✻ Baked for ...）、アクティブ時はコンテンツ行
   const idle = session.status === "idle" || isIdle;

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -430,6 +430,17 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     });
 
     socket.on("session:previews", previews => {
+      // セッションのstatusをプレビューから更新
+      setSessions(prev => {
+        const next = new Map(prev);
+        for (const p of previews) {
+          const existing = next.get(p.sessionId);
+          if (existing && existing.status !== p.status) {
+            next.set(p.sessionId, { ...existing, status: p.status });
+          }
+        }
+        return next;
+      });
       setSessionPreviews(prev => {
         const next = new Map(prev);
         for (const p of previews) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -875,7 +875,7 @@ async function startServer() {
       beaconManager.closeSession();
     });
 
-    // セッションプレビューのポーリング（3秒間隔）
+    // セッションプレビューのポーリング（1秒間隔）
     const previewInterval = setInterval(() => {
       try {
         const previews = sessionOrchestrator.getAllPreviews();
@@ -885,7 +885,7 @@ async function startServer() {
       } catch (err) {
         console.error("[Preview] Error:", getErrorMessage(err));
       }
-    }, 3000);
+    }, 1000);
 
     // 接続時に初回プレビューを送信
     try {

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -392,8 +392,14 @@ export class SessionOrchestrator extends EventEmitter {
       // コンテンツ行あり → active
       const status: SessionStatus = text === "" ? "idle" : "active";
       // ステータス変化時のみDB更新（不要なI/Oを回避）
+      // stopped/errorはライフサイクル駆動のstatusなので上書きしない
       const dbSession = db.getSessionByWorktreePath(session.worktreePath);
-      if (!dbSession || dbSession.status !== status) {
+      if (
+        dbSession &&
+        dbSession.status !== "stopped" &&
+        dbSession.status !== "error" &&
+        dbSession.status !== status
+      ) {
         db.updateSessionStatus(session.id, status);
       }
 

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -337,6 +337,7 @@ export class SessionOrchestrator extends EventEmitter {
     sessionId: string;
     text: string;
     activityText: string;
+    status: SessionStatus;
     timestamp: number;
   }> {
     const allSessions = tmuxManager.getAllSessions();
@@ -344,6 +345,7 @@ export class SessionOrchestrator extends EventEmitter {
       sessionId: string;
       text: string;
       activityText: string;
+      status: SessionStatus;
       timestamp: number;
     }> = [];
 
@@ -384,23 +386,16 @@ export class SessionOrchestrator extends EventEmitter {
       // ✢✻行（アイドル時表示用）
       const activityLine = allLines.findLast(line => /[✢✻]/.test(line)) || "";
 
-      // Claude Codeのアクティビティ記号でステータスを判定
-      // ✢ = 稼働中（スピナー）、✻ = 待機中（Baked for ...）
-      const hasActiveSpinner = allLines.some(line => /✢/.test(line));
-      const hasIdleIndicator = allLines.some(line => /✻/.test(line));
-
-      if (hasActiveSpinner) {
-        db.updateSessionStatus(session.id, "active");
-      } else if (hasIdleIndicator || text === "") {
-        // ✻表示（待機中）またはコンテンツなし（起動中等）→ idle
-        db.updateSessionStatus(session.id, "idle");
-      }
-      // どちらの記号もなくコンテンツありの場合はDB状態を維持（許可待ち等）
+      // コンテンツ行が空 → idle（起動中アニメーションやno content）
+      // コンテンツ行あり → active
+      const status: SessionStatus = text === "" ? "idle" : "active";
+      db.updateSessionStatus(session.id, status);
 
       previews.push({
         sessionId: session.id,
         text,
         activityText: activityLine,
+        status,
         timestamp: Date.now(),
       });
     }

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -359,8 +359,10 @@ export class SessionOrchestrator extends EventEmitter {
 
       // Claude Code UI行を判定する関数
       const isUiLine = (line: string): boolean => {
-        // アニメーション記号行（✢ ✻ 等）は常にUI行として除外
-        if (/[✢✻]/.test(line)) return true;
+        // アニメーション記号行（✢ ✻ や起動アニメーションのブロック要素）は常にUI行として除外
+        if (/[✢✻▘▝▛▜▐▌█]/.test(line)) return true;
+        // Sautéed/Baked等のアイドル表示
+        if (line.includes("Sautéed for")) return true;
         // ステータスバー・モード表示
         if (line.includes("⏵")) return true;
         if (line.includes("bypass permissions")) return true;

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -391,7 +391,11 @@ export class SessionOrchestrator extends EventEmitter {
       // コンテンツ行が空 → idle（起動中アニメーションやno content）
       // コンテンツ行あり → active
       const status: SessionStatus = text === "" ? "idle" : "active";
-      db.updateSessionStatus(session.id, status);
+      // ステータス変化時のみDB更新（不要なI/Oを回避）
+      const dbSession = db.getSessionByWorktreePath(session.worktreePath);
+      if (!dbSession || dbSession.status !== status) {
+        db.updateSessionStatus(session.id, status);
+      }
 
       previews.push({
         sessionId: session.id,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -123,6 +123,7 @@ export interface ServerToClientEvents {
       sessionId: string;
       text: string;
       activityText: string;
+      status: SessionStatus;
       timestamp: number;
     }>
   ) => void;


### PR DESCRIPTION
## Summary
- no content / 起動中アニメーション → 青（サーバー側でidle判定、DB永続化）
- コンテンツ変化なし10秒以上（Baked for...等） → 赤（クライアント側idle）
- コンテンツ変化中 → 緑（active）
- session:previewsにstatusを含めてリアルタイム同期
- ポーリング間隔を3秒→1秒に変更
- isUiLineに起動アニメーション文字・Sautéed forを追加
- post-edit-lint.shのフォーマッターをprettier→biomeに変更

## Test plan
- [ ] リロード後にidle状態が青で維持されること
- [ ] 起動中アニメーション表示時に青であること
- [ ] Baked for / Sautéed for 表示時に赤であること
- [ ] Claude稼働中に緑であること
- [ ] セッション停止時に赤であること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Session status updates more frequently for near-real-time visibility.
  * Session preview data now synchronizes status into live session state for better consistency.
  * Preview filtering refined to reduce noisy animation/irrelevant lines.

* **Bug Fixes**
  * Refined idle/error indicator behavior so UI colors better reflect true session status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->