### PR TITLE
feat: リロード時にリポジトリスキャン結果を自動復元

### DIFF
--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -248,12 +248,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       if (repoPathRef.current) {
         socket.emit("repo:select", repoPathRef.current);
       }
-
-      // localStorageに保存済みのbasePathがあれば自動スキャン
-      const savedBasePath = localStorage.getItem("scanBasePath");
-      if (savedBasePath) {
-        socket.emit("repo:scan", savedBasePath);
-      }
     });
 
     socket.on("disconnect", () => {

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -283,6 +283,8 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
     socket.on("repo:error", err => {
       setError(err);
+      // 楽観的更新のロールバック（selectRepoで先行設定したrepoPathを戻す）
+      setRepoPath(null);
     });
 
     // Repository scanning events

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -248,6 +248,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       if (repoPathRef.current) {
         socket.emit("repo:select", repoPathRef.current);
       }
+
+      // localStorageに保存済みのbasePathがあれば自動スキャン
+      const savedBasePath = localStorage.getItem("scanBasePath");
+      if (savedBasePath) {
+        socket.emit("repo:scan", savedBasePath);
+      }
     });
 
     socket.on("disconnect", () => {
@@ -516,6 +522,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
   // Repository actions
   const selectRepo = useCallback((path: string) => {
+    setRepoPath(path);
     socketRef.current?.emit("repo:select", path);
   }, []);
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -193,8 +193,10 @@ export default function Dashboard() {
   const handleSelectRepo = (path: string) => {
     selectRepo(path);
     setIsSelectRepoOpen(false);
-    // リポジトリ選択後にWorktree作成ダイアログを開く
-    setIsCreateWorktreeOpen(true);
+    // Drawer閉じアニメーション完了後にWorktree作成ダイアログを開く
+    setTimeout(() => {
+      setIsCreateWorktreeOpen(true);
+    }, 350);
   };
 
   const handleCreateWorktree = (branchName: string, baseBranch?: string) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -665,6 +665,11 @@ async function startServer() {
           })
           .catch(err => {
             console.error("[Socket] 自動スキャン失敗:", getErrorMessage(err));
+            socket.emit("repos:scanning", {
+              basePath: savedBasePath,
+              status: "error",
+              error: getErrorMessage(err),
+            });
           });
       }
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -652,6 +652,23 @@ async function startServer() {
       });
     }
 
+    // 保存済みbasePathがあれば自動スキャン（リロード時のリポジトリ一覧復元）
+    if (allowedRepos.length === 0) {
+      const savedBasePath = db.getSetting("scanBasePath") as string | undefined;
+      if (savedBasePath) {
+        scanRepositories(savedBasePath)
+          .then(repos => {
+            for (const repo of repos) {
+              knownRepos.add(repo.path);
+            }
+            socket.emit("repos:scanned", repos);
+          })
+          .catch(err => {
+            console.error("[Socket] 自動スキャン失敗:", getErrorMessage(err));
+          });
+      }
+    }
+
     // ===== Repository Commands =====
 
     socket.on("repo:scan", async basePath => {
@@ -662,6 +679,8 @@ async function startServer() {
         for (const repo of repos) {
           knownRepos.add(repo.path);
         }
+        // スキャン成功時にbasePathを永続化（リロード時の自動スキャン用）
+        db.setSetting("scanBasePath", basePath);
         socket.emit("repos:scanned", repos);
         socket.emit("repos:scanning", { basePath, status: "complete" });
       } catch (error) {


### PR DESCRIPTION
## Summary
- サーバー: スキャン成功時にbasePathをSQLiteに永続化し、Socket接続時に自動スキャン
- クライアント: localStorageのbasePathで接続時に自動スキャン発行
- selectRepoで即座にrepoPathを設定（worktree作成の確実性向上）
- モバイルDrawer閉じアニメーション完了後にworktree作成ダイアログを表示

## Test plan
- [ ] リポジトリをスキャンしてからリロードし、スキャン結果が復元されることを確認
- [ ] スキャン結果からリポジトリを選択し、worktreeが作成できることを確認
- [ ] モバイルでリポジトリ選択→worktree作成ダイアログが正常に表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository scan results now persist and are automatically restored when reconnecting.

* **Bug Fixes / UX**
  * Repository selection now updates immediately in the UI for faster feedback.
  * Opening the "Create Worktree" dialog is delayed briefly after closing the repo picker to avoid UI overlap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->