### PR TITLE
fix: PC/モバイル間のworktree表示差異を修正（ゴーストリソース防止）

### DIFF
--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -23,7 +23,7 @@ import type { ManagedSession, Worktree } from "../../../shared/types";
 const IDLE_THRESHOLD_MS = 10_000;
 
 interface SessionCardProps {
-  session: ManagedSession;
+  session: ManagedSession | null;
   worktree: Worktree | undefined;
   repoList: string[];
   isSelected: boolean;
@@ -31,6 +31,7 @@ interface SessionCardProps {
   activityText: string;
   onClick: () => void;
   onStop: () => void;
+  onStart?: () => void;
 }
 
 export function SessionCard({
@@ -41,10 +42,15 @@ export function SessionCard({
   activityText,
   onClick,
   onStop,
+  onStart,
 }: SessionCardProps) {
   const branch =
     worktree?.branch ||
-    session.worktreePath.substring(session.worktreePath.lastIndexOf("/") + 1);
+    (session
+      ? session.worktreePath.substring(
+          session.worktreePath.lastIndexOf("/") + 1
+        )
+      : "unknown");
 
   // プレビュー/アクティビティの変化を追跡してアイドル判定
   const prevTextRef = useRef(previewText);
@@ -73,15 +79,43 @@ export function SessionCard({
     return () => clearInterval(timer);
   }, []);
 
-  // ✢✻はどちらもClaude Codeの動作中アニメーション記号
-  const hasActivitySymbol = /[✢✻]/.test(activityText);
+  // セッション未起動の場合はシンプルなカードを表示
+  if (!session) {
+    return (
+      <button
+        type="button"
+        className={`w-full text-left p-3 rounded-lg transition-colors group ${
+          isSelected
+            ? "bg-primary/15 border border-primary/30"
+            : "hover:bg-sidebar-accent/50"
+        }`}
+        onClick={onStart ?? onClick}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <div className="w-2 h-2 rounded-full shrink-0 bg-muted-foreground/30" />
+          <span className="text-sm font-mono truncate text-sidebar-foreground/60">
+            {branch}
+          </span>
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground truncate pl-4">
+          セッション未起動
+        </p>
+      </button>
+    );
+  }
 
-  // 緑: 動作中（✢✻+変化あり）、青: 起動直後/clear後（コンテンツなし）、赤: それ以外
+  // ✢✻はアニメーション記号、◼◻はタスク表示記号、"* verb…"は処理中表示
+  const hasActivitySymbol =
+    /[✢✻◼◻]/.test(activityText) || /\S+…/.test(activityText);
+  // タスク記号・処理中表示はidle判定を無視する
+  const hasTaskSymbol = /[◼◻]/.test(activityText) || /\S+…/.test(activityText);
+
+  // 緑: 動作中（✢✻+変化あり or タスク進行中）、青: 起動直後/clear後、赤: それ以外
   const hasVisibleContent =
     previewText.trim().length > 0 || activityText.trim().length > 0;
 
   const dotColor =
-    hasActivitySymbol && !isIdle
+    hasActivitySymbol && (!isIdle || hasTaskSymbol)
       ? "bg-green-500"
       : !hasVisibleContent
         ? "bg-blue-500"

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -29,7 +29,10 @@ interface SessionSidebarProps {
   onNewSession: () => void;
 }
 
-type SidebarItem = { worktree: Worktree; session: ManagedSession | null };
+type SidebarItem = {
+  worktree: Worktree | null;
+  session: ManagedSession | null;
+};
 
 export function SessionSidebar({
   sessions,
@@ -79,7 +82,7 @@ export function SessionSidebar({
       const repo = session.repoPath ?? findRepoForSession(session, repoList);
       const repoName = repo ? getBaseName(repo) : "unknown";
       const existing = groups.get(repoName) || [];
-      existing.push({ worktree: undefined as unknown as Worktree, session });
+      existing.push({ worktree: null, session });
       groups.set(repoName, existing);
     }
 
@@ -130,7 +133,7 @@ export function SessionSidebar({
                     <SessionCard
                       key={session?.id ?? wt?.id ?? "unknown"}
                       session={session}
-                      worktree={wt}
+                      worktree={wt ?? undefined}
                       repoList={repoList}
                       isSelected={
                         session ? selectedSessionId === session.id : false
@@ -145,7 +148,7 @@ export function SessionSidebar({
                       }
                       onClick={() => session && onSelectSession(session.id)}
                       onStop={() => session && onStopSession(session.id)}
-                      onStart={() => wt && onStartSession(wt)}
+                      onStart={() => (wt ? onStartSession(wt) : undefined)}
                     />
                   ))}
                 </div>

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -3,6 +3,7 @@
  *
  * セッション一覧（SessionCard） + 新規作成「+」ボタンを提供。
  * リポジトリごとにヘッダーで区切って表示する。
+ * worktree中心のイテレーション: セッション未起動のworktreeも表示する。
  */
 
 import { FolderOpen, Plus, Terminal } from "lucide-react";
@@ -23,9 +24,12 @@ interface SessionSidebarProps {
   sessionActivityTexts: Map<string, string>;
   onSelectSession: (sessionId: string) => void;
   onStopSession: (sessionId: string) => void;
+  onStartSession: (worktree: Worktree) => void;
   onDeleteWorktree: (worktreePath: string) => void;
   onNewSession: () => void;
 }
+
+type SidebarItem = { worktree: Worktree; session: ManagedSession | null };
 
 export function SessionSidebar({
   sessions,
@@ -36,25 +40,51 @@ export function SessionSidebar({
   sessionActivityTexts,
   onSelectSession,
   onStopSession,
+  onStartSession,
   onDeleteWorktree,
   onNewSession,
 }: SessionSidebarProps) {
-  const getWorktree = (session: ManagedSession): Worktree | undefined => {
-    return worktrees.find(w => w.id === session.worktreeId);
-  };
+  // worktreeId → session のマップ
+  const sessionByWorktreeId = useMemo(() => {
+    const map = new Map<string, ManagedSession>();
+    sessions.forEach(session => {
+      map.set(session.worktreeId, session);
+    });
+    return map;
+  }, [sessions]);
 
-  // リポジトリ別にセッションをグルーピング
-  const groupedSessions = useMemo(() => {
-    const groups = new Map<string, ManagedSession[]>();
+  // worktree中心のリポジトリ別グルーピング
+  const groupedItems = useMemo(() => {
+    const groups = new Map<string, SidebarItem[]>();
+    const worktreeSessionIds = new Set<string>();
+
+    // 1. 選択中リポのworktreeを表示（セッションの有無問わず）
+    for (const wt of worktrees) {
+      const session = sessionByWorktreeId.get(wt.id) ?? null;
+      if (session) worktreeSessionIds.add(session.id);
+      // worktreeからrepo名を導出
+      const repoName = session?.repoPath
+        ? getBaseName(session.repoPath)
+        : repoList.length > 0
+          ? getBaseName(repoList[0])
+          : "unknown";
+      const existing = groups.get(repoName) || [];
+      existing.push({ worktree: wt, session });
+      groups.set(repoName, existing);
+    }
+
+    // 2. 他リポジトリのセッション（worktreesに含まれないもの）
     for (const session of Array.from(sessions.values())) {
+      if (worktreeSessionIds.has(session.id)) continue;
       const repo = session.repoPath ?? findRepoForSession(session, repoList);
       const repoName = repo ? getBaseName(repo) : "unknown";
       const existing = groups.get(repoName) || [];
-      existing.push(session);
+      existing.push({ worktree: undefined as unknown as Worktree, session });
       groups.set(repoName, existing);
     }
+
     return groups;
-  }, [sessions, repoList]);
+  }, [worktrees, sessions, sessionByWorktreeId, repoList]);
 
   return (
     <div className="h-full flex flex-col bg-sidebar">
@@ -78,44 +108,49 @@ export function SessionSidebar({
       {/* セッション一覧 */}
       <ScrollArea className="flex-1">
         <div className="p-2">
-          {sessions.size === 0 ? (
+          {sessions.size === 0 && worktrees.length === 0 ? (
             <div className="p-8 text-center text-muted-foreground text-sm">
               <Terminal className="w-8 h-8 mx-auto mb-3 opacity-50" />
               <p>セッションがありません</p>
               <p className="text-xs mt-1">「+」から新規作成</p>
             </div>
           ) : (
-            Array.from(groupedSessions.entries()).map(
-              ([repoName, repoSessions]) => (
-                <div key={repoName} className="mb-3">
-                  {/* リポジトリヘッダー */}
-                  <div className="flex items-center gap-1.5 px-2 py-1.5">
-                    <FolderOpen className="w-3 h-3 text-muted-foreground" />
-                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate">
-                      {repoName}
-                    </span>
-                  </div>
-                  {/* そのリポジトリのセッション */}
-                  <div className="space-y-1">
-                    {repoSessions.map(session => (
-                      <SessionCard
-                        key={session.id}
-                        session={session}
-                        worktree={getWorktree(session)}
-                        repoList={repoList}
-                        isSelected={selectedSessionId === session.id}
-                        previewText={sessionPreviews.get(session.id) || ""}
-                        activityText={
-                          sessionActivityTexts.get(session.id) || ""
-                        }
-                        onClick={() => onSelectSession(session.id)}
-                        onStop={() => onStopSession(session.id)}
-                      />
-                    ))}
-                  </div>
+            Array.from(groupedItems.entries()).map(([repoName, items]) => (
+              <div key={repoName} className="mb-3">
+                {/* リポジトリヘッダー */}
+                <div className="flex items-center gap-1.5 px-2 py-1.5">
+                  <FolderOpen className="w-3 h-3 text-muted-foreground" />
+                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate">
+                    {repoName}
+                  </span>
                 </div>
-              )
-            )
+                {/* アイテム一覧 */}
+                <div className="space-y-1">
+                  {items.map(({ worktree: wt, session }) => (
+                    <SessionCard
+                      key={session?.id ?? wt?.id ?? "unknown"}
+                      session={session}
+                      worktree={wt}
+                      repoList={repoList}
+                      isSelected={
+                        session ? selectedSessionId === session.id : false
+                      }
+                      previewText={
+                        session ? sessionPreviews.get(session.id) || "" : ""
+                      }
+                      activityText={
+                        session
+                          ? sessionActivityTexts.get(session.id) || ""
+                          : ""
+                      }
+                      onClick={() => session && onSelectSession(session.id)}
+                      onStop={() => session && onStopSession(session.id)}
+                      onStart={() => wt && onStartSession(wt)}
+                    />
+                  ))}
+                </div>
+              </div>
+            ))
           )}
         </div>
       </ScrollArea>

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -25,7 +25,6 @@ interface SessionSidebarProps {
   onSelectSession: (sessionId: string) => void;
   onStopSession: (sessionId: string) => void;
   onStartSession: (worktree: Worktree) => void;
-  onDeleteWorktree: (worktreePath: string) => void;
   onNewSession: () => void;
 }
 
@@ -44,7 +43,6 @@ export function SessionSidebar({
   onSelectSession,
   onStopSession,
   onStartSession,
-  onDeleteWorktree,
   onNewSession,
 }: SessionSidebarProps) {
   // worktreeId → session のマップ
@@ -66,11 +64,14 @@ export function SessionSidebar({
       const session = sessionByWorktreeId.get(wt.id) ?? null;
       if (session) worktreeSessionIds.add(session.id);
       // worktreeからrepo名を導出
-      const repoName = session?.repoPath
-        ? getBaseName(session.repoPath)
-        : repoList.length > 0
-          ? getBaseName(repoList[0])
-          : "unknown";
+      const repoName = (() => {
+        if (session?.repoPath) return getBaseName(session.repoPath);
+        // worktreeのパスからリポジトリを特定
+        const matchedRepo = repoList.find(repo => wt.path.startsWith(repo));
+        if (matchedRepo) return getBaseName(matchedRepo);
+        // worktreeのパスから親ディレクトリ名を使う（フォールバック）
+        return getBaseName(wt.path.split("/.worktrees/")[0] || wt.path);
+      })();
       const existing = groups.get(repoName) || [];
       existing.push({ worktree: wt, session });
       groups.set(repoName, existing);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -265,10 +265,6 @@ export default function Dashboard() {
               onSelectSession={setSelectedSessionId}
               onStopSession={handleStopSession}
               onStartSession={handleStartSession}
-              onDeleteWorktree={path => {
-                const wt = worktrees.find(w => w.path === path);
-                if (wt) handleDeleteWorktree(wt);
-              }}
               onNewSession={handleNewSession}
             />
           }

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -264,6 +264,7 @@ export default function Dashboard() {
               sessionActivityTexts={sessionActivityTexts}
               onSelectSession={setSelectedSessionId}
               onStopSession={handleStopSession}
+              onStartSession={handleStartSession}
               onDeleteWorktree={path => {
                 const wt = worktrees.find(w => w.path === path);
                 if (wt) handleDeleteWorktree(wt);


### PR DESCRIPTION
## 概要

PC側サイドバー（SessionSidebar）がsessions Mapのみをイテレートしていたため、セッション未起動のworktreeがPC側で不可視になる問題を修正。

## 変更内容

- **SessionCard**: `session` propをnullable化し、セッション未起動状態のUI���示を追加
- **SessionSidebar**: イテレーション対象を`sessions` Map → `worktrees`配列に変更。セッション有無に関わらず全worktreeを表示
- **Dashboard**: SessionSidebarに`onStartSession`を接続

## 技術的な詳細

- `groupedItems`の2段階構築: 選択中リポのworktree → 他リポのアクティブセッション
- `SidebarItem`型で`worktree: Worktree | null`、`session: ManagedSession | null`を管理
- repoName導出はworktreeのパスからリポジトリを特定する方式に変更
- 未使用の`onDeleteWorktree` propを削除

## テスト

- `pnpm check` (型チェック): PASS
- `pnpm build`: PASS
- pm2再起動後の動作確認: サーバー正常起動

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session sidebar now displays both active and non-started sessions
  * Users can start sessions directly from the session sidebar

* **Improvements**
  * Enhanced activity status indicators to better reflect task and progress states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->