### PR TITLE
fix: esbuildバンドル時のDBパス解決バグを修正

### DIFF
--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -8,8 +8,7 @@
  */
 
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import Database from "better-sqlite3";
 import type {
   Message,
@@ -18,13 +17,9 @@ import type {
   SessionStatus,
 } from "../../shared/types.js";
 
-// ESM環境での__dirname相当を取得
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
 // プロジェクトルートからの相対パスでDBファイルを配置
-const PROJECT_ROOT = join(__dirname, "..", "..");
-const DATA_DIR = join(PROJECT_ROOT, "data");
+// NOTE: esbuildバンドル時にimport.meta.urlのパスが変わるため、process.cwd()を使用
+const DATA_DIR = join(process.cwd(), "data");
 const DB_PATH = join(DATA_DIR, "sessions.db");
 
 /** データベースに保存されるセッションの行データ */


### PR DESCRIPTION
## 概要

esbuildでバンドルした際に `import.meta.url` のパスがバンドル出力先に変わり、`data/sessions.db` が意図しない場所に作られるバグを修正。

## 変更内容

- `server/lib/database.ts`: DBパスの解決方法を `import.meta.url` ベースから `process.cwd()` ベースに変更
- pm2の `ecosystem.config.js` で `cwd` が固定されているため、`process.cwd()` で正しくプロジェクトルートが取得される

## テスト計画

- [x] `pnpm build` でビルド成功確認
- [x] pm2再起動後にDBが `data/sessions.db` に正しく作成されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * データベースのパス解決ロジックを改善し、より一貫性のある動作を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->