### PR TITLE
feat: /tmpファイルアクセス許可と画像プレビュー対応

### DIFF
--- a/client/src/components/BrowserPane.tsx
+++ b/client/src/components/BrowserPane.tsx
@@ -100,7 +100,6 @@ export function BrowserPane({ url }: BrowserPaneProps) {
           src={resolvedUrl}
           className="w-full h-full border-0"
           title={`Browser - ${url}`}
-          sandbox="allow-scripts allow-same-origin allow-forms"
         />
       </div>
     </div>

--- a/client/src/components/FileViewerPane.tsx
+++ b/client/src/components/FileViewerPane.tsx
@@ -82,8 +82,8 @@ function ImageRenderer({
   mimeType: string;
   filePath: string;
 }) {
+  // SVGはテキストコンテンツからdata URLを生成
   if (mimeType === "image/svg+xml") {
-    // SVGは<img>タグでdata URLとして表示し、スクリプト実行をブロック
     const utf8Bytes = new TextEncoder().encode(content);
     const binaryString = Array.from(utf8Bytes, byte =>
       String.fromCharCode(byte)
@@ -99,6 +99,20 @@ function ImageRenderer({
       </div>
     );
   }
+
+  // PNG/JPG/GIF/WebP等はサーバーからdata URLとして受信済み
+  if (content) {
+    return (
+      <div className="p-4 flex items-center justify-center h-full">
+        <img
+          src={content}
+          alt={filePath.split("/").pop()}
+          className="max-w-full max-h-full object-contain"
+        />
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center justify-center h-full text-muted-foreground">
       <p>画像ファイル: {filePath.split("/").pop()}</p>

--- a/server/index.ts
+++ b/server/index.ts
@@ -1021,6 +1021,13 @@ async function startServer() {
       lastFileReadTime = now;
 
       try {
+        // /tmp配下のファイルはsessionに依存せず直接読み取り
+        if (filePath.startsWith("/tmp/")) {
+          const result = await readFileFromWorktree("", filePath);
+          socket.emit("file:content", result);
+          return;
+        }
+
         // sessionIdからworktreePathをサーバー側で解決
         const session = sessionOrchestrator.getSession(sessionId);
         if (!session?.worktreePath) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1023,7 +1023,18 @@ async function startServer() {
       try {
         // /tmp配下のファイルはsessionに依存せず直接読み取り
         if (filePath.startsWith("/tmp/")) {
-          const result = await readFileFromWorktree("", filePath);
+          const normalizedPath = path.resolve(filePath);
+          if (!normalizedPath.startsWith("/tmp/")) {
+            socket.emit("file:content", {
+              filePath,
+              content: "",
+              mimeType: "application/octet-stream",
+              size: 0,
+              error: "不正なパスです",
+            });
+            return;
+          }
+          const result = await readFileFromWorktree("", normalizedPath);
           socket.emit("file:content", result);
           return;
         }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1022,7 +1022,18 @@ async function startServer() {
 
       try {
         // /tmp配下のファイルはsessionに依存せず直接読み取り
+        // sessionIdの存在チェック（認証済みソケットであることを確認）
         if (filePath.startsWith("/tmp/")) {
+          if (!sessionId || !sessionOrchestrator.getSession(sessionId)) {
+            socket.emit("file:content", {
+              filePath,
+              content: "",
+              mimeType: "application/octet-stream",
+              size: 0,
+              error: "有効なセッションが必要です",
+            });
+            return;
+          }
           const normalizedPath = path.resolve(filePath);
           if (!normalizedPath.startsWith("/tmp/")) {
             socket.emit("file:content", {

--- a/server/lib/file-manager.ts
+++ b/server/lib/file-manager.ts
@@ -108,13 +108,26 @@ async function resolveSafePath(
   worktreePath: string,
   filePath: string
 ): Promise<string> {
-  if (path.isAbsolute(filePath)) {
-    throw new Error("ファイルへのアクセスが拒否されました");
-  }
   if (filePath.includes("..")) {
     throw new Error("ファイルへのアクセスが拒否されました");
   }
 
+  // /tmp配下のファイルは直接アクセスを許可
+  if (path.isAbsolute(filePath)) {
+    const resolved = path.resolve(filePath);
+    let realResolved: string;
+    try {
+      realResolved = await realpath(resolved);
+    } catch {
+      throw new Error(`ファイルが見つかりません: ${filePath}`);
+    }
+    if (!realResolved.startsWith("/tmp/")) {
+      throw new Error("ファイルへのアクセスが拒否されました");
+    }
+    return realResolved;
+  }
+
+  // worktree内の相対パスは従来通り
   const resolvedWorktree = await realpath(worktreePath);
   const resolved = path.resolve(resolvedWorktree, filePath);
 
@@ -162,6 +175,17 @@ export async function readFileFromWorktree(
   const mimeType = detectMimeType(filePath);
 
   if (!isTextMimeType(mimeType)) {
+    // 画像ファイルはBase64エンコードしてdata URLで返す
+    if (mimeType.startsWith("image/")) {
+      const buffer = await readFile(safePath);
+      const base64 = buffer.toString("base64");
+      return {
+        filePath,
+        content: `data:${mimeType};base64,${base64}`,
+        mimeType,
+        size: fileStat.size,
+      };
+    }
     return {
       filePath,
       content: "",

--- a/server/lib/file-manager.ts
+++ b/server/lib/file-manager.ts
@@ -121,7 +121,11 @@ async function resolveSafePath(
     } catch {
       throw new Error(`ファイルが見つかりません: ${filePath}`);
     }
-    if (!realResolved.startsWith("/tmp/")) {
+    // macOSでは realpath("/tmp/...") が "/private/tmp/..." になるため両方チェック
+    if (
+      !realResolved.startsWith("/tmp/") &&
+      !realResolved.startsWith("/private/tmp/")
+    ) {
       throw new Error("ファイルへのアクセスが拒否されました");
     }
     return realResolved;

--- a/server/lib/file-manager.ts
+++ b/server/lib/file-manager.ts
@@ -1,7 +1,7 @@
 import { readFile, realpath, stat } from "node:fs/promises";
 import path from "node:path";
 
-const MAX_FILE_SIZE = 1024 * 1024; // 1MB
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
 
 // 拡張子→MIMEタイプのマッピング
 const EXTENSION_MIME_MAP: Record<string, string> = {


### PR DESCRIPTION
## Summary
- /tmp配下のファイルをホワイトリスト許可（スクリーンショット等の一時ファイル用）
- PNG/JPG/GIF/WebP画像をBase64 data URLでプレビュー表示
- ファイルサイズ上限を1MB→10MBに引き上げ
- iframeのsandbox属性を削除（アプリ内ブラウザタブの互換性向上）
- /tmpパスのパストラバーサル防御チェックを追加

Related: #60 (プロキシCSS問題は別issue)

## Test plan
- [ ] /tmp配下のファイル（スクリーンショット等）がファイルビューアタブで表示できること
- [ ] PNG/JPG画像がプレビュー表示されること
- [ ] /tmp/../etc/passwd のようなパストラバーサルが拒否されること
- [ ] 10MB以下のファイルが正常に読み込めること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image files (PNG, JPG, GIF, WebP) now display inline previews when content is available.
  * Files under the system temporary directory can be read directly.

* **Improvements**
  * Maximum readable file size increased to 10MB.
  * Iframe sandboxing configuration changed (affects embedded content behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->