### PR TITLE
fix: ターミナル内URLクリックで2タブ開くバグを修正

### DIFF
--- a/.claude/skills/merge-and-cleanup/SKILL.md
+++ b/.claude/skills/merge-and-cleanup/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: merge-and-cleanup
-description: PRマージ→main最新化→Jiraチケット完了を一括実行
+description: PRマージ→main最新化→ブランチ削除を一括実行
 allowed-tools: Bash, Read, Agent
-argument-hint: [PR番号] [Jiraチケット番号]
+argument-hint: [PR番号]
 ---
 
 ## PRマージ後のクリーンアップ
 
-PR $0 をマージし、Jiraチケット $1 を完了にする。
+PR $0 をマージし、ローカルブランチを最新化する。
 
 ## 手順
 
@@ -31,20 +31,9 @@ git checkout main && git pull
 git branch -vv | grep '\[origin/.*: gone\]' | awk '{print $$1}' | xargs -r git branch -d
 ```
 
-### 3. Jiraチケット完了
-
-チケット $1 のステータスを「完了」に遷移する。
-
-1. `getTransitionsForJiraIssue` で利用可能な遷移を取得
-2. 「完了」遷移のIDを特定
-3. `transitionJiraIssue` で遷移を実行
-
-cloudIdは `ignission.atlassian.net` を使用する。
-
 ## 完了報告
 
 全ステップ完了後、以下を報告:
 
 - PR #$0 マージ完了
-- $1 → 完了
 - ブランチ: main (最新)

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/client/src/components/ui/chart.tsx
+++ b/client/src/components/ui/chart.tsx
@@ -10,9 +10,14 @@ import { cn } from "@/lib/utils";
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
 
+// recharts v3でValueType/NameTypeはトップレベルからエクスポートされていないため、
+// 型定義と一致するローカル型エイリアスを定義
+type ValueType = number | string | Array<number | string>;
+type NameType = number | string;
+
 // recharts v3の内部型をpublicな型から抽出
 type TooltipPayloadEntry = NonNullable<
-  DefaultTooltipContentProps["payload"]
+  DefaultTooltipContentProps<ValueType, NameType>["payload"]
 >[number];
 type LegendPayloadEntry = NonNullable<
   DefaultLegendContentProps["payload"]
@@ -128,10 +133,10 @@ function ChartTooltipContent({
   color,
   nameKey,
   labelKey,
-}: Partial<DefaultTooltipContentProps> & {
+}: Partial<DefaultTooltipContentProps<ValueType, NameType>> & {
   active?: boolean;
-  payload?: DefaultTooltipContentProps["payload"];
-  label?: DefaultTooltipContentProps["label"];
+  payload?: DefaultTooltipContentProps<ValueType, NameType>["payload"];
+  label?: DefaultTooltipContentProps<ValueType, NameType>["label"];
 } & React.ComponentProps<"div"> & {
     hideLabel?: boolean;
     hideIndicator?: boolean;

--- a/client/src/hooks/useTerminalLinkInjection.ts
+++ b/client/src/hooks/useTerminalLinkInjection.ts
@@ -67,6 +67,12 @@ export function useTerminalLinkInjection(
           // WebLinksAddonが優先的にactivateされても、ここで完全URLに復元できる。
           const urlExtensionMap = new Map<string, string>();
 
+          // registerLinkProviderのactivateで処理済みのURLを記録するSet。
+          // window.openオーバーライド側でこのSetに含まれるURLをスキップすることで、
+          // WebLinksAddonとregisterLinkProviderの二重発火を防止する。
+          // setTimeout(, 0)でマイクロタスク後にクリアするため、同一クリックイベント内でのみ有効。
+          const handledUrls = new Set<string>();
+
           // xterm.js WebLinksAddonのURLを横取りする。
           // WebLinksAddonは window.open() を引数なしで呼び、返されたウィンドウの
           // location.href にURLを設定するパターン:
@@ -83,9 +89,10 @@ export function useTerminalLinkInjection(
             features?: string
           ): Window | null => {
             // 引数ありの呼び出し（URL直接指定）
-            // 全URLをpostMessage経由で親ウィンドウに委譲（二重タブ防止）
+            // registerLinkProviderで処理済みのURLはスキップ（二重タブ防止）
             if (url) {
               const urlStr = urlExtensionMap.get(String(url)) || String(url);
+              if (handledUrls.has(urlStr)) return null;
               arkWindow.postMessage(
                 { type: "ark:open-url", url: urlStr },
                 arkWindow.location.origin
@@ -100,8 +107,9 @@ export function useTerminalLinkInjection(
               location: {
                 _href: "",
                 set href(u: string) {
-                  // 全URLをpostMessage経由で親ウィンドウに委譲（二重タブ防止）
+                  // registerLinkProviderで処理済みのURLはスキップ（二重タブ防止）
                   const resolved = urlExtensionMap.get(u) || u;
+                  if (handledUrls.has(resolved)) return;
                   arkWindow.postMessage(
                     { type: "ark:open-url", url: resolved },
                     arkWindow.location.origin
@@ -303,6 +311,9 @@ export function useTerminalLinkInjection(
                   },
                   text: finalUrl,
                   activate() {
+                    // 処理済みURLとして記録し、WebLinksAddonのwindow.open側をスキップさせる
+                    handledUrls.add(finalUrl);
+                    setTimeout(() => handledUrls.delete(finalUrl), 0);
                     arkWindow.postMessage(
                       { type: "ark:open-url", url: finalUrl },
                       arkWindow.location.origin

--- a/client/src/hooks/useTerminalLinkInjection.ts
+++ b/client/src/hooks/useTerminalLinkInjection.ts
@@ -76,7 +76,6 @@ export function useTerminalLinkInjection(
           // そのため、フェイクWindowオブジェクトを返してlocation.hrefのセッターで
           // URLを検出し、postMessageに変換する。
           const arkWindow = window;
-          const origOpen = iframeWindow.open.bind(iframeWindow);
           // biome-ignore lint/suspicious/noExplicitAny: ttyd iframe内のwindow.openをオーバーライドするため型を緩める
           (iframeWindow as any).open = (
             url?: string | URL,
@@ -84,18 +83,14 @@ export function useTerminalLinkInjection(
             features?: string
           ): Window | null => {
             // 引数ありの呼び出し（URL直接指定）
+            // 全URLをpostMessage経由で親ウィンドウに委譲（二重タブ防止）
             if (url) {
               const urlStr = urlExtensionMap.get(String(url)) || String(url);
-              if (
-                /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/.test(urlStr)
-              ) {
-                arkWindow.postMessage(
-                  { type: "ark:open-url", url: urlStr },
-                  arkWindow.location.origin
-                );
-                return null;
-              }
-              return origOpen(urlStr, target, features);
+              arkWindow.postMessage(
+                { type: "ark:open-url", url: urlStr },
+                arkWindow.location.origin
+              );
+              return null;
             }
 
             // 引数なしの呼び出し（WebLinksAddonパターン）
@@ -105,27 +100,12 @@ export function useTerminalLinkInjection(
               location: {
                 _href: "",
                 set href(u: string) {
-                  // URL拡張マップで折り返しURLを完全URLに復元
+                  // 全URLをpostMessage経由で親ウィンドウに委譲（二重タブ防止）
                   const resolved = urlExtensionMap.get(u) || u;
-                  if (
-                    /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/.test(
-                      resolved
-                    )
-                  ) {
-                    arkWindow.postMessage(
-                      { type: "ark:open-url", url: resolved },
-                      arkWindow.location.origin
-                    );
-                  } else {
-                    // localhost以外は実際に新しいウィンドウで開く
-                    const real = origOpen();
-                    if (real) {
-                      try {
-                        real.opener = null;
-                      } catch {}
-                      real.location.href = resolved;
-                    }
-                  }
+                  arkWindow.postMessage(
+                    { type: "ark:open-url", url: resolved },
+                    arkWindow.location.origin
+                  );
                 },
                 get href() {
                   return this._href;

--- a/client/src/hooks/useViewerTabs.ts
+++ b/client/src/hooks/useViewerTabs.ts
@@ -102,10 +102,6 @@ export function useViewerTabs(
 
   // postMessageリスナー（ttyd iframe内のリンククリックを受信）
   useEffect(() => {
-    // 同一URLの重複オープン防止（WebLinksAddonとregisterLinkProviderの両方が発火した場合）
-    let lastOpenedUrl = "";
-    let lastOpenedTime = 0;
-
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
       const { type } = event.data ?? {};
@@ -113,12 +109,6 @@ export function useViewerTabs(
       if (type === "ark:open-url") {
         const { url } = event.data;
         if (typeof url !== "string" || !url) return;
-
-        // 同一URL/500ms以内の重複を無視
-        const now = Date.now();
-        if (url === lastOpenedUrl && now - lastOpenedTime < 500) return;
-        lastOpenedUrl = url;
-        lastOpenedTime = now;
 
         try {
           const parsed = new URL(url);

--- a/client/src/hooks/useViewerTabs.ts
+++ b/client/src/hooks/useViewerTabs.ts
@@ -102,6 +102,10 @@ export function useViewerTabs(
 
   // postMessageリスナー（ttyd iframe内のリンククリックを受信）
   useEffect(() => {
+    // 同一URLの重複オープン防止（WebLinksAddonとregisterLinkProviderの両方が発火した場合）
+    let lastOpenedUrl = "";
+    let lastOpenedTime = 0;
+
     const handleMessage = (event: MessageEvent) => {
       if (event.origin !== window.location.origin) return;
       const { type } = event.data ?? {};
@@ -109,6 +113,13 @@ export function useViewerTabs(
       if (type === "ark:open-url") {
         const { url } = event.data;
         if (typeof url !== "string" || !url) return;
+
+        // 同一URL/500ms以内の重複を無視
+        const now = Date.now();
+        if (url === lastOpenedUrl && now - lastOpenedTime < 500) return;
+        lastOpenedUrl = url;
+        lastOpenedTime = now;
+
         try {
           const parsed = new URL(url);
           if (parsed.protocol !== "http:" && parsed.protocol !== "https:")


### PR DESCRIPTION
## 概要

ターミナル内のURLクリック時にタブが2つ開くバグを修正。

- WebLinksAddonとregisterLinkProviderが同じクリックで両方発火し、それぞれ独立にタブを開いていた
- `window.open` overrideからorigOpen()を削除し、全URLをpostMessage経由に統一
- useViewerTabsに同一URL/500ms以内の重複`ark:open-url`メッセージのdedup追加

## その他の変更

- recharts v3の`DefaultTooltipContentProps`ジェネリック型引数を追加（型エラー修正）
- merge-and-cleanupスキルからJira関連を削除

## 変更ファイル

- `client/src/hooks/useTerminalLinkInjection.ts` — URL処理をpostMessage一本化
- `client/src/hooks/useViewerTabs.ts` — 500ms dedup追加
- `client/src/components/ui/chart.tsx` — recharts v3型修正
- `.claude/skills/merge-and-cleanup/SKILL.md` — Jira関連削除

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ターミナル内URLの二重処理を防止するため処理済URLを記録し、同一URLの重複開放を抑制

* **Refactor**
  * 親ウィンドウへのURL委譲を常にpostMessageで行うよう簡潔化
  * チャートのツールチップ型定義を明確化
  * リサイズ用コンポーネントのインポート/使用を名寄せに変更

* **Chores**
  * マージ・クリーンアップ機能からJira処理を削除しPRマージ／ブランチ削除に特化
  * 設定スキーマ参照バージョンを更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->