### PR TITLE
revert: ターミナル内URLクリック修正をrevert

### DIFF
--- a/.claude/skills/merge-and-cleanup/SKILL.md
+++ b/.claude/skills/merge-and-cleanup/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: merge-and-cleanup
-description: PRマージ→main最新化→ブランチ削除を一括実行
+description: PRマージ→main最新化→Jiraチケット完了を一括実行
 allowed-tools: Bash, Read, Agent
-argument-hint: [PR番号]
+argument-hint: [PR番号] [Jiraチケット番号]
 ---
 
 ## PRマージ後のクリーンアップ
 
-PR $0 をマージし、ローカルブランチを最新化する。
+PR $0 をマージし、Jiraチケット $1 を完了にする。
 
 ## 手順
 
@@ -31,9 +31,20 @@ git checkout main && git pull
 git branch -vv | grep '\[origin/.*: gone\]' | awk '{print $$1}' | xargs -r git branch -d
 ```
 
+### 3. Jiraチケット完了
+
+チケット $1 のステータスを「完了」に遷移する。
+
+1. `getTransitionsForJiraIssue` で利用可能な遷移を取得
+2. 「完了」遷移のIDを特定
+3. `transitionJiraIssue` で遷移を実行
+
+cloudIdは `ignission.atlassian.net` を使用する。
+
 ## 完了報告
 
 全ステップ完了後、以下を報告:
 
 - PR #$0 マージ完了
+- $1 → 完了
 - ブランチ: main (最新)

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/client/src/components/ui/chart.tsx
+++ b/client/src/components/ui/chart.tsx
@@ -10,14 +10,9 @@ import { cn } from "@/lib/utils";
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const;
 
-// recharts v3でValueType/NameTypeはトップレベルからエクスポートされていないため、
-// 型定義と一致するローカル型エイリアスを定義
-type ValueType = number | string | Array<number | string>;
-type NameType = number | string;
-
 // recharts v3の内部型をpublicな型から抽出
 type TooltipPayloadEntry = NonNullable<
-  DefaultTooltipContentProps<ValueType, NameType>["payload"]
+  DefaultTooltipContentProps["payload"]
 >[number];
 type LegendPayloadEntry = NonNullable<
   DefaultLegendContentProps["payload"]
@@ -133,10 +128,10 @@ function ChartTooltipContent({
   color,
   nameKey,
   labelKey,
-}: Partial<DefaultTooltipContentProps<ValueType, NameType>> & {
+}: Partial<DefaultTooltipContentProps> & {
   active?: boolean;
-  payload?: DefaultTooltipContentProps<ValueType, NameType>["payload"];
-  label?: DefaultTooltipContentProps<ValueType, NameType>["label"];
+  payload?: DefaultTooltipContentProps["payload"];
+  label?: DefaultTooltipContentProps["label"];
 } & React.ComponentProps<"div"> & {
     hideLabel?: boolean;
     hideIndicator?: boolean;

--- a/client/src/hooks/useTerminalLinkInjection.ts
+++ b/client/src/hooks/useTerminalLinkInjection.ts
@@ -67,12 +67,6 @@ export function useTerminalLinkInjection(
           // WebLinksAddonが優先的にactivateされても、ここで完全URLに復元できる。
           const urlExtensionMap = new Map<string, string>();
 
-          // registerLinkProviderのactivateで処理済みのURLを記録するSet。
-          // window.openオーバーライド側でこのSetに含まれるURLをスキップすることで、
-          // WebLinksAddonとregisterLinkProviderの二重発火を防止する。
-          // setTimeout(, 0)でマイクロタスク後にクリアするため、同一クリックイベント内でのみ有効。
-          const handledUrls = new Set<string>();
-
           // xterm.js WebLinksAddonのURLを横取りする。
           // WebLinksAddonは window.open() を引数なしで呼び、返されたウィンドウの
           // location.href にURLを設定するパターン:
@@ -82,6 +76,7 @@ export function useTerminalLinkInjection(
           // そのため、フェイクWindowオブジェクトを返してlocation.hrefのセッターで
           // URLを検出し、postMessageに変換する。
           const arkWindow = window;
+          const origOpen = iframeWindow.open.bind(iframeWindow);
           // biome-ignore lint/suspicious/noExplicitAny: ttyd iframe内のwindow.openをオーバーライドするため型を緩める
           (iframeWindow as any).open = (
             url?: string | URL,
@@ -89,15 +84,18 @@ export function useTerminalLinkInjection(
             features?: string
           ): Window | null => {
             // 引数ありの呼び出し（URL直接指定）
-            // registerLinkProviderで処理済みのURLはスキップ（二重タブ防止）
             if (url) {
               const urlStr = urlExtensionMap.get(String(url)) || String(url);
-              if (handledUrls.has(urlStr)) return null;
-              arkWindow.postMessage(
-                { type: "ark:open-url", url: urlStr },
-                arkWindow.location.origin
-              );
-              return null;
+              if (
+                /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/.test(urlStr)
+              ) {
+                arkWindow.postMessage(
+                  { type: "ark:open-url", url: urlStr },
+                  arkWindow.location.origin
+                );
+                return null;
+              }
+              return origOpen(urlStr, target, features);
             }
 
             // 引数なしの呼び出し（WebLinksAddonパターン）
@@ -107,13 +105,27 @@ export function useTerminalLinkInjection(
               location: {
                 _href: "",
                 set href(u: string) {
-                  // registerLinkProviderで処理済みのURLはスキップ（二重タブ防止）
+                  // URL拡張マップで折り返しURLを完全URLに復元
                   const resolved = urlExtensionMap.get(u) || u;
-                  if (handledUrls.has(resolved)) return;
-                  arkWindow.postMessage(
-                    { type: "ark:open-url", url: resolved },
-                    arkWindow.location.origin
-                  );
+                  if (
+                    /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/.test(
+                      resolved
+                    )
+                  ) {
+                    arkWindow.postMessage(
+                      { type: "ark:open-url", url: resolved },
+                      arkWindow.location.origin
+                    );
+                  } else {
+                    // localhost以外は実際に新しいウィンドウで開く
+                    const real = origOpen();
+                    if (real) {
+                      try {
+                        real.opener = null;
+                      } catch {}
+                      real.location.href = resolved;
+                    }
+                  }
                 },
                 get href() {
                   return this._href;
@@ -311,9 +323,6 @@ export function useTerminalLinkInjection(
                   },
                   text: finalUrl,
                   activate() {
-                    // 処理済みURLとして記録し、WebLinksAddonのwindow.open側をスキップさせる
-                    handledUrls.add(finalUrl);
-                    setTimeout(() => handledUrls.delete(finalUrl), 0);
                     arkWindow.postMessage(
                       { type: "ark:open-url", url: finalUrl },
                       arkWindow.location.origin

--- a/client/src/hooks/useViewerTabs.ts
+++ b/client/src/hooks/useViewerTabs.ts
@@ -109,7 +109,6 @@ export function useViewerTabs(
       if (type === "ark:open-url") {
         const { url } = event.data;
         if (typeof url !== "string" || !url) return;
-
         try {
           const parsed = new URL(url);
           if (parsed.protocol !== "http:" && parsed.protocol !== "https:")


### PR DESCRIPTION
## Summary
- #110 の修正（d410eab）をrevertする
- 以下のリグレッションが確認されたため：
  1. 折り返しURLの復元が正しく動作しない
  2. localhost以外の外部URLがアプリ内ブラウザで開かれる（`origOpen()` 廃止の副作用）

## 背景
#110 では「URLクリックで2タブ開くバグ」を修正したが、`origOpen()` を廃止して全URLを `postMessage` 経由に統一したことで、外部URLの開き方が変わり、折り返しURL復元にも影響が出た。

2タブバグの根本原因（WebLinksAddonとregisterLinkProviderの二重発火）は別途対応する。

## Test plan
- [x] revert後にビルド・デプロイして動作確認済み
- [x] ターミナル内URLクリックで外部URLが正しくブラウザの新タブで開くことを確認
- [x] 折り返しURLの復元が正常に動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ワークフロー自動化にJiraチケット完了機能を追加

* **バグ修正**
  * ターミナルリンク処理におけるURLハンドリングを改善

* **Chores**
  * ツール設定を更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->