### PR TITLE
fix: esbuildバンドル時のDBパス解決バグを修正

### DIFF
--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -8,8 +8,7 @@
  */
 
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import type {
   Message,
@@ -18,13 +17,9 @@ import type {
   SessionStatus,
 } from "../../shared/types.js";
 
-// ESM環境での__dirname相当を取得
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
 // プロジェクトルートからの相対パスでDBファイルを配置
-const PROJECT_ROOT = join(__dirname, "..", "..");
-const DATA_DIR = join(PROJECT_ROOT, "data");
+// NOTE: esbuildバンドル時にimport.meta.urlのパスが変わるため、process.cwd()を使用
+const DATA_DIR = join(process.cwd(), "data");
 const DB_PATH = join(DATA_DIR, "sessions.db");
 
 /** データベースに保存されるセッションの行データ */


### PR DESCRIPTION
## Summary
- esbuildの`--bundle`でdatabase.tsがdist/index.jsにインライン化された際、`import.meta.url`のパスが`dist/lib/database.js`→`dist/index.js`に変わり、`__dirname`ベースの`join(__dirname, "..", "..")`が1段ずれてプロジェクトルートの親ディレクトリにDBが作成されるバグを修正
- `process.cwd()`ベースに変更し、pm2/開発環境いずれでも正しく`<project-root>/data/sessions.db`に解決されるようにした

## Test plan
- [x] ビルド後のdist/index.js内で`process.cwd()`が使用されていることを確認
- [x] VM上でpm2再起動後、正しいパス（`<project-root>/data/sessions.db`）にDBが作成されることを確認
- [x] 間違ったパス（`<project-root>/../data/`）にDBが作成されないことを確認
- [x] セッション6個が正常に復元・動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * アプリケーションのバンドル時のセッションデータの保存場所の処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->