### PR TITLE
fix: Express 5のpath-to-regexp v8で無名ワイルドカード廃止に対応

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -510,7 +510,7 @@ async function startServer() {
 
   // ===== ローカルポートプロキシ（リモートアクセス時にlocalhost URLを表示するため） =====
 
-  app.all("/proxy/:port/*", (req, res) => {
+  app.all("/proxy/:port/*path", (req, res) => {
     const rawPort = req.params.port;
     if (!/^\d+$/.test(rawPort)) {
       res.status(400).json({ error: "Invalid port" });


### PR DESCRIPTION
## Summary
- Express 4→5アップグレードで`path-to-regexp` v8が無名ワイルドカード`*`を廃止
- `/proxy/:port/*` → `/proxy/:port/*path` に変更してサーバー起動時クラッシュを修正

## 原因
`pnpm install`によりExpressが4→5にメジャーアップデートされ、内部の`path-to-regexp`がv8に更新。v8では`*`にパラメータ名が必須になり、ルート登録時に`PathError: Missing parameter name`が発生してサーバーが起動不能になった。

## Test plan
- [x] VM内でビルド&起動確認済み（pm2 restart後、エラーログなし）
- [x] https://ccm.ignission.tech 経由でアクセス可能を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * プロキシルーティング機構を最適化しました。

---

**注：** このリリースには、ユーザーに直接影響する変更は含まれていません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->