### PR TITLE
モバイル・PCで「セッションを削除」アクションを統合

### DIFF
--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -30,7 +30,8 @@ interface MobileLayoutProps {
   repoList: string[];
   repoPath: string | null;
   onStartSession: (worktree: Worktree) => void;
-  onStopSession: (sessionId: string) => void;
+  /** セッション削除（停止 + メイン以外のWorktree削除） */
+  onDeleteSession: (sessionId: string, worktree: Worktree | undefined) => void;
   onDeleteWorktree: (worktree: Worktree) => void;
   onSendMessage: (sessionId: string, message: string) => void;
   onSendKey: (sessionId: string, key: SpecialKey) => void;
@@ -74,7 +75,7 @@ export function MobileLayout({
   repoList,
   repoPath: _repoPath,
   onStartSession,
-  onStopSession,
+  onDeleteSession,
   onDeleteWorktree,
   onSendMessage,
   onSendKey,
@@ -196,7 +197,7 @@ export function MobileLayout({
           repoList={repoList}
           onOpenSession={handleOpenSession}
           onStartSession={onStartSession}
-          onStopSession={onStopSession}
+          onDeleteSession={onDeleteSession}
           onDeleteWorktree={onDeleteWorktree}
           onNewSession={onNewSession}
         />
@@ -221,7 +222,9 @@ export function MobileLayout({
               onBack={handleBack}
               onSendMessage={message => onSendMessage(sessionId, message)}
               onSendKey={key => onSendKey(sessionId, key)}
-              onStopSession={() => onStopSession(sessionId)}
+              onDeleteSession={() =>
+                onDeleteSession(sessionId, getWorktreeForSession(session))
+              }
               onUploadImage={
                 onUploadImage
                   ? (base64Data, mimeType) =>

--- a/client/src/components/MobileSessionList.tsx
+++ b/client/src/components/MobileSessionList.tsx
@@ -12,7 +12,6 @@ import {
   MoreVertical,
   Play,
   Plus,
-  Square,
   Trash2,
 } from "lucide-react";
 import { useState } from "react";
@@ -44,10 +43,27 @@ interface MobileSessionListProps {
   repoList: string[];
   onOpenSession: (sessionId: string) => void;
   onStartSession: (worktree: Worktree) => void;
-  onStopSession: (sessionId: string) => void;
+  /** セッション削除（停止 + メイン以外のWorktree削除） */
+  onDeleteSession: (sessionId: string, worktree: Worktree | undefined) => void;
   onDeleteWorktree: (worktree: Worktree) => void;
   onNewSession: () => void;
 }
+
+/**
+ * 削除確認ダイアログのターゲット。
+ * - type=session: セッションあり（worktree有無はworktreeフィールドで判定）
+ * - type=worktree: セッションなしでworktree単体を削除
+ */
+type DeleteTarget =
+  | {
+      type: "session";
+      sessionId: string;
+      worktree: Worktree | undefined;
+    }
+  | {
+      type: "worktree";
+      worktree: Worktree;
+    };
 
 export function MobileSessionList({
   sessions,
@@ -55,11 +71,11 @@ export function MobileSessionList({
   repoList,
   onOpenSession,
   onStartSession,
-  onStopSession,
+  onDeleteSession,
   onDeleteWorktree,
   onNewSession,
 }: MobileSessionListProps) {
-  const [deleteTarget, setDeleteTarget] = useState<Worktree | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
   const { groupedItems } = useGroupedWorktreeItems(
     worktrees,
     sessions,
@@ -151,29 +167,42 @@ export function MobileSessionList({
                                 {session ? (
                                   <DropdownMenuItem
                                     className="text-destructive focus:text-destructive"
-                                    onSelect={() => onStopSession(session.id)}
+                                    onSelect={() =>
+                                      setDeleteTarget({
+                                        type: "session",
+                                        sessionId: session.id,
+                                        worktree,
+                                      })
+                                    }
                                   >
-                                    <Square className="w-4 h-4 mr-2" />
-                                    セッションを停止
+                                    <Trash2 className="w-4 h-4 mr-2" />
+                                    セッションを削除
                                   </DropdownMenuItem>
                                 ) : (
-                                  <DropdownMenuItem
-                                    onSelect={() => onStartSession(worktree)}
-                                  >
-                                    <Play className="w-4 h-4 mr-2" />
-                                    セッションを開始
-                                  </DropdownMenuItem>
-                                )}
-                                {!worktree.isMain && (
                                   <>
-                                    <DropdownMenuSeparator />
                                     <DropdownMenuItem
-                                      className="text-destructive focus:text-destructive"
-                                      onSelect={() => setDeleteTarget(worktree)}
+                                      onSelect={() => onStartSession(worktree)}
                                     >
-                                      <Trash2 className="w-4 h-4 mr-2" />
-                                      Worktreeを削除
+                                      <Play className="w-4 h-4 mr-2" />
+                                      セッションを開始
                                     </DropdownMenuItem>
+                                    {!worktree.isMain && (
+                                      <>
+                                        <DropdownMenuSeparator />
+                                        <DropdownMenuItem
+                                          className="text-destructive focus:text-destructive"
+                                          onSelect={() =>
+                                            setDeleteTarget({
+                                              type: "worktree",
+                                              worktree,
+                                            })
+                                          }
+                                        >
+                                          <Trash2 className="w-4 h-4 mr-2" />
+                                          Worktreeを削除
+                                        </DropdownMenuItem>
+                                      </>
+                                    )}
                                   </>
                                 )}
                               </DropdownMenuContent>
@@ -219,10 +248,16 @@ export function MobileSessionList({
                             <DropdownMenuContent align="end" className="w-48">
                               <DropdownMenuItem
                                 className="text-destructive focus:text-destructive"
-                                onSelect={() => onStopSession(session.id)}
+                                onSelect={() =>
+                                  setDeleteTarget({
+                                    type: "session",
+                                    sessionId: session.id,
+                                    worktree: undefined,
+                                  })
+                                }
                               >
-                                <Square className="w-4 h-4 mr-2" />
-                                セッションを停止
+                                <Trash2 className="w-4 h-4 mr-2" />
+                                セッションを削除
                               </DropdownMenuItem>
                             </DropdownMenuContent>
                           </DropdownMenu>
@@ -245,9 +280,19 @@ export function MobileSessionList({
       >
         <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
           <AlertDialogHeader>
-            <AlertDialogTitle>Worktreeを削除</AlertDialogTitle>
+            <AlertDialogTitle>
+              {deleteTarget?.type === "session"
+                ? "セッションを削除"
+                : "Worktreeを削除"}
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              このWorktreeを削除しますか？関連するブランチも削除されます。
+              {deleteTarget?.type === "session"
+                ? deleteTarget.worktree === undefined
+                  ? "このセッションを削除しますか？"
+                  : deleteTarget.worktree.isMain
+                    ? "このセッションを削除しますか？メインWorktreeは削除されません。"
+                    : "このセッションとWorktreeを削除しますか？関連するブランチも削除されます。"
+                : "このWorktreeを削除しますか？関連するブランチも削除されます。"}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
@@ -255,7 +300,16 @@ export function MobileSessionList({
             <AlertDialogAction
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12"
               onClick={() => {
-                if (deleteTarget) onDeleteWorktree(deleteTarget);
+                if (deleteTarget) {
+                  if (deleteTarget.type === "session") {
+                    onDeleteSession(
+                      deleteTarget.sessionId,
+                      deleteTarget.worktree
+                    );
+                  } else {
+                    onDeleteWorktree(deleteTarget.worktree);
+                  }
+                }
                 setDeleteTarget(null);
               }}
             >

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -17,6 +17,16 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -88,6 +98,7 @@ export function MobileSessionView({
     preview: string;
   } | null>(null);
   const [imageMessage, setImageMessage] = useState("");
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
@@ -305,7 +316,7 @@ export function MobileSessionView({
             variant="ghost"
             size="icon"
             className="h-10 w-10 text-destructive hover:text-destructive"
-            onClick={onDeleteSession}
+            onClick={() => setShowDeleteDialog(true)}
             title="セッションを削除"
           >
             <Trash2 className="w-5 h-5" />
@@ -492,6 +503,32 @@ export function MobileSessionView({
           </Button>
         </div>
       </form>
+
+      {/* 削除確認ダイアログ */}
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle>セッションを削除</AlertDialogTitle>
+            <AlertDialogDescription>
+              このセッションとWorktreeを削除しますか？関連するブランチも削除されます。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
+            <AlertDialogCancel className="h-12 md:h-10">
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
+              onClick={() => {
+                onDeleteSession();
+                setShowDeleteDialog(false);
+              }}
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -48,7 +48,8 @@ interface MobileSessionViewProps {
   onBack: () => void;
   onSendMessage: (message: string) => void;
   onSendKey: (key: SpecialKey) => void;
-  onStopSession: () => void;
+  /** セッション削除（停止 + メイン以外のWorktree削除） */
+  onDeleteSession: () => void;
   onUploadImage?: (base64Data: string, mimeType: string) => void;
   imageUploadResult?: { path: string; filename: string } | null;
   imageUploadError?: string | null;
@@ -67,7 +68,7 @@ export function MobileSessionView({
   onBack,
   onSendMessage,
   onSendKey,
-  onStopSession,
+  onDeleteSession,
   onUploadImage,
   imageUploadResult,
   imageUploadError,
@@ -299,12 +300,12 @@ export function MobileSessionView({
               ))}
             </DropdownMenuContent>
           </DropdownMenu>
-          {/* 削除ボタン */}
+          {/* 削除ボタン（セッション停止 + メイン以外のWorktree削除） */}
           <Button
             variant="ghost"
             size="icon"
             className="h-10 w-10 text-destructive hover:text-destructive"
-            onClick={onStopSession}
+            onClick={onDeleteSession}
             title="セッションを削除"
           >
             <Trash2 className="w-5 h-5" />

--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -510,7 +510,11 @@ export function MobileSessionView({
           <AlertDialogHeader>
             <AlertDialogTitle>セッションを削除</AlertDialogTitle>
             <AlertDialogDescription>
-              このセッションとWorktreeを削除しますか？関連するブランチも削除されます。
+              {worktree === undefined
+                ? "このセッションを削除しますか？"
+                : worktree.isMain
+                  ? "このセッションを削除しますか？メインWorktreeは削除されません。"
+                  : "このセッションとWorktreeを削除しますか？関連するブランチも削除されます。"}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="flex-col gap-2 sm:flex-row">

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -30,7 +30,8 @@ interface SessionCardProps {
   previewText: string;
   activityText: string;
   onClick: () => void;
-  onStop: () => void;
+  /** セッション削除（停止 + メイン以外のWorktree削除） */
+  onDelete: () => void;
   onStart?: () => void;
 }
 
@@ -41,7 +42,7 @@ export function SessionCard({
   previewText,
   activityText,
   onClick,
-  onStop,
+  onDelete,
   onStart,
 }: SessionCardProps) {
   const branch =
@@ -191,7 +192,7 @@ export function SessionCard({
             <AlertDialogAction
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
               onClick={() => {
-                onStop();
+                onDelete();
                 setShowDeleteDialog(false);
               }}
             >

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -21,7 +21,8 @@ interface SessionSidebarProps {
   sessionPreviews: Map<string, string>;
   sessionActivityTexts: Map<string, string>;
   onSelectSession: (sessionId: string) => void;
-  onStopSession: (sessionId: string) => void;
+  /** セッション削除（停止 + メイン以外のWorktree削除） */
+  onDeleteSession: (sessionId: string, worktree: Worktree | undefined) => void;
   onStartSession: (worktree: Worktree) => void;
   onNewSession: () => void;
   /** ブラウザ選択コールバック（リモートアクセス時のみ使用） */
@@ -40,7 +41,7 @@ export function SessionSidebar({
   sessionPreviews,
   sessionActivityTexts,
   onSelectSession,
-  onStopSession,
+  onDeleteSession,
   onStartSession,
   onNewSession,
   onSelectBrowser,
@@ -129,7 +130,9 @@ export function SessionSidebar({
                           : ""
                       }
                       onClick={() => session && onSelectSession(session.id)}
-                      onStop={() => session && onStopSession(session.id)}
+                      onDelete={() =>
+                        session && onDeleteSession(session.id, wt ?? undefined)
+                      }
                       onStart={() => (wt ? onStartSession(wt) : undefined)}
                     />
                   ))}

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -24,6 +24,16 @@ import {
   XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import type {
@@ -95,6 +105,7 @@ export function TerminalPane({
   const [inputValue, setInputValue] = useState("");
   const [showInput, setShowInput] = useState(true);
   const [showQuickCommands, setShowQuickCommands] = useState(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
   // PCでは入力バーをデフォルト非表示にする
   useEffect(() => {
@@ -341,7 +352,7 @@ export function TerminalPane({
             variant="ghost"
             size="icon"
             className="h-10 w-10 md:h-6 md:w-6 text-destructive hover:text-destructive"
-            onClick={onDeleteSession}
+            onClick={() => setShowDeleteDialog(true)}
             title="セッションを削除"
           >
             <Trash2 className="w-5 h-5 md:w-3 md:h-3" />
@@ -580,6 +591,32 @@ export function TerminalPane({
           </form>
         </div>
       )}
+
+      {/* 削除確認ダイアログ */}
+      <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
+        <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle>セッションを削除</AlertDialogTitle>
+            <AlertDialogDescription>
+              このセッションとWorktreeを削除しますか？関連するブランチも削除されます。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
+            <AlertDialogCancel className="h-12 md:h-10">
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
+              onClick={() => {
+                onDeleteSession();
+                setShowDeleteDialog(false);
+              }}
+            >
+              削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -598,7 +598,11 @@ export function TerminalPane({
           <AlertDialogHeader>
             <AlertDialogTitle>セッションを削除</AlertDialogTitle>
             <AlertDialogDescription>
-              このセッションとWorktreeを削除しますか？関連するブランチも削除されます。
+              {worktree === undefined
+                ? "このセッションを削除しますか？"
+                : worktree.isMain
+                  ? "このセッションを削除しますか？メインWorktreeは削除されません。"
+                  : "このセッションとWorktreeを削除しますか？関連するブランチも削除されます。"}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="flex-col gap-2 sm:flex-row">

--- a/client/src/components/TerminalPane.tsx
+++ b/client/src/components/TerminalPane.tsx
@@ -61,7 +61,8 @@ interface TerminalPaneProps {
   repoName?: string;
   onSendMessage: (message: string) => void;
   onSendKey: (key: SpecialKey) => void;
-  onStopSession: () => void;
+  /** セッション削除（停止 + メイン以外のWorktree削除） */
+  onDeleteSession: () => void;
   onUploadImage?: (base64Data: string, mimeType: string) => void;
   imageUploadResult?: { path: string; filename: string } | null;
   imageUploadError?: string | null;
@@ -79,7 +80,7 @@ export function TerminalPane({
   repoName,
   onSendMessage,
   onSendKey,
-  onStopSession,
+  onDeleteSession,
   onUploadImage,
   imageUploadResult,
   imageUploadError,
@@ -340,8 +341,8 @@ export function TerminalPane({
             variant="ghost"
             size="icon"
             className="h-10 w-10 md:h-6 md:w-6 text-destructive hover:text-destructive"
-            onClick={onStopSession}
-            title="Delete session"
+            onClick={onDeleteSession}
+            title="セッションを削除"
           >
             <Trash2 className="w-5 h-5 md:w-3 md:h-3" />
           </Button>

--- a/client/src/components/WorktreeContextMenu.tsx
+++ b/client/src/components/WorktreeContextMenu.tsx
@@ -1,10 +1,4 @@
-import {
-  MessageSquare,
-  MoreVertical,
-  Play,
-  Square,
-  Trash2,
-} from "lucide-react";
+import { MessageSquare, MoreVertical, Play, Trash2 } from "lucide-react";
 import { useState } from "react";
 import {
   AlertDialog,
@@ -39,8 +33,10 @@ interface WorktreeContextMenuProps {
   worktree: Worktree;
   session: ManagedSession | undefined;
   onStartSession: (worktree: Worktree) => void;
-  onStopSession: (sessionId: string) => void;
+  /** セッション削除（停止 + メイン以外のWorktree削除） */
+  onDeleteSession: (sessionId: string, worktree: Worktree) => void;
   onSelectSession: (sessionId: string) => void;
+  /** セッションなし状態でのWorktree単体削除 */
   onDeleteWorktree: (worktree: Worktree) => void;
 }
 
@@ -49,21 +45,30 @@ export function WorktreeContextMenu({
   worktree,
   session,
   onStartSession,
-  onStopSession,
+  onDeleteSession,
   onSelectSession,
   onDeleteWorktree,
 }: WorktreeContextMenuProps) {
   const isMobile = useIsMobile();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
 
+  // セッション有無で削除対象が変わる:
+  // - セッションあり: stopSession + (メイン以外なら)deleteWorktree
+  // - セッションなし(非mainのみ表示): deleteWorktreeのみ
+  const hasSession = session !== undefined;
+  const dialogTitle = hasSession ? "セッションを削除" : "Worktreeを削除";
+  const dialogDescription = hasSession
+    ? worktree.isMain
+      ? "このセッションを削除しますか？メインWorktreeは削除されません。"
+      : "このセッションとWorktreeを削除しますか？関連するブランチも削除されます。"
+    : "このWorktreeを削除しますか？関連するブランチも削除されます。";
+
   const deleteDialog = (
     <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>
       <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
         <AlertDialogHeader>
-          <AlertDialogTitle>Worktreeを削除</AlertDialogTitle>
-          <AlertDialogDescription>
-            このWorktreeを削除しますか？関連するブランチも削除されます。
-          </AlertDialogDescription>
+          <AlertDialogTitle>{dialogTitle}</AlertDialogTitle>
+          <AlertDialogDescription>{dialogDescription}</AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
           <AlertDialogCancel className="h-12 md:h-10">
@@ -72,7 +77,11 @@ export function WorktreeContextMenu({
           <AlertDialogAction
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90 h-12 md:h-10"
             onClick={() => {
-              onDeleteWorktree(worktree);
+              if (session) {
+                onDeleteSession(session.id, worktree);
+              } else {
+                onDeleteWorktree(worktree);
+              }
               setShowDeleteDialog(false);
             }}
           >
@@ -109,30 +118,33 @@ export function WorktreeContextMenu({
                     <MessageSquare className="w-4 h-4 mr-2" />
                     セッションを開く
                   </DropdownMenuItem>
-                  <DropdownMenuItem
-                    className="text-destructive focus:text-destructive"
-                    onSelect={() => onStopSession(session.id)}
-                  >
-                    <Square className="w-4 h-4 mr-2" />
-                    セッションを停止
-                  </DropdownMenuItem>
-                </>
-              ) : (
-                <DropdownMenuItem onSelect={() => onStartSession(worktree)}>
-                  <Play className="w-4 h-4 mr-2" />
-                  セッションを開始
-                </DropdownMenuItem>
-              )}
-              {!worktree.isMain && (
-                <>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
                     className="text-destructive focus:text-destructive"
                     onSelect={() => setShowDeleteDialog(true)}
                   >
                     <Trash2 className="w-4 h-4 mr-2" />
-                    Worktreeを削除
+                    セッションを削除
                   </DropdownMenuItem>
+                </>
+              ) : (
+                <>
+                  <DropdownMenuItem onSelect={() => onStartSession(worktree)}>
+                    <Play className="w-4 h-4 mr-2" />
+                    セッションを開始
+                  </DropdownMenuItem>
+                  {!worktree.isMain && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem
+                        className="text-destructive focus:text-destructive"
+                        onSelect={() => setShowDeleteDialog(true)}
+                      >
+                        <Trash2 className="w-4 h-4 mr-2" />
+                        Worktreeを削除
+                      </DropdownMenuItem>
+                    </>
+                  )}
                 </>
               )}
             </DropdownMenuContent>
@@ -154,30 +166,33 @@ export function WorktreeContextMenu({
                 <MessageSquare className="w-4 h-4 mr-2" />
                 セッションを開く
               </ContextMenuItem>
-              <ContextMenuItem
-                className="text-destructive focus:text-destructive"
-                onSelect={() => onStopSession(session.id)}
-              >
-                <Square className="w-4 h-4 mr-2" />
-                セッションを停止
-              </ContextMenuItem>
-            </>
-          ) : (
-            <ContextMenuItem onSelect={() => onStartSession(worktree)}>
-              <Play className="w-4 h-4 mr-2" />
-              セッションを開始
-            </ContextMenuItem>
-          )}
-          {!worktree.isMain && (
-            <>
               <ContextMenuSeparator />
               <ContextMenuItem
                 className="text-destructive focus:text-destructive"
                 onSelect={() => setShowDeleteDialog(true)}
               >
                 <Trash2 className="w-4 h-4 mr-2" />
-                Worktreeを削除
+                セッションを削除
               </ContextMenuItem>
+            </>
+          ) : (
+            <>
+              <ContextMenuItem onSelect={() => onStartSession(worktree)}>
+                <Play className="w-4 h-4 mr-2" />
+                セッションを開始
+              </ContextMenuItem>
+              {!worktree.isMain && (
+                <>
+                  <ContextMenuSeparator />
+                  <ContextMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onSelect={() => setShowDeleteDialog(true)}
+                  >
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Worktreeを削除
+                  </ContextMenuItem>
+                </>
+              )}
             </>
           )}
         </ContextMenuContent>

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -301,17 +301,15 @@ export default function Dashboard() {
     worktree: Worktree | undefined
   ) => {
     stopSession(sessionId);
-    const shouldDeleteWorktree = worktree && !worktree.isMain;
-    if (shouldDeleteWorktree) {
-      deleteWorktree(worktree.path);
-    }
+    // server側の session:stop ハンドラが !isMain のworktreeを自動削除するため、
+    // クライアント側で deleteWorktree を呼ぶと重複リクエストになる
     if (selectedSessionId === sessionId) {
       const remaining = Array.from(sessions.values()).filter(
         s => s.id !== sessionId
       );
       setSelectedSessionId(remaining.length > 0 ? remaining[0].id : null);
     }
-    if (shouldDeleteWorktree) {
+    if (worktree && !worktree.isMain) {
       toast.success("セッションを削除しました");
     } else {
       toast.info("セッションを停止しました");

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -302,13 +302,9 @@ export default function Dashboard() {
   ) => {
     stopSession(sessionId);
     // server側の session:stop ハンドラが !isMain のworktreeを自動削除するため、
-    // クライアント側で deleteWorktree を呼ぶと重複リクエストになる
-    if (selectedSessionId === sessionId) {
-      const remaining = Array.from(sessions.values()).filter(
-        s => s.id !== sessionId
-      );
-      setSelectedSessionId(remaining.length > 0 ? remaining[0].id : null);
-    }
+    // クライアント側で deleteWorktree を呼ぶと重複リクエストになる。
+    // 選択セッションの切り替えは sessions 変化を検出する useEffect に任せる
+    // （削除失敗時に optimistic update で別セッションへ誤遷移するのを防ぐため）。
     if (worktree && !worktree.isMain) {
       toast.success("セッションを削除しました");
     } else {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -290,6 +290,34 @@ export default function Dashboard() {
     toast.info("Session stopped");
   };
 
+  /**
+   * セッションを削除（統合アクション）
+   * - セッションを停止
+   * - 関連Worktreeがメイン以外なら削除
+   * - 選択中セッションなら残りのセッションへフォーカスを移す
+   */
+  const handleDeleteSession = (
+    sessionId: string,
+    worktree: Worktree | undefined
+  ) => {
+    stopSession(sessionId);
+    const shouldDeleteWorktree = worktree && !worktree.isMain;
+    if (shouldDeleteWorktree) {
+      deleteWorktree(worktree.path);
+    }
+    if (selectedSessionId === sessionId) {
+      const remaining = Array.from(sessions.values()).filter(
+        s => s.id !== sessionId
+      );
+      setSelectedSessionId(remaining.length > 0 ? remaining[0].id : null);
+    }
+    if (shouldDeleteWorktree) {
+      toast.success("セッションを削除しました");
+    } else {
+      toast.info("セッションを停止しました");
+    }
+  };
+
   const handleNewSession = () => {
     // まずリポジトリ選択（なければスキャン、あれば選択→worktree作成へ）
     setIsSelectRepoOpen(true);
@@ -305,7 +333,7 @@ export default function Dashboard() {
           repoList={repoList}
           repoPath={repoPath}
           onStartSession={handleStartSession}
-          onStopSession={handleStopSession}
+          onDeleteSession={handleDeleteSession}
           onDeleteWorktree={handleDeleteWorktree}
           onSendMessage={sendMessage}
           onSendKey={sendKey}
@@ -339,7 +367,7 @@ export default function Dashboard() {
               sessionPreviews={sessionPreviews}
               sessionActivityTexts={sessionActivityTexts}
               onSelectSession={setSelectedSessionId}
-              onStopSession={handleStopSession}
+              onDeleteSession={handleDeleteSession}
               onStartSession={handleStartSession}
               onNewSession={handleNewSession}
               onSelectBrowser={handleSelectBrowser}
@@ -397,7 +425,9 @@ export default function Dashboard() {
                         onTabClose={idx => handleTabClose(session.id, idx)}
                         onSendMessage={msg => sendMessage(session.id, msg)}
                         onSendKey={key => sendKey(session.id, key)}
-                        onStopSession={() => handleStopSession(session.id)}
+                        onDeleteSession={() =>
+                          handleDeleteSession(session.id, wt)
+                        }
                         onUploadImage={(base64, mimeType) =>
                           uploadImage(session.id, base64, mimeType)
                         }


### PR DESCRIPTION
## 背景

モバイル版は「セッションを停止」と「Worktreeを削除」が別メニュー項目になっており、PC版（「セッションを削除」の1項目で完結）と挙動が食い違っていた。

## 変更

### 統合
- 「セッションを削除」を PC・モバイル両方で統一アクションに
- 実体は `session:stop` 1本。server側が自動的に非mainのworktree削除まで実行（`server/index.ts:997`）

### UX改善
- `TerminalPane.tsx` / `MobileSessionView.tsx` のヘッダー削除ボタンに確認AlertDialogを追加
  - 従来はワンクリックで破壊的動作だったがsidebar/list側と同じUXに統一
- 確認ダイアログの文言を worktree の種別で動的切替
  - `undefined`（orphan session）: 「このセッションを削除しますか？」
  - `isMain=true`: 「メインWorktreeは削除されません」
  - 非main: 「Worktreeとブランチも削除されます」

## テスト計画
- [ ] モバイルで「セッションを削除」メニューが表示される
- [ ] PC・モバイルともに確認ダイアログ経由で削除できる
- [ ] メインworktreeのセッションは停止のみでworktreeは残る
- [ ] 非mainのセッション削除で worktree + branch も削除される
- [ ] orphanセッションの削除でサーバーエラーが出ない

## 既知の課題（スコープ外）
- Dashboard.tsx の toast タイミング: `session:stop` 送信直後に成功toastを出すが、worktree削除失敗時に `session:error` が続けて出るケースがある（Codex [P3]）。既存 `handleStopSession` から継続している問題のため別途Issue化予定。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッション削除アクションに確認ダイアログを追加しました
  * 削除時に関連ワークツリーの有無／種類を考慮して削除動作と文言を切替えます
  * 複数画面（モバイル一覧・詳細・サイドバー・端末ペイン・コンテキストメニュー）で「セッション停止」→「セッション削除」へ表示と挙動を統一しました
  * 削除結果に応じた適切な通知メッセージを表示します
<!-- end of auto-generated comment: release notes by coderabbit.ai -->