### PR TITLE
セッション削除時のDB/worktreeクリーンアップとworktree作成フロー改善

### DIFF
--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -13,7 +13,7 @@ import {
   MoreVertical,
   RefreshCw,
   Send,
-  Square,
+  Trash2,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -328,14 +328,15 @@ export function MobileSessionView({
               ))}
             </DropdownMenuContent>
           </DropdownMenu>
-          {/* Stopボタン */}
+          {/* 削除ボタン */}
           <Button
             variant="ghost"
             size="icon"
             className="h-10 w-10 text-destructive hover:text-destructive"
             onClick={onStopSession}
+            title="セッションを削除"
           >
-            <Square className="w-5 h-5" />
+            <Trash2 className="w-5 h-5" />
           </Button>
         </div>
       </header>

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -1,6 +1,16 @@
 import { MessageSquare, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
@@ -21,7 +31,6 @@ interface SessionCardProps {
   activityText: string;
   onClick: () => void;
   onStop: () => void;
-  onDeleteWorktree: () => void;
 }
 
 export function SessionCard({
@@ -32,7 +41,6 @@ export function SessionCard({
   activityText,
   onClick,
   onStop,
-  onDeleteWorktree,
 }: SessionCardProps) {
   const branch =
     worktree?.branch ||
@@ -43,6 +51,7 @@ export function SessionCard({
   const prevActivityRef = useRef(activityText);
   const lastChangedRef = useRef(Date.now());
   const [isIdle, setIsIdle] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   useEffect(() => {
     if (
@@ -119,13 +128,37 @@ export function SessionCard({
           <ContextMenuSeparator />
           <ContextMenuItem
             className="text-destructive focus:text-destructive"
-            onSelect={onStop}
+            onSelect={() => setShowDeleteDialog(true)}
           >
             <Trash2 className="w-4 h-4 mr-2" />
             セッションを削除
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle>セッションを削除</AlertDialogTitle>
+            <AlertDialogDescription>
+              このセッションとWorktreeを削除しますか？関連するブランチも削除されます。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
+            <AlertDialogCancel className="h-12 md:h-10">
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
+              onClick={() => {
+                onStop();
+                setShowDeleteDialog(false);
+              }}
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -140,7 +140,9 @@ export function SessionCard({
           <AlertDialogHeader>
             <AlertDialogTitle>セッションを削除</AlertDialogTitle>
             <AlertDialogDescription>
-              このセッションとWorktreeを削除しますか？関連するブランチも削除されます。
+              {worktree?.isMain
+                ? "このセッションを削除しますか？メインWorktreeは削除されません。"
+                : "このセッションとWorktreeを削除しますか？関連するブランチも削除されます。"}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="flex-col gap-2 sm:flex-row">

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -1,15 +1,5 @@
-import { MessageSquare, Square, Trash2 } from "lucide-react";
+import { MessageSquare, Trash2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -74,8 +64,6 @@ export function SessionCard({
     return () => clearInterval(timer);
   }, []);
 
-  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
-
   // ✢✻はどちらもClaude Codeの動作中アニメーション記号
   const hasActivitySymbol = /[✢✻]/.test(activityText);
 
@@ -133,48 +121,11 @@ export function SessionCard({
             className="text-destructive focus:text-destructive"
             onSelect={onStop}
           >
-            <Square className="w-4 h-4 mr-2" />
-            セッションを停止
+            <Trash2 className="w-4 h-4 mr-2" />
+            セッションを削除
           </ContextMenuItem>
-          {worktree?.isMain !== true && (
-            <>
-              <ContextMenuSeparator />
-              <ContextMenuItem
-                className="text-destructive focus:text-destructive"
-                onSelect={() => setShowDeleteDialog(true)}
-              >
-                <Trash2 className="w-4 h-4 mr-2" />
-                Worktreeを削除
-              </ContextMenuItem>
-            </>
-          )}
         </ContextMenuContent>
       </ContextMenu>
-      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
-        <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
-          <AlertDialogHeader>
-            <AlertDialogTitle>Worktreeを削除</AlertDialogTitle>
-            <AlertDialogDescription>
-              このWorktreeを削除しますか？関連するブランチも削除されます。
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
-            <AlertDialogCancel className="h-12 md:h-10">
-              キャンセル
-            </AlertDialogCancel>
-            <AlertDialogAction
-              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
-              onClick={() => {
-                onStop();
-                onDeleteWorktree();
-                setShowDeleteDialog(false);
-              }}
-            >
-              削除
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </>
   );
 }

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -110,10 +110,6 @@ export function SessionSidebar({
                         }
                         onClick={() => onSelectSession(session.id)}
                         onStop={() => onStopSession(session.id)}
-                        onDeleteWorktree={() => {
-                          const wt = getWorktree(session);
-                          onDeleteWorktree(wt?.path ?? session.worktreePath);
-                        }}
                       />
                     ))}
                   </div>

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -313,7 +313,7 @@ export function TerminalPane({
             size="icon"
             className="h-10 w-10 md:h-6 md:w-6 text-destructive hover:text-destructive"
             onClick={onStopSession}
-            title="セッションを削除"
+            title="Delete session"
           >
             <Trash2 className="w-5 h-5 md:w-3 md:h-3" />
           </Button>

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -19,8 +19,8 @@ import {
   Keyboard,
   RefreshCw,
   Send,
-  Square,
   StopCircle,
+  Trash2,
   XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -313,9 +313,9 @@ export function TerminalPane({
             size="icon"
             className="h-10 w-10 md:h-6 md:w-6 text-destructive hover:text-destructive"
             onClick={onStopSession}
-            title="Stop session (kills tmux)"
+            title="セッションを削除"
           >
-            <Square className="w-5 h-5 md:w-3 md:h-3" />
+            <Trash2 className="w-5 h-5 md:w-3 md:h-3" />
           </Button>
         </div>
       </header>

--- a/server/index.ts
+++ b/server/index.ts
@@ -652,25 +652,30 @@ async function startServer() {
     socket.on(
       "worktree:create",
       async ({ repoPath, branchName, baseBranch }) => {
+        let worktree: Awaited<ReturnType<typeof createWorktree>>;
         try {
-          const worktree = await createWorktree(
-            repoPath,
-            branchName,
-            baseBranch
-          );
+          worktree = await createWorktree(repoPath, branchName, baseBranch);
           socket.emit("worktree:created", worktree);
 
           const worktrees = await listWorktrees(repoPath);
           socket.emit("worktree:list", worktrees);
-
-          // worktree作成後にセッションを自動起動
-          const managed = await sessionOrchestrator.startSession(
-            worktree.id,
-            worktree.path
-          );
-          socket.emit("session:created", managed);
         } catch (error) {
           socket.emit("worktree:error", getErrorMessage(error));
+          return;
+        }
+
+        // worktree作成後にセッションを自動起動（orchestratorのイベント転送に委ねる）
+        try {
+          await sessionOrchestrator.startSession(
+            worktree.id,
+            worktree.path,
+            repoPath
+          );
+        } catch (error) {
+          socket.emit("session:error", {
+            sessionId: "",
+            error: getErrorMessage(error),
+          });
         }
       }
     );
@@ -739,30 +744,27 @@ async function startServer() {
     });
 
     socket.on("session:stop", async sessionId => {
-      const result = sessionOrchestrator.stopSession(sessionId);
+      try {
+        const result = sessionOrchestrator.stopSession(sessionId);
 
-      // worktreeも削除（メインworktreeは除外）
-      if (result?.worktreePath && result.repoPath) {
-        try {
+        // worktreeも削除（メインworktreeは除外）
+        if (result?.worktreePath && result.repoPath) {
           const isMain = result.worktreePath === result.repoPath;
           if (!isMain) {
             const deletedWorktreeId = Buffer.from(result.worktreePath)
               .toString("base64")
               .replace(/[/+=]/g, "");
             await deleteWorktree(result.repoPath, result.worktreePath);
-            io.emit("worktree:deleted", deletedWorktreeId);
+            socket.emit("worktree:deleted", deletedWorktreeId);
             const worktrees = await listWorktrees(result.repoPath);
-            io.emit("worktree:list", worktrees);
+            socket.emit("worktree:list", worktrees);
           }
-        } catch (error) {
-          console.error(
-            `[Session] Failed to delete worktree: ${getErrorMessage(error)}`
-          );
-          socket.emit("session:error", {
-            sessionId,
-            error: `Worktreeの削除に失敗しました: ${getErrorMessage(error)}`,
-          });
         }
+      } catch (error) {
+        socket.emit("session:error", {
+          sessionId,
+          error: getErrorMessage(error),
+        });
       }
     });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -656,12 +656,16 @@ async function startServer() {
         try {
           worktree = await createWorktree(repoPath, branchName, baseBranch);
           socket.emit("worktree:created", worktree);
-
-          const worktrees = await listWorktrees(repoPath);
-          socket.emit("worktree:list", worktrees);
         } catch (error) {
           socket.emit("worktree:error", getErrorMessage(error));
           return;
+        }
+
+        try {
+          const worktrees = await listWorktrees(repoPath);
+          socket.emit("worktree:list", worktrees);
+        } catch {
+          // worktree一覧の更新失敗はセッション起動をブロックしない
         }
 
         // worktree作成後にセッションを自動起動（orchestratorのイベント転送に委ねる）
@@ -757,8 +761,6 @@ async function startServer() {
                 .replace(/[/+=]/g, "");
               await deleteWorktree(result.repoPath, result.worktreePath);
               socket.emit("worktree:deleted", deletedWorktreeId);
-              const worktrees = await listWorktrees(result.repoPath);
-              socket.emit("worktree:list", worktrees);
             } catch (wtError) {
               console.error(
                 `[Session] Worktree削除に失敗（セッションは削除済み）: ${getErrorMessage(wtError)}`
@@ -767,6 +769,14 @@ async function startServer() {
                 sessionId,
                 error: `セッションは削除しましたが、Worktreeの削除に失敗しました: ${getErrorMessage(wtError)}`,
               });
+              return;
+            }
+
+            try {
+              const worktrees = await listWorktrees(result.repoPath);
+              socket.emit("worktree:list", worktrees);
+            } catch {
+              // worktree一覧の更新失敗は無視
             }
           }
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -662,6 +662,13 @@ async function startServer() {
 
           const worktrees = await listWorktrees(repoPath);
           socket.emit("worktree:list", worktrees);
+
+          // worktree作成後にセッションを自動起動
+          const managed = await sessionOrchestrator.startSession(
+            worktree.id,
+            worktree.path
+          );
+          socket.emit("session:created", managed);
         } catch (error) {
           socket.emit("worktree:error", getErrorMessage(error));
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -751,6 +751,10 @@ async function startServer() {
           console.error(
             `[Session] Failed to delete worktree: ${getErrorMessage(error)}`
           );
+          socket.emit("session:error", {
+            sessionId,
+            error: `Worktreeの削除に失敗しました: ${getErrorMessage(error)}`,
+          });
         }
       }
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -751,13 +751,23 @@ async function startServer() {
         if (result?.worktreePath && result.repoPath) {
           const isMain = result.worktreePath === result.repoPath;
           if (!isMain) {
-            const deletedWorktreeId = Buffer.from(result.worktreePath)
-              .toString("base64")
-              .replace(/[/+=]/g, "");
-            await deleteWorktree(result.repoPath, result.worktreePath);
-            socket.emit("worktree:deleted", deletedWorktreeId);
-            const worktrees = await listWorktrees(result.repoPath);
-            socket.emit("worktree:list", worktrees);
+            try {
+              const deletedWorktreeId = Buffer.from(result.worktreePath)
+                .toString("base64")
+                .replace(/[/+=]/g, "");
+              await deleteWorktree(result.repoPath, result.worktreePath);
+              socket.emit("worktree:deleted", deletedWorktreeId);
+              const worktrees = await listWorktrees(result.repoPath);
+              socket.emit("worktree:list", worktrees);
+            } catch (wtError) {
+              console.error(
+                `[Session] Worktree削除に失敗（セッションは削除済み）: ${getErrorMessage(wtError)}`
+              );
+              socket.emit("session:error", {
+                sessionId,
+                error: `セッションは削除しましたが、Worktreeの削除に失敗しました: ${getErrorMessage(wtError)}`,
+              });
+            }
           }
         }
       } catch (error) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -731,8 +731,28 @@ async function startServer() {
       }
     });
 
-    socket.on("session:stop", sessionId => {
-      sessionOrchestrator.stopSession(sessionId);
+    socket.on("session:stop", async sessionId => {
+      const result = sessionOrchestrator.stopSession(sessionId);
+
+      // worktreeも削除（メインworktreeは除外）
+      if (result?.worktreePath && result.repoPath) {
+        try {
+          const isMain = result.worktreePath === result.repoPath;
+          if (!isMain) {
+            const deletedWorktreeId = Buffer.from(result.worktreePath)
+              .toString("base64")
+              .replace(/[/+=]/g, "");
+            await deleteWorktree(result.repoPath, result.worktreePath);
+            io.emit("worktree:deleted", deletedWorktreeId);
+            const worktrees = await listWorktrees(result.repoPath);
+            io.emit("worktree:list", worktrees);
+          }
+        } catch (error) {
+          console.error(
+            `[Session] Failed to delete worktree: ${getErrorMessage(error)}`
+          );
+        }
+      }
     });
 
     socket.on("session:send", ({ sessionId, message }) => {

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -299,7 +299,9 @@ interface BeaconSession {
 export interface BeaconDeps {
   getAllSessions: () => unknown[];
   startSession: (worktreeId: string, worktreePath: string) => Promise<unknown>;
-  stopSession: (sessionId: string) => void;
+  stopSession: (
+    sessionId: string
+  ) => { worktreePath: string; repoPath?: string } | null;
   sendMessage: (sessionId: string, message: string) => void;
   sendKey: (sessionId: string, key: SpecialKey) => void;
   capturePane: (sessionId: string, lines?: number) => string | null;

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -274,13 +274,25 @@ export class SessionOrchestrator extends EventEmitter {
   }
 
   /**
-   * セッションを停止
+   * セッションを削除（tmux/ttyd停止 + DB削除）
+   * worktreeの削除はserver/index.tsのハンドラ側で行う
    */
-  stopSession(sessionId: string): void {
+  stopSession(
+    sessionId: string
+  ): { worktreePath: string; repoPath?: string } | null {
+    const tmuxSession = tmuxManager.getSession(sessionId);
+    const dbSession = tmuxSession
+      ? db.getSessionByWorktreePath(tmuxSession.worktreePath)
+      : null;
+    const worktreePath = tmuxSession?.worktreePath || "";
+    const repoPath = dbSession?.repoPath || undefined;
+
     ttydManager.stopInstance(sessionId);
     tmuxManager.killSession(sessionId);
     db.deleteSession(sessionId);
     this.emit("session:stopped", sessionId);
+
+    return worktreePath ? { worktreePath, repoPath } : null;
   }
 
   /**

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -65,7 +65,7 @@ export class SessionOrchestrator extends EventEmitter {
         tmuxManager.killSession(tmuxSession.id);
         const dbSession = db.getSessionByWorktreePath(tmuxSession.worktreePath);
         if (dbSession) {
-          db.updateSessionStatus(dbSession.id, "stopped");
+          db.deleteSession(dbSession.id);
         }
         continue;
       }
@@ -279,7 +279,7 @@ export class SessionOrchestrator extends EventEmitter {
   stopSession(sessionId: string): void {
     ttydManager.stopInstance(sessionId);
     tmuxManager.killSession(sessionId);
-    db.updateSessionStatus(sessionId, "stopped");
+    db.deleteSession(sessionId);
     this.emit("session:stopped", sessionId);
   }
 
@@ -351,7 +351,7 @@ export class SessionOrchestrator extends EventEmitter {
         tmuxManager.killSession(s.id);
         const dbSession = db.getSessionByWorktreePath(s.worktreePath);
         if (dbSession) {
-          db.updateSessionStatus(dbSession.id, "stopped");
+          db.deleteSession(dbSession.id);
         }
         this.emit("session:stopped", s.id);
       }

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -285,7 +285,10 @@ export class SessionOrchestrator extends EventEmitter {
       ? db.getSessionByWorktreePath(tmuxSession.worktreePath)
       : null;
     const worktreePath = tmuxSession?.worktreePath || "";
-    const repoPath = dbSession?.repoPath || undefined;
+    // DBにrepoPathがない場合はgitコマンドで導出を試みる
+    const repoPath =
+      dbSession?.repoPath ||
+      (worktreePath ? this.deriveRepoPath(worktreePath) : undefined);
 
     ttydManager.stopInstance(sessionId);
     tmuxManager.killSession(sessionId);


### PR DESCRIPTION
## Summary

- セッション停止を「セッション削除」に統一し、停止時にDB レコードとworktreeを自動削除するように変更
- worktree作成時にセッションを自動起動するフローを追加
- レビュー指摘対応（session:created二重発行修正、repoPath引き渡し、エラーハンドリング改善）

## 変更内容

- **セッション削除**: `stopSession`がDB レコードを物理削除 + worktree/ブランチも自動削除（メインworktree除外）
- **UI統一**: 停止アイコン(Square)を削除アイコン(Trash2)に変更、ラベルを「セッションを削除」に統一
- **worktree作成フロー**: `worktree:create`後にセッションを自動起動（repoPath付き）
- **エラーハンドリング**: worktree作成とセッション起動のtry/catch分離、session:stopのtry/catch追加
- **イベント修正**: session:created二重発行を解消、io.emitをsocket.emitに統一

## Test plan

- [ ] サイドバーの「+」からworktree作成→セッションが自動起動されサイドバーに表示される
- [ ] セッション右クリック→「セッションを削除」でセッション・worktree・ブランチが削除される
- [ ] メインworktreeのセッション削除時、worktreeは削除されない
- [ ] モバイルからのセッション削除が動作する

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI: Session controls relabeled from "Stop session" to "Delete session" with updated icons and tooltips.
  * UX: Context menu and confirmation dialog unified to a single "Delete session" flow with clearer wording for main vs non-main worktrees.

* **Refactor**
  * Behavior: Stopping/deleting a session now can remove associated worktree and branch data and fully removes session records from the system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->