### PR TITLE
chore: 最新hookに追従

### DIFF
--- a/.claude/hooks/check-ci-coderabbit.sh
+++ b/.claude/hooks/check-ci-coderabbit.sh
@@ -76,63 +76,21 @@ fi
 # === 3. 未解決レビュースレッド取得（GraphQL API） ===
 # PUSH_TIMEベースのフィルタは不要。未解決スレッド数がCodeRabbit指摘の判定基準。
 
-CR_UNRESOLVED=0
-CR_COMMENTS_JSON="[]"
-CR_GQL_ERROR="false"
-REPO_OWNER=$(printf '%s\n' "$REPO_INFO" | cut -d'/' -f1)
-REPO_NAME=$(printf '%s\n' "$REPO_INFO" | cut -d'/' -f2)
-PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null) || PR_NUM=""
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/fetch-unresolved-threads.sh"
+fetch_unresolved_threads
 
-if [[ -n "$PR_NUM" ]]; then
-  UNRESOLVED_DATA=$(gh api graphql -f query="
-    {
-      repository(owner: \"${REPO_OWNER}\", name: \"${REPO_NAME}\") {
-        pullRequest(number: ${PR_NUM}) {
-          reviewThreads(first: 100) {
-            nodes {
-              isResolved
-              comments(first: 1) {
-                nodes {
-                  author { login }
-                  body
-                  path
-                  line
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  " 2>/dev/null) || UNRESOLVED_DATA=""
+CR_UNRESOLVED="$UNRESOLVED_THREADS_COUNT"
+CR_GQL_ERROR="$UNRESOLVED_THREADS_ERROR"
 
-  if [[ -z "$UNRESOLVED_DATA" ]]; then
-    CR_GQL_ERROR="true"
-  else
-    CR_UNRESOLVED=$(printf '%s\n' "$UNRESOLVED_DATA" | jq '
-      [
-        .data.repository.pullRequest.reviewThreads.nodes[]
-        | select(.isResolved == false)
-        | select(.comments.nodes[0].author.login == "coderabbitai")
-      ] | length
-    ' 2>/dev/null) || CR_UNRESOLVED=0
-
-    CR_COMMENTS_JSON=$(printf '%s\n' "$UNRESOLVED_DATA" | jq '
-      [
-        .data.repository.pullRequest.reviewThreads.nodes[]
-        | select(.isResolved == false)
-        | .comments.nodes[0]
-        | select(.author.login == "coderabbitai")
-        | {
-            path: .path,
-            line: (.line // 0),
-            body_preview: (.body | .[0:100])
-          }
-      ]
-    ' 2>/dev/null) || CR_COMMENTS_JSON="[]"
-
-  fi
-fi
+# 監視スクリプト用のJSON形式に変換
+CR_COMMENTS_JSON=$(printf '%s\n' "$UNRESOLVED_THREADS_JSON" | jq '
+  [.[] | {
+    path: .path,
+    line: (.line // 0),
+    body_preview: (.body | .[0:100])
+  }]
+' 2>/dev/null) || CR_COMMENTS_JSON="[]"
 
 # === 4. 総合判定と出力 ===
 

--- a/.claude/hooks/fetch-unresolved-threads.sh
+++ b/.claude/hooks/fetch-unresolved-threads.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# 未解決CodeRabbitレビュースレッドをGraphQL APIで取得する共通ヘルパー
+#
+# 使い方:
+#   source fetch-unresolved-threads.sh
+#   fetch_unresolved_threads
+#
+# 出力変数:
+#   UNRESOLVED_THREADS_JSON - フィルタ済みの未解決CodeRabbitスレッド配列（JSON）
+#   UNRESOLVED_THREADS_COUNT - 未解決スレッド数
+#   UNRESOLVED_THREADS_ERROR - "true" or "false"（GraphQL取得失敗時）
+
+fetch_unresolved_threads() {
+  UNRESOLVED_THREADS_JSON="[]"
+  UNRESOLVED_THREADS_COUNT=0
+  UNRESOLVED_THREADS_ERROR="false"
+
+  local pr_num
+  pr_num=$(gh pr view --json number -q '.number' 2>/dev/null) || pr_num=""
+  if [[ -z "$pr_num" ]]; then
+    return 0
+  fi
+
+  local repo_info
+  repo_info=$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null) || repo_info=""
+  if [[ -z "$repo_info" ]]; then
+    return 0
+  fi
+
+  local repo_owner repo_name
+  repo_owner=$(printf '%s\n' "$repo_info" | cut -d'/' -f1)
+  repo_name=$(printf '%s\n' "$repo_info" | cut -d'/' -f2)
+
+  local raw_data
+  raw_data=$(gh api graphql -f query="
+    {
+      repository(owner: \"${repo_owner}\", name: \"${repo_name}\") {
+        pullRequest(number: ${pr_num}) {
+          reviewThreads(first: 100) {
+            nodes {
+              isResolved
+              comments(first: 1) {
+                nodes {
+                  author { login }
+                  body
+                  path
+                  line
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  " 2>/dev/null) || raw_data=""
+
+  if [[ -z "$raw_data" ]]; then
+    UNRESOLVED_THREADS_ERROR="true"
+    return 0
+  fi
+
+  if printf '%s\n' "$raw_data" | jq -e '.errors | length > 0' >/dev/null 2>&1; then
+    UNRESOLVED_THREADS_ERROR="true"
+    return 0
+  fi
+
+  UNRESOLVED_THREADS_JSON=$(printf '%s\n' "$raw_data" | jq '
+    [
+      .data.repository.pullRequest.reviewThreads.nodes[]
+      | select(.isResolved == false)
+      | .comments.nodes[0]
+      | select(.author.login == "coderabbitai")
+    ]
+  ' 2>/dev/null) || UNRESOLVED_THREADS_JSON="[]"
+
+  UNRESOLVED_THREADS_COUNT=$(printf '%s\n' "$UNRESOLVED_THREADS_JSON" | jq 'length' 2>/dev/null) || UNRESOLVED_THREADS_COUNT=0
+}

--- a/.claude/hooks/post-edit-lint.sh
+++ b/.claude/hooks/post-edit-lint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 # PostToolUse (Write|Edit) フック
-# ファイル編集後に自動フォーマットを実行
+# ファイル編集後に自動リント・フォーマットを実行し、残った違反をadditionalContextとしてClaudeに返す
+# 自動修正を先に行い、残った違反だけを報告する方針
 # リントエラーでスクリプト自体が終了しないよう set -eo pipefail は使わない
 
 # プロジェクトルート
@@ -30,7 +31,7 @@ case "$EXT" in
   ts|tsx|js|jsx)
     # --- TypeScript/JavaScriptファイル ---
 
-    # biomeで自動フォーマット（出力は捨てる）
+    # biome formatで自動フォーマット（出力は捨てる）
     (cd "$PROJECT_ROOT" && npx biome format --write "$FILE_PATH" >/dev/null 2>&1) || true
 
     # フォーマットが変更されたか確認（git diffで検出）
@@ -39,6 +40,19 @@ case "$EXT" in
         "hookSpecificOutput": {
           "hookEventName": "PostToolUse",
           "additionalContext": "biomeによりフォーマットが自動修正されました。変更内容を確認してください。"
+        }
+      }'
+    fi
+
+    # biome checkで残りの違反を取得
+    LINT_OUTPUT=$(cd "$PROJECT_ROOT" && npx biome check "$FILE_PATH" 2>&1 | head -20) || true
+
+    # biomeの出力にエラーや警告が含まれている場合のみ報告
+    if echo "$LINT_OUTPUT" | grep -qE '(diagnostics|FIXABLE|error|×)'; then
+      jq -n --arg violations "$LINT_OUTPUT" '{
+        "hookSpecificOutput": {
+          "hookEventName": "PostToolUse",
+          "additionalContext": ("リント違反が検出されました。修正してください:\n" + $violations)
         }
       }'
     fi

--- a/.claude/hooks/post-push-monitor.sh
+++ b/.claude/hooks/post-push-monitor.sh
@@ -15,6 +15,10 @@ IS_GH_PR_CREATE=false
 # git push の検出（git stash push 等の誤検出を防ぐ）
 if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+(.+[[:space:]]+)?push([[:space:]]|$) ]] && ! [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+(stash|submodule)[[:space:]] ]]; then
   IS_GIT_PUSH=true
+  # dry-run（-n/--dry-run）は実際にpushしないため全処理をスキップ
+  if [[ "$COMMAND" =~ (^|[[:space:]])(-n|--dry-run)([[:space:]]|$) ]]; then
+    exit 0
+  fi
 fi
 
 # gh pr create の検出（gh -R owner/repo pr create 等、オプションが間に入るケースにも対応）
@@ -39,10 +43,26 @@ CHECK_SCRIPT="$PROJECT_DIR/.claude/hooks/check-ci-coderabbit.sh"
 # CodeRabbit返信はpush完了後にのみ許可するため、push成功の証跡を残す
 # -------------------------------------------------------------------
 if $IS_GIT_PUSH; then
-  # dry-run（-n/--dry-run）は実際にpushしないためマーカー作成をスキップ
-  if ! [[ "$COMMAND" =~ (^|[[:space:]])(-n|--dry-run)([[:space:]]|$) ]]; then
-    # マーカーにpush時のHEAD commit SHAを記録（push完了の証跡+SHA一致検証用）
-    git rev-parse HEAD > "$PROJECT_DIR/.claude/push-completed.marker"
+  UNRESOLVED_CONTEXT=""
+  # マーカーにpush時のHEAD commit SHAを記録（push完了の証跡+SHA一致検証用）
+  git rev-parse HEAD > "$PROJECT_DIR/.claude/push-completed.marker"
+
+  # 未解決CodeRabbitスレッドの取得（push直後に一覧表示するため）
+  source "$PROJECT_DIR/.claude/hooks/fetch-unresolved-threads.sh"
+  fetch_unresolved_threads
+
+  if [[ "$UNRESOLVED_THREADS_ERROR" == "true" ]]; then
+    UNRESOLVED_CONTEXT="[CodeRabbit未解決スレッド: 取得失敗]\n"
+    UNRESOLVED_CONTEXT="${UNRESOLVED_CONTEXT}未解決スレッドの取得に失敗しました。/check-coderabbit で再確認してください。\n\n"
+  elif [[ "$UNRESOLVED_THREADS_COUNT" -gt 0 ]]; then
+    PUSH_UNRESOLVED_LIST=$(printf '%s\n' "$UNRESOLVED_THREADS_JSON" | jq -r '
+      [.[] | "- " + (.path // "(no path)") + (if .line == null then "" else ":" + (.line | tostring) end) + " — " + ((.body // "") | split("\n")[0] | .[0:120])]
+      | join("\n")
+    ' 2>/dev/null) || PUSH_UNRESOLVED_LIST=""
+
+    UNRESOLVED_CONTEXT="[CodeRabbit未解決スレッド: ${UNRESOLVED_THREADS_COUNT}件]\n"
+    UNRESOLVED_CONTEXT="${UNRESOLVED_CONTEXT}以下のスレッドが未解決です。修正コミットをpushした場合は、各スレッドへの返信を忘れないでください。\n"
+    UNRESOLVED_CONTEXT="${UNRESOLVED_CONTEXT}${PUSH_UNRESOLVED_LIST}\n\n"
   fi
 fi
 
@@ -53,6 +73,8 @@ CONTEXT=""
 
 if $IS_GIT_PUSH; then
   CONTEXT="[CI・CodeRabbit監視 - push後]\n"
+  # 未解決スレッド一覧を追加（0件の場合はUNRESOLVED_CONTEXTが空なので何も追加されない）
+  CONTEXT="${CONTEXT}${UNRESOLVED_CONTEXT}"
 elif $IS_GH_PR_CREATE; then
   PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null) || true
   CONTEXT="[CI・CodeRabbit監視 - PR #${PR_NUMBER:-?} 作成後]\n"

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -16,7 +16,13 @@ fi
 
 
 # --- pre-push-reviewフラグファイル作成のガード ---
+# コマンド文字列にフラグ名が含まれていれば検査
+# スキルの正規パターンのみ許可、それ以外は全てブロック
 if [[ "$COMMAND" =~ claude-pre-push-review-done ]]; then
+  # スキルの厳密なパターン: touch "$(git rev-parse --git-dir)/claude-pre-push-review-done"
+  # 5条件全て満たす場合のみ許可:
+  # (1) touchで始まる (2) git rev-parseを含む (3) コマンド連結(;|&)なし
+  # (4) コメント(#)なし (5) リダイレクト(>)なし (6) 改行なし
   if [[ "$COMMAND" =~ ^[[:space:]]*touch[[:space:]] ]] && \
      [[ "$COMMAND" =~ git[[:space:]]+rev-parse[[:space:]]+--git-dir ]] && \
      ! [[ "$COMMAND" =~ [\;\|\&] ]] && \
@@ -33,13 +39,19 @@ fi
 
 
 # --- 破壊的コマンドガード ---
+# rm -rf: ビルドキャッシュ（node_modules, target, dist, .next, build等）削除のみ許可
+# 引数を個別に検査し、全operandがキャッシュ系ディレクトリの場合のみ通過させる
 if [[ "$COMMAND" =~ rm[[:space:]]+-[[:alpha:]]*r[[:alpha:]]*f ]] || [[ "$COMMAND" =~ rm[[:space:]]+-[[:alpha:]]*f[[:alpha:]]*r ]] || [[ "$COMMAND" =~ rm[[:space:]]+--recursive[[:space:]]+--force ]] || [[ "$COMMAND" =~ rm[[:space:]]+--force[[:space:]]+--recursive ]] || [[ "$COMMAND" =~ rm[[:space:]]+-r[[:space:]]+-f ]] || [[ "$COMMAND" =~ rm[[:space:]]+-f[[:space:]]+-r ]]; then
+  # rm コマンドの引数を抽出（オプション以外）
   SAFE_DIRS="node_modules|target|dist|\.next|build|__pycache__|\.pytest_cache"
+  # 引数を1つずつ検査し、全てがキャッシュ系ディレクトリパスか確認
   ALL_SAFE=true
   for arg in $COMMAND; do
+    # rm自体とオプション（-で始まる）はスキップ
     case "$arg" in
       rm|-*) continue ;;
     esac
+    # 引数のbasenameがキャッシュ系ディレクトリか判定
     arg_base=$(basename "$arg" 2>/dev/null) || arg_base="$arg"
     if ! [[ "$arg_base" =~ ^(${SAFE_DIRS})$ ]]; then
       ALL_SAFE=false
@@ -49,54 +61,80 @@ if [[ "$COMMAND" =~ rm[[:space:]]+-[[:alpha:]]*r[[:alpha:]]*f ]] || [[ "$COMMAND
   if ! $ALL_SAFE; then
     echo "BLOCKED: rm -rf は危険なコマンドです" >&2
     echo "  WHY: エージェントが意図せず重要ファイルを削除するインシデントを防止" >&2
-    echo "  FIX: ビルドキャッシュ削除なら rm -rf node_modules / rm -rf dist を使用" >&2
+    echo "  FIX: ビルドキャッシュ削除なら rm -rf node_modules / rm -rf target を使用" >&2
     exit 2
   fi
 fi
 
+# git reset --hard: 作業ツリーの全変更を破棄する危険なコマンド
 if [[ "$COMMAND" =~ git[[:space:]]+reset[[:space:]]+--hard ]]; then
   echo "BLOCKED: git reset --hard は作業ツリーの全変更を破棄する危険なコマンドです" >&2
+  echo "  WHY: 未コミットの作業内容が全て失われ、復元不可能になる" >&2
+  echo "  FIX: 特定ファイルの復元は git checkout -- <file> を使用" >&2
   exit 2
 fi
 
+# git clean -f / git clean -fd: 未追跡ファイルを削除する危険なコマンド
 if [[ "$COMMAND" =~ git[[:space:]]+clean[[:space:]]+-[[:alpha:]]*f ]]; then
   echo "BLOCKED: git clean -f は未追跡ファイルを削除する危険なコマンドです" >&2
+  echo "  WHY: 新規作成したファイルが全て失われ、復元不可能になる" >&2
+  echo "  FIX: 特定ファイルの削除は rm <file> を使用" >&2
   exit 2
 fi
 
+# git checkout -- .: ファイル全体の変更を復元する危険なコマンド
 if [[ "$COMMAND" =~ git[[:space:]]+checkout[[:space:]]+--[[:space:]]+\. ]]; then
   echo "BLOCKED: git checkout -- . は作業ツリーの全変更を破棄する危険なコマンドです" >&2
+  echo "  WHY: 全ファイルの変更が一括で破棄され、復元不可能になる" >&2
+  echo "  FIX: 特定ファイルの復元は git checkout -- <specific-file> を使用" >&2
   exit 2
 fi
 
+# git push --force / git push -f: --force-with-leaseは許可
 if [[ "$COMMAND" =~ git[[:space:]]+(.+[[:space:]]+)?push[[:space:]]+.*--force ]] || [[ "$COMMAND" =~ git[[:space:]]+(.+[[:space:]]+)?push[[:space:]]+.*-f([[:space:]]|$) ]]; then
   if ! [[ "$COMMAND" =~ --force-with-lease ]]; then
-    echo "BLOCKED: git push --force は危険なコマンドです。--force-with-lease を使用してください" >&2
+    echo "BLOCKED: git push --force は危険なコマンドです" >&2
+    echo "  WHY: リモートの他の人のコミットを上書きし、チームの作業が失われる" >&2
+    echo "  FIX: --force-with-lease を使用（リモートが変更されていない場合のみ上書き）" >&2
     exit 2
   fi
 fi
 
+# --no-verify: git hooksのバイパスを禁止（エージェントがLefthookをスキップするのを防ぐ）
+# git push --no-verify もpre-pushフックをバイパスするためブロック対象
 if [[ "$COMMAND" =~ git[[:space:]]+.+--no-verify ]]; then
   echo "BLOCKED: --no-verify によるgit hookのバイパスは禁止されています" >&2
+  echo "  WHY: Lefthookによる品質チェック（fmt/lint/test）がスキップされ、CIで失敗するコードがpushされる" >&2
+  echo "  FIX: Lefthookの問題はlefthook.ymlの設定を確認" >&2
   exit 2
 fi
 
+# -n フラグ: git commit -n は --no-verify の短縮形なのでブロック
+# ただし git push -n はdry-runなので許可
 if [[ "$COMMAND" =~ git[[:space:]]+.+-n([[:space:]]|$) ]]; then
   if [[ "$COMMAND" =~ git[[:space:]]+push ]] || [[ "$COMMAND" =~ git[[:space:]]+.*push ]]; then
     : # git push -n はdry-run、許可
   else
     echo "BLOCKED: -n（--no-verify短縮形）によるgit hookのバイパスは禁止されています" >&2
+    echo "  WHY: Lefthookによる品質チェック（fmt/lint/test）がスキップされ、CIで失敗するコードがpushされる" >&2
+    echo "  FIX: Lefthookの問題はlefthook.ymlの設定を確認" >&2
     exit 2
   fi
 fi
 
+# chmod 777: 過度な権限付与
 if [[ "$COMMAND" =~ chmod[[:space:]]+777 ]]; then
   echo "BLOCKED: chmod 777 は過度な権限付与です" >&2
+  echo "  WHY: 全ユーザーに読み書き実行権限を付与し、セキュリティリスクとなる" >&2
+  echo "  FIX: 適切な権限 644（ファイル）/ 755（実行可能ファイル）を使用" >&2
   exit 2
 fi
 
+# デバイス直接書き込み: /dev/sdX 等への書き込みをブロック
 if [[ "$COMMAND" =~ \>[[:space:]]*/dev/sd ]] || [[ "$COMMAND" =~ \>[[:space:]]*/dev/nvme ]] || [[ "$COMMAND" =~ \>[[:space:]]*/dev/hd ]]; then
   echo "BLOCKED: デバイスファイルへの直接書き込みは禁止されています" >&2
+  echo "  WHY: ディスクデバイスへの直接書き込みはデータ破壊・OS破損の原因となる" >&2
+  echo "  FIX: ファイルへの書き込みは > output.txt を使用" >&2
   exit 2
 fi
 
@@ -157,40 +195,137 @@ if [[ "$COMMAND" =~ ^[[:space:]]*gh[[:space:]]+pr[[:space:]]+create([[:space:]]|
   exit 2
 fi
 
-# --- resolveReviewThread ガード ---
+# --- resolveReviewThread ガード: レビューコメントの自動resolveを禁止 ---
 if [[ "$COMMAND" =~ resolveReviewThread ]]; then
   echo "BLOCKED: resolveReviewThreadの実行は禁止されています。レビューコメントの解決はユーザーが手動で行ってください" >&2
   exit 2
 fi
 
-# --- CodeRabbit返信ガード ---
-if [[ "$COMMAND" =~ gh[[:space:]]+api.*replies.*-f[[:space:]]+body= ]] || [[ "$COMMAND" =~ /replies.sh ]]; then
+
+# --- GitHub PRコメント・返信ガード: push完了マーカー確認 + 先送り表現禁止 ---
+# push完了前の返信を防止（バックグラウンドpush時にCodeRabbitが修正を確認できない問題の対策）
+# 全てのGitHub PRコメント・返信コマンドをキャッチする（gh api / gh pr comment / gh pr review）
+
+# シェルトークンの引用符・末尾区切りを正規化するヘルパー
+_normalize_shell_token() {
+  local token="$1"
+  token="${token%%[;&|]*}"
+  token="${token%\"}"; token="${token#\"}"
+  token="${token%\'}"; token="${token#\'}"
+  printf '%s' "$token"
+}
+
+# GraphQL mutation検出ヘルパー（インライン・query=@file・--input fileに対応）
+_is_graphql_mutation() {
+  local segment="$1"
+  # インラインのmutationキーワードを検出
+  [[ "$segment" =~ mutation([[:space:]]|\{|\() ]] && return 0
+  # query=@file のファイル内容を検査
+  if [[ "$segment" =~ query=@([^[:space:]]+) ]]; then
+    local file
+    file="$(_normalize_shell_token "${BASH_REMATCH[1]}")"
+    [[ -f "$file" ]] && grep -qE 'mutation([[:space:]]|\{|\()' "$file" 2>/dev/null && return 0
+  fi
+  # --input file のファイル内容を検査（--input - は検査不能なのでスキップ）
+  if [[ "$segment" =~ --input[=[:space:]]([^[:space:]]+) ]]; then
+    local file
+    file="$(_normalize_shell_token "${BASH_REMATCH[1]}")"
+    [[ "$file" != "-" ]] && [[ -f "$file" ]] && grep -qE 'mutation([[:space:]]|\{|\()' "$file" 2>/dev/null && return 0
+  fi
+  return 1
+}
+
+# gh apiセグメントを全て抽出して走査（tail -n1ではなく全セグメント対象）
+IS_PR_COMMENT=false
+if [[ "$COMMAND" =~ gh[[:space:]]+api ]]; then
+  while IFS= read -r GH_API_SEGMENT; do
+    [[ -z "$GH_API_SEGMENT" ]] && continue
+    # gh api REST: コメント系エンドポイント + 書き込みフラグの両方が必要（GETは許可）
+    if [[ "$GH_API_SEGMENT" =~ (/issues/[0-9]+/comments|/pulls/[0-9]+/comments|/pulls/[0-9]+/reviews|/comments/[0-9]+/replies) ]] \
+      && [[ "$GH_API_SEGMENT" =~ (-f[[:space:]]|-F[[:space:]]|--field[[:space:]]|--raw-field[[:space:]]|--input|(-X|--method)[[:space:]]*(POST|PATCH|PUT)) ]]; then
+      IS_PR_COMMENT=true
+      break
+    # gh api GraphQL: mutationのみキャッチ（queryは許可）
+    elif [[ "$GH_API_SEGMENT" =~ graphql ]] && _is_graphql_mutation "$GH_API_SEGMENT"; then
+      IS_PR_COMMENT=true
+      break
+    fi
+  done < <(printf '%s\n' "$COMMAND" | grep -oE '(^|[|;&]+[[:space:]]*)gh[[:space:]]+api[^|;&]*')
+fi
+# gh pr comment / gh pr review: CLIコマンド経由
+if ! $IS_PR_COMMENT && [[ "$COMMAND" =~ gh[[:space:]]+pr[[:space:]]+(comment|review)[[:space:]] ]]; then
+  IS_PR_COMMENT=true
+# gh issue comment: Issue向けコメント
+elif ! $IS_PR_COMMENT && [[ "$COMMAND" =~ gh[[:space:]]+issue[[:space:]]+comment[[:space:]] ]]; then
+  IS_PR_COMMENT=true
+# レガシーパターン: replies.shスクリプト経由
+elif ! $IS_PR_COMMENT && [[ "$COMMAND" =~ /replies.sh ]]; then
+  IS_PR_COMMENT=true
+fi
+if $IS_PR_COMMENT; then
+  # push完了マーカーの確認（60秒以内に作成されたものが必要）
   PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
   MARKER="$PROJECT_DIR/.claude/push-completed.marker"
   if [ ! -f "$MARKER" ]; then
     echo "BLOCKED: push完了前にCodeRabbit返信はできません" >&2
+    echo "  WHY: push前に返信するとCodeRabbitが修正を確認できない" >&2
+    echo "  FIX: 先にgit pushを実行してください" >&2
     exit 2
   fi
+  # GNU stat (-c) と BSD stat (-f) の両方に対応。両方失敗時は明示的にブロック
   MARKER_MTIME=$(stat -c %Y "$MARKER" 2>/dev/null || stat -f %m "$MARKER" 2>/dev/null) || {
     echo "BLOCKED: pushマーカーの読み取りに失敗しました" >&2
+    echo "  WHY: マーカーファイルが削除された可能性がある" >&2
+    echo "  FIX: git pushを再実行してください" >&2
     exit 2
   }
   MARKER_AGE=$(( $(date +%s) - MARKER_MTIME ))
   if [ "$MARKER_AGE" -gt 60 ]; then
-    echo "BLOCKED: pushマーカーが古くなっています（${MARKER_AGE}秒前）。git pushを再実行してください" >&2
+    echo "BLOCKED: pushマーカーが古くなっています（${MARKER_AGE}秒前、有効期限60秒）" >&2
+    echo "  WHY: 古いpushの後に新しい変更がある可能性がある" >&2
+    echo "  FIX: 最新の変更をgit pushしてから返信してください" >&2
     exit 2
   fi
+  # push時のcommit SHAと現在のHEADが一致するか検証（バックグラウンドpush対策）
   MARKER_HEAD=$(head -1 "$MARKER" 2>/dev/null) || MARKER_HEAD=""
   CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null) || CURRENT_HEAD=""
   if [ -n "$CURRENT_HEAD" ] && [ "$MARKER_HEAD" != "$CURRENT_HEAD" ]; then
-    echo "BLOCKED: push後に新しいコミットがあります。git pushしてから返信してください" >&2
+    echo "BLOCKED: push後に新しいコミットが追加されています" >&2
+    echo "  WHY: マーカーのSHA(${MARKER_HEAD:0:8})と現在のHEAD(${CURRENT_HEAD:0:8})が不一致" >&2
+    echo "  FIX: 最新の変更をgit pushしてから返信してください" >&2
     exit 2
   fi
 
-  if [[ "$COMMAND" =~ (次回|今後|後日|将来的に|検討します|改善予定|後で対応|いずれ対応|追って対応) ]]; then
-    echo "BLOCKED: PRコメント返信に先送り表現が含まれています" >&2
+  # 先送り表現の検出対象テキストを決定（--body-file等からのファイル内容を抽出）
+  COMMENT_TEXT="$COMMAND"
+  if [[ "$COMMAND" =~ --body-file[=[:space:]]([^[:space:]]+) ]]; then
+    BODY_FILE="$(_normalize_shell_token "${BASH_REMATCH[1]}")"
+    [[ -f "$BODY_FILE" ]] && COMMENT_TEXT="$(cat "$BODY_FILE")"
+  elif [[ "$COMMAND" =~ (-f|-F|--field|--raw-field)[[:space:]]*body=@([^[:space:]]+) ]]; then
+    BODY_FILE="$(_normalize_shell_token "${BASH_REMATCH[2]}")"
+    [[ -f "$BODY_FILE" ]] && COMMENT_TEXT="$(cat "$BODY_FILE")"
+  elif [[ "$COMMAND" =~ --input[=[:space:]]([^[:space:]]+) ]] && [[ "${BASH_REMATCH[1]}" != "-" ]]; then
+    INPUT_FILE="$(_normalize_shell_token "${BASH_REMATCH[1]}")"
+    [[ -f "$INPUT_FILE" ]] && COMMENT_TEXT="$(jq -r '.. | objects | .body? // empty' "$INPUT_FILE" 2>/dev/null)"
+  elif [[ "$COMMAND" =~ --input[=[:space:]]- ]] || [[ "$COMMAND" =~ (--editor|--web) ]]; then
+    echo "BLOCKED: 本文を事前検査できないコメント投稿方法は禁止です（--editor / --input - / --web）" >&2
     exit 2
+  fi
+
+  # 先送り表現の検出（エージェントはステートレスなので「次回」の保証がない）
+  # 「スコープ外」のバリアント（スコープから除外）、「見送り」、「現時点では」「優先度が低い」も検出
+  if [[ "$COMMENT_TEXT" =~ (次回|今後|後日|将来的に|検討します|改善予定|後で対応|いずれ対応|追って対応|別チケット|別ticket|後続チケット|後続対応|後続で|スコープ外|スコープから除外|別途対応|見送り|現時点では|優先度が低い) ]]; then
+    # Issue番号（#数字）またはJiraチケット番号が含まれていれば許可
+    if [[ "$COMMENT_TEXT" =~ \#[0-9]+ ]]; then
+      : # Issue番号付きなので許可
+    else
+      echo "BLOCKED: PRコメント返信に先送り表現が含まれています" >&2
+      echo "  WHY: エージェントはステートレスなので次回の保証がない" >&2
+      echo "  FIX: (1) このPRで修正する (2) gh issue createでIssue作成してからIssue番号を含めて返信する (3) 技術的根拠を示して対応不要と返信する" >&2
+      exit 2
+    fi
   fi
 fi
 
+# 対象外コマンドは何もせず通過
 exit 0

--- a/.claude/hooks/pre-edit-guard.sh
+++ b/.claude/hooks/pre-edit-guard.sh
@@ -29,7 +29,7 @@ basename="$(basename "$file")"
 
 # 保護対象の判定（basename判定）
 case "$basename" in
-  .prettierrc|.prettierrc.*|prettier.config.*) ;;
+  biome.json|biome.jsonc) ;;
   .eslintrc*|eslint.config.*) ;;
   .editorconfig) ;;
   tsconfig.json) ;;


### PR DESCRIPTION
## Summary

- promarche `.claude/hooks/` の最新改善をArkに移植
- PRコメントガード全面強化（GraphQL mutation検出、body-file検査、先送り表現20パターン）
- 未解決スレッド取得を共通ヘルパーに抽出（DRY化）
- push後監視にdry-run検出と未解決スレッド表示を追加
- post-edit-lintにbiome check追加（format後にlintも実行）
- pre-edit-guardの保護ファイルリストをprettier→biomeに更新

## 変更ファイル

| ファイル | 変更 |
|---------|------|
| `pre-bash-guard.sh` | PRコメントガード強化（197→331行） |
| `fetch-unresolved-threads.sh` | **新規** 共通ヘルパー |
| `check-ci-coderabbit.sh` | ヘルパーに委譲（179→137行） |
| `post-push-monitor.sh` | dry-run検出+未解決スレッド表示 |
| `post-edit-lint.sh` | biome check追加 |
| `pre-edit-guard.sh` | prettier→biome置換 |

## Test plan

- [x] 全hookの `bash -n` 構文チェック通過
- [x] pre-push-review実施済み（HIGH指摘はpromarche同一パターン）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved CodeRabbit review thread monitoring and integration across development workflows.
  * Added linting checks to the code editing pipeline.

* **Improvements**
  * Enhanced safety guards for destructive git commands with detailed guidance.
  * Strengthened protection against unintended PR comments and replies.
  * Refined configuration file handling in pre-edit workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->