### PR TITLE
feat: noVNC方式によるリモートブラウザ機能（issue #60解決）

### DIFF
--- a/client/src/components/BrowserPane.tsx
+++ b/client/src/components/BrowserPane.tsx
@@ -11,9 +11,13 @@ function getUrlToken(): string | null {
 
 export function BrowserPane({ browserSession }: BrowserPaneProps) {
   const token = getUrlToken();
-  const wsPath = `browser/${browserSession.id}/websockify`;
-  const tokenParam = token ? `&token=${encodeURIComponent(token)}` : "";
-  const src = `/browser/${browserSession.id}/vnc.html?autoconnect=true&resize=scale&path=${encodeURIComponent(wsPath)}${tokenParam}`;
+  // tokenはpath内のクエリに含める必要がある。
+  // noVNCは `path` をそのままWebSocket URLに使うため、
+  // vnc.htmlのクエリに `token=` を付けるだけではupgradeリクエストに届かない。
+  const wsPath = token
+    ? `browser/${browserSession.id}/websockify?token=${encodeURIComponent(token)}`
+    : `browser/${browserSession.id}/websockify`;
+  const src = `/browser/${browserSession.id}/vnc.html?autoconnect=true&resize=scale&path=${encodeURIComponent(wsPath)}`;
 
   return (
     <div className="h-full bg-background">

--- a/client/src/components/BrowserPane.tsx
+++ b/client/src/components/BrowserPane.tsx
@@ -1,246 +1,27 @@
-import {
-  ArrowLeft,
-  ArrowRight,
-  ExternalLink,
-  Loader2,
-  Monitor,
-  RotateCw,
-} from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import type { Socket } from "socket.io-client";
-import type {
-  BrowserSession,
-  ClientToServerEvents,
-  ServerToClientEvents,
-} from "../../../shared/types";
-import { Button } from "./ui/button";
-
-type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+import type { BrowserSession } from "../../../shared/types";
 
 interface BrowserPaneProps {
-  url: string;
-  port: number;
-  socket: TypedSocket | null;
-}
-
-/** ローカルアクセスかどうかを判定 */
-function isLocalAccess(): boolean {
-  return (
-    window.location.hostname === "localhost" ||
-    window.location.hostname === "127.0.0.1"
-  );
-}
-
-/** URLをローカル/リモートに応じて解決 */
-function resolveUrl(url: string): string {
-  if (isLocalAccess()) {
-    return url;
-  }
-  try {
-    const parsed = new URL(url);
-    if (parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1") {
-      const defaultPort = parsed.protocol === "https:" ? "443" : "80";
-      return `/proxy/${parsed.port || defaultPort}${parsed.pathname}${parsed.search}`;
-    }
-  } catch {
-    // パース失敗時はそのまま返す
-  }
-  return url;
+  browserSession: BrowserSession;
 }
 
 /** URLからtokenパラメータを取得 */
 function getUrlToken(): string | null {
-  const params = new URLSearchParams(window.location.search);
-  return params.get("token");
+  return new URLSearchParams(window.location.search).get("token");
 }
 
-export function BrowserPane({ url, port, socket }: BrowserPaneProps) {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  const [iframeKey, setIframeKey] = useState(0);
-  const isLocal = isLocalAccess();
-  const resolvedUrl = resolveUrl(url);
-
-  // リモート時のnoVNCセッション管理
-  const [browserSession, setBrowserSession] = useState<BrowserSession | null>(
-    null
-  );
-  const [isLoading, setIsLoading] = useState(false);
-  const [remoteError, setRemoteError] = useState<string | null>(null);
-  const browserSessionRef = useRef<BrowserSession | null>(null);
-
-  // browserSessionRefを同期
-  useEffect(() => {
-    browserSessionRef.current = browserSession;
-  }, [browserSession]);
-
-  // リモートアクセス時: Socket.IOでnoVNCセッションを起動
-  useEffect(() => {
-    if (isLocal || !socket) return;
-
-    setIsLoading(true);
-    setRemoteError(null);
-
-    const handleStarted = (session: BrowserSession) => {
-      setBrowserSession(session);
-      browserSessionRef.current = session;
-      setIsLoading(false);
-      setRemoteError(null);
-    };
-
-    const handleError = (data: { message: string }) => {
-      setRemoteError(data.message);
-      setIsLoading(false);
-    };
-
-    socket.on("browser:started", handleStarted);
-    socket.on("browser:error", handleError);
-
-    // ブラウザセッション起動をリクエスト
-    socket.emit("browser:start", { port, url });
-
-    return () => {
-      socket.off("browser:started", handleStarted);
-      socket.off("browser:error", handleError);
-
-      // クリーンアップ: セッションを停止
-      const currentSession = browserSessionRef.current;
-      if (currentSession) {
-        socket.emit("browser:stop", { browserId: currentSession.id });
-      }
-    };
-  }, [isLocal, socket, port, url]);
-
-  const handleReload = useCallback(() => {
-    setIframeKey(k => k + 1);
-  }, []);
-
-  const handleOpenExternal = useCallback(() => {
-    window.open(url, "_blank");
-  }, [url]);
-
-  // リモートアクセス時のnoVNC URL構築
-  const getNoVncUrl = (): string | null => {
-    if (!browserSession) return null;
-    const token = getUrlToken();
-    const tokenParam = token ? `&token=${encodeURIComponent(token)}` : "";
-    const wsPath = `browser/${browserSession.id}/websockify`;
-    return `/browser/${browserSession.id}/vnc.html?autoconnect=true&resize=scale&path=${encodeURIComponent(wsPath)}${tokenParam}`;
-  };
-
-  // ローディング状態（リモートのみ）
-  if (!isLocal && isLoading) {
-    return (
-      <div className="h-full flex flex-col bg-background">
-        <div className="flex-1 flex items-center justify-center">
-          <div className="flex flex-col items-center gap-3 text-muted-foreground">
-            <Loader2 className="h-8 w-8 animate-spin" />
-            <span className="text-sm">ブラウザセッションを起動中...</span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // エラー状態（リモートのみ）
-  if (!isLocal && remoteError) {
-    return (
-      <div className="h-full flex flex-col bg-background">
-        <div className="flex-1 flex items-center justify-center">
-          <div className="flex flex-col items-center gap-3 text-destructive">
-            <span className="text-sm">
-              ブラウザセッションエラー: {remoteError}
-            </span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // リモートでnoVNCセッションがまだない場合
-  const noVncUrl = !isLocal ? getNoVncUrl() : null;
-  if (!isLocal && !noVncUrl) {
-    return (
-      <div className="h-full flex flex-col bg-background">
-        <div className="flex-1 flex items-center justify-center">
-          <div className="flex flex-col items-center gap-3 text-muted-foreground">
-            <Loader2 className="h-8 w-8 animate-spin" />
-            <span className="text-sm">ブラウザセッションを起動中...</span>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  const iframeSrc = isLocal ? resolvedUrl : (noVncUrl as string);
-  const isRemote = !isLocal;
+export function BrowserPane({ browserSession }: BrowserPaneProps) {
+  const token = getUrlToken();
+  const wsPath = `browser/${browserSession.id}/websockify`;
+  const tokenParam = token ? `&token=${encodeURIComponent(token)}` : "";
+  const src = `/browser/${browserSession.id}/vnc.html?autoconnect=true&resize=scale&path=${encodeURIComponent(wsPath)}${tokenParam}`;
 
   return (
-    <div className="h-full flex flex-col bg-background">
-      <div className="flex items-center gap-1 px-2 py-1 border-b border-border shrink-0">
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6"
-          disabled={isRemote}
-          onClick={() => {
-            try {
-              iframeRef.current?.contentWindow?.history.back();
-            } catch {
-              // クロスオリジンiframe
-            }
-          }}
-          title="戻る"
-        >
-          <ArrowLeft className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6"
-          disabled={isRemote}
-          onClick={() => {
-            try {
-              iframeRef.current?.contentWindow?.history.forward();
-            } catch {
-              // クロスオリジンiframe
-            }
-          }}
-          title="進む"
-        >
-          <ArrowRight className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6"
-          onClick={handleReload}
-          title="リロード"
-        >
-          <RotateCw className="h-3.5 w-3.5" />
-        </Button>
-        <div className="flex-1 flex items-center bg-muted rounded px-2 py-0.5 text-xs text-muted-foreground truncate mx-1 gap-1">
-          {isRemote && <Monitor className="h-3 w-3 shrink-0" />}
-          <span className="truncate">{url}</span>
-        </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-6 w-6"
-          onClick={handleOpenExternal}
-          title="外部ブラウザで開く"
-        >
-          <ExternalLink className="h-3.5 w-3.5" />
-        </Button>
-      </div>
-      <div className="flex-1 min-h-0">
-        <iframe
-          key={iframeKey}
-          ref={iframeRef}
-          src={iframeSrc}
-          className="w-full h-full border-0"
-          title={`Browser - ${url}`}
-        />
-      </div>
+    <div className="h-full bg-background">
+      <iframe
+        src={src}
+        className="w-full h-full border-0"
+        title="Remote Browser"
+      />
     </div>
   );
 }

--- a/client/src/components/BrowserPane.tsx
+++ b/client/src/components/BrowserPane.tsx
@@ -123,7 +123,8 @@ export function BrowserPane({ url, port, socket }: BrowserPaneProps) {
     if (!browserSession) return null;
     const token = getUrlToken();
     const tokenParam = token ? `&token=${encodeURIComponent(token)}` : "";
-    return `/browser/${browserSession.id}/vnc.html?autoconnect=true&resize=scale${tokenParam}`;
+    const wsPath = `browser/${browserSession.id}/websockify`;
+    return `/browser/${browserSession.id}/vnc.html?autoconnect=true&resize=scale&path=${encodeURIComponent(wsPath)}${tokenParam}`;
   };
 
   // ローディング状態（リモートのみ）

--- a/client/src/components/BrowserPane.tsx
+++ b/client/src/components/BrowserPane.tsx
@@ -1,16 +1,39 @@
-import { ArrowLeft, ArrowRight, ExternalLink, RotateCw } from "lucide-react";
-import { useCallback, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  ArrowRight,
+  ExternalLink,
+  Loader2,
+  Monitor,
+  RotateCw,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
+import type {
+  BrowserSession,
+  ClientToServerEvents,
+  ServerToClientEvents,
+} from "../../../shared/types";
 import { Button } from "./ui/button";
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
 interface BrowserPaneProps {
   url: string;
+  port: number;
+  socket: TypedSocket | null;
 }
 
-function resolveUrl(url: string): string {
-  if (
+/** ローカルアクセスかどうかを判定 */
+function isLocalAccess(): boolean {
+  return (
     window.location.hostname === "localhost" ||
     window.location.hostname === "127.0.0.1"
-  ) {
+  );
+}
+
+/** URLをローカル/リモートに応じて解決 */
+function resolveUrl(url: string): string {
+  if (isLocalAccess()) {
     return url;
   }
   try {
@@ -25,10 +48,67 @@ function resolveUrl(url: string): string {
   return url;
 }
 
-export function BrowserPane({ url }: BrowserPaneProps) {
+/** URLからtokenパラメータを取得 */
+function getUrlToken(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("token");
+}
+
+export function BrowserPane({ url, port, socket }: BrowserPaneProps) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   const [iframeKey, setIframeKey] = useState(0);
+  const isLocal = isLocalAccess();
   const resolvedUrl = resolveUrl(url);
+
+  // リモート時のnoVNCセッション管理
+  const [browserSession, setBrowserSession] = useState<BrowserSession | null>(
+    null
+  );
+  const [isLoading, setIsLoading] = useState(false);
+  const [remoteError, setRemoteError] = useState<string | null>(null);
+  const browserSessionRef = useRef<BrowserSession | null>(null);
+
+  // browserSessionRefを同期
+  useEffect(() => {
+    browserSessionRef.current = browserSession;
+  }, [browserSession]);
+
+  // リモートアクセス時: Socket.IOでnoVNCセッションを起動
+  useEffect(() => {
+    if (isLocal || !socket) return;
+
+    setIsLoading(true);
+    setRemoteError(null);
+
+    const handleStarted = (session: BrowserSession) => {
+      setBrowserSession(session);
+      browserSessionRef.current = session;
+      setIsLoading(false);
+      setRemoteError(null);
+    };
+
+    const handleError = (data: { message: string }) => {
+      setRemoteError(data.message);
+      setIsLoading(false);
+    };
+
+    socket.on("browser:started", handleStarted);
+    socket.on("browser:error", handleError);
+
+    // ブラウザセッション起動をリクエスト
+    socket.emit("browser:start", { port, url });
+
+    return () => {
+      socket.off("browser:started", handleStarted);
+      socket.off("browser:error", handleError);
+
+      // クリーンアップ: セッションを停止
+      const currentSession = browserSessionRef.current;
+      if (currentSession) {
+        socket.emit("browser:stop", { browserId: currentSession.id });
+      }
+    };
+  }, [isLocal, socket, port, url]);
 
   const handleReload = useCallback(() => {
     setIframeKey(k => k + 1);
@@ -38,6 +118,61 @@ export function BrowserPane({ url }: BrowserPaneProps) {
     window.open(url, "_blank");
   }, [url]);
 
+  // リモートアクセス時のnoVNC URL構築
+  const getNoVncUrl = (): string | null => {
+    if (!browserSession) return null;
+    const token = getUrlToken();
+    const tokenParam = token ? `&token=${encodeURIComponent(token)}` : "";
+    return `/browser/${browserSession.id}/vnc.html?autoconnect=true&resize=scale${tokenParam}`;
+  };
+
+  // ローディング状態（リモートのみ）
+  if (!isLocal && isLoading) {
+    return (
+      <div className="h-full flex flex-col bg-background">
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3 text-muted-foreground">
+            <Loader2 className="h-8 w-8 animate-spin" />
+            <span className="text-sm">ブラウザセッションを起動中...</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // エラー状態（リモートのみ）
+  if (!isLocal && remoteError) {
+    return (
+      <div className="h-full flex flex-col bg-background">
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3 text-destructive">
+            <span className="text-sm">
+              ブラウザセッションエラー: {remoteError}
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // リモートでnoVNCセッションがまだない場合
+  const noVncUrl = !isLocal ? getNoVncUrl() : null;
+  if (!isLocal && !noVncUrl) {
+    return (
+      <div className="h-full flex flex-col bg-background">
+        <div className="flex-1 flex items-center justify-center">
+          <div className="flex flex-col items-center gap-3 text-muted-foreground">
+            <Loader2 className="h-8 w-8 animate-spin" />
+            <span className="text-sm">ブラウザセッションを起動中...</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const iframeSrc = isLocal ? resolvedUrl : (noVncUrl as string);
+  const isRemote = !isLocal;
+
   return (
     <div className="h-full flex flex-col bg-background">
       <div className="flex items-center gap-1 px-2 py-1 border-b border-border shrink-0">
@@ -45,6 +180,7 @@ export function BrowserPane({ url }: BrowserPaneProps) {
           variant="ghost"
           size="icon"
           className="h-6 w-6"
+          disabled={isRemote}
           onClick={() => {
             try {
               iframeRef.current?.contentWindow?.history.back();
@@ -60,6 +196,7 @@ export function BrowserPane({ url }: BrowserPaneProps) {
           variant="ghost"
           size="icon"
           className="h-6 w-6"
+          disabled={isRemote}
           onClick={() => {
             try {
               iframeRef.current?.contentWindow?.history.forward();
@@ -80,8 +217,9 @@ export function BrowserPane({ url }: BrowserPaneProps) {
         >
           <RotateCw className="h-3.5 w-3.5" />
         </Button>
-        <div className="flex-1 bg-muted rounded px-2 py-0.5 text-xs text-muted-foreground truncate mx-1">
-          {url}
+        <div className="flex-1 flex items-center bg-muted rounded px-2 py-0.5 text-xs text-muted-foreground truncate mx-1 gap-1">
+          {isRemote && <Monitor className="h-3 w-3 shrink-0" />}
+          <span className="truncate">{url}</span>
         </div>
         <Button
           variant="ghost"
@@ -97,7 +235,7 @@ export function BrowserPane({ url }: BrowserPaneProps) {
         <iframe
           key={iframeKey}
           ref={iframeRef}
-          src={resolvedUrl}
+          src={iframeSrc}
           className="w-full h-full border-0"
           title={`Browser - ${url}`}
         />

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -63,6 +63,7 @@ interface MobileLayoutProps {
   // ブラウザ（noVNC）
   activeBrowserSession: BrowserSession | null;
   onSelectBrowser: () => void;
+  navigateBrowser: (url: string) => void;
   isRemote: boolean;
 }
 
@@ -93,6 +94,7 @@ export function MobileLayout({
   onBeaconClear,
   activeBrowserSession,
   onSelectBrowser,
+  navigateBrowser,
   isRemote,
 }: MobileLayoutProps) {
   const [activeView, setActiveView] = useState<
@@ -103,13 +105,32 @@ export function MobileLayout({
   );
   const [openedSessions, setOpenedSessions] = useState<Set<string>>(new Set());
 
+  const handleOpenUrl = useCallback(
+    (url: string) => {
+      if (isRemote) {
+        onSelectBrowser();
+        setActiveView("browser");
+        navigateBrowser(url);
+      } else {
+        window.open(url, "_blank");
+      }
+    },
+    [isRemote, onSelectBrowser, navigateBrowser]
+  );
+
   // タブ状態管理（共通フック）
   const {
     getTabsForSession,
     getActiveTabForSession,
     handleTabSelect,
     handleTabClose,
-  } = useViewerTabs(selectedSessionId, sessions, readFile, fileContent);
+  } = useViewerTabs(
+    selectedSessionId,
+    sessions,
+    readFile,
+    fileContent,
+    handleOpenUrl
+  );
 
   // セッションを選択して詳細画面に遷移
   const handleOpenSession = useCallback(

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -174,6 +174,7 @@ export function MobileLayout({
   const handleOpenBrowser = useCallback(() => {
     onSelectBrowser();
     setActiveView("browser");
+    setHasBrowserOpened(true);
   }, [onSelectBrowser]);
 
   // ボトムナビゲーションの表示判定（セッション詳細画面・ブラウザ画面以外で表示）
@@ -258,9 +259,14 @@ export function MobileLayout({
         />
       </div>
 
-      {/* ブラウザビュー（noVNC） */}
-      {activeView === "browser" && (
-        <div className="flex-1 flex flex-col min-h-0">
+      {/* ブラウザビュー（noVNC）- 一度開いたら常に描画し、display:hiddenで切り替え。
+          BrowserPaneの再マウントによるVNC再接続を防ぐ。 */}
+      {hasBrowserOpened && (
+        <div
+          className={
+            activeView === "browser" ? "flex-1 flex flex-col min-h-0" : "hidden"
+          }
+        >
           <div className="h-12 border-b border-border flex items-center px-4 shrink-0">
             <button
               type="button"

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -116,7 +116,7 @@ export function MobileLayout({
         setHasBrowserOpened(true);
         navigateBrowser(url);
       } else {
-        window.open(url, "_blank");
+        window.open(url, "_blank", "noopener");
       }
     },
     [isRemote, onSelectBrowser, navigateBrowser]

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -8,10 +8,12 @@
 
 import { useCallback, useEffect, useState } from "react";
 import type { Socket } from "socket.io-client";
+import { BrowserPane } from "@/components/BrowserPane";
 import { MobileChatView } from "@/components/MobileChatView";
 import { MobileSessionList } from "@/components/MobileSessionList";
 import { MobileSessionView } from "@/components/MobileSessionView";
 import type {
+  BrowserSession,
   ChatMessage,
   ClientToServerEvents,
   ManagedSession,
@@ -58,6 +60,10 @@ interface MobileLayoutProps {
   beaconStreamText: string;
   onBeaconSend: (message: string) => void;
   onBeaconClear?: () => void;
+  // ブラウザ（noVNC）
+  activeBrowserSession: BrowserSession | null;
+  onSelectBrowser: () => void;
+  isRemote: boolean;
 }
 
 export function MobileLayout({
@@ -85,10 +91,13 @@ export function MobileLayout({
   beaconStreamText,
   onBeaconSend,
   onBeaconClear,
+  activeBrowserSession,
+  onSelectBrowser,
+  isRemote,
 }: MobileLayoutProps) {
-  const [activeView, setActiveView] = useState<"list" | "detail" | "beacon">(
-    "list"
-  );
+  const [activeView, setActiveView] = useState<
+    "list" | "detail" | "beacon" | "browser"
+  >("list");
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     null
   );
@@ -136,8 +145,14 @@ export function MobileLayout({
     return worktrees.find(w => w.id === session.worktreeId);
   };
 
-  // ボトムナビゲーションの表示判定（セッション詳細画面以外で表示）
-  const showBottomNav = activeView !== "detail";
+  // ブラウザを選択して画面遷移
+  const handleOpenBrowser = useCallback(() => {
+    onSelectBrowser();
+    setActiveView("browser");
+  }, [onSelectBrowser]);
+
+  // ボトムナビゲーションの表示判定（セッション詳細画面・ブラウザ画面以外で表示）
+  const showBottomNav = activeView !== "detail" && activeView !== "browser";
 
   return (
     <div className="h-full flex flex-col min-h-0 overflow-hidden">
@@ -218,13 +233,38 @@ export function MobileLayout({
         />
       </div>
 
-      {/* ボトムナビゲーション（セッション詳細画面以外で表示） */}
+      {/* ブラウザビュー（noVNC） */}
+      {activeView === "browser" && (
+        <div className="flex-1 flex flex-col min-h-0">
+          <div className="h-12 border-b border-border flex items-center px-4 shrink-0">
+            <button
+              type="button"
+              className="text-sm text-muted-foreground mr-3"
+              onClick={handleBack}
+            >
+              ← 戻る
+            </button>
+            <span className="text-sm font-medium">ブラウザ</span>
+          </div>
+          <div className="flex-1 min-h-0">
+            {activeBrowserSession ? (
+              <BrowserPane browserSession={activeBrowserSession} />
+            ) : (
+              <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+                ブラウザを起動中...
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ボトムナビゲーション（セッション詳細画面・ブラウザ画面以外で表示） */}
       {showBottomNav && (
         <nav className="fixed bottom-0 left-0 right-0 border-t border-border bg-background z-50 flex">
           <button
             type="button"
             className={`flex-1 py-3 text-center text-sm font-medium ${
-              activeView !== "beacon"
+              activeView === "list"
                 ? "text-primary border-t-2 border-primary"
                 : "text-muted-foreground"
             }`}
@@ -232,6 +272,19 @@ export function MobileLayout({
           >
             セッション
           </button>
+          {isRemote && (
+            <button
+              type="button"
+              className={`flex-1 py-3 text-center text-sm font-medium ${
+                activeView === "browser"
+                  ? "text-primary border-t-2 border-primary"
+                  : "text-muted-foreground"
+              }`}
+              onClick={handleOpenBrowser}
+            >
+              ブラウザ
+            </button>
+          )}
           <button
             type="button"
             className={`flex-1 py-3 text-center text-sm font-medium ${

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -296,11 +296,7 @@ export function MobileLayout({
           {isRemote && (
             <button
               type="button"
-              className={`flex-1 py-3 text-center text-sm font-medium ${
-                activeView === "browser"
-                  ? "text-primary border-t-2 border-primary"
-                  : "text-muted-foreground"
-              }`}
+              className="flex-1 py-3 text-center text-sm font-medium text-muted-foreground"
               onClick={handleOpenBrowser}
             >
               ブラウザ

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -104,12 +104,16 @@ export function MobileLayout({
     null
   );
   const [openedSessions, setOpenedSessions] = useState<Set<string>>(new Set());
+  // ブラウザビューを一度でも開いたかどうかのフラグ
+  // 一度開いたらdisplay:hiddenで切り替え、BrowserPaneの再マウント（WebSocket再接続）を防ぐ
+  const [hasBrowserOpened, setHasBrowserOpened] = useState(false);
 
   const handleOpenUrl = useCallback(
     (url: string) => {
       if (isRemote) {
         onSelectBrowser();
         setActiveView("browser");
+        setHasBrowserOpened(true);
         navigateBrowser(url);
       } else {
         window.open(url, "_blank");

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -37,23 +37,9 @@ import type {
 import { useTerminalLinkInjection } from "../hooks/useTerminalLinkInjection";
 import { useTerminalSwipeScroll } from "../hooks/useTerminalSwipeScroll";
 import { useVisualViewport } from "../hooks/useVisualViewport";
-import { BrowserPane } from "./BrowserPane";
 import { FileViewerPane } from "./FileViewerPane";
 import type { ViewerTab } from "./TerminalPane";
 import { ViewerTabBar } from "./ViewerTabBar";
-
-/** URLからポート番号を抽出 */
-function extractPort(url: string): number {
-  try {
-    const parsed = new URL(url);
-    return Number.parseInt(
-      parsed.port || (parsed.protocol === "https:" ? "443" : "80"),
-      10
-    );
-  } catch {
-    return 80;
-  }
-}
 
 interface MobileSessionViewProps {
   session: ManagedSession;
@@ -374,19 +360,6 @@ export function MobileSessionView({
                 size={tab.size}
                 targetLine={tab.targetLine}
                 error={tab.error}
-              />
-            </div>
-          );
-        })()}
-      {tabs[activeTabIndex]?.type === "browser" &&
-        (() => {
-          const tab = tabs[activeTabIndex] as ViewerTab & { type: "browser" };
-          return (
-            <div className="flex-1 min-h-0">
-              <BrowserPane
-                url={tab.url}
-                port={extractPort(tab.url)}
-                socket={socket}
               />
             </div>
           );

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -42,6 +42,19 @@ import { FileViewerPane } from "./FileViewerPane";
 import type { ViewerTab } from "./TerminalPane";
 import { ViewerTabBar } from "./ViewerTabBar";
 
+/** URLからポート番号を抽出 */
+function extractPort(url: string): number {
+  try {
+    const parsed = new URL(url);
+    return Number.parseInt(
+      parsed.port || (parsed.protocol === "https:" ? "443" : "80"),
+      10
+    );
+  } catch {
+    return 80;
+  }
+}
+
 interface MobileSessionViewProps {
   session: ManagedSession;
   worktree: Worktree | undefined;
@@ -370,7 +383,11 @@ export function MobileSessionView({
           const tab = tabs[activeTabIndex] as ViewerTab & { type: "browser" };
           return (
             <div className="flex-1 min-h-0">
-              <BrowserPane url={tab.url} />
+              <BrowserPane
+                url={tab.url}
+                port={extractPort(tab.url)}
+                socket={socket}
+              />
             </div>
           );
         })()}

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -6,7 +6,7 @@
  * worktree中心のイテレーション: セッション未起動のworktreeも表示する。
  */
 
-import { FolderOpen, Plus, Terminal } from "lucide-react";
+import { FolderOpen, Globe, Plus, Terminal } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useGroupedWorktreeItems } from "@/hooks/useGroupedWorktreeItems";
@@ -24,6 +24,12 @@ interface SessionSidebarProps {
   onStopSession: (sessionId: string) => void;
   onStartSession: (worktree: Worktree) => void;
   onNewSession: () => void;
+  /** ブラウザ起動/停止コールバック（リモートアクセス時のみ使用） */
+  onToggleBrowser?: () => void;
+  /** ブラウザセッションがアクティブか */
+  isBrowserActive?: boolean;
+  /** リモートアクセス中か */
+  isRemote?: boolean;
 }
 
 export function SessionSidebar({
@@ -37,6 +43,9 @@ export function SessionSidebar({
   onStopSession,
   onStartSession,
   onNewSession,
+  onToggleBrowser,
+  isBrowserActive = false,
+  isRemote = false,
 }: SessionSidebarProps) {
   const { groupedItems } = useGroupedWorktreeItems(
     worktrees,
@@ -52,15 +61,28 @@ export function SessionSidebar({
           <Terminal className="w-4 h-4 text-primary" />
           <h1 className="font-semibold text-sm text-sidebar-foreground">Ark</h1>
         </div>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={onNewSession}
-          title="新規セッション"
-        >
-          <Plus className="w-4 h-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          {isRemote && onToggleBrowser && (
+            <Button
+              variant={isBrowserActive ? "default" : "ghost"}
+              size="icon"
+              className="h-8 w-8"
+              onClick={onToggleBrowser}
+              title={isBrowserActive ? "ブラウザを閉じる" : "ブラウザを開く"}
+            >
+              <Globe className="w-4 h-4" />
+            </Button>
+          )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={onNewSession}
+            title="新規セッション"
+          >
+            <Plus className="w-4 h-4" />
+          </Button>
+        </div>
       </div>
 
       {/* セッション一覧 */}

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -68,6 +68,10 @@ export function SessionSidebar({
               size="icon"
               className="h-8 w-8"
               onClick={onSelectBrowser}
+              aria-label={
+                isBrowserSelected ? "ブラウザを選択中" : "ブラウザを開く"
+              }
+              aria-pressed={isBrowserSelected}
               title="ブラウザ"
             >
               <Globe className="w-4 h-4" />
@@ -78,6 +82,7 @@ export function SessionSidebar({
             size="icon"
             className="h-8 w-8"
             onClick={onNewSession}
+            aria-label="新規セッション"
             title="新規セッション"
           >
             <Plus className="w-4 h-4" />

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -24,10 +24,10 @@ interface SessionSidebarProps {
   onStopSession: (sessionId: string) => void;
   onStartSession: (worktree: Worktree) => void;
   onNewSession: () => void;
-  /** ブラウザ起動/停止コールバック（リモートアクセス時のみ使用） */
-  onToggleBrowser?: () => void;
-  /** ブラウザセッションがアクティブか */
-  isBrowserActive?: boolean;
+  /** ブラウザ選択コールバック（リモートアクセス時のみ使用） */
+  onSelectBrowser?: () => void;
+  /** ブラウザが選択中か */
+  isBrowserSelected?: boolean;
   /** リモートアクセス中か */
   isRemote?: boolean;
 }
@@ -43,8 +43,8 @@ export function SessionSidebar({
   onStopSession,
   onStartSession,
   onNewSession,
-  onToggleBrowser,
-  isBrowserActive = false,
+  onSelectBrowser,
+  isBrowserSelected = false,
   isRemote = false,
 }: SessionSidebarProps) {
   const { groupedItems } = useGroupedWorktreeItems(
@@ -62,13 +62,13 @@ export function SessionSidebar({
           <h1 className="font-semibold text-sm text-sidebar-foreground">Ark</h1>
         </div>
         <div className="flex items-center gap-1">
-          {isRemote && onToggleBrowser && (
+          {isRemote && onSelectBrowser && (
             <Button
-              variant={isBrowserActive ? "default" : "ghost"}
+              variant={isBrowserSelected ? "default" : "ghost"}
               size="icon"
               className="h-8 w-8"
-              onClick={onToggleBrowser}
-              title={isBrowserActive ? "ブラウザを閉じる" : "ブラウザを開く"}
+              onClick={onSelectBrowser}
+              title="ブラウザ"
             >
               <Globe className="w-4 h-4" />
             </Button>

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -24,7 +24,6 @@ import {
   XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Socket } from "socket.io-client";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import type {
@@ -36,7 +35,6 @@ import type {
 } from "../../../shared/types";
 import { useIsMobile } from "../hooks/useMobile";
 import { useTerminalLinkInjection } from "../hooks/useTerminalLinkInjection";
-import { BrowserPane } from "./BrowserPane";
 import { FileViewerPane } from "./FileViewerPane";
 import { ViewerTabBar } from "./ViewerTabBar";
 
@@ -51,27 +49,12 @@ export type ViewerTab =
       size: number;
       targetLine?: number | null;
       error?: string;
-    }
-  | { type: "browser"; id: string; url: string };
-
-/** URLからポート番号を抽出 */
-function extractPort(url: string): number {
-  try {
-    const parsed = new URL(url);
-    return Number.parseInt(
-      parsed.port || (parsed.protocol === "https:" ? "443" : "80"),
-      10
-    );
-  } catch {
-    return 80;
-  }
-}
+    };
 
 interface TerminalPaneProps {
   session: ManagedSession;
   worktree: Worktree | undefined;
   repoName?: string;
-  socket: Socket<ServerToClientEvents, ClientToServerEvents> | null;
   onSendMessage: (message: string) => void;
   onSendKey: (key: SpecialKey) => void;
   onStopSession: () => void;
@@ -90,7 +73,6 @@ export function TerminalPane({
   session,
   worktree,
   repoName,
-  socket,
   onSendMessage,
   onSendKey,
   onStopSession,
@@ -414,20 +396,6 @@ export function TerminalPane({
             </div>
           );
         })()}
-      {tabs[activeTabIndex]?.type === "browser" &&
-        (() => {
-          const tab = tabs[activeTabIndex] as ViewerTab & { type: "browser" };
-          return (
-            <div className="flex-1 min-h-0">
-              <BrowserPane
-                url={tab.url}
-                port={extractPort(tab.url)}
-                socket={socket}
-              />
-            </div>
-          );
-        })()}
-
       {/* Image paste preview dialog */}
       {pastedImage && (
         <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-50">

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -27,9 +27,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import type {
-  ClientToServerEvents,
   ManagedSession,
-  ServerToClientEvents,
   SpecialKey,
   Worktree,
 } from "../../../shared/types";

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -24,10 +24,13 @@ import {
   XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import type {
+  ClientToServerEvents,
   ManagedSession,
+  ServerToClientEvents,
   SpecialKey,
   Worktree,
 } from "../../../shared/types";
@@ -51,10 +54,24 @@ export type ViewerTab =
     }
   | { type: "browser"; id: string; url: string };
 
+/** URLからポート番号を抽出 */
+function extractPort(url: string): number {
+  try {
+    const parsed = new URL(url);
+    return Number.parseInt(
+      parsed.port || (parsed.protocol === "https:" ? "443" : "80"),
+      10
+    );
+  } catch {
+    return 80;
+  }
+}
+
 interface TerminalPaneProps {
   session: ManagedSession;
   worktree: Worktree | undefined;
   repoName?: string;
+  socket: Socket<ServerToClientEvents, ClientToServerEvents> | null;
   onSendMessage: (message: string) => void;
   onSendKey: (key: SpecialKey) => void;
   onStopSession: () => void;
@@ -73,6 +90,7 @@ export function TerminalPane({
   session,
   worktree,
   repoName,
+  socket,
   onSendMessage,
   onSendKey,
   onStopSession,
@@ -401,7 +419,11 @@ export function TerminalPane({
           const tab = tabs[activeTabIndex] as ViewerTab & { type: "browser" };
           return (
             <div className="flex-1 min-h-0">
-              <BrowserPane url={tab.url} />
+              <BrowserPane
+                url={tab.url}
+                port={extractPort(tab.url)}
+                socket={socket}
+              />
             </div>
           );
         })()}

--- a/client/src/components/ViewerTabBar.tsx
+++ b/client/src/components/ViewerTabBar.tsx
@@ -9,12 +9,7 @@ interface ViewerTabBarProps {
 
 function getTabLabel(tab: ViewerTab): string {
   if (tab.type === "terminal") return "Terminal";
-  if (tab.type === "file") return tab.filePath.split("/").pop() || "File";
-  try {
-    return new URL(tab.url).host;
-  } catch {
-    return tab.url;
-  }
+  return tab.filePath.split("/").pop() || "File";
 }
 
 export function ViewerTabBar({

--- a/client/src/components/ViewerTabBar.tsx
+++ b/client/src/components/ViewerTabBar.tsx
@@ -9,7 +9,7 @@ interface ViewerTabBarProps {
 
 function getTabLabel(tab: ViewerTab): string {
   if (tab.type === "terminal") return "Terminal";
-  return tab.filePath.split("/").pop() || "File";
+  return tab.filePath?.split("/").pop() || "File";
 }
 
 export function ViewerTabBar({

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -130,6 +130,7 @@ interface UseSocketReturn {
   browserError: string | null;
   startBrowser: () => void;
   stopBrowser: (browserId: string) => void;
+  navigateBrowser: (url: string) => void;
 }
 
 export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
@@ -738,6 +739,10 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     socketRef.current?.emit("browser:stop", { browserId });
   }, []);
 
+  const navigateBrowser = useCallback((url: string) => {
+    socketRef.current?.emit("browser:navigate", { url });
+  }, []);
+
   return {
     socket: socketRef.current,
     isConnected,
@@ -799,5 +804,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     browserError,
     startBrowser,
     stopBrowser,
+    navigateBrowser,
   };
 }

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -128,7 +128,7 @@ interface UseSocketReturn {
   // Browser sessions
   browserSessions: Map<string, BrowserSession>;
   browserError: string | null;
-  startBrowser: (port: number, url?: string, devtools?: boolean) => void;
+  startBrowser: () => void;
   stopBrowser: (browserId: string) => void;
 }
 
@@ -730,12 +730,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   );
 
   // Browser session actions
-  const startBrowser = useCallback(
-    (port: number, url?: string, devtools?: boolean) => {
-      socketRef.current?.emit("browser:start", { port, url, devtools });
-    },
-    []
-  );
+  const startBrowser = useCallback(() => {
+    socketRef.current?.emit("browser:start");
+  }, []);
 
   const stopBrowser = useCallback((browserId: string) => {
     socketRef.current?.emit("browser:stop", { browserId });

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { io, type Socket } from "socket.io-client";
 import type {
   BeaconStreamChunk,
+  BrowserSession,
   ChatMessage,
   ClientToServerEvents,
   ManagedSession,
@@ -123,6 +124,12 @@ interface UseSocketReturn {
   beaconLoadHistory: () => void;
   beaconClose: () => void;
   beaconClear: () => void;
+
+  // Browser sessions
+  browserSessions: Map<string, BrowserSession>;
+  browserError: string | null;
+  startBrowser: (port: number, url?: string, devtools?: boolean) => void;
+  stopBrowser: (browserId: string) => void;
 }
 
 export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
@@ -187,6 +194,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   const [sessionActivityTexts, setSessionActivityTexts] = useState<
     Map<string, string>
   >(new Map());
+
+  // Browser session state
+  const [browserSessions, setBrowserSessions] = useState<
+    Map<string, BrowserSession>
+  >(new Map());
+  const [browserError, setBrowserError] = useState<string | null>(null);
 
   // Beacon状態
   const [beaconMessages, setBeaconMessages] = useState<ChatMessage[]>([]);
@@ -501,6 +514,28 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       });
     });
 
+    // Browser session events (noVNC)
+    socket.on("browser:started", (session: BrowserSession) => {
+      setBrowserSessions(prev => {
+        const next = new Map(prev);
+        next.set(session.id, session);
+        return next;
+      });
+      setBrowserError(null);
+    });
+
+    socket.on("browser:stopped", ({ browserId }: { browserId: string }) => {
+      setBrowserSessions(prev => {
+        const next = new Map(prev);
+        next.delete(browserId);
+        return next;
+      });
+    });
+
+    socket.on("browser:error", ({ message }: { message: string }) => {
+      setBrowserError(message);
+    });
+
     // Cleanup on unmount
     return () => {
       socket.off("ports:list");
@@ -512,6 +547,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       socket.off("beacon:history");
       socket.off("beacon:error");
       socket.off("session:previews");
+      socket.off("browser:started");
+      socket.off("browser:stopped");
+      socket.off("browser:error");
       socket.disconnect();
     };
   }, [enabled]);
@@ -691,6 +729,18 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     []
   );
 
+  // Browser session actions
+  const startBrowser = useCallback(
+    (port: number, url?: string, devtools?: boolean) => {
+      socketRef.current?.emit("browser:start", { port, url, devtools });
+    },
+    []
+  );
+
+  const stopBrowser = useCallback((browserId: string) => {
+    socketRef.current?.emit("browser:stop", { browserId });
+  }, []);
+
   return {
     socket: socketRef.current,
     isConnected,
@@ -747,5 +797,10 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     beaconLoadHistory,
     beaconClose,
     beaconClear,
+    // Browser sessions
+    browserSessions,
+    browserError,
+    startBrowser,
+    stopBrowser,
   };
 }

--- a/client/src/hooks/useTerminalLinkInjection.ts
+++ b/client/src/hooks/useTerminalLinkInjection.ts
@@ -288,16 +288,16 @@ export function useTerminalLinkInjection(
                     const contMatch = trimmedNext.match(/^[^\s<>"'()]+/);
                     if (!contMatch) break;
 
-                    matchedUrl += contMatch[0];
+                    // 継続部分の直後が行末でなければ、この行はURL継続ではない
                     const leadingSpaces = nextText.length - trimmedNext.length;
-                    endY = nextIdx + 1;
-                    endX = leadingSpaces + contMatch[0].length + 1;
-
-                    // 継続部分の直後が行末でなければ終了
                     const afterCont = nextText.substring(
                       leadingSpaces + contMatch[0].length
                     );
                     if (!/^\s*$/.test(afterCont)) break;
+
+                    matchedUrl += contMatch[0];
+                    endY = nextIdx + 1;
+                    endX = leadingSpaces + contMatch[0].length + 1;
                   }
                 }
 

--- a/client/src/hooks/useViewerTabs.ts
+++ b/client/src/hooks/useViewerTabs.ts
@@ -105,20 +105,8 @@ export function useViewerTabs(
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
       const { type } = event.data ?? {};
-      if (!selectedSessionId) return;
-      const session = sessions.get(selectedSessionId);
-      if (!session) return;
 
-      if (type === "ark:open-file") {
-        const { path: filePath, line } = event.data;
-        if (typeof filePath !== "string" || !filePath) return;
-        openFileTab(
-          selectedSessionId,
-          filePath,
-          typeof line === "number" ? line : undefined
-        );
-        readFile(selectedSessionId, filePath);
-      } else if (type === "ark:open-url") {
+      if (type === "ark:open-url") {
         const { url } = event.data;
         if (typeof url !== "string" || !url) return;
         try {
@@ -133,6 +121,23 @@ export function useViewerTabs(
         } else {
           window.open(url, "_blank");
         }
+        return;
+      }
+
+      // 以下はセッション選択中のみ有効（ファイルビューワー）
+      if (!selectedSessionId) return;
+      const session = sessions.get(selectedSessionId);
+      if (!session) return;
+
+      if (type === "ark:open-file") {
+        const { path: filePath, line } = event.data;
+        if (typeof filePath !== "string" || !filePath) return;
+        openFileTab(
+          selectedSessionId,
+          filePath,
+          typeof line === "number" ? line : undefined
+        );
+        readFile(selectedSessionId, filePath);
       }
     };
 

--- a/client/src/hooks/useViewerTabs.ts
+++ b/client/src/hooks/useViewerTabs.ts
@@ -119,7 +119,7 @@ export function useViewerTabs(
         if (onOpenUrl) {
           onOpenUrl(url);
         } else {
-          window.open(url, "_blank");
+          window.open(url, "_blank", "noopener");
         }
         return;
       }

--- a/client/src/hooks/useViewerTabs.ts
+++ b/client/src/hooks/useViewerTabs.ts
@@ -99,29 +99,6 @@ export function useViewerTabs(
     []
   );
 
-  const openBrowserTab = useCallback((sessionId: string, url: string) => {
-    let newActiveIndex: number | null = null;
-    setSessionTabs(prev => {
-      const tabs = [
-        ...(prev[sessionId] ?? [{ type: "terminal" as const, id: "terminal" }]),
-      ];
-      const existing = tabs.findIndex(
-        t => t.type === "browser" && t.url === url
-      );
-      if (existing >= 0) {
-        newActiveIndex = existing;
-        return prev;
-      }
-      tabs.push({ type: "browser", id: `browser-${Date.now()}`, url });
-      newActiveIndex = tabs.length - 1;
-      return { ...prev, [sessionId]: tabs };
-    });
-    if (newActiveIndex !== null) {
-      const idx = newActiveIndex;
-      setSessionActiveTab(p => ({ ...p, [sessionId]: idx }));
-    }
-  }, []);
-
   // postMessageリスナー（ttyd iframe内のリンククリックを受信）
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
@@ -150,13 +127,14 @@ export function useViewerTabs(
         } catch {
           return;
         }
-        openBrowserTab(selectedSessionId, url);
+        // ブラウザタブはシングルトンnoVNC内で開くため、新しいウィンドウで開く
+        window.open(url, "_blank");
       }
     };
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [selectedSessionId, sessions, openFileTab, openBrowserTab, readFile]);
+  }, [selectedSessionId, sessions, openFileTab, readFile]);
 
   // fileContent受信時にタブを更新（全セッションを検索してレースコンディション対策）
   useEffect(() => {
@@ -199,6 +177,5 @@ export function useViewerTabs(
     handleTabSelect,
     handleTabClose,
     openFileTab,
-    openBrowserTab,
   };
 }

--- a/client/src/hooks/useViewerTabs.ts
+++ b/client/src/hooks/useViewerTabs.ts
@@ -15,7 +15,8 @@ export function useViewerTabs(
     mimeType: string;
     size: number;
     error?: string;
-  } | null
+  } | null,
+  onOpenUrl?: (url: string) => void
 ) {
   const [sessionTabs, setSessionTabs] = useState<Record<string, ViewerTab[]>>(
     {}
@@ -127,14 +128,17 @@ export function useViewerTabs(
         } catch {
           return;
         }
-        // ブラウザタブはシングルトンnoVNC内で開くため、新しいウィンドウで開く
-        window.open(url, "_blank");
+        if (onOpenUrl) {
+          onOpenUrl(url);
+        } else {
+          window.open(url, "_blank");
+        }
       }
     };
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [selectedSessionId, sessions, openFileTab, readFile]);
+  }, [selectedSessionId, sessions, openFileTab, readFile, onOpenUrl]);
 
   // fileContent受信時にタブを更新（全セッションを検索してレースコンディション対策）
   useEffect(() => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { AlertCircle, Copy, Loader2, Terminal } from "lucide-react";
 import { BrowserPane } from "@/components/BrowserPane";
 import { QRCodeSVG } from "qrcode.react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { CreateWorktreeDialog } from "@/components/CreateWorktreeDialog";
 import { MobileChatView } from "@/components/MobileChatView";

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -112,6 +112,9 @@ export default function Dashboard() {
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     null
   );
+  // ブラウザビューを一度でも開いたかどうかのフラグ
+  // 一度開いたら常に描画してdisplay:hiddenで切り替え、BrowserPaneの再マウント（VNC再接続）を防ぐ
+  const [hasBrowserOpened, setHasBrowserOpened] = useState(false);
 
   /** ブラウザを選択（未起動なら起動） */
   const handleSelectBrowser = useCallback(() => {
@@ -119,6 +122,7 @@ export default function Dashboard() {
       startBrowser();
     }
     setSelectedSessionId("browser");
+    setHasBrowserOpened(true);
   }, [activeBrowserSession, startBrowser]);
 
   /** localhost URLクリック時: ブラウザに遷移して選択 */
@@ -127,8 +131,9 @@ export default function Dashboard() {
       if (isRemote) {
         navigateBrowser(url);
         setSelectedSessionId("browser");
+        setHasBrowserOpened(true);
       } else {
-        window.open(url, "_blank");
+        window.open(url, "_blank", "noopener");
       }
     },
     [isRemote, navigateBrowser]
@@ -341,8 +346,14 @@ export default function Dashboard() {
                 </div>
               )}
               <div className="flex-1 overflow-hidden relative">
-                {selectedSessionId === "browser" && (
-                  <div className="h-full">
+                {/* ブラウザビュー: 一度開いたら常に描画してdisplay:hiddenで切り替え。
+                    BrowserPaneの再マウント（VNC再接続）を防ぐ */}
+                {hasBrowserOpened && (
+                  <div
+                    className={
+                      selectedSessionId === "browser" ? "h-full" : "hidden"
+                    }
+                  >
                     {activeBrowserSession ? (
                       <BrowserPane browserSession={activeBrowserSession} />
                     ) : (

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { AlertCircle, Copy, Loader2, Terminal } from "lucide-react";
+import { BrowserPane } from "@/components/BrowserPane";
 import { QRCodeSVG } from "qrcode.react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -88,6 +89,9 @@ export default function Dashboard() {
     sessionActivityTexts,
     readFile,
     fileContent,
+    browserSessions,
+    startBrowser,
+    stopBrowser,
   } = useSocket({
     enabled: !isSettingsLoading,
     initialRepoList: savedRepoList,
@@ -97,6 +101,24 @@ export default function Dashboard() {
   });
 
   const isMobile = useIsMobile();
+
+  const isRemote =
+    typeof window !== "undefined" &&
+    window.location.hostname !== "localhost" &&
+    window.location.hostname !== "127.0.0.1";
+
+  const [showBrowser, setShowBrowser] = useState(false);
+  const activeBrowserSession = Array.from(browserSessions.values())[0] ?? null;
+
+  const handleToggleBrowser = () => {
+    if (activeBrowserSession) {
+      stopBrowser(activeBrowserSession.id);
+      setShowBrowser(false);
+    } else {
+      startBrowser();
+      setShowBrowser(true);
+    }
+  };
 
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     null
@@ -283,6 +305,9 @@ export default function Dashboard() {
               onStopSession={handleStopSession}
               onStartSession={handleStartSession}
               onNewSession={handleNewSession}
+              onToggleBrowser={handleToggleBrowser}
+              isBrowserActive={!!activeBrowserSession}
+              isRemote={isRemote}
             />
           }
           main={
@@ -294,44 +319,51 @@ export default function Dashboard() {
                 </div>
               )}
               <div className="flex-1 overflow-hidden relative">
-                {Array.from(sessions.values()).map(session => {
-                  const isActive = selectedSessionId === session.id;
-                  const wt = worktrees.find(w => w.id === session.worktreeId);
-                  const rn = (() => {
-                    if (repoList.length === 0) return undefined;
-                    const repo = findRepoForSession(session, repoList);
-                    return repo ? getBaseName(repo) : undefined;
-                  })();
-                  return (
-                    <div
-                      key={session.id}
-                      className={isActive ? "h-full flex flex-col" : "hidden"}
-                    >
-                      <TerminalPane
-                        session={session}
-                        worktree={wt}
-                        repoName={rn}
-                        socket={socket}
-                        tabs={getTabsForSession(session.id)}
-                        activeTabIndex={getActiveTabForSession(session.id)}
-                        onTabSelect={idx => handleTabSelect(session.id, idx)}
-                        onTabClose={idx => handleTabClose(session.id, idx)}
-                        onSendMessage={msg => sendMessage(session.id, msg)}
-                        onSendKey={key => sendKey(session.id, key)}
-                        onStopSession={() => handleStopSession(session.id)}
-                        onUploadImage={(base64, mimeType) =>
-                          uploadImage(session.id, base64, mimeType)
-                        }
-                        imageUploadResult={imageUploadResult}
-                        imageUploadError={imageUploadError}
-                        onClearImageUploadState={clearImageUploadState}
-                        onCopyBuffer={
-                          copyBuffer ? () => copyBuffer(session.id) : undefined
-                        }
-                      />
-                    </div>
-                  );
-                })}
+                {showBrowser && activeBrowserSession && (
+                  <div className="h-full">
+                    <BrowserPane browserSession={activeBrowserSession} />
+                  </div>
+                )}
+                {(!showBrowser || !activeBrowserSession) &&
+                  Array.from(sessions.values()).map(session => {
+                    const isActive = selectedSessionId === session.id;
+                    const wt = worktrees.find(w => w.id === session.worktreeId);
+                    const rn = (() => {
+                      if (repoList.length === 0) return undefined;
+                      const repo = findRepoForSession(session, repoList);
+                      return repo ? getBaseName(repo) : undefined;
+                    })();
+                    return (
+                      <div
+                        key={session.id}
+                        className={isActive ? "h-full flex flex-col" : "hidden"}
+                      >
+                        <TerminalPane
+                          session={session}
+                          worktree={wt}
+                          repoName={rn}
+                          tabs={getTabsForSession(session.id)}
+                          activeTabIndex={getActiveTabForSession(session.id)}
+                          onTabSelect={idx => handleTabSelect(session.id, idx)}
+                          onTabClose={idx => handleTabClose(session.id, idx)}
+                          onSendMessage={msg => sendMessage(session.id, msg)}
+                          onSendKey={key => sendKey(session.id, key)}
+                          onStopSession={() => handleStopSession(session.id)}
+                          onUploadImage={(base64, mimeType) =>
+                            uploadImage(session.id, base64, mimeType)
+                          }
+                          imageUploadResult={imageUploadResult}
+                          imageUploadError={imageUploadError}
+                          onClearImageUploadState={clearImageUploadState}
+                          onCopyBuffer={
+                            copyBuffer
+                              ? () => copyBuffer(session.id)
+                              : undefined
+                          }
+                        />
+                      </div>
+                    );
+                  })}
                 {sessions.size === 0 && (
                   <div className="h-full flex items-center justify-center">
                     <div className="text-center">

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -180,6 +180,16 @@ export default function Dashboard() {
     }
   }, [selectedSessionId, setSetting]);
 
+  // リロード時にブラウザ選択状態を維持:
+  // selectedSessionIdが"browser"のまま復元された場合、
+  // browserSessionがまだなければ自動的に起動する。
+  useEffect(() => {
+    if (selectedSessionId === "browser" && !activeBrowserSession && isRemote) {
+      startBrowser();
+      setHasBrowserOpened(true);
+    }
+  }, [selectedSessionId, activeBrowserSession, isRemote, startBrowser]);
+
   const [isCreateWorktreeOpen, setIsCreateWorktreeOpen] = useState(false);
   const [isSelectRepoOpen, setIsSelectRepoOpen] = useState(false);
   const [showTunnelDialog, setShowTunnelDialog] = useState(false);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -110,28 +110,29 @@ export default function Dashboard() {
 
   const activeBrowserSession = Array.from(browserSessions.values())[0] ?? null;
 
-  /** ブラウザを選択（未起動なら起動してから選択） */
-  const handleSelectBrowser = () => {
-    if (!activeBrowserSession) {
-      startBrowser();
-    }
-    setSelectedSessionId("browser");
-  };
-
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
     null
   );
 
+  /** ブラウザを選択（未起動なら起動） */
+  const handleSelectBrowser = useCallback(() => {
+    if (!activeBrowserSession) {
+      startBrowser();
+    }
+    setSelectedSessionId("browser");
+  }, [activeBrowserSession, startBrowser]);
+
+  /** localhost URLクリック時: ブラウザに遷移して選択 */
   const handleOpenUrl = useCallback(
     (url: string) => {
       if (isRemote) {
-        handleSelectBrowser();
         navigateBrowser(url);
+        setSelectedSessionId("browser");
       } else {
         window.open(url, "_blank");
       }
     },
-    [isRemote, handleSelectBrowser, navigateBrowser]
+    [isRemote, navigateBrowser]
   );
 
   const {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -316,9 +316,16 @@ export default function Dashboard() {
                 </div>
               )}
               <div className="flex-1 overflow-hidden relative">
-                {selectedSessionId === "browser" && activeBrowserSession && (
+                {selectedSessionId === "browser" && (
                   <div className="h-full">
-                    <BrowserPane browserSession={activeBrowserSession} />
+                    {activeBrowserSession ? (
+                      <BrowserPane browserSession={activeBrowserSession} />
+                    ) : (
+                      <div className="h-full flex items-center justify-center text-muted-foreground">
+                        <Loader2 className="h-6 w-6 animate-spin mr-2" />
+                        ブラウザを起動中...
+                      </div>
+                    )}
                   </div>
                 )}
                 {Array.from(sessions.values()).map(session => {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -92,6 +92,7 @@ export default function Dashboard() {
     browserSessions,
     startBrowser,
     stopBrowser,
+    navigateBrowser,
   } = useSocket({
     enabled: !isSettingsLoading,
     initialRepoList: savedRepoList,
@@ -121,12 +122,30 @@ export default function Dashboard() {
     null
   );
 
+  const handleOpenUrl = useCallback(
+    (url: string) => {
+      if (isRemote) {
+        handleSelectBrowser();
+        navigateBrowser(url);
+      } else {
+        window.open(url, "_blank");
+      }
+    },
+    [isRemote, handleSelectBrowser, navigateBrowser]
+  );
+
   const {
     getTabsForSession,
     getActiveTabForSession,
     handleTabSelect,
     handleTabClose,
-  } = useViewerTabs(selectedSessionId, sessions, readFile, fileContent);
+  } = useViewerTabs(
+    selectedSessionId,
+    sessions,
+    readFile,
+    fileContent,
+    handleOpenUrl
+  );
 
   // サーバーからの設定が読み込まれたらセッションIDを復元
   const settingsInitializedRef = useRef(false);
@@ -289,6 +308,7 @@ export default function Dashboard() {
           onBeaconClear={beaconClear}
           activeBrowserSession={activeBrowserSession}
           onSelectBrowser={handleSelectBrowser}
+          navigateBrowser={navigateBrowser}
           isRemote={isRemote}
         />
       ) : (

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -107,17 +107,14 @@ export default function Dashboard() {
     window.location.hostname !== "localhost" &&
     window.location.hostname !== "127.0.0.1";
 
-  const [showBrowser, setShowBrowser] = useState(false);
   const activeBrowserSession = Array.from(browserSessions.values())[0] ?? null;
 
-  const handleToggleBrowser = () => {
-    if (activeBrowserSession) {
-      stopBrowser(activeBrowserSession.id);
-      setShowBrowser(false);
-    } else {
+  /** ブラウザを選択（未起動なら起動してから選択） */
+  const handleSelectBrowser = () => {
+    if (!activeBrowserSession) {
       startBrowser();
-      setShowBrowser(true);
     }
+    setSelectedSessionId("browser");
   };
 
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(
@@ -305,8 +302,8 @@ export default function Dashboard() {
               onStopSession={handleStopSession}
               onStartSession={handleStartSession}
               onNewSession={handleNewSession}
-              onToggleBrowser={handleToggleBrowser}
-              isBrowserActive={!!activeBrowserSession}
+              onSelectBrowser={handleSelectBrowser}
+              isBrowserSelected={selectedSessionId === "browser"}
               isRemote={isRemote}
             />
           }
@@ -319,51 +316,48 @@ export default function Dashboard() {
                 </div>
               )}
               <div className="flex-1 overflow-hidden relative">
-                {showBrowser && activeBrowserSession && (
+                {selectedSessionId === "browser" && activeBrowserSession && (
                   <div className="h-full">
                     <BrowserPane browserSession={activeBrowserSession} />
                   </div>
                 )}
-                {(!showBrowser || !activeBrowserSession) &&
-                  Array.from(sessions.values()).map(session => {
-                    const isActive = selectedSessionId === session.id;
-                    const wt = worktrees.find(w => w.id === session.worktreeId);
-                    const rn = (() => {
-                      if (repoList.length === 0) return undefined;
-                      const repo = findRepoForSession(session, repoList);
-                      return repo ? getBaseName(repo) : undefined;
-                    })();
-                    return (
-                      <div
-                        key={session.id}
-                        className={isActive ? "h-full flex flex-col" : "hidden"}
-                      >
-                        <TerminalPane
-                          session={session}
-                          worktree={wt}
-                          repoName={rn}
-                          tabs={getTabsForSession(session.id)}
-                          activeTabIndex={getActiveTabForSession(session.id)}
-                          onTabSelect={idx => handleTabSelect(session.id, idx)}
-                          onTabClose={idx => handleTabClose(session.id, idx)}
-                          onSendMessage={msg => sendMessage(session.id, msg)}
-                          onSendKey={key => sendKey(session.id, key)}
-                          onStopSession={() => handleStopSession(session.id)}
-                          onUploadImage={(base64, mimeType) =>
-                            uploadImage(session.id, base64, mimeType)
-                          }
-                          imageUploadResult={imageUploadResult}
-                          imageUploadError={imageUploadError}
-                          onClearImageUploadState={clearImageUploadState}
-                          onCopyBuffer={
-                            copyBuffer
-                              ? () => copyBuffer(session.id)
-                              : undefined
-                          }
-                        />
-                      </div>
-                    );
-                  })}
+                {Array.from(sessions.values()).map(session => {
+                  const isActive = selectedSessionId === session.id;
+                  const wt = worktrees.find(w => w.id === session.worktreeId);
+                  const rn = (() => {
+                    if (repoList.length === 0) return undefined;
+                    const repo = findRepoForSession(session, repoList);
+                    return repo ? getBaseName(repo) : undefined;
+                  })();
+                  return (
+                    <div
+                      key={session.id}
+                      className={isActive ? "h-full flex flex-col" : "hidden"}
+                    >
+                      <TerminalPane
+                        session={session}
+                        worktree={wt}
+                        repoName={rn}
+                        tabs={getTabsForSession(session.id)}
+                        activeTabIndex={getActiveTabForSession(session.id)}
+                        onTabSelect={idx => handleTabSelect(session.id, idx)}
+                        onTabClose={idx => handleTabClose(session.id, idx)}
+                        onSendMessage={msg => sendMessage(session.id, msg)}
+                        onSendKey={key => sendKey(session.id, key)}
+                        onStopSession={() => handleStopSession(session.id)}
+                        onUploadImage={(base64, mimeType) =>
+                          uploadImage(session.id, base64, mimeType)
+                        }
+                        imageUploadResult={imageUploadResult}
+                        imageUploadError={imageUploadError}
+                        onClearImageUploadState={clearImageUploadState}
+                        onCopyBuffer={
+                          copyBuffer ? () => copyBuffer(session.id) : undefined
+                        }
+                      />
+                    </div>
+                  );
+                })}
                 {sessions.size === 0 && (
                   <div className="h-full flex items-center justify-center">
                     <div className="text-center">

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
 import { AlertCircle, Copy, Loader2, Terminal } from "lucide-react";
-import { BrowserPane } from "@/components/BrowserPane";
 import { QRCodeSVG } from "qrcode.react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { BrowserPane } from "@/components/BrowserPane";
 import { CreateWorktreeDialog } from "@/components/CreateWorktreeDialog";
 import { MobileChatView } from "@/components/MobileChatView";
 import { MobileLayout } from "@/components/MobileLayout";
@@ -91,7 +91,6 @@ export default function Dashboard() {
     fileContent,
     browserSessions,
     startBrowser,
-    stopBrowser,
     navigateBrowser,
   } = useSocket({
     enabled: !isSettingsLoading,

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -207,6 +207,8 @@ export default function Dashboard() {
 
   // セッション自動選択
   useEffect(() => {
+    // ブラウザ選択中はリセットしない
+    if (selectedSessionId === "browser") return;
     if (!selectedSessionId && sessions.size > 0) {
       const first = Array.from(sessions.values())[0];
       setSelectedSessionId(first.id);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -287,6 +287,9 @@ export default function Dashboard() {
           beaconStreamText={beaconStreamText}
           onBeaconSend={beaconSend}
           onBeaconClear={beaconClear}
+          activeBrowserSession={activeBrowserSession}
+          onSelectBrowser={handleSelectBrowser}
+          isRemote={isRemote}
         />
       ) : (
         <SidebarMainLayout

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -311,6 +311,7 @@ export default function Dashboard() {
                         session={session}
                         worktree={wt}
                         repoName={rn}
+                        socket={socket}
                         tabs={getTabsForSession(session.id)}
                         activeTabIndex={getActiveTabForSession(session.id)}
                         onTabSelect={idx => handleTabSelect(session.id, idx)}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1162,6 +1162,14 @@ async function startServer() {
       }
     });
 
+    socket.on("browser:navigate", async data => {
+      try {
+        await browserManager.navigate(data.url);
+      } catch (error) {
+        socket.emit("browser:error", { message: getErrorMessage(error) });
+      }
+    });
+
     // ===== Beacon Commands =====
 
     // Beaconメッセージ送信

--- a/server/index.ts
+++ b/server/index.ts
@@ -1134,55 +1134,17 @@ async function startServer() {
     // ソケットごとのブラウザセッション追跡（disconnect時のクリーンアップ用）
     const socketBrowserSessions = new Set<string>();
 
-    socket.on("browser:start", async data => {
+    socket.on("browser:start", async () => {
       try {
-        // 依存チェック
         if (!browserManager.isAvailable()) {
           socket.emit("browser:error", {
             message:
-              "リモートブラウザ機能の依存が不足しています。サーバーログを確認してください。",
+              "ブラウザタブ機能は無効です。依存パッケージをインストールしてください。",
           });
           return;
         }
 
-        // ポート範囲チェック
-        const { port: targetPort, url, devtools } = data;
-        if (
-          typeof targetPort !== "number" ||
-          !Number.isFinite(targetPort) ||
-          targetPort < 1 ||
-          targetPort > 65535
-        ) {
-          socket.emit("browser:error", {
-            message: "無効なポート番号です（1-65535）",
-          });
-          return;
-        }
-
-        // ブロックリスト: サーバーポート、ttyd範囲、VNC範囲、WS範囲
-        const serverPort = parseInt(process.env.PORT || "3001", 10);
-        if (
-          targetPort === serverPort ||
-          (targetPort >= TTYD_PORT_START && targetPort <= TTYD_PORT_END) ||
-          (targetPort >= VNC_PORT_START && targetPort <= VNC_PORT_END) ||
-          (targetPort >= WS_PORT_START && targetPort <= WS_PORT_END)
-        ) {
-          socket.emit("browser:error", {
-            message: "このポートはブラウザセッションの対象外です",
-          });
-          return;
-        }
-
-        // per-socket上限チェック
-        if (socketBrowserSessions.size >= 3) {
-          socket.emit("browser:error", {
-            message:
-              "ブラウザセッションの上限（3）に達しています。不要なセッションを停止してください。",
-          });
-          return;
-        }
-
-        const session = await browserManager.start(targetPort, url, devtools);
+        const session = await browserManager.start();
         socketBrowserSessions.add(session.id);
         socket.emit("browser:started", session);
       } catch (error) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -27,6 +27,7 @@ import { authManager } from "./lib/auth.js";
 import { beaconManager } from "./lib/beacon-manager.js";
 import { browserManager } from "./lib/browser-manager.js";
 import {
+  CDP_PORT,
   TTYD_PORT_END,
   TTYD_PORT_START,
   VNC_PORT_END,
@@ -516,9 +517,9 @@ async function startServer() {
       return;
     }
 
-    // Ark自体のポートとttydポート範囲をブロック（SSRF対策）
+    // Ark自体のポート・CDPポート・ttydポート範囲をブロック（SSRF対策）
     const serverPort = parseInt(process.env.PORT || "3001", 10);
-    if (port === serverPort) {
+    if (port === serverPort || port === CDP_PORT) {
       res.status(403).json({ error: "This port is not accessible via proxy" });
       return;
     }
@@ -652,10 +653,11 @@ async function startServer() {
 
       const proxyPort = parseInt(proxyMatch[1], 10);
       if (proxyPort >= 1 && proxyPort <= 65535) {
-        // SSRF対策: Ark自体のポート、ttydポート範囲、VNC/WSポート範囲をブロック
+        // SSRF対策: Ark自体のポート、CDPポート、ttydポート範囲、VNC/WSポート範囲をブロック
         const serverPort = parseInt(process.env.PORT || "3001", 10);
         if (
           proxyPort === serverPort ||
+          proxyPort === CDP_PORT ||
           (proxyPort >= TTYD_PORT_START && proxyPort <= TTYD_PORT_END) ||
           (proxyPort >= VNC_PORT_START && proxyPort <= VNC_PORT_END) ||
           (proxyPort >= WS_PORT_START && proxyPort <= WS_PORT_END)

--- a/server/index.ts
+++ b/server/index.ts
@@ -1164,7 +1164,12 @@ async function startServer() {
 
     socket.on("browser:navigate", async data => {
       try {
-        await browserManager.navigate(data.url);
+        const session = await browserManager.navigate(data.url);
+        // セッションが新規起動された場合（クライアントがまだ知らない場合）はbrowser:startedも発火
+        if (!socketBrowserSessions.has(session.id)) {
+          socketBrowserSessions.add(session.id);
+          socket.emit("browser:started", session);
+        }
       } catch (error) {
         socket.emit("browser:error", { message: getErrorMessage(error) });
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1200,7 +1200,9 @@ async function startServer() {
         }
 
         const session = await browserManager.start();
-        socket.emit("browser:started", session);
+        // シングルトンブラウザは全クライアントで共有されるため、
+        // 他の接続クライアントにも同期する。
+        io.emit("browser:started", session);
       } catch (error) {
         socket.emit("browser:error", { message: getErrorMessage(error) });
       }
@@ -1209,7 +1211,8 @@ async function startServer() {
     socket.on("browser:stop", async data => {
       try {
         await browserManager.stop(data.browserId);
-        socket.emit("browser:stopped", { browserId: data.browserId });
+        // 全クライアントにブラウザ停止を通知
+        io.emit("browser:stopped", { browserId: data.browserId });
       } catch (error) {
         socket.emit("browser:error", { message: getErrorMessage(error) });
       }
@@ -1218,9 +1221,10 @@ async function startServer() {
     socket.on("browser:navigate", async data => {
       try {
         const session = await browserManager.navigate(data.url);
-        // 呼び出し元のクライアントには常にbrowser:startedを通知する
-        // （当該クライアントがまだセッションを知らない場合の初期同期）
-        socket.emit("browser:started", session);
+        // 全クライアントに通知
+        // （セッションを知らないクライアントの初期同期、および
+        //  他クライアントにもナビゲーション結果を共有する）
+        io.emit("browser:started", session);
       } catch (error) {
         socket.emit("browser:error", { message: getErrorMessage(error) });
       }

--- a/server/index.ts
+++ b/server/index.ts
@@ -25,7 +25,15 @@ import type {
 } from "../shared/types.js";
 import { authManager } from "./lib/auth.js";
 import { beaconManager } from "./lib/beacon-manager.js";
-import { TTYD_PORT_END, TTYD_PORT_START } from "./lib/constants.js";
+import { browserManager } from "./lib/browser-manager.js";
+import {
+  TTYD_PORT_END,
+  TTYD_PORT_START,
+  VNC_PORT_END,
+  VNC_PORT_START,
+  WS_PORT_END,
+  WS_PORT_START,
+} from "./lib/constants.js";
 import { db } from "./lib/database.js";
 import { getErrorMessage } from "./lib/errors.js";
 import { readFileFromWorktree } from "./lib/file-manager.js";
@@ -477,6 +485,21 @@ async function startServer() {
     });
   });
 
+  // ===== noVNC Browser Proxy Routes =====
+
+  app.use("/browser/:browserId", (req, res) => {
+    const { browserId } = req.params;
+    const session = browserManager.getSession(browserId);
+    if (!session) {
+      res.status(404).json({ error: "Browser session not found" });
+      return;
+    }
+    // http-proxyインスタンスはttydProxyを共用する
+    const subPath = req.url || "/";
+    req.url = subPath;
+    ttydProxy.web(req, res, { target: `http://127.0.0.1:${session.wsPort}` });
+  });
+
   // ===== ローカルポートプロキシ（リモートアクセス時にlocalhost URLを表示するため） =====
 
   app.all("/proxy/:port/*", (req, res) => {
@@ -497,6 +520,15 @@ async function startServer() {
       res.status(403).json({ error: "This port is not accessible via proxy" });
       return;
     }
+    // VNC/WSポート範囲もブロック（noVNCブラウザセッション用）
+    if (port >= VNC_PORT_START && port <= VNC_PORT_END) {
+      res.status(403).json({ error: "This port is not accessible via proxy" });
+      return;
+    }
+    if (port >= WS_PORT_START && port <= WS_PORT_END) {
+      res.status(403).json({ error: "This port is not accessible via proxy" });
+      return;
+    }
 
     const targetPath = req.url.replace(`/proxy/${port}`, "") || "/";
     req.url = targetPath;
@@ -514,8 +546,8 @@ async function startServer() {
     app.use(express.static(staticPath));
 
     // Handle client-side routing - serve index.html for all routes
-    // Exclude ttyd and proxy routes
-    app.get(/^(?!\/ttyd\/|\/proxy\/).*$/, (_req, res) => {
+    // Exclude ttyd, proxy, and browser routes
+    app.get(/^(?!\/ttyd\/|\/proxy\/|\/browser\/).*$/, (_req, res) => {
       res.sendFile(path.join(staticPath, "index.html"));
     });
   }
@@ -548,16 +580,35 @@ async function startServer() {
       }
     }
 
+    // Handle browser (noVNC) WebSocket connections
+    const browserMatch = pathname.match(/^\/browser\/([^/]+)(\/.*)?$/);
+    if (browserMatch) {
+      const browserId = browserMatch[1];
+      const session = browserManager.getSession(browserId);
+      if (session) {
+        const targetPath = browserMatch[2] || "/";
+        req.url = targetPath;
+        ttydProxy.ws(req, socket, head, {
+          target: `ws://127.0.0.1:${session.wsPort}`,
+        });
+        return;
+      }
+      socket.destroy();
+      return;
+    }
+
     // Handle proxy WebSocket connections（ローカルポートプロキシ用）
     const proxyMatch = pathname.match(/^\/proxy\/(\d+)(\/.*)?$/);
     if (proxyMatch) {
       const proxyPort = parseInt(proxyMatch[1], 10);
       if (proxyPort >= 1 && proxyPort <= 65535) {
-        // SSRF対策: Ark自体のポートとttydポート範囲をブロック
+        // SSRF対策: Ark自体のポート、ttydポート範囲、VNC/WSポート範囲をブロック
         const serverPort = parseInt(process.env.PORT || "3001", 10);
         if (
           proxyPort === serverPort ||
-          (proxyPort >= TTYD_PORT_START && proxyPort <= TTYD_PORT_END)
+          (proxyPort >= TTYD_PORT_START && proxyPort <= TTYD_PORT_END) ||
+          (proxyPort >= VNC_PORT_START && proxyPort <= VNC_PORT_END) ||
+          (proxyPort >= WS_PORT_START && proxyPort <= WS_PORT_END)
         ) {
           socket.destroy();
           return;
@@ -1078,6 +1129,77 @@ async function startServer() {
       }
     });
 
+    // ===== Browser Session Commands (noVNC) =====
+
+    // ソケットごとのブラウザセッション追跡（disconnect時のクリーンアップ用）
+    const socketBrowserSessions = new Set<string>();
+
+    socket.on("browser:start", async data => {
+      try {
+        // 依存チェック
+        if (!browserManager.isAvailable()) {
+          socket.emit("browser:error", {
+            message:
+              "リモートブラウザ機能の依存が不足しています。サーバーログを確認してください。",
+          });
+          return;
+        }
+
+        // ポート範囲チェック
+        const { port: targetPort, url, devtools } = data;
+        if (
+          typeof targetPort !== "number" ||
+          !Number.isFinite(targetPort) ||
+          targetPort < 1 ||
+          targetPort > 65535
+        ) {
+          socket.emit("browser:error", {
+            message: "無効なポート番号です（1-65535）",
+          });
+          return;
+        }
+
+        // ブロックリスト: サーバーポート、ttyd範囲、VNC範囲、WS範囲
+        const serverPort = parseInt(process.env.PORT || "3001", 10);
+        if (
+          targetPort === serverPort ||
+          (targetPort >= TTYD_PORT_START && targetPort <= TTYD_PORT_END) ||
+          (targetPort >= VNC_PORT_START && targetPort <= VNC_PORT_END) ||
+          (targetPort >= WS_PORT_START && targetPort <= WS_PORT_END)
+        ) {
+          socket.emit("browser:error", {
+            message: "このポートはブラウザセッションの対象外です",
+          });
+          return;
+        }
+
+        // per-socket上限チェック
+        if (socketBrowserSessions.size >= 3) {
+          socket.emit("browser:error", {
+            message:
+              "ブラウザセッションの上限（3）に達しています。不要なセッションを停止してください。",
+          });
+          return;
+        }
+
+        const session = await browserManager.start(targetPort, url, devtools);
+        socketBrowserSessions.add(session.id);
+        socket.emit("browser:started", session);
+      } catch (error) {
+        socket.emit("browser:error", { message: getErrorMessage(error) });
+      }
+    });
+
+    socket.on("browser:stop", async data => {
+      try {
+        await browserManager.stop(data.browserId);
+        socketBrowserSessions.delete(data.browserId);
+        socket.emit("browser:stopped", { browserId: data.browserId });
+      } catch (error) {
+        socket.emit("browser:error", { message: getErrorMessage(error) });
+      }
+    });
+
     // ===== Beacon Commands =====
 
     // Beaconメッセージ送信
@@ -1140,6 +1262,12 @@ async function startServer() {
       forwardHandlers.forEach((handler, event) => {
         sessionOrchestrator.off(event, handler);
       });
+
+      // Socket切断時に全ブラウザセッションをクリーンアップ
+      Array.from(socketBrowserSessions).forEach(browserId => {
+        browserManager.stop(browserId);
+      });
+      socketBrowserSessions.clear();
     });
   });
 
@@ -1236,6 +1364,7 @@ async function startServer() {
     console.log("Shutting down...");
     sessionOrchestrator.cleanup();
     beaconManager.cleanup();
+    browserManager.cleanup();
     server.close(() => {
       process.exit(0);
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -155,6 +155,13 @@ async function startServer() {
     }
   });
 
+  // プロキシ経由のレスポンスに強制的にクリックジャッキング対策ヘッダを付与する。
+  // ttyd/noVNCはiframe埋め込みで使うため、SAMEORIGINまで許可する。
+  ttydProxy.on("proxyRes", proxyRes => {
+    proxyRes.headers["x-frame-options"] = "SAMEORIGIN";
+    proxyRes.headers["content-security-policy"] = "frame-ancestors 'self'";
+  });
+
   if (enableRemote) {
     console.log(
       "Remote access mode enabled - using Cloudflare Access for authentication"
@@ -554,15 +561,47 @@ async function startServer() {
 
   // ===== WebSocket Upgrade Handler =====
 
+  /**
+   * WebSocket upgradeリクエストの認証を検証する
+   * authManagerが有効な場合、Quick Tunnel経由のアクセスのみトークン認証を要求する。
+   * ローカル/プライベートIPは認証スキップ。
+   * @returns 認証OKならtrue、失敗時はfalse（呼び出し側でsocket.destroy()する）
+   */
+  function authorizeWebSocketUpgrade(
+    req: import("node:http").IncomingMessage,
+    url: URL
+  ): boolean {
+    if (!authManager.isEnabled()) {
+      return true;
+    }
+
+    // Quick Tunnel以外（ローカル等）はスキップ
+    const host =
+      (req.headers["x-forwarded-host"] as string | undefined) ||
+      req.headers.host;
+    const hostname = host?.split(":")[0] ?? "";
+    const isQuickTunnel = hostname.endsWith(".trycloudflare.com");
+    if (!isQuickTunnel) {
+      return true;
+    }
+
+    const token = url.searchParams.get("token") ?? undefined;
+    return authManager.validateToken(token);
+  }
+
   server.on("upgrade", (req, socket, head) => {
     const url = new URL(req.url || "", `http://${req.headers.host}`);
     const pathname = url.pathname;
 
-    // ttyd WebSocket接続は内部プロキシ（ws://127.0.0.1）経由のため認証不要
-
     // Handle ttyd WebSocket connections
     const ttydMatch = pathname.match(/^\/ttyd\/([^/]+)/);
     if (ttydMatch) {
+      // 認証検証（Quick Tunnel時のみ）
+      if (!authorizeWebSocketUpgrade(req, url)) {
+        socket.destroy();
+        return;
+      }
+
       const sessionId = ttydMatch[1];
       const session = sessionOrchestrator.getSession(sessionId);
 
@@ -574,15 +613,20 @@ async function startServer() {
           target: `ws://127.0.0.1:${session.ttydPort}`,
         });
         return;
-      } else {
-        socket.destroy();
-        return;
       }
+      socket.destroy();
+      return;
     }
 
     // Handle browser (noVNC) WebSocket connections
     const browserMatch = pathname.match(/^\/browser\/([^/]+)(\/.*)?$/);
     if (browserMatch) {
+      // 認証検証（Quick Tunnel時のみ）
+      if (!authorizeWebSocketUpgrade(req, url)) {
+        socket.destroy();
+        return;
+      }
+
       const browserId = browserMatch[1];
       const session = browserManager.getSession(browserId);
       if (session) {
@@ -600,6 +644,12 @@ async function startServer() {
     // Handle proxy WebSocket connections（ローカルポートプロキシ用）
     const proxyMatch = pathname.match(/^\/proxy\/(\d+)(\/.*)?$/);
     if (proxyMatch) {
+      // 認証検証（Quick Tunnel時のみ）
+      if (!authorizeWebSocketUpgrade(req, url)) {
+        socket.destroy();
+        return;
+      }
+
       const proxyPort = parseInt(proxyMatch[1], 10);
       if (proxyPort >= 1 && proxyPort <= 65535) {
         // SSRF対策: Ark自体のポート、ttydポート範囲、VNC/WSポート範囲をブロック
@@ -1130,9 +1180,12 @@ async function startServer() {
     });
 
     // ===== Browser Session Commands (noVNC) =====
-
-    // ソケットごとのブラウザセッション追跡（disconnect時のクリーンアップ用）
-    const socketBrowserSessions = new Set<string>();
+    //
+    // 設計: ブラウザセッションはシングルトンのため、
+    // 特定のクライアントの切断で停止させると他クライアントの画面が消える。
+    // そのため明示的な`browser:stop`のみで停止する方針を取り、
+    // disconnect時の自動停止は行わない。
+    // 最終的なプロセス掃除はSIGTERM/SIGINT時の`browserManager.cleanup()`で行う。
 
     socket.on("browser:start", async () => {
       try {
@@ -1145,7 +1198,6 @@ async function startServer() {
         }
 
         const session = await browserManager.start();
-        socketBrowserSessions.add(session.id);
         socket.emit("browser:started", session);
       } catch (error) {
         socket.emit("browser:error", { message: getErrorMessage(error) });
@@ -1155,7 +1207,6 @@ async function startServer() {
     socket.on("browser:stop", async data => {
       try {
         await browserManager.stop(data.browserId);
-        socketBrowserSessions.delete(data.browserId);
         socket.emit("browser:stopped", { browserId: data.browserId });
       } catch (error) {
         socket.emit("browser:error", { message: getErrorMessage(error) });
@@ -1165,11 +1216,9 @@ async function startServer() {
     socket.on("browser:navigate", async data => {
       try {
         const session = await browserManager.navigate(data.url);
-        // セッションが新規起動された場合（クライアントがまだ知らない場合）はbrowser:startedも発火
-        if (!socketBrowserSessions.has(session.id)) {
-          socketBrowserSessions.add(session.id);
-          socket.emit("browser:started", session);
-        }
+        // 呼び出し元のクライアントには常にbrowser:startedを通知する
+        // （当該クライアントがまだセッションを知らない場合の初期同期）
+        socket.emit("browser:started", session);
       } catch (error) {
         socket.emit("browser:error", { message: getErrorMessage(error) });
       }
@@ -1238,11 +1287,8 @@ async function startServer() {
         sessionOrchestrator.off(event, handler);
       });
 
-      // Socket切断時に全ブラウザセッションをクリーンアップ
-      Array.from(socketBrowserSessions).forEach(browserId => {
-        browserManager.stop(browserId);
-      });
-      socketBrowserSessions.clear();
+      // ブラウザセッションはシングルトンのため、socket切断では停止しない。
+      // 明示的なbrowser:stopまたはSIGTERM/SIGINT時のcleanup()で停止する。
     });
   });
 

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -25,7 +25,11 @@ import { getErrorMessage } from "./errors.js";
 
 /** 各プロセスの起動タイムアウト（ミリ秒） */
 const XVFB_TIMEOUT = 5000;
-const CHROMIUM_DELAY = 2000;
+const CHROMIUM_TIMEOUT = 10000;
+/** CDP readinessチェックのポーリング間隔（ミリ秒） */
+const CHROMIUM_POLL_INTERVAL = 200;
+/** CDP readinessチェックの1回あたりのfetchタイムアウト（ミリ秒） */
+const CHROMIUM_FETCH_TIMEOUT = 500;
 const X11VNC_TIMEOUT = 5000;
 const WEBSOCKIFY_TIMEOUT = 5000;
 
@@ -209,6 +213,18 @@ export class BrowserManager extends EventEmitter {
    */
   isAvailable(): boolean {
     return this.available;
+  }
+
+  /**
+   * 現在アクティブなブラウザセッションが使用中のポート一覧を返す
+   * port-scannerで内部ポートのみを除外するために使用する
+   */
+  getUsedPorts(): number[] {
+    const ports: number[] = [CDP_PORT];
+    for (const session of Array.from(this.sessions.values())) {
+      ports.push(session.vncPort, session.wsPort);
+    }
+    return ports;
   }
 
   /**
@@ -448,8 +464,53 @@ export class BrowserManager extends EventEmitter {
       });
       startedProcesses.push(chromium);
 
-      // Chromiumはreadiness出力がないため固定ディレイで待機
-      await new Promise<void>(resolve => setTimeout(resolve, CHROMIUM_DELAY));
+      // CDPエンドポイントが応答するまでポーリングしてChromium readinessを検出
+      // 早期exitやerrorも検出してreject
+      await new Promise<void>((resolve, reject) => {
+        const overallTimeout = setTimeout(() => {
+          chromium.off("exit", onEarlyExit);
+          chromium.off("error", onEarlyError);
+          reject(new Error("Chromium起動タイムアウト"));
+        }, 10000);
+
+        const onEarlyExit = (code: number | null) => {
+          clearTimeout(overallTimeout);
+          reject(new Error(`Chromiumが予期せず終了しました (code: ${code})`));
+        };
+        const onEarlyError = (err: Error) => {
+          clearTimeout(overallTimeout);
+          reject(new Error(`Chromium起動エラー: ${err.message}`));
+        };
+        chromium.once("exit", onEarlyExit);
+        chromium.once("error", onEarlyError);
+
+        const cleanup = () => {
+          clearTimeout(overallTimeout);
+          chromium.off("exit", onEarlyExit);
+          chromium.off("error", onEarlyError);
+        };
+
+        const checkReady = async () => {
+          try {
+            const controller = new AbortController();
+            const fetchTimeout = setTimeout(() => controller.abort(), 500);
+            const res = await fetch(
+              `http://127.0.0.1:${CDP_PORT}/json/version`,
+              { signal: controller.signal }
+            );
+            clearTimeout(fetchTimeout);
+            if (res.ok) {
+              cleanup();
+              resolve();
+              return;
+            }
+          } catch {
+            // まだ起動していない
+          }
+          setTimeout(checkReady, 200);
+        };
+        checkReady();
+      });
 
       console.log(
         `[BrowserManager] Chromium起動完了: ${targetUrl} (DISPLAY=:${displayNum})`
@@ -773,6 +834,20 @@ export class BrowserManager extends EventEmitter {
     // singletonSessionが残っているがsessionsには無い場合（stale）はクリア
     if (this.singletonSession && !this.sessions.has(this.singletonSession.id)) {
       this.singletonSession = null;
+    }
+
+    // 起動中（pendingStart）の場合、そのstart()が終わるのを待ってから
+    // 改めてnavigate()を実行する。
+    // これをしないと、先行のstart(about:blank)が返ってきた時点で
+    // 既にsingletonSessionが存在するため、新しいURLへのCDPナビゲートが
+    // 実行されず、URLが飲み込まれてしまう。
+    if (this.pendingStart) {
+      try {
+        await this.pendingStart;
+      } catch {
+        // 起動失敗時は以下の通常フローでstart(url)が呼ばれる
+      }
+      return this.navigate(url);
     }
 
     // セッションがなければ初期URLとして起動

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -14,6 +14,7 @@ import net from "node:net";
 import os from "node:os";
 import type { BrowserSession } from "../../shared/types.js";
 import {
+  CDP_PORT,
   DISPLAY_START,
   VNC_PORT_END,
   VNC_PORT_START,
@@ -33,9 +34,6 @@ const KILL_GRACE_PERIOD = 3000;
 
 /** Xvfb仮想ディスプレイの解像度 */
 const DISPLAY_RESOLUTION = "1280x900x24";
-
-/** CDPリモートデバッグポート */
-const CDP_PORT = 9222;
 
 /** Chromiumの起動フラグ */
 const CHROMIUM_FLAGS = [
@@ -793,6 +791,9 @@ export class BrowserManager extends EventEmitter {
     } finally {
       clearTimeout(fetchTimeout);
     }
+    if (!res.ok) {
+      throw new Error(`CDPエンドポイント応答エラー: ${res.status}`);
+    }
     const tabs = (await res.json()) as Array<{
       id: string;
       type: string;
@@ -861,8 +862,18 @@ export class BrowserManager extends EventEmitter {
 
   /**
    * 全セッションを停止
+   * 起動中のセッションがある場合は完了を待ってからクリーンアップする
+   * （起動完了後にプロセスが残留するのを防ぐ）
    */
   async cleanup(): Promise<void> {
+    // 起動中のセッションがあれば完了を待つ
+    if (this.pendingStart) {
+      try {
+        await this.pendingStart;
+      } catch {
+        // 起動失敗時は無視（プロセスは_startInternal側で既にクリーンアップ済み）
+      }
+    }
     const ids = Array.from(this.sessions.keys());
     await Promise.all(ids.map(id => this.stop(id)));
     this.singletonSession = null;

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -668,27 +668,62 @@ export class BrowserManager extends EventEmitter {
 
   /**
    * CDP経由でChromiumを指定URLにナビゲート
+   * WebSocket DevTools Protocol の Page.navigate を使用
    */
   async navigate(url: string): Promise<void> {
     if (!this.singletonSession) {
       throw new Error("ブラウザセッションが起動していません");
     }
 
-    // CDP: アクティブなタブを取得
+    // CDP: ページ型のタブを取得
     const res = await fetch(`http://127.0.0.1:${CDP_PORT}/json`);
     const tabs = (await res.json()) as Array<{
       id: string;
+      type: string;
       webSocketDebuggerUrl: string;
+      url: string;
     }>;
-    if (tabs.length === 0) {
-      throw new Error("Chromiumのタブが見つかりません");
+    const pageTab = tabs.find(t => t.type === "page");
+    if (!pageTab) {
+      throw new Error("Chromiumのページタブが見つかりません");
     }
 
-    // 最初のタブにナビゲート
-    const tabId = tabs[0].id;
-    await fetch(
-      `http://127.0.0.1:${CDP_PORT}/json/navigate?${tabId}&url=${encodeURIComponent(url)}`
-    );
+    // WebSocketでPage.navigateコマンドを送信
+    await new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(pageTab.webSocketDebuggerUrl);
+      const timeout = setTimeout(() => {
+        ws.close();
+        reject(new Error("CDP navigate タイムアウト"));
+      }, 5000);
+
+      ws.addEventListener("open", () => {
+        ws.send(
+          JSON.stringify({
+            id: 1,
+            method: "Page.navigate",
+            params: { url },
+          })
+        );
+      });
+
+      ws.addEventListener("message", event => {
+        const msg = JSON.parse(event.data.toString());
+        if (msg.id === 1) {
+          clearTimeout(timeout);
+          ws.close();
+          if (msg.error) {
+            reject(new Error(`CDP navigate エラー: ${msg.error.message}`));
+          } else {
+            resolve();
+          }
+        }
+      });
+
+      ws.addEventListener("error", err => {
+        clearTimeout(timeout);
+        reject(new Error(`CDP WebSocket エラー: ${err}`));
+      });
+    });
 
     console.log(`[BrowserManager] ナビゲート: ${url}`);
   }

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -20,9 +20,6 @@ import {
   WS_PORT_START,
 } from "./constants.js";
 
-/** ブラウザセッションの最大同時数 */
-const MAX_SESSIONS = 10;
-
 /** 各プロセスの起動タイムアウト（ミリ秒） */
 const XVFB_TIMEOUT = 5000;
 const CHROMIUM_DELAY = 2000;
@@ -34,11 +31,6 @@ const KILL_GRACE_PERIOD = 3000;
 
 /** Xvfb仮想ディスプレイの解像度 */
 const DISPLAY_RESOLUTION = "1280x900x24";
-
-/** 許可するURLのプロトコル */
-const ALLOWED_PROTOCOLS = ["http:", "https:"];
-/** 許可するホスト名（SSRF対策） */
-const ALLOWED_HOSTNAMES = ["localhost", "127.0.0.1"];
 
 /** Chromiumの起動フラグ */
 const CHROMIUM_FLAGS = [
@@ -73,8 +65,10 @@ interface BrowserProcessSet {
 
 export class BrowserManager extends EventEmitter {
   private sessions: Map<string, BrowserProcessSet> = new Map();
-  /** 起動中のPromiseを保持し、同じポートへの重複起動を防ぐ */
-  private pendingStarts: Map<number, Promise<BrowserSession>> = new Map();
+  /** シングルトンセッション（1つだけ起動） */
+  private singletonSession: BrowserSession | null = null;
+  /** 起動中のPromiseを保持し、重複起動を防ぐ */
+  private pendingStart: Promise<BrowserSession> | null = null;
   private nextVncPort: number;
   private nextWsPort: number;
   private nextDisplay: number;
@@ -313,62 +307,35 @@ export class BrowserManager extends EventEmitter {
   }
 
   /**
-   * URLのSSRF検証
-   * localhost/127.0.0.1 かつ http/https のみ許可
+   * ブラウザセッションを開始（シングルトン）
+   * 既にセッションがあればそのまま返す。起動中なら待つ。
    */
-  private validateUrl(url: string): void {
-    const parsed = new URL(url);
-    if (!ALLOWED_PROTOCOLS.includes(parsed.protocol)) {
-      throw new Error(
-        `許可されていないプロトコルです: ${parsed.protocol} (http/httpsのみ許可)`
-      );
-    }
-    if (!ALLOWED_HOSTNAMES.includes(parsed.hostname)) {
-      throw new Error(
-        `許可されていないホスト名です: ${parsed.hostname} (localhost/127.0.0.1のみ許可)`
-      );
-    }
-  }
-
-  /**
-   * ブラウザセッションを開始
-   * 重複起動ガード付き: 同じポートに対する並行起動を防ぐ
-   */
-  async start(
-    port: number,
-    url?: string,
-    devtools?: boolean
-  ): Promise<BrowserSession> {
+  async start(): Promise<BrowserSession> {
     if (!this.available) {
       throw new Error(
-        "リモートブラウザ機能の依存が不足しています。サーバーログを確認してください。"
+        "ブラウザタブ機能は無効です。依存パッケージをインストールしてください。"
       );
     }
 
-    // セッション上限チェック
-    if (this.sessions.size >= MAX_SESSIONS) {
-      throw new Error(
-        `ブラウザセッションの上限（${MAX_SESSIONS}）に達しています`
-      );
+    // 既にセッションがあればそのまま返す
+    if (this.singletonSession) {
+      return this.singletonSession;
     }
 
-    // URL検証（SSRF対策）
-    const targetUrl = url || `http://localhost:${port}`;
-    this.validateUrl(targetUrl);
-
-    // 同じポートへの重複起動防止
-    const pending = this.pendingStarts.get(port);
-    if (pending) {
-      return pending;
+    // 起動中なら待つ
+    if (this.pendingStart) {
+      return this.pendingStart;
     }
 
-    const promise = this._startInternal(port, targetUrl, devtools ?? false);
-    this.pendingStarts.set(port, promise);
+    const promise = this._startInternal();
+    this.pendingStart = promise;
 
     try {
-      return await promise;
+      const session = await promise;
+      this.singletonSession = session;
+      return session;
     } finally {
-      this.pendingStarts.delete(port);
+      this.pendingStart = null;
     }
   }
 
@@ -376,11 +343,10 @@ export class BrowserManager extends EventEmitter {
    * ブラウザセッションの実際の起動処理（内部用）
    * 起動順: Xvfb → Chromium → x11vnc → websockify
    */
-  private async _startInternal(
-    targetPort: number,
-    targetUrl: string,
-    devtools: boolean
-  ): Promise<BrowserSession> {
+  private async _startInternal(): Promise<BrowserSession> {
+    const targetUrl = "about:blank";
+    const targetPort = 0;
+    const devtools = false;
     const id = randomUUID();
     const displayNum = this.findAvailableDisplay();
     const vncPort = await this.findAvailableVncPort();
@@ -679,6 +645,11 @@ export class BrowserManager extends EventEmitter {
     // 先にMapから削除して、異常終了監視のハンドラが再度stopを呼ばないようにする
     this.sessions.delete(browserId);
 
+    // シングルトンセッションをクリア
+    if (this.singletonSession?.id === browserId) {
+      this.singletonSession = null;
+    }
+
     console.log(`[BrowserManager] ブラウザセッション停止中: ${browserId}`);
 
     // 逆順でプロセスを停止
@@ -697,6 +668,8 @@ export class BrowserManager extends EventEmitter {
   async cleanup(): Promise<void> {
     const ids = Array.from(this.sessions.keys());
     await Promise.all(ids.map(id => this.stop(id)));
+    this.singletonSession = null;
+    this.pendingStart = null;
     console.log(
       "[BrowserManager] 全ブラウザセッションをクリーンアップしました"
     );

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -314,7 +314,7 @@ export class BrowserManager extends EventEmitter {
    * ブラウザセッションを開始（シングルトン）
    * 既にセッションがあればそのまま返す。起動中なら待つ。
    */
-  async start(): Promise<BrowserSession> {
+  async start(initialUrl = "about:blank"): Promise<BrowserSession> {
     if (!this.available) {
       throw new Error(
         "ブラウザタブ機能は無効です。依存パッケージをインストールしてください。"
@@ -331,7 +331,7 @@ export class BrowserManager extends EventEmitter {
       return this.pendingStart;
     }
 
-    const promise = this._startInternal();
+    const promise = this._startInternal(initialUrl);
     this.pendingStart = promise;
 
     try {
@@ -347,8 +347,10 @@ export class BrowserManager extends EventEmitter {
    * ブラウザセッションの実際の起動処理（内部用）
    * 起動順: Xvfb → Chromium → x11vnc → websockify
    */
-  private async _startInternal(): Promise<BrowserSession> {
-    const targetUrl = "about:blank";
+  private async _startInternal(
+    initialUrl = "about:blank"
+  ): Promise<BrowserSession> {
+    const targetUrl = initialUrl;
     const targetPort = 0;
     const devtools = false;
     const id = randomUUID();
@@ -670,9 +672,10 @@ export class BrowserManager extends EventEmitter {
    * CDP経由でChromiumを指定URLにナビゲート
    * WebSocket DevTools Protocol の Page.navigate を使用
    */
-  async navigate(url: string): Promise<void> {
+  async navigate(url: string): Promise<BrowserSession> {
+    // セッションがなければ初期URLとして起動
     if (!this.singletonSession) {
-      throw new Error("ブラウザセッションが起動していません");
+      return this.start(url);
     }
 
     // CDP: ページ型のタブを取得
@@ -726,6 +729,7 @@ export class BrowserManager extends EventEmitter {
     });
 
     console.log(`[BrowserManager] ナビゲート: ${url}`);
+    return this.singletonSession;
   }
 
   /**

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -32,6 +32,9 @@ const KILL_GRACE_PERIOD = 3000;
 /** Xvfb仮想ディスプレイの解像度 */
 const DISPLAY_RESOLUTION = "1280x900x24";
 
+/** CDPリモートデバッグポート */
+const CDP_PORT = 9222;
+
 /** Chromiumの起動フラグ */
 const CHROMIUM_FLAGS = [
   "--no-sandbox",
@@ -45,6 +48,7 @@ const CHROMIUM_FLAGS = [
   "--disable-default-apps",
   "--window-size=1280,900",
   "--window-position=0,0",
+  `--remote-debugging-port=${CDP_PORT}`,
 ];
 
 /** セッションに紐づく4プロセスの組 */
@@ -660,6 +664,33 @@ export class BrowserManager extends EventEmitter {
 
     this.emit("session:stopped", browserId);
     console.log(`[BrowserManager] ブラウザセッション停止完了: ${browserId}`);
+  }
+
+  /**
+   * CDP経由でChromiumを指定URLにナビゲート
+   */
+  async navigate(url: string): Promise<void> {
+    if (!this.singletonSession) {
+      throw new Error("ブラウザセッションが起動していません");
+    }
+
+    // CDP: アクティブなタブを取得
+    const res = await fetch(`http://127.0.0.1:${CDP_PORT}/json`);
+    const tabs = (await res.json()) as Array<{
+      id: string;
+      webSocketDebuggerUrl: string;
+    }>;
+    if (tabs.length === 0) {
+      throw new Error("Chromiumのタブが見つかりません");
+    }
+
+    // 最初のタブにナビゲート
+    const tabId = tabs[0].id;
+    await fetch(
+      `http://127.0.0.1:${CDP_PORT}/json/navigate?${tabId}&url=${encodeURIComponent(url)}`
+    );
+
+    console.log(`[BrowserManager] ナビゲート: ${url}`);
   }
 
   /**

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -11,6 +11,7 @@ import { randomUUID } from "node:crypto";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import net from "node:net";
+import os from "node:os";
 import type { BrowserSession } from "../../shared/types.js";
 import {
   DISPLAY_START,
@@ -19,6 +20,7 @@ import {
   WS_PORT_END,
   WS_PORT_START,
 } from "./constants.js";
+import { getErrorMessage } from "./errors.js";
 
 /** 各プロセスの起動タイムアウト（ミリ秒） */
 const XVFB_TIMEOUT = 5000;
@@ -49,6 +51,7 @@ const CHROMIUM_FLAGS = [
   "--window-size=1280,900",
   "--window-position=0,0",
   `--remote-debugging-port=${CDP_PORT}`,
+  "--remote-debugging-address=127.0.0.1",
 ];
 
 /** セッションに紐づく4プロセスの組 */
@@ -158,7 +161,7 @@ export class BrowserManager extends EventEmitter {
    */
   private findChromiumBinary(): string | null {
     // 1. Playwright版Chromium（snap制約なし）
-    const homeDir = process.env.HOME || "/root";
+    const homeDir = process.env.HOME || os.homedir();
     const playwrightDir = `${homeDir}/.cache/ms-playwright`;
     if (fs.existsSync(playwrightDir)) {
       try {
@@ -208,6 +211,28 @@ export class BrowserManager extends EventEmitter {
    */
   isAvailable(): boolean {
     return this.available;
+  }
+
+  /**
+   * URLスキーマ検証
+   * - http://またはhttps://のみ許可
+   * - ホスト名はlocalhost/127.0.0.1のみ許可
+   * - about:blankは特例で許可
+   */
+  private validateUrl(url: string): void {
+    if (url === "about:blank") return;
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      throw new Error("無効なURL形式です");
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("http://またはhttps://のみ許可されています");
+    }
+    if (parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1") {
+      throw new Error("localhost/127.0.0.1のみ許可されています");
+    }
   }
 
   /**
@@ -289,6 +314,8 @@ export class BrowserManager extends EventEmitter {
 
   /**
    * 利用可能なディスプレイ番号を探す
+   * 内部sessionsマップだけでなく、OSレベルでX11ソケットの存在も確認する
+   * （他プロセスが使用中のディスプレイ番号を避ける）
    */
   private findAvailableDisplay(): number {
     const usedDisplays = new Set(
@@ -301,6 +328,8 @@ export class BrowserManager extends EventEmitter {
         DISPLAY_START +
         ((this.nextDisplay - DISPLAY_START + i) % totalDisplays);
       if (usedDisplays.has(display)) continue;
+      // OSレベルでX11ソケットの存在を確認
+      if (fs.existsSync(`/tmp/.X11-unix/X${display}`)) continue;
       this.nextDisplay = display + 1;
       if (this.nextDisplay > maxDisplay) {
         this.nextDisplay = DISPLAY_START;
@@ -315,6 +344,8 @@ export class BrowserManager extends EventEmitter {
    * 既にセッションがあればそのまま返す。起動中なら待つ。
    */
   async start(initialUrl = "about:blank"): Promise<BrowserSession> {
+    this.validateUrl(initialUrl);
+
     if (!this.available) {
       throw new Error(
         "ブラウザタブ機能は無効です。依存パッケージをインストールしてください。"
@@ -405,7 +436,9 @@ export class BrowserManager extends EventEmitter {
       if (devtools) {
         chromiumFlags.push("--auto-open-devtools-for-tabs");
       }
-      chromiumFlags.push(targetUrl);
+      // `--`（フラグ終端子）を付けることでtargetUrlが`--`で始まる場合も
+      // 位置引数として安全に解釈される（引数インジェクション対策）
+      chromiumFlags.push("--", targetUrl);
 
       const chromium = spawn(this.chromiumCmd, chromiumFlags, {
         stdio: ["ignore", "pipe", "pipe"],
@@ -445,6 +478,7 @@ export class BrowserManager extends EventEmitter {
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
+          cleanup();
           reject(new Error("x11vnc起動タイムアウト"));
         }, X11VNC_TIMEOUT);
 
@@ -455,26 +489,44 @@ export class BrowserManager extends EventEmitter {
           // x11vncは起動時に "PORT=XXXX" を stdout に出力する
           if (outputData.includes("PORT=")) {
             clearTimeout(timeout);
+            cleanup();
             resolve();
           }
         };
 
-        x11vnc.stdout?.on("data", onData);
-        x11vnc.stderr?.on("data", onData);
-
-        x11vnc.on("error", error => {
+        const onError = (error: Error) => {
           clearTimeout(timeout);
+          cleanup();
           reject(error);
-        });
+        };
 
-        x11vnc.on("exit", code => {
+        const onExit = (code: number | null) => {
           if (code !== 0 && code !== null) {
             clearTimeout(timeout);
+            cleanup();
             reject(
               new Error(`x11vncが終了しました (code: ${code}): ${outputData}`)
             );
           }
-        });
+        };
+
+        // resolve/reject後にリスナーを除去してメモリリークを防ぐ。
+        // ただしstdout/stderrはパイプバッファが詰まらないよう
+        // 軽量なドレインリスナーを残す必要がある。
+        const drain = () => {};
+        const cleanup = () => {
+          x11vnc.stdout?.off("data", onData);
+          x11vnc.stderr?.off("data", onData);
+          x11vnc.off("error", onError);
+          x11vnc.off("exit", onExit);
+          x11vnc.stdout?.on("data", drain);
+          x11vnc.stderr?.on("data", drain);
+        };
+
+        x11vnc.stdout?.on("data", onData);
+        x11vnc.stderr?.on("data", onData);
+        x11vnc.on("error", onError);
+        x11vnc.on("exit", onExit);
       });
 
       console.log(`[BrowserManager] x11vnc起動完了: ポート ${vncPort}`);
@@ -494,6 +546,7 @@ export class BrowserManager extends EventEmitter {
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
+          cleanup();
           reject(new Error("websockify起動タイムアウト"));
         }, WEBSOCKIFY_TIMEOUT);
 
@@ -506,28 +559,45 @@ export class BrowserManager extends EventEmitter {
             outputData.includes("listening")
           ) {
             clearTimeout(timeout);
+            cleanup();
             resolve();
           }
         };
 
-        websockify.stdout?.on("data", onData);
-        websockify.stderr?.on("data", onData);
-
-        websockify.on("error", error => {
+        const onError = (error: Error) => {
           clearTimeout(timeout);
+          cleanup();
           reject(error);
-        });
+        };
 
-        websockify.on("exit", code => {
+        const onExit = (code: number | null) => {
           if (code !== 0 && code !== null) {
             clearTimeout(timeout);
+            cleanup();
             reject(
               new Error(
                 `websockifyが終了しました (code: ${code}): ${outputData}`
               )
             );
           }
-        });
+        };
+
+        // resolve/reject後にリスナーを除去してメモリリークを防ぐ。
+        // stdout/stderrは軽量なドレインリスナーを残してパイプバッファ詰まりを防ぐ。
+        const drain = () => {};
+        const cleanup = () => {
+          websockify.stdout?.off("data", onData);
+          websockify.stderr?.off("data", onData);
+          websockify.off("error", onError);
+          websockify.off("exit", onExit);
+          websockify.stdout?.on("data", drain);
+          websockify.stderr?.on("data", drain);
+        };
+
+        websockify.stdout?.on("data", onData);
+        websockify.stderr?.on("data", onData);
+        websockify.on("error", onError);
+        websockify.on("exit", onExit);
       });
 
       console.log(
@@ -599,34 +669,42 @@ export class BrowserManager extends EventEmitter {
     } catch (error) {
       // 起動失敗時: 既に起動したプロセスをクリーンアップ
       console.error(
-        `[BrowserManager] ブラウザセッション起動失敗。プロセスをクリーンアップします。`
+        "[BrowserManager] ブラウザセッション起動失敗。プロセスをクリーンアップします。"
       );
-      for (const proc of startedProcesses) {
-        try {
-          proc.kill("SIGTERM");
-        } catch {
-          // killに失敗しても無視
-        }
+      // 起動順とは逆順でkillProcessを呼ぶ
+      for (let i = startedProcesses.length - 1; i >= 0; i--) {
+        await this.killProcess(startedProcesses[i], `process${i}`).catch(() => {
+          // 失敗は無視（既に死んでいる可能性）
+        });
       }
       throw error;
     }
   }
 
   /**
-   * プロセスを安全に停止（SIGTERM→待機→SIGKILL）
+   * プロセスを安全に停止（SIGTERM→待機→SIGKILL→再待機）
    */
   private async killProcess(proc: ChildProcess, name: string): Promise<void> {
-    if (proc.exitCode !== null) {
+    if (proc.exitCode !== null || proc.killed) {
       // 既に終了している
       return;
     }
 
-    proc.kill("SIGTERM");
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      // killに失敗（既に死んでいる等）は無視
+      return;
+    }
 
     // SIGTERM後の猶予時間を待つ
     const exited = await new Promise<boolean>(resolve => {
+      if (proc.exitCode !== null || proc.killed) {
+        resolve(true);
+        return;
+      }
       const timeout = setTimeout(() => resolve(false), KILL_GRACE_PERIOD);
-      proc.on("exit", () => {
+      proc.once("exit", () => {
         clearTimeout(timeout);
         resolve(true);
       });
@@ -636,13 +714,30 @@ export class BrowserManager extends EventEmitter {
       console.warn(
         `[BrowserManager] ${name}がSIGTERMで停止しなかったためSIGKILLを送信`
       );
-      proc.kill("SIGKILL");
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        // 既に死んでいる
+        return;
+      }
+      // SIGKILL後もexitを待つ（プロセステーブルからの削除確認）
+      await new Promise<void>(resolve => {
+        if (proc.exitCode !== null || proc.killed) {
+          resolve();
+          return;
+        }
+        const timeout = setTimeout(() => resolve(), 1000);
+        proc.once("exit", () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
     }
   }
 
   /**
    * ブラウザセッションを停止
-   * 逆順停止: websockify → x11vnc → chromium → xvfb
+   * 並列停止で速度を優先（プロセス間の依存順序は致命的ではない）
    */
   async stop(browserId: string): Promise<void> {
     const processSet = this.sessions.get(browserId);
@@ -658,11 +753,13 @@ export class BrowserManager extends EventEmitter {
 
     console.log(`[BrowserManager] ブラウザセッション停止中: ${browserId}`);
 
-    // 逆順でプロセスを停止
-    await this.killProcess(processSet.websockify, "websockify");
-    await this.killProcess(processSet.x11vnc, "x11vnc");
-    await this.killProcess(processSet.chromium, "chromium");
-    await this.killProcess(processSet.xvfb, "xvfb");
+    // 並列停止（依存関係は致命的ではなく、停止時間の短縮を優先）
+    await Promise.all([
+      this.killProcess(processSet.websockify, "websockify"),
+      this.killProcess(processSet.x11vnc, "x11vnc"),
+      this.killProcess(processSet.chromium, "chromium"),
+      this.killProcess(processSet.xvfb, "xvfb"),
+    ]);
 
     this.emit("session:stopped", browserId);
     console.log(`[BrowserManager] ブラウザセッション停止完了: ${browserId}`);
@@ -673,13 +770,29 @@ export class BrowserManager extends EventEmitter {
    * WebSocket DevTools Protocol の Page.navigate を使用
    */
   async navigate(url: string): Promise<BrowserSession> {
+    this.validateUrl(url);
+
+    // singletonSessionが残っているがsessionsには無い場合（stale）はクリア
+    if (this.singletonSession && !this.sessions.has(this.singletonSession.id)) {
+      this.singletonSession = null;
+    }
+
     // セッションがなければ初期URLとして起動
     if (!this.singletonSession) {
       return this.start(url);
     }
 
-    // CDP: ページ型のタブを取得
-    const res = await fetch(`http://127.0.0.1:${CDP_PORT}/json`);
+    // CDP: ページ型のタブを取得（タイムアウト付き）
+    const controller = new AbortController();
+    const fetchTimeout = setTimeout(() => controller.abort(), 5000);
+    let res: Response;
+    try {
+      res = await fetch(`http://127.0.0.1:${CDP_PORT}/json`, {
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(fetchTimeout);
+    }
     const tabs = (await res.json()) as Array<{
       id: string;
       type: string;
@@ -689,6 +802,13 @@ export class BrowserManager extends EventEmitter {
     const pageTab = tabs.find(t => t.type === "page");
     if (!pageTab) {
       throw new Error("Chromiumのページタブが見つかりません");
+    }
+
+    // webSocketDebuggerUrl が期待するCDPエンドポイント（ws://127.0.0.1:CDP_PORT/）
+    // で始まることを検証（SSRF/CDP乗っ取り対策）
+    const expectedPrefix = `ws://127.0.0.1:${CDP_PORT}/`;
+    if (!pageTab.webSocketDebuggerUrl.startsWith(expectedPrefix)) {
+      throw new Error("不正なCDPエンドポイント");
     }
 
     // WebSocketでPage.navigateコマンドを送信
@@ -710,21 +830,28 @@ export class BrowserManager extends EventEmitter {
       });
 
       ws.addEventListener("message", event => {
-        const msg = JSON.parse(event.data.toString());
-        if (msg.id === 1) {
+        try {
+          const msg = JSON.parse(event.data.toString());
+          if (msg.id === 1) {
+            clearTimeout(timeout);
+            ws.close();
+            if (msg.error) {
+              reject(new Error(`CDP navigate エラー: ${msg.error.message}`));
+            } else {
+              resolve();
+            }
+          }
+        } catch (e) {
           clearTimeout(timeout);
           ws.close();
-          if (msg.error) {
-            reject(new Error(`CDP navigate エラー: ${msg.error.message}`));
-          } else {
-            resolve();
-          }
+          reject(new Error(`CDP応答パースエラー: ${getErrorMessage(e)}`));
         }
       });
 
-      ws.addEventListener("error", err => {
+      ws.addEventListener("error", () => {
         clearTimeout(timeout);
-        reject(new Error(`CDP WebSocket エラー: ${err}`));
+        ws.close();
+        reject(new Error("CDP WebSocket エラー"));
       });
     });
 

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -116,20 +116,12 @@ export class BrowserManager extends EventEmitter {
     }
 
     // Chromium（複数の候補から探す）
-    const chromiumCandidates = [
-      "chromium-browser",
-      "chromium",
-      "google-chrome",
-    ];
-    let found = false;
-    for (const cmd of chromiumCandidates) {
-      if (this.commandExists(cmd)) {
-        this.chromiumCmd = cmd;
-        found = true;
-        break;
-      }
-    }
-    if (!found) {
+    // snap版chromium-browserはpm2/systemd環境でX11にアクセスできないため、
+    // Playwright版のchromiumバイナリを優先的に使用する
+    const chromiumFound = this.findChromiumBinary();
+    if (chromiumFound) {
+      this.chromiumCmd = chromiumFound;
+    } else {
       missing.push("chromium-browser/chromium/google-chrome");
     }
 
@@ -159,6 +151,46 @@ export class BrowserManager extends EventEmitter {
           "  Ubuntu: apt install xvfb x11vnc novnc websockify chromium-browser"
       );
     }
+  }
+
+  /**
+   * Chromiumバイナリを検索する
+   * snap版はpm2/systemd環境でX11にアクセスできないため、
+   * Playwright版のバイナリパスを優先的に探す
+   */
+  private findChromiumBinary(): string | null {
+    // 1. Playwright版Chromium（snap制約なし）
+    const homeDir = process.env.HOME || "/root";
+    const playwrightDir = `${homeDir}/.cache/ms-playwright`;
+    if (fs.existsSync(playwrightDir)) {
+      try {
+        const dirs = fs
+          .readdirSync(playwrightDir)
+          .filter(d => d.startsWith("chromium-"))
+          .sort()
+          .reverse(); // 最新版を優先
+        for (const dir of dirs) {
+          const chromePath = `${playwrightDir}/${dir}/chrome-linux/chrome`;
+          if (fs.existsSync(chromePath)) {
+            console.log(
+              `[BrowserManager] Playwright Chromium検出: ${chromePath}`
+            );
+            return chromePath;
+          }
+        }
+      } catch {
+        // ディレクトリ読み取り失敗は無視
+      }
+    }
+
+    // 2. システムのChromium（snap版でないもの）
+    for (const cmd of ["chromium-browser", "chromium", "google-chrome"]) {
+      if (this.commandExists(cmd)) {
+        return cmd;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -1,0 +1,705 @@
+/**
+ * Browser Manager（noVNC方式）
+ *
+ * Xvfb + Chromium + x11vnc + websockify を使用して
+ * ブラウザをリモートから操作可能にするマネージャー。
+ * TtydManagerと同じEventEmitter + シングルトンパターンで実装。
+ */
+
+import { type ChildProcess, execFileSync, spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import net from "node:net";
+import type { BrowserSession } from "../../shared/types.js";
+import {
+  DISPLAY_START,
+  VNC_PORT_END,
+  VNC_PORT_START,
+  WS_PORT_END,
+  WS_PORT_START,
+} from "./constants.js";
+
+/** ブラウザセッションの最大同時数 */
+const MAX_SESSIONS = 10;
+
+/** 各プロセスの起動タイムアウト（ミリ秒） */
+const XVFB_TIMEOUT = 5000;
+const CHROMIUM_DELAY = 2000;
+const X11VNC_TIMEOUT = 5000;
+const WEBSOCKIFY_TIMEOUT = 5000;
+
+/** stop時のSIGTERM→SIGKILL待機時間（ミリ秒） */
+const KILL_GRACE_PERIOD = 3000;
+
+/** Xvfb仮想ディスプレイの解像度 */
+const DISPLAY_RESOLUTION = "1280x900x24";
+
+/** 許可するURLのプロトコル */
+const ALLOWED_PROTOCOLS = ["http:", "https:"];
+/** 許可するホスト名（SSRF対策） */
+const ALLOWED_HOSTNAMES = ["localhost", "127.0.0.1"];
+
+/** Chromiumの起動フラグ */
+const CHROMIUM_FLAGS = [
+  "--no-sandbox",
+  "--disable-gpu",
+  "--disable-dev-shm-usage",
+  "--disable-background-networking",
+  "--disable-extensions",
+  "--disable-sync",
+  "--disable-translate",
+  "--no-first-run",
+  "--disable-default-apps",
+  "--window-size=1280,900",
+  "--window-position=0,0",
+];
+
+/** セッションに紐づく4プロセスの組 */
+interface BrowserProcessSet {
+  id: string;
+  targetPort: number;
+  targetUrl: string;
+  wsPort: number;
+  vncPort: number;
+  displayNum: number;
+  devtools: boolean;
+  xvfb: ChildProcess;
+  chromium: ChildProcess;
+  x11vnc: ChildProcess;
+  websockify: ChildProcess;
+  createdAt: Date;
+}
+
+export class BrowserManager extends EventEmitter {
+  private sessions: Map<string, BrowserProcessSet> = new Map();
+  /** 起動中のPromiseを保持し、同じポートへの重複起動を防ぐ */
+  private pendingStarts: Map<number, Promise<BrowserSession>> = new Map();
+  private nextVncPort: number;
+  private nextWsPort: number;
+  private nextDisplay: number;
+  /** 依存コマンドが全て揃っているか */
+  private available = true;
+  /** 検出されたChromiumコマンド名 */
+  private chromiumCmd = "";
+  /** noVNCの静的ファイルパス */
+  private novncPath = "";
+
+  constructor() {
+    super();
+    this.nextVncPort = VNC_PORT_START;
+    this.nextWsPort = WS_PORT_START;
+    this.nextDisplay = DISPLAY_START;
+    this.checkDependencies();
+  }
+
+  /**
+   * 依存コマンド・パスの存在チェック
+   * 不足時はavailable=falseにしてログ警告（Ark全体の起動は妨げない）
+   */
+  private checkDependencies(): void {
+    const missing: string[] = [];
+
+    // Xvfb
+    if (!this.commandExists("Xvfb")) {
+      missing.push("Xvfb");
+    }
+
+    // x11vnc
+    if (!this.commandExists("x11vnc")) {
+      missing.push("x11vnc");
+    }
+
+    // websockify
+    if (!this.commandExists("websockify")) {
+      missing.push("websockify");
+    }
+
+    // Chromium（複数の候補から探す）
+    const chromiumCandidates = [
+      "chromium-browser",
+      "chromium",
+      "google-chrome",
+    ];
+    let found = false;
+    for (const cmd of chromiumCandidates) {
+      if (this.commandExists(cmd)) {
+        this.chromiumCmd = cmd;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      missing.push("chromium-browser/chromium/google-chrome");
+    }
+
+    // noVNCパス
+    const novncCandidates = [
+      "/usr/share/novnc",
+      "/usr/share/noVNC",
+      "/usr/local/share/novnc",
+    ];
+    let novncFound = false;
+    for (const p of novncCandidates) {
+      if (fs.existsSync(p)) {
+        this.novncPath = p;
+        novncFound = true;
+        break;
+      }
+    }
+    if (!novncFound) {
+      missing.push("noVNC (/usr/share/novnc)");
+    }
+
+    if (missing.length > 0) {
+      this.available = false;
+      console.warn(
+        `[BrowserManager] 以下の依存が不足しています: ${missing.join(", ")}\n` +
+          "  リモートブラウザ機能は無効化されます。\n" +
+          "  Ubuntu: apt install xvfb x11vnc novnc websockify chromium-browser"
+      );
+    }
+  }
+
+  /**
+   * コマンドの存在チェック（シェルインジェクション防止のためexecFileSync使用）
+   */
+  private commandExists(cmd: string): boolean {
+    try {
+      execFileSync("which", [cmd], { stdio: "pipe" });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * リモートブラウザ機能が利用可能かどうか
+   */
+  isAvailable(): boolean {
+    return this.available;
+  }
+
+  /**
+   * 指定ポートがOSレベルで使用可能かチェック
+   */
+  private checkPortAvailable(port: number): Promise<boolean> {
+    return new Promise(resolve => {
+      const timeout = setTimeout(() => {
+        server.close();
+        resolve(false);
+      }, 3000);
+
+      const server = net.createServer();
+      server.once("error", () => {
+        clearTimeout(timeout);
+        resolve(false);
+      });
+      server.once("listening", () => {
+        clearTimeout(timeout);
+        server.close(() => resolve(true));
+      });
+      server.listen(port, "127.0.0.1");
+    });
+  }
+
+  /**
+   * 利用可能なVNCポートを探す（循環ポート探索パターン）
+   */
+  private async findAvailableVncPort(): Promise<number> {
+    const usedPorts = new Set(
+      Array.from(this.sessions.values()).map(s => s.vncPort)
+    );
+    const totalPorts = VNC_PORT_END - VNC_PORT_START + 1;
+    for (let i = 0; i < totalPorts; i++) {
+      const port =
+        VNC_PORT_START + ((this.nextVncPort - VNC_PORT_START + i) % totalPorts);
+      if (usedPorts.has(port)) continue;
+      const available = await this.checkPortAvailable(port);
+      if (!available) {
+        console.log(
+          `[BrowserManager] VNCポート ${port} は使用中のためスキップ`
+        );
+        continue;
+      }
+      this.nextVncPort = port + 1;
+      if (this.nextVncPort > VNC_PORT_END) {
+        this.nextVncPort = VNC_PORT_START;
+      }
+      return port;
+    }
+    throw new Error("利用可能なVNCポートがありません");
+  }
+
+  /**
+   * 利用可能なWebSocketポートを探す（循環ポート探索パターン）
+   */
+  private async findAvailableWsPort(): Promise<number> {
+    const usedPorts = new Set(
+      Array.from(this.sessions.values()).map(s => s.wsPort)
+    );
+    const totalPorts = WS_PORT_END - WS_PORT_START + 1;
+    for (let i = 0; i < totalPorts; i++) {
+      const port =
+        WS_PORT_START + ((this.nextWsPort - WS_PORT_START + i) % totalPorts);
+      if (usedPorts.has(port)) continue;
+      const available = await this.checkPortAvailable(port);
+      if (!available) {
+        console.log(`[BrowserManager] WSポート ${port} は使用中のためスキップ`);
+        continue;
+      }
+      this.nextWsPort = port + 1;
+      if (this.nextWsPort > WS_PORT_END) {
+        this.nextWsPort = WS_PORT_START;
+      }
+      return port;
+    }
+    throw new Error("利用可能なWebSocketポートがありません");
+  }
+
+  /**
+   * 利用可能なディスプレイ番号を探す
+   */
+  private findAvailableDisplay(): number {
+    const usedDisplays = new Set(
+      Array.from(this.sessions.values()).map(s => s.displayNum)
+    );
+    const maxDisplay = DISPLAY_START + 100; // 99〜198
+    const totalDisplays = maxDisplay - DISPLAY_START + 1;
+    for (let i = 0; i < totalDisplays; i++) {
+      const display =
+        DISPLAY_START +
+        ((this.nextDisplay - DISPLAY_START + i) % totalDisplays);
+      if (usedDisplays.has(display)) continue;
+      this.nextDisplay = display + 1;
+      if (this.nextDisplay > maxDisplay) {
+        this.nextDisplay = DISPLAY_START;
+      }
+      return display;
+    }
+    throw new Error("利用可能なディスプレイ番号がありません");
+  }
+
+  /**
+   * URLのSSRF検証
+   * localhost/127.0.0.1 かつ http/https のみ許可
+   */
+  private validateUrl(url: string): void {
+    const parsed = new URL(url);
+    if (!ALLOWED_PROTOCOLS.includes(parsed.protocol)) {
+      throw new Error(
+        `許可されていないプロトコルです: ${parsed.protocol} (http/httpsのみ許可)`
+      );
+    }
+    if (!ALLOWED_HOSTNAMES.includes(parsed.hostname)) {
+      throw new Error(
+        `許可されていないホスト名です: ${parsed.hostname} (localhost/127.0.0.1のみ許可)`
+      );
+    }
+  }
+
+  /**
+   * ブラウザセッションを開始
+   * 重複起動ガード付き: 同じポートに対する並行起動を防ぐ
+   */
+  async start(
+    port: number,
+    url?: string,
+    devtools?: boolean
+  ): Promise<BrowserSession> {
+    if (!this.available) {
+      throw new Error(
+        "リモートブラウザ機能の依存が不足しています。サーバーログを確認してください。"
+      );
+    }
+
+    // セッション上限チェック
+    if (this.sessions.size >= MAX_SESSIONS) {
+      throw new Error(
+        `ブラウザセッションの上限（${MAX_SESSIONS}）に達しています`
+      );
+    }
+
+    // URL検証（SSRF対策）
+    const targetUrl = url || `http://localhost:${port}`;
+    this.validateUrl(targetUrl);
+
+    // 同じポートへの重複起動防止
+    const pending = this.pendingStarts.get(port);
+    if (pending) {
+      return pending;
+    }
+
+    const promise = this._startInternal(port, targetUrl, devtools ?? false);
+    this.pendingStarts.set(port, promise);
+
+    try {
+      return await promise;
+    } finally {
+      this.pendingStarts.delete(port);
+    }
+  }
+
+  /**
+   * ブラウザセッションの実際の起動処理（内部用）
+   * 起動順: Xvfb → Chromium → x11vnc → websockify
+   */
+  private async _startInternal(
+    targetPort: number,
+    targetUrl: string,
+    devtools: boolean
+  ): Promise<BrowserSession> {
+    const id = randomUUID();
+    const displayNum = this.findAvailableDisplay();
+    const vncPort = await this.findAvailableVncPort();
+    const wsPort = await this.findAvailableWsPort();
+
+    const startedProcesses: ChildProcess[] = [];
+
+    try {
+      // 1. Xvfb起動
+      const xvfb = spawn(
+        "Xvfb",
+        [`:${displayNum}`, "-screen", "0", DISPLAY_RESOLUTION],
+        { stdio: ["ignore", "pipe", "pipe"], detached: false }
+      );
+      startedProcesses.push(xvfb);
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("Xvfb起動タイムアウト"));
+        }, XVFB_TIMEOUT);
+
+        const socketPath = `/tmp/.X11-unix/X${displayNum}`;
+        const checkInterval = setInterval(() => {
+          if (fs.existsSync(socketPath)) {
+            clearTimeout(timeout);
+            clearInterval(checkInterval);
+            resolve();
+          }
+        }, 100);
+
+        xvfb.on("error", error => {
+          clearTimeout(timeout);
+          clearInterval(checkInterval);
+          reject(error);
+        });
+
+        xvfb.on("exit", code => {
+          if (code !== 0 && code !== null) {
+            clearTimeout(timeout);
+            clearInterval(checkInterval);
+            reject(new Error(`Xvfbが終了しました (code: ${code})`));
+          }
+        });
+      });
+
+      console.log(`[BrowserManager] Xvfb起動完了: ディスプレイ :${displayNum}`);
+
+      // 2. Chromium起動
+      const chromiumFlags = [...CHROMIUM_FLAGS];
+      if (devtools) {
+        chromiumFlags.push("--auto-open-devtools-for-tabs");
+      }
+      chromiumFlags.push(targetUrl);
+
+      const chromium = spawn(this.chromiumCmd, chromiumFlags, {
+        stdio: ["ignore", "pipe", "pipe"],
+        detached: false,
+        env: {
+          ...process.env,
+          DISPLAY: `:${displayNum}`,
+        },
+      });
+      startedProcesses.push(chromium);
+
+      // Chromiumはreadiness出力がないため固定ディレイで待機
+      await new Promise<void>(resolve => setTimeout(resolve, CHROMIUM_DELAY));
+
+      console.log(
+        `[BrowserManager] Chromium起動完了: ${targetUrl} (DISPLAY=:${displayNum})`
+      );
+
+      // 3. x11vnc起動
+      const x11vnc = spawn(
+        "x11vnc",
+        [
+          "-display",
+          `:${displayNum}`,
+          "-rfbport",
+          vncPort.toString(),
+          "-listen",
+          "127.0.0.1",
+          "-shared",
+          "-forever",
+          "-nopw",
+          "-noxdamage",
+        ],
+        { stdio: ["ignore", "pipe", "pipe"], detached: false }
+      );
+      startedProcesses.push(x11vnc);
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("x11vnc起動タイムアウト"));
+        }, X11VNC_TIMEOUT);
+
+        let stderrData = "";
+
+        x11vnc.stderr?.on("data", (data: Buffer) => {
+          stderrData += data.toString();
+          // x11vncは起動時に "PORT=XXXX" を stderr に出力する
+          if (stderrData.includes("PORT=")) {
+            clearTimeout(timeout);
+            resolve();
+          }
+        });
+
+        x11vnc.on("error", error => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+
+        x11vnc.on("exit", code => {
+          if (code !== 0 && code !== null) {
+            clearTimeout(timeout);
+            reject(
+              new Error(`x11vncが終了しました (code: ${code}): ${stderrData}`)
+            );
+          }
+        });
+      });
+
+      console.log(`[BrowserManager] x11vnc起動完了: ポート ${vncPort}`);
+
+      // 4. websockify起動
+      const websockify = spawn(
+        "websockify",
+        [
+          "--web",
+          this.novncPath,
+          `127.0.0.1:${wsPort}`,
+          `127.0.0.1:${vncPort}`,
+        ],
+        { stdio: ["ignore", "pipe", "pipe"], detached: false }
+      );
+      startedProcesses.push(websockify);
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("websockify起動タイムアウト"));
+        }, WEBSOCKIFY_TIMEOUT);
+
+        let outputData = "";
+
+        const onData = (data: Buffer) => {
+          outputData += data.toString();
+          if (
+            outputData.includes("WebSocket") ||
+            outputData.includes("listening")
+          ) {
+            clearTimeout(timeout);
+            resolve();
+          }
+        };
+
+        websockify.stdout?.on("data", onData);
+        websockify.stderr?.on("data", onData);
+
+        websockify.on("error", error => {
+          clearTimeout(timeout);
+          reject(error);
+        });
+
+        websockify.on("exit", code => {
+          if (code !== 0 && code !== null) {
+            clearTimeout(timeout);
+            reject(
+              new Error(
+                `websockifyが終了しました (code: ${code}): ${outputData}`
+              )
+            );
+          }
+        });
+      });
+
+      console.log(
+        `[BrowserManager] websockify起動完了: WSポート ${wsPort} → VNCポート ${vncPort}`
+      );
+
+      // セッション情報を保存
+      const processSet: BrowserProcessSet = {
+        id,
+        targetPort,
+        targetUrl,
+        wsPort,
+        vncPort,
+        displayNum,
+        devtools,
+        xvfb,
+        chromium,
+        x11vnc,
+        websockify,
+        createdAt: new Date(),
+      };
+      this.sessions.set(id, processSet);
+
+      // プロセスの異常終了監視: いずれかが終了したらセッション全体をstop
+      const processNames = [
+        "xvfb",
+        "chromium",
+        "x11vnc",
+        "websockify",
+      ] as const;
+      const processes = [xvfb, chromium, x11vnc, websockify];
+
+      for (let i = 0; i < processes.length; i++) {
+        const proc = processes[i];
+        const name = processNames[i];
+        proc.on("exit", code => {
+          // セッションがまだ存在する場合のみ（明示的なstopではない場合）
+          if (this.sessions.has(id)) {
+            console.warn(
+              `[BrowserManager] ${name}が予期せず終了しました (code: ${code})。セッション ${id} を停止します。`
+            );
+            this.stop(id).catch(err => {
+              console.error(
+                `[BrowserManager] セッション ${id} の停止に失敗:`,
+                err
+              );
+            });
+          }
+        });
+      }
+
+      const session: BrowserSession = {
+        id,
+        targetPort,
+        targetUrl,
+        wsPort,
+        vncPort,
+        displayNum,
+        devtools,
+        createdAt: processSet.createdAt,
+      };
+
+      this.emit("session:started", session);
+      console.log(
+        `[BrowserManager] ブラウザセッション開始: ${id} (ポート ${targetPort} → noVNC ws://${wsPort})`
+      );
+
+      return session;
+    } catch (error) {
+      // 起動失敗時: 既に起動したプロセスをクリーンアップ
+      console.error(
+        `[BrowserManager] ブラウザセッション起動失敗。プロセスをクリーンアップします。`
+      );
+      for (const proc of startedProcesses) {
+        try {
+          proc.kill("SIGTERM");
+        } catch {
+          // killに失敗しても無視
+        }
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * プロセスを安全に停止（SIGTERM→待機→SIGKILL）
+   */
+  private async killProcess(proc: ChildProcess, name: string): Promise<void> {
+    if (proc.exitCode !== null) {
+      // 既に終了している
+      return;
+    }
+
+    proc.kill("SIGTERM");
+
+    // SIGTERM後の猶予時間を待つ
+    const exited = await new Promise<boolean>(resolve => {
+      const timeout = setTimeout(() => resolve(false), KILL_GRACE_PERIOD);
+      proc.on("exit", () => {
+        clearTimeout(timeout);
+        resolve(true);
+      });
+    });
+
+    if (!exited) {
+      console.warn(
+        `[BrowserManager] ${name}がSIGTERMで停止しなかったためSIGKILLを送信`
+      );
+      proc.kill("SIGKILL");
+    }
+  }
+
+  /**
+   * ブラウザセッションを停止
+   * 逆順停止: websockify → x11vnc → chromium → xvfb
+   */
+  async stop(browserId: string): Promise<void> {
+    const processSet = this.sessions.get(browserId);
+    if (!processSet) return;
+
+    // 先にMapから削除して、異常終了監視のハンドラが再度stopを呼ばないようにする
+    this.sessions.delete(browserId);
+
+    console.log(`[BrowserManager] ブラウザセッション停止中: ${browserId}`);
+
+    // 逆順でプロセスを停止
+    await this.killProcess(processSet.websockify, "websockify");
+    await this.killProcess(processSet.x11vnc, "x11vnc");
+    await this.killProcess(processSet.chromium, "chromium");
+    await this.killProcess(processSet.xvfb, "xvfb");
+
+    this.emit("session:stopped", browserId);
+    console.log(`[BrowserManager] ブラウザセッション停止完了: ${browserId}`);
+  }
+
+  /**
+   * 全セッションを停止
+   */
+  async cleanup(): Promise<void> {
+    const ids = Array.from(this.sessions.keys());
+    await Promise.all(ids.map(id => this.stop(id)));
+    console.log(
+      "[BrowserManager] 全ブラウザセッションをクリーンアップしました"
+    );
+  }
+
+  /**
+   * セッションIDでブラウザセッション情報を取得
+   */
+  getSession(browserId: string): BrowserSession | undefined {
+    const processSet = this.sessions.get(browserId);
+    if (!processSet) return undefined;
+    return {
+      id: processSet.id,
+      targetPort: processSet.targetPort,
+      targetUrl: processSet.targetUrl,
+      wsPort: processSet.wsPort,
+      vncPort: processSet.vncPort,
+      displayNum: processSet.displayNum,
+      devtools: processSet.devtools,
+      createdAt: processSet.createdAt,
+    };
+  }
+
+  /**
+   * 全セッション情報を取得
+   */
+  getAllSessions(): BrowserSession[] {
+    return Array.from(this.sessions.values()).map(s => ({
+      id: s.id,
+      targetPort: s.targetPort,
+      targetUrl: s.targetUrl,
+      wsPort: s.wsPort,
+      vncPort: s.vncPort,
+      displayNum: s.displayNum,
+      devtools: s.devtools,
+      createdAt: s.createdAt,
+    }));
+  }
+}
+
+export const browserManager = new BrowserManager();

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -444,16 +444,19 @@ export class BrowserManager extends EventEmitter {
           reject(new Error("x11vnc起動タイムアウト"));
         }, X11VNC_TIMEOUT);
 
-        let stderrData = "";
+        let outputData = "";
 
-        x11vnc.stderr?.on("data", (data: Buffer) => {
-          stderrData += data.toString();
-          // x11vncは起動時に "PORT=XXXX" を stderr に出力する
-          if (stderrData.includes("PORT=")) {
+        const onData = (data: Buffer) => {
+          outputData += data.toString();
+          // x11vncは起動時に "PORT=XXXX" を stdout に出力する
+          if (outputData.includes("PORT=")) {
             clearTimeout(timeout);
             resolve();
           }
-        });
+        };
+
+        x11vnc.stdout?.on("data", onData);
+        x11vnc.stderr?.on("data", onData);
 
         x11vnc.on("error", error => {
           clearTimeout(timeout);
@@ -464,7 +467,7 @@ export class BrowserManager extends EventEmitter {
           if (code !== 0 && code !== null) {
             clearTimeout(timeout);
             reject(
-              new Error(`x11vncが終了しました (code: ${code}): ${stderrData}`)
+              new Error(`x11vncが終了しました (code: ${code}): ${outputData}`)
             );
           }
         });

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -25,3 +25,12 @@ export const WS_PORT_END = 6179;
  * （上記VNC_PORT_STARTのコメント参照）。
  */
 export const DISPLAY_START = 99;
+
+/**
+ * CDP（Chrome DevTools Protocol）リモートデバッグポート
+ *
+ * browser-manager.tsが起動するChromiumの `--remote-debugging-port` として使用する。
+ * このポートはローカル127.0.0.1のみでリッスンされるが、`/proxy/:port/*` や
+ * ポートスキャンから露出しないようブロックリストに含める必要がある。
+ */
+export const CDP_PORT = 9222;

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -3,3 +3,14 @@ export const TTYD_PORT_START = 7680;
 
 /** ttydポート範囲の終了ポート */
 export const TTYD_PORT_END = 7780;
+
+/** VNCポート範囲の開始ポート（x11vnc用） */
+export const VNC_PORT_START = 5900;
+/** VNCポート範囲の終了ポート */
+export const VNC_PORT_END = 5999;
+/** WebSocketポート範囲の開始ポート（websockify用） */
+export const WS_PORT_START = 6080;
+/** WebSocketポート範囲の終了ポート */
+export const WS_PORT_END = 6179;
+/** Xvfb仮想ディスプレイ番号の開始値 */
+export const DISPLAY_START = 99;

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -4,7 +4,13 @@ export const TTYD_PORT_START = 7680;
 /** ttydポート範囲の終了ポート */
 export const TTYD_PORT_END = 7780;
 
-/** VNCポート範囲の開始ポート（x11vnc用） */
+/**
+ * VNCポート範囲の開始ポート（x11vnc用）
+ *
+ * 注: x11vncには `-rfbport <port>` で明示的にポートを指定して起動しているため、
+ * 標準のVNC `port = 5900 + display` マッピングには依存しない。
+ * VNCポートとディスプレイ番号は独立して動的に割り当てられる。
+ */
 export const VNC_PORT_START = 5900;
 /** VNCポート範囲の終了ポート */
 export const VNC_PORT_END = 5999;
@@ -12,5 +18,10 @@ export const VNC_PORT_END = 5999;
 export const WS_PORT_START = 6080;
 /** WebSocketポート範囲の終了ポート */
 export const WS_PORT_END = 6179;
-/** Xvfb仮想ディスプレイ番号の開始値 */
+/**
+ * Xvfb仮想ディスプレイ番号の開始値
+ *
+ * 注: 標準VNCの `port = 5900 + display` マッピングには依存しない
+ * （上記VNC_PORT_STARTのコメント参照）。
+ */
 export const DISPLAY_START = 99;

--- a/server/lib/port-scanner.ts
+++ b/server/lib/port-scanner.ts
@@ -1,13 +1,6 @@
 import { execSync } from "node:child_process";
-import {
-  CDP_PORT,
-  TTYD_PORT_END,
-  TTYD_PORT_START,
-  VNC_PORT_END,
-  VNC_PORT_START,
-  WS_PORT_END,
-  WS_PORT_START,
-} from "./constants.js";
+import { browserManager } from "./browser-manager.js";
+import { TTYD_PORT_END, TTYD_PORT_START } from "./constants.js";
 
 export interface ListeningPort {
   port: number;
@@ -50,17 +43,20 @@ function collectPorts(
     const ports: ListeningPort[] = [];
     const seen = new Set<number>();
 
+    // 実際にBrowserManagerが使用中のポート（VNC/WS/CDP）のみ除外。
+    // VNC/WS範囲を一括除外するとユーザーアプリのポートも隠れてしまうため、
+    // 動的に使用中のポートだけをフィルタリングする。
+    const browserUsedPorts = new Set(browserManager.getUsedPorts());
+
     for (const line of output.trim().split("\n")) {
       const parsed = parseLine(line);
       if (!parsed) continue;
 
       const { port, processName, pid } = parsed;
 
-      // ttyd/VNC/WebSocket/CDPポートを除外（内部用ポートのため表示しない）
-      if (port === CDP_PORT) continue;
+      // ttydポート範囲（固定）とBrowserManager使用中ポート（動的）を除外
       if (port >= TTYD_PORT_START && port <= TTYD_PORT_END) continue;
-      if (port >= VNC_PORT_START && port <= VNC_PORT_END) continue;
-      if (port >= WS_PORT_START && port <= WS_PORT_END) continue;
+      if (browserUsedPorts.has(port)) continue;
 
       if (!seen.has(port)) {
         seen.add(port);

--- a/server/lib/port-scanner.ts
+++ b/server/lib/port-scanner.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import {
+  CDP_PORT,
   TTYD_PORT_END,
   TTYD_PORT_START,
   VNC_PORT_END,
@@ -55,7 +56,8 @@ function collectPorts(
 
       const { port, processName, pid } = parsed;
 
-      // ttyd/VNC/WebSocketポートを除外（内部用ポートのため表示しない）
+      // ttyd/VNC/WebSocket/CDPポートを除外（内部用ポートのため表示しない）
+      if (port === CDP_PORT) continue;
       if (port >= TTYD_PORT_START && port <= TTYD_PORT_END) continue;
       if (port >= VNC_PORT_START && port <= VNC_PORT_END) continue;
       if (port >= WS_PORT_START && port <= WS_PORT_END) continue;

--- a/server/lib/port-scanner.ts
+++ b/server/lib/port-scanner.ts
@@ -55,8 +55,10 @@ function collectPorts(
 
       const { port, processName, pid } = parsed;
 
-      // ttydポートを除外
+      // ttyd/VNC/WebSocketポートを除外（内部用ポートのため表示しない）
       if (port >= TTYD_PORT_START && port <= TTYD_PORT_END) continue;
+      if (port >= VNC_PORT_START && port <= VNC_PORT_END) continue;
+      if (port >= WS_PORT_START && port <= WS_PORT_END) continue;
 
       if (!seen.has(port)) {
         seen.add(port);

--- a/server/lib/port-scanner.ts
+++ b/server/lib/port-scanner.ts
@@ -1,5 +1,12 @@
 import { execSync } from "node:child_process";
-import { TTYD_PORT_END, TTYD_PORT_START } from "./constants.js";
+import {
+  TTYD_PORT_END,
+  TTYD_PORT_START,
+  VNC_PORT_END,
+  VNC_PORT_START,
+  WS_PORT_END,
+  WS_PORT_START,
+} from "./constants.js";
 
 export interface ListeningPort {
   port: number;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -246,11 +246,7 @@ export interface ClientToServerEvents {
   "file:read": (data: { sessionId: string; filePath: string }) => void;
 
   // ブラウザセッション（noVNC）
-  "browser:start": (data: {
-    port: number;
-    url?: string;
-    devtools?: boolean;
-  }) => void;
+  "browser:start": () => void;
   "browser:stop": (data: { browserId: string }) => void;
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -248,6 +248,7 @@ export interface ClientToServerEvents {
   // ブラウザセッション（noVNC）
   "browser:start": () => void;
   "browser:stop": (data: { browserId: string }) => void;
+  "browser:navigate": (data: { url: string }) => void;
 }
 
 /** Beaconチャットのメッセージ */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -49,6 +49,17 @@ export interface ManagedSession extends Session {
 
 export type SessionStatus = "active" | "idle" | "error" | "stopped";
 
+export interface BrowserSession {
+  id: string;
+  targetPort: number;
+  targetUrl: string;
+  wsPort: number;
+  vncPort: number;
+  displayNum: number;
+  devtools: boolean;
+  createdAt: Date;
+}
+
 export interface Message {
   id: string;
   sessionId: string;
@@ -174,6 +185,11 @@ export interface ServerToClientEvents {
     size: number;
     error?: string;
   }) => void;
+
+  // ブラウザセッション（noVNC）
+  "browser:started": (session: BrowserSession) => void;
+  "browser:stopped": (data: { browserId: string }) => void;
+  "browser:error": (data: { message: string }) => void;
 }
 
 export interface ClientToServerEvents {
@@ -228,6 +244,14 @@ export interface ClientToServerEvents {
 
   // ファイルビューワー
   "file:read": (data: { sessionId: string; filePath: string }) => void;
+
+  // ブラウザセッション（noVNC）
+  "browser:start": (data: {
+    port: number;
+    url?: string;
+    devtools?: boolean;
+  }) => void;
+  "browser:stop": (data: { browserId: string }) => void;
 }
 
 /** Beaconチャットのメッセージ */


### PR DESCRIPTION
## Summary

Issue ignission/claude-code-ark#60 のリモートアクセス時にブラウザタブで`http://localhost:PORT`を表示するとCSSが効かない問題を、noVNC方式（Xvfb + Chromium + x11vnc + websockify）で根本解決します。

## アーキテクチャ

```
[リモートブラウザ] ←WSS→ [Cloudflare Tunnel] ←→ [Ark Server]
    ↕ /browser/:browserId/*
[websockify :6080+] ←VNC→ [x11vnc] ←X11→ [Xvfb :99+]
    └── Chromium → http://localhost:PORT（直接アクセス）
```

Chromiumがlocalhostに直接アクセスし、画面をVNC経由で転送することでパス書き換えの問題を完全に回避します。

## 主な機能

- **シングルトンブラウザ**: 1つのChromiumインスタンスをタブで使い回す
- **サイドバーにブラウザボタン**: Globeアイコンクリックでブラウザペイン表示（worktreeクリックと同じ挙動）
- **モバイル対応**: ボトムナビにブラウザタブ追加
- **localhostリンククリック**: ターミナル内のlocalhost URLクリックで自動的にブラウザ起動・ナビゲート（CDP経由）
- **VNC再接続防止**: display:hiddenパターンでBrowserPaneをアンマウントしない

## セキュリティ対策

- **URL検証**: `http:/https:` + `localhost/127.0.0.1` のみ許可
- **引数インジェクション対策**: Chromiumフラグに `--` 終端子を追加
- **CDP localhost binding**: `--remote-debugging-address=127.0.0.1`
- **CDPポート(9222)露出対策**: `/proxy/9222/` ブロック、port-scannerで除外
- **WebSocket認証**: Quick Tunnel時のWS upgradeでトークン検証
- **クリックジャッキング対策**: proxyResで`X-Frame-Options: SAMEORIGIN`強制
- **SSRFブロックリスト**: VNC/WSポート範囲を/proxyとport-scannerで除外
- **noopener**: window.open に noopener フラグ追加

## 実装詳細

新規ファイル:
- `server/lib/browser-manager.ts`: BrowserManager（Xvfb + Chromium + x11vnc + websockifyの統合管理）

変更ファイル:
- `server/index.ts`: noVNCプロキシルート、Socket.IOハンドラー、WS認証
- `server/lib/constants.ts`: VNC/WS/CDPポート定数
- `server/lib/port-scanner.ts`: 内部ポート除外
- `shared/types.ts`: BrowserSession型、Socket.IOイベント
- `client/src/components/BrowserPane.tsx`: noVNC iframe表示
- `client/src/components/SessionSidebar.tsx`: Globeボタン追加
- `client/src/components/MobileLayout.tsx`: モバイルブラウザビュー
- `client/src/pages/Dashboard.tsx`: ブラウザペイン統合
- `client/src/hooks/useSocket.ts`: ブラウザイベント

設計・計画ドキュメント: ignission/claude-code-ark#62

## Test plan

- [ ] ローカルアクセス時: 既存のブラウザタブ動作が変わらないこと
- [ ] リモートアクセス時: サイドバーのGlobeアイコンクリックでnoVNCブラウザ起動
- [ ] リモートアクセス時: ターミナル内のlocalhostリンククリックでブラウザに自動遷移
- [ ] モバイル: ボトムナビのブラウザボタンで遷移
- [ ] ブラウザビュー切り替え時にVNCが再接続されないこと（display:hidden）
- [ ] 引数インジェクション拒否: `browser:navigate` に `--user-data-dir=/tmp` 等を送信して拒否されること
- [ ] URLスキーマ検証: `file://`, `chrome://`, `javascript:` 等が拒否されること

Closes ignission/claude-code-ark#60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote browser sessions with start/stop/navigate controls and integrated noVNC viewer
  * Mobile layout and sidebar now include a dedicated browser view and selection toggle
  * Links can open in the remote browser when available

* **Improvements**
  * More accurate terminal URL detection
  * WebSocket authorization and anti-clickjacking headers for safer remote access
  * Improved port management and automatic browser startup/restore on reload
<!-- end of auto-generated comment: release notes by coderabbit.ai -->