### PR TITLE
chore: デフォルトポートを3000系から4000系に変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ test-results/
 
 # Superpowers
 .superpowers/
+.gstack/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,7 +287,7 @@ claude-code-ark/
 | `--remote` / `-r`       | `ARK_PUBLIC_DOMAIN`     | Named Tunnel（固定URL + Cloudflare Access）を起動        |
 | `--skip-permissions`    | `SKIP_PERMISSIONS=true` | Claude CLIを `--dangerously-skip-permissions` 付きで起動 |
 | `--repos /path1,/path2` | -                       | 許可するリポジトリパスを制限                             |
-| -                       | `PORT`                  | サーバーポート（デフォルト: 3001）                       |
+| -                       | `PORT`                  | サーバーポート（デフォルト: 4001）                       |
 | -                       | `ARK_TUNNEL_NAME`       | Named Tunnel名（デフォルト: `claude-code-ark`）          |
 
 ---

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ pnpm build
 pnpm start
 ```
 
-ブラウザで http://localhost:3001 を開く。
+ブラウザで http://localhost:4001 を開く。
 
 ### 起動オプション
 
@@ -72,7 +72,7 @@ pnpm start
 
 | 環境変数            | 説明                                            |
 | ------------------- | ----------------------------------------------- |
-| `PORT`              | サーバーポート（デフォルト: 3001）              |
+| `PORT`              | サーバーポート（デフォルト: 4001）              |
 | `SKIP_PERMISSIONS`  | `true` で権限確認スキップ                       |
 | `ARK_PUBLIC_DOMAIN` | Named Tunnel用の固定ドメイン                    |
 | `ARK_TUNNEL_NAME`   | Named Tunnel名（デフォルト: `claude-code-ark`） |

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -241,7 +241,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     }
 
     const serverUrl = import.meta.env.DEV
-      ? "http://localhost:3001"
+      ? "http://localhost:4001"
       : window.location.origin;
 
     const token = getTokenFromUrl();

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,7 @@ import { defineConfig, devices } from "@playwright/test";
  * Playwright E2Eテスト設定
  *
  * サーバーはpm2で既に稼働しているため、webServer設定は不要。
- * localhost:3001 に対してテストを実行する。
+ * localhost:4001 に対してテストを実行する。
  */
 export default defineConfig({
   testDir: "./e2e",
@@ -16,7 +16,7 @@ export default defineConfig({
   timeout: 30_000,
 
   use: {
-    baseURL: "http://localhost:3001",
+    baseURL: "http://localhost:4001",
     trace: "on-first-retry",
   },
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -212,7 +212,7 @@ main() {
     echo ""
     log_success "デプロイが完了しました!"
     echo ""
-    echo "アクセス URL: http://localhost:3000"
+    echo "アクセス URL: http://localhost:4001"
     echo ""
     echo "便利なコマンド:"
     echo "  pm2 logs claude-code-ark  # ログを表示"

--- a/server/index.ts
+++ b/server/index.ts
@@ -131,7 +131,7 @@ function loadTunnelState(): { active: boolean; port: number } | null {
 async function startServer() {
   const app = express();
   const server = createServer(app);
-  const port = Number(process.env.PORT) || 3001;
+  const port = Number(process.env.PORT) || 4001;
 
   // --skip-permissions が指定された場合、Claudeを --dangerously-skip-permissions 付きで起動
   if (skipPermissions) {
@@ -523,7 +523,7 @@ async function startServer() {
     }
 
     // Ark自体のポート・CDPポート・ttydポート範囲をブロック（SSRF対策）
-    const serverPort = parseInt(process.env.PORT || "3001", 10);
+    const serverPort = parseInt(process.env.PORT || "4001", 10);
     if (port === serverPort || port === CDP_PORT) {
       res.status(403).json({ error: "This port is not accessible via proxy" });
       return;
@@ -659,7 +659,7 @@ async function startServer() {
       const proxyPort = parseInt(proxyMatch[1], 10);
       if (proxyPort >= 1 && proxyPort <= 65535) {
         // SSRF対策: Ark自体のポート、CDPポート、ttydポート範囲、VNC/WSポート範囲をブロック
-        const serverPort = parseInt(process.env.PORT || "3001", 10);
+        const serverPort = parseInt(process.env.PORT || "4001", 10);
         if (
           proxyPort === serverPort ||
           proxyPort === CDP_PORT ||

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,23 +21,23 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
-    port: 3000,
-    strictPort: false, // Will find next available port if 3000 is busy
+    port: 4000,
+    strictPort: false, // Will find next available port if 4000 is busy
     host: true,
     allowedHosts: ["localhost", "127.0.0.1"],
     // APIとSocket.IOをバックエンドにプロキシ
     proxy: {
       "/api": {
-        target: process.env.VITE_API_URL || "http://localhost:3001",
+        target: process.env.VITE_API_URL || "http://localhost:4001",
         changeOrigin: true,
       },
       "/socket.io": {
-        target: process.env.VITE_API_URL || "http://localhost:3001",
+        target: process.env.VITE_API_URL || "http://localhost:4001",
         ws: true,
         changeOrigin: true,
       },
       "/ttyd": {
-        target: process.env.VITE_API_URL || "http://localhost:3001",
+        target: process.env.VITE_API_URL || "http://localhost:4001",
         ws: true,
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary
- メインサーバーのデフォルトポートを3000系から4000系に変更（Vite: 3000→4000, Express: 3001→4001）
- 他の開発サーバーとのポート競合を回避するための対応
- ttyd/VNC/websockify等の内部ポートは変更なし

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `vite.config.ts` | devサーバー 3000→4000、プロキシ先 3001→4001 |
| `server/index.ts` | Expressデフォルトポート 3001→4001（SSRF対策含む3箇所） |
| `client/src/hooks/useSocket.ts` | Socket.IO接続先 3001→4001 |
| `playwright.config.ts` | E2Eテストの baseURL 3001→4001 |
| `scripts/deploy.sh` | デプロイ後の案内URL 3000→4001 |
| `README.md` / `CLAUDE.md` | ドキュメントのポート記載更新 |

## Test plan
- [ ] `pnpm dev:full` でVite(4000)+Express(4001)が起動すること
- [ ] ブラウザで `http://localhost:4000` にアクセスし正常動作すること
- [ ] 本番ビルド (`pnpm build && pnpm start`) で `http://localhost:4001` が動作すること
- [ ] SSRF対策: `/proxy/4001/` へのアクセスが403で拒否されること