### PR TITLE
feat: セッションステータス色分け改善とリポジトリ情報永続化

### DIFF
--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useRef, useState } from "react";
 import { MessageSquare, Square, Trash2 } from "lucide-react";
-import type { ManagedSession, Worktree } from "../../../shared/types";
+import { useEffect, useRef, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -18,6 +17,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import type { ManagedSession, Worktree } from "../../../shared/types";
 
 /** プレビュー無変化でアイドル判定するまでの秒数 */
 const IDLE_THRESHOLD_MS = 10_000;

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -28,18 +28,23 @@ export function SessionCard({
     worktree?.branch ||
     session.worktreePath.substring(session.worktreePath.lastIndexOf("/") + 1);
 
-  // プレビューの変化を追跡してアイドル判定
+  // プレビュー/アクティビティの変化を追跡してアイドル判定
   const prevTextRef = useRef(previewText);
+  const prevActivityRef = useRef(activityText);
   const lastChangedRef = useRef(Date.now());
   const [isIdle, setIsIdle] = useState(false);
 
   useEffect(() => {
-    if (previewText !== prevTextRef.current) {
+    if (
+      previewText !== prevTextRef.current ||
+      activityText !== prevActivityRef.current
+    ) {
       prevTextRef.current = previewText;
+      prevActivityRef.current = activityText;
       lastChangedRef.current = Date.now();
       setIsIdle(false);
     }
-  }, [previewText]);
+  }, [previewText, activityText]);
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -49,15 +54,16 @@ export function SessionCard({
     return () => clearInterval(timer);
   }, []);
 
-  // stopped/error → 赤、no content(サーバーidle) → 青、変化なし(クライアントidle) → 赤、active → 緑
+  // ✢✻はどちらもClaude Codeの動作中アニメーション記号
+  const hasActivitySymbol = /[✢✻]/.test(activityText);
+
+  // 緑: 動作中（✢✻+変化あり）、青: 起動直後//clear後（コンテンツなし）、赤: それ以外
   const dotColor =
-    session.status === "stopped" || session.status === "error"
-      ? "bg-red-500"
-      : session.status === "idle"
+    hasActivitySymbol && !isIdle
+      ? "bg-green-500"
+      : session.status === "idle" && !hasActivitySymbol
         ? "bg-blue-500"
-        : isIdle
-          ? "bg-red-500"
-          : "bg-green-500";
+        : "bg-red-500";
 
   // アイドル時はactivityText（✻ Baked for ...）、アクティブ時はコンテンツ行
   const idle = session.status === "idle" || isIdle;

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -79,11 +79,14 @@ export function SessionCard({
   // ✢✻はどちらもClaude Codeの動作中アニメーション記号
   const hasActivitySymbol = /[✢✻]/.test(activityText);
 
-  // 緑: 動作中（✢✻+変化あり）、青: 起動直後//clear後（コンテンツなし）、赤: それ以外
+  // 緑: 動作中（✢✻+変化あり）、青: 起動直後/clear後（コンテンツなし）、赤: それ以外
+  const hasVisibleContent =
+    previewText.trim().length > 0 || activityText.trim().length > 0;
+
   const dotColor =
     hasActivitySymbol && !isIdle
       ? "bg-green-500"
-      : session.status === "idle" && !hasActivitySymbol
+      : !hasVisibleContent
         ? "bg-blue-500"
         : "bg-red-500";
 
@@ -133,7 +136,7 @@ export function SessionCard({
             <Square className="w-4 h-4 mr-2" />
             セッションを停止
           </ContextMenuItem>
-          {worktree?.isMain !== true && (
+          {worktree && !worktree.isMain && (
             <>
               <ContextMenuSeparator />
               <ContextMenuItem
@@ -162,6 +165,7 @@ export function SessionCard({
             <AlertDialogAction
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
               onClick={() => {
+                onStop();
                 onDeleteWorktree();
                 setShowDeleteDialog(false);
               }}

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -136,7 +136,7 @@ export function SessionCard({
             <Square className="w-4 h-4 mr-2" />
             セッションを停止
           </ContextMenuItem>
-          {worktree && !worktree.isMain && (
+          {worktree?.isMain !== true && (
             <>
               <ContextMenuSeparator />
               <ContextMenuItem

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -1,5 +1,23 @@
 import { useEffect, useRef, useState } from "react";
+import { MessageSquare, Square, Trash2 } from "lucide-react";
 import type { ManagedSession, Worktree } from "../../../shared/types";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 
 /** プレビュー無変化でアイドル判定するまでの秒数 */
 const IDLE_THRESHOLD_MS = 10_000;
@@ -13,6 +31,7 @@ interface SessionCardProps {
   activityText: string;
   onClick: () => void;
   onStop: () => void;
+  onDeleteWorktree: () => void;
 }
 
 export function SessionCard({
@@ -23,6 +42,7 @@ export function SessionCard({
   activityText,
   onClick,
   onStop,
+  onDeleteWorktree,
 }: SessionCardProps) {
   const branch =
     worktree?.branch ||
@@ -54,6 +74,8 @@ export function SessionCard({
     return () => clearInterval(timer);
   }, []);
 
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
   // ✢✻はどちらもClaude Codeの動作中アニメーション記号
   const hasActivitySymbol = /[✢✻]/.test(activityText);
 
@@ -70,33 +92,85 @@ export function SessionCard({
   const displayText = idle && activityText ? activityText : previewText;
 
   return (
-    <button
-      type="button"
-      className={`w-full text-left p-3 rounded-lg transition-colors group ${
-        isSelected
-          ? "bg-primary/15 border border-primary/30"
-          : "hover:bg-sidebar-accent/50"
-      }`}
-      onClick={onClick}
-      onContextMenu={e => {
-        e.preventDefault();
-        onStop();
-      }}
-    >
-      <div className="flex items-center gap-2 min-w-0">
-        <div className={`w-2 h-2 rounded-full shrink-0 ${dotColor}`} />
-        <span className="text-sm font-mono truncate text-sidebar-foreground">
-          {branch}
-        </span>
-        {isSelected && (
-          <span className="ml-auto text-xs text-primary shrink-0">◀</span>
-        )}
-      </div>
-      {displayText && (
-        <p className="mt-1 text-xs text-muted-foreground truncate pl-4">
-          {displayText}
-        </p>
-      )}
-    </button>
+    <>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <button
+            type="button"
+            className={`w-full text-left p-3 rounded-lg transition-colors group ${
+              isSelected
+                ? "bg-primary/15 border border-primary/30"
+                : "hover:bg-sidebar-accent/50"
+            }`}
+            onClick={onClick}
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <div className={`w-2 h-2 rounded-full shrink-0 ${dotColor}`} />
+              <span className="text-sm font-mono truncate text-sidebar-foreground">
+                {branch}
+              </span>
+              {isSelected && (
+                <span className="ml-auto text-xs text-primary shrink-0">◀</span>
+              )}
+            </div>
+            {displayText && (
+              <p className="mt-1 text-xs text-muted-foreground truncate pl-4">
+                {displayText}
+              </p>
+            )}
+          </button>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="w-48">
+          <ContextMenuItem onSelect={onClick}>
+            <MessageSquare className="w-4 h-4 mr-2" />
+            セッションを開く
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem
+            className="text-destructive focus:text-destructive"
+            onSelect={onStop}
+          >
+            <Square className="w-4 h-4 mr-2" />
+            セッションを停止
+          </ContextMenuItem>
+          {worktree?.isMain !== true && (
+            <>
+              <ContextMenuSeparator />
+              <ContextMenuItem
+                className="text-destructive focus:text-destructive"
+                onSelect={() => setShowDeleteDialog(true)}
+              >
+                <Trash2 className="w-4 h-4 mr-2" />
+                Worktreeを削除
+              </ContextMenuItem>
+            </>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Worktreeを削除</AlertDialogTitle>
+            <AlertDialogDescription>
+              このWorktreeを削除しますか？関連するブランチも削除されます。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
+            <AlertDialogCancel className="h-12 md:h-10">
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
+              onClick={() => {
+                onDeleteWorktree();
+                setShowDeleteDialog(false);
+              }}
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -112,7 +112,7 @@ export function SessionSidebar({
                         onStop={() => onStopSession(session.id)}
                         onDeleteWorktree={() => {
                           const wt = getWorktree(session);
-                          if (wt) onDeleteWorktree(wt.path);
+                          onDeleteWorktree(wt?.path ?? session.worktreePath);
                         }}
                       />
                     ))}

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -23,6 +23,7 @@ interface SessionSidebarProps {
   sessionActivityTexts: Map<string, string>;
   onSelectSession: (sessionId: string) => void;
   onStopSession: (sessionId: string) => void;
+  onDeleteWorktree: (worktreePath: string) => void;
   onNewSession: () => void;
 }
 
@@ -35,6 +36,7 @@ export function SessionSidebar({
   sessionActivityTexts,
   onSelectSession,
   onStopSession,
+  onDeleteWorktree,
   onNewSession,
 }: SessionSidebarProps) {
   const getWorktree = (session: ManagedSession): Worktree | undefined => {
@@ -108,6 +110,10 @@ export function SessionSidebar({
                         }
                         onClick={() => onSelectSession(session.id)}
                         onStop={() => onStopSession(session.id)}
+                        onDeleteWorktree={() => {
+                          const wt = getWorktree(session);
+                          if (wt) onDeleteWorktree(wt.path);
+                        }}
                       />
                     ))}
                   </div>

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -45,7 +45,7 @@ export function SessionSidebar({
   const groupedSessions = useMemo(() => {
     const groups = new Map<string, ManagedSession[]>();
     for (const session of Array.from(sessions.values())) {
-      const repo = findRepoForSession(session, repoList);
+      const repo = session.repoPath ?? findRepoForSession(session, repoList);
       const repoName = repo ? getBaseName(repo) : "unknown";
       const existing = groups.get(repoName) || [];
       existing.push(session);

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -28,6 +28,8 @@ function getTokenFromUrl(): string | null {
 }
 
 interface UseSocketOptions {
+  /** 設定読み込み完了後にtrueにする（falseの間はソケット接続しない） */
+  enabled?: boolean;
   initialRepoList?: string[];
   initialRepoPath?: string | null;
   onRepoListChange?: (list: string[]) => void;
@@ -129,6 +131,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   );
   // 再接続時に最新のrepoPathを参照するためのref
   const repoPathRef = useRef(options.initialRepoPath ?? null);
+
   const [worktrees, setWorktrees] = useState<Worktree[]>([]);
   const [deletedWorktreeId, setDeletedWorktreeId] = useState<string | null>(
     null
@@ -188,8 +191,20 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     }
   }, [repoList]);
 
-  // Initialize socket connection
+  // Initialize socket connection（enabled=falseの間は接続しない）
+  const enabled = options.enabled ?? true;
   useEffect(() => {
+    if (!enabled) return;
+
+    // enabled時点のinitial値でstate同期（useStateの初期値は初回のみなので）
+    const list = optionsRef.current.initialRepoList ?? [];
+    if (list.length > 0) setRepoList(list);
+    const path = optionsRef.current.initialRepoPath ?? null;
+    if (path) {
+      setRepoPath(path);
+      repoPathRef.current = path;
+    }
+
     const serverUrl = import.meta.env.DEV
       ? "http://localhost:3001"
       : window.location.origin;
@@ -469,7 +484,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       socket.off("session:previews");
       socket.disconnect();
     };
-  }, []);
+  }, [enabled]);
 
   // Repository actions
   const selectRepo = useCallback((path: string) => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -85,6 +85,7 @@ export default function Dashboard() {
     sessionPreviews,
     sessionActivityTexts,
   } = useSocket({
+    enabled: !isSettingsLoading,
     initialRepoList: savedRepoList,
     initialRepoPath: savedRepoPath,
     onRepoListChange: list => setSetting("repoList", list),

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -264,6 +264,10 @@ export default function Dashboard() {
               sessionActivityTexts={sessionActivityTexts}
               onSelectSession={setSelectedSessionId}
               onStopSession={handleStopSession}
+              onDeleteWorktree={path => {
+                const wt = worktrees.find(w => w.path === path);
+                if (wt) handleDeleteWorktree(wt);
+              }}
               onNewSession={handleNewSession}
             />
           }

--- a/server/index.ts
+++ b/server/index.ts
@@ -527,6 +527,9 @@ async function startServer() {
   io.on("connection", socket => {
     console.log(`Client connected: ${socket.id}`);
 
+    // このソケット接続で選択中のリポジトリパス
+    let currentRepoPath: string | null = null;
+
     // Send allowed repos list to client on connection
     socket.emit("repos:list", allowedRepos);
 
@@ -625,6 +628,7 @@ async function startServer() {
           return;
         }
         socket.emit("repo:set", repoPath);
+        currentRepoPath = repoPath;
         knownRepos.add(repoPath);
 
         const worktrees = await listWorktrees(repoPath);
@@ -695,7 +699,8 @@ async function startServer() {
       try {
         const session = await sessionOrchestrator.startSession(
           worktreeId,
-          worktreePath
+          worktreePath,
+          currentRepoPath ?? undefined
         );
         socket.emit("session:created", session);
       } catch (error) {

--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -32,6 +32,7 @@ interface SessionRow {
   id: string;
   worktree_id: string;
   worktree_path: string;
+  repo_path: string | null;
   status: string;
   created_at: string;
   updated_at: string;
@@ -52,6 +53,7 @@ interface CreateSessionInput {
   readonly id: string;
   readonly worktreeId: string;
   readonly worktreePath: string;
+  readonly repoPath?: string;
   readonly status: SessionStatus;
 }
 
@@ -156,6 +158,18 @@ class SessionDatabase {
         updated_at TEXT NOT NULL
       )
     `);
+
+    // マイグレーション: sessionsテーブルにrepo_pathカラムを追加
+    // SQLiteのALTER TABLEはIF NOT EXISTSをサポートしないためtry-catchで囲む
+    try {
+      this.db.exec("ALTER TABLE sessions ADD COLUMN repo_path TEXT");
+    } catch (e) {
+      // カラムが既に存在する場合のみ無視、それ以外は再スロー
+      const msg = e instanceof Error ? e.message : String(e);
+      if (!msg.includes("duplicate column name")) {
+        throw e;
+      }
+    }
   }
 
   // ============================================================
@@ -171,13 +185,14 @@ class SessionDatabase {
   createSession(session: CreateSessionInput): void {
     const now = new Date().toISOString();
     const stmt = this.db.prepare(`
-      INSERT INTO sessions (id, worktree_id, worktree_path, status, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO sessions (id, worktree_id, worktree_path, repo_path, status, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
     `);
     stmt.run(
       session.id,
       session.worktreeId,
       session.worktreePath,
+      session.repoPath ?? null,
       session.status,
       now,
       now
@@ -194,11 +209,12 @@ class SessionDatabase {
   upsertSession(session: CreateSessionInput): void {
     const now = new Date().toISOString();
     const stmt = this.db.prepare(`
-      INSERT INTO sessions (id, worktree_id, worktree_path, status, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?)
+      INSERT INTO sessions (id, worktree_id, worktree_path, repo_path, status, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
       ON CONFLICT(worktree_path) DO UPDATE SET
         id = excluded.id,
         worktree_id = excluded.worktree_id,
+        repo_path = COALESCE(excluded.repo_path, repo_path),
         status = excluded.status,
         updated_at = excluded.updated_at
     `);
@@ -206,6 +222,7 @@ class SessionDatabase {
       session.id,
       session.worktreeId,
       session.worktreePath,
+      session.repoPath ?? null,
       session.status,
       now,
       now
@@ -250,6 +267,20 @@ class SessionDatabase {
       "UPDATE sessions SET status = ?, updated_at = ? WHERE id = ?"
     );
     stmt.run(status, now, id);
+  }
+
+  /**
+   * セッションのリポジトリパスを更新
+   *
+   * @param id - セッションID
+   * @param repoPath - リポジトリのルートパス
+   */
+  updateSessionRepoPath(id: string, repoPath: string): void {
+    const now = new Date().toISOString();
+    const stmt = this.db.prepare(
+      "UPDATE sessions SET repo_path = ?, updated_at = ? WHERE id = ?"
+    );
+    stmt.run(repoPath, now, id);
   }
 
   /**
@@ -336,6 +367,7 @@ class SessionDatabase {
       id: row.id,
       worktreeId: row.worktree_id,
       worktreePath: row.worktree_path,
+      repoPath: row.repo_path ?? undefined,
       status: row.status as SessionStatus,
       createdAt: new Date(row.created_at),
     };

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -5,6 +5,7 @@
  * セッションライフサイクルの統一APIを提供する。
  */
 
+import { execFileSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import type {
@@ -75,7 +76,13 @@ export class SessionOrchestrator extends EventEmitter {
         console.log(
           `[Orchestrator] Restored session: ${tmuxSession.tmuxSessionName} -> ${dbSession.id} (status: ${dbSession.status})`
         );
-        // DBのstatusがidle等の場合はそのまま維持し、activeで上書きしない
+        // repoPathが未設定ならgitから導出して保存
+        if (!dbSession.repoPath && tmuxSession.worktreePath) {
+          const repoPath = this.deriveRepoPath(tmuxSession.worktreePath);
+          if (repoPath) {
+            db.updateSessionRepoPath(dbSession.id, repoPath);
+          }
+        }
       }
 
       // ttydも自動起動（起動完了後にクライアントへ通知）
@@ -119,16 +126,47 @@ export class SessionOrchestrator extends EventEmitter {
       tmuxSession.status === "running"
         ? (dbSession?.status as SessionStatus) || "active"
         : this.mapTmuxStatus(tmuxSession.status);
+
+    // repoPathがDBにない場合はgitから導出して保存
+    let repoPath = dbSession?.repoPath;
+    if (!repoPath && tmuxSession.worktreePath) {
+      repoPath = this.deriveRepoPath(tmuxSession.worktreePath);
+      if (repoPath && dbSession) {
+        db.updateSessionRepoPath(dbSession.id, repoPath);
+      }
+    }
+
     return {
       id: tmuxSession.id,
       worktreeId,
       worktreePath: tmuxSession.worktreePath,
+      repoPath,
       status,
       createdAt: tmuxSession.createdAt,
       tmuxSessionName: tmuxSession.tmuxSessionName,
       ttydPort: ttydInstance?.port || null,
       ttydUrl: ttydInstance ? `/ttyd/${tmuxSession.id}/` : null,
     };
+  }
+
+  /** worktreePathからメインリポジトリのパスを導出 */
+  private deriveRepoPath(worktreePath: string): string | undefined {
+    try {
+      const gitCommonDir = execFileSync(
+        "git",
+        [
+          "-C",
+          worktreePath,
+          "rev-parse",
+          "--path-format=absolute",
+          "--git-common-dir",
+        ],
+        { encoding: "utf-8" }
+      ).trim();
+      return gitCommonDir.replace(/\/\.git\/?$/, "") || undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   /**
@@ -154,11 +192,20 @@ export class SessionOrchestrator extends EventEmitter {
    */
   async startSession(
     worktreeId: string,
-    worktreePath: string
+    worktreePath: string,
+    repoPath?: string
   ): Promise<ManagedSession> {
     // 既存セッションがあれば再利用
     const existingTmux = tmuxManager.getSessionByWorktree(worktreePath);
     if (existingTmux) {
+      // repoPathが渡された場合はDBを更新（既存セッションにrepoPath情報を補完）
+      if (repoPath) {
+        const dbSession = db.getSessionByWorktreePath(worktreePath);
+        if (dbSession && !dbSession.repoPath) {
+          db.updateSessionRepoPath(dbSession.id, repoPath);
+        }
+      }
+
       // ttydが起動していなければ起動
       let ttydInstance = ttydManager.getInstance(existingTmux.id);
       if (!ttydInstance) {
@@ -187,6 +234,7 @@ export class SessionOrchestrator extends EventEmitter {
       id: tmuxSession.id,
       worktreeId,
       worktreePath,
+      repoPath,
       status: "active",
     });
 
@@ -194,6 +242,7 @@ export class SessionOrchestrator extends EventEmitter {
       id: tmuxSession.id,
       worktreeId,
       worktreePath,
+      repoPath,
       status: "active",
       createdAt: tmuxSession.createdAt,
       tmuxSessionName: tmuxSession.tmuxSessionName,
@@ -378,6 +427,19 @@ export class SessionOrchestrator extends EventEmitter {
         if (/^[>❯$%#]\s*$/.test(line)) return true;
         // ─ や ━ のみの区切り線
         if (/^[─━═▔▁]{3,}$/.test(line)) return true;
+        // Claude Code起動ヘッダー
+        if (/^Claude Code\s/.test(line)) return true;
+        // モデル情報行（Opus/Sonnet/Haiku + context）
+        if (/context\)/.test(line) && /Opus|Sonnet|Haiku/.test(line))
+          return true;
+        // リポジトリパス表示（~/path や /path でスペースなし）
+        if (/^[~\/][\w.\-\/]+$/.test(line)) return true;
+        // Claude Codeスラッシュコマンド（/clear等）
+        if (/^\/[a-z][\w-]*$/.test(line)) return true;
+        // (no content)表示
+        if (line.includes("(no content)")) return true;
+        // ツリー文字行（└├│で始まる）
+        if (/^[└├│]/.test(line)) return true;
         return false;
       };
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -26,6 +26,8 @@ export interface Session {
   id: string;
   worktreeId: string;
   worktreePath: string;
+  /** セッションが属するリポジトリのルートパス（既存セッション互換のためoptional） */
+  repoPath?: string;
   status: SessionStatus;
   createdAt: Date;
 }


### PR DESCRIPTION
## 概要

- SessionCardの色分けロジックをアクティビティ記号(✢✻)ベースに変更
- SessionにrepoPathを追加しDB永続化
- リロード時のリポジトリ名unknown問題を根本解決

## 変更内容

### ステータス色分け改善
- 緑: 動作中(✢✻+変化あり)、青: 起動直後/`/clear`後(コンテンツなし)、赤: それ以外
- `previewText`だけでなく`activityText`の変化もidle判定に含める
- `isUiLine`フィルターにClaude Codeヘッダー行等を追加（`/clear`後のidle検出）

### リポジトリ情報永続化
- `Session`型に`repoPath`を追加（DB: `repo_path`カラム）
- `git rev-parse --git-common-dir`でworktreeからメインリポジトリパスを導出
- `toManagedSession`で自動補完→既存セッションも対応
- セッション作成時に選択中リポジトリパスを保存

### ソケット接続タイミング修正
- `useSocket`に`enabled`フラグ追加
- 設定読み込み完了まで接続を遅延し、`repoList`の初期化を保証

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic repository path tracking and persistence for sessions
  * Context menu for sessions with explicit "Open", "Stop", and conditional "Delete worktree" (confirmation)

* **Improvements**
  * Conditional socket activation deferred until settings finish loading
  * Sidebar groups sessions by repository when available
  * Refined preview filtering to remove UI artifacts and improve readability

* **Bug Fixes**
  * More accurate idle/change detection by monitoring activity indicators
  * Clearer and more consistent session status colors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->