### PR TITLE
fix: ターミナル内URLクリックで2つwindowが開くバグを修正

### DIFF
--- a/client/src/hooks/useTerminalLinkInjection.ts
+++ b/client/src/hooks/useTerminalLinkInjection.ts
@@ -67,6 +67,15 @@ export function useTerminalLinkInjection(
           // WebLinksAddonが優先的にactivateされても、ここで完全URLに復元できる。
           const urlExtensionMap = new Map<string, string>();
 
+          // 同一URLの重複open抑制用（WebLinksAddonと独自provider両発火対策）
+          // 1クリックで両経路が発火するため、先に処理した方がマーク、後発はskipする
+          const handledUrls = new Set<string>();
+          const markHandled = (u: string) => {
+            handledUrls.add(u);
+            // 同期的に発火した2経路をカバーしつつ、連続クリックは妨げない
+            setTimeout(() => handledUrls.delete(u), 200);
+          };
+
           // xterm.js WebLinksAddonのURLを横取りする。
           // WebLinksAddonは window.open() を引数なしで呼び、返されたウィンドウの
           // location.href にURLを設定するパターン:
@@ -86,6 +95,8 @@ export function useTerminalLinkInjection(
             // 引数ありの呼び出し（URL直接指定）
             if (url) {
               const urlStr = urlExtensionMap.get(String(url)) || String(url);
+              if (handledUrls.has(urlStr)) return null;
+              markHandled(urlStr);
               if (
                 /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/.test(urlStr)
               ) {
@@ -107,6 +118,8 @@ export function useTerminalLinkInjection(
                 set href(u: string) {
                   // URL拡張マップで折り返しURLを完全URLに復元
                   const resolved = urlExtensionMap.get(u) || u;
+                  if (handledUrls.has(resolved)) return;
+                  markHandled(resolved);
                   if (
                     /^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?/.test(
                       resolved
@@ -340,10 +353,10 @@ export function useTerminalLinkInjection(
                   },
                   text: finalUrl,
                   activate() {
-                    arkWindow.postMessage(
-                      { type: "ark:open-url", url: finalUrl },
-                      arkWindow.location.origin
-                    );
+                    // iframeWindow.open override にURL種別判定とdedupを委譲。
+                    // 非localhost URLは override 内で origOpen() 経由で実ウィンドウに開かれる。
+                    // biome-ignore lint/suspicious/noExplicitAny: overrideされたopenを呼ぶため型を緩める
+                    (iframeWindow as any).open(finalUrl, "_blank");
                   },
                 });
               }


### PR DESCRIPTION
## Summary
- WebLinksAddonと独自`registerLinkProvider`が同一クリックで両発火し、それぞれ独立にwindowを開く問題を修正
- `useTerminalLinkInjection` クロージャ内に `handledUrls` Set + 200ms TTL の `markHandled` ヘルパーを追加
- `window.open` override（URL引数版・fakeWindow `href` setter 版）と独自providerの `activate()` でdedup判定
- 独自providerの `activate()` を `iframeWindow.open` 経由に変更し、URL種別判定・dedupをoverrideに一元化

## 修正の経緯
過去のPR #110 で同じバグを修正したが、`origOpen()` 廃止により非localhost外部URLが埋め込みブラウザに流れる・折り返しURL復元が壊れる副作用が出てrevert済み（#113）。
本修正は両経路の挙動（localhost→postMessage / 非localhost→実ウィンドウ、`urlExtensionMap` による折り返しURL復元）を保持したまま、dedupのみを追加する点が異なる。

## 動作パターン
- localhost URL: `postMessage('ark:open-url')` → `handleOpenUrl` → `window.open`（local） or `navigateBrowser`（remote）
- 非localhost URL: `origOpen()` で実ウィンドウを開く
- 折り返しURL: `urlExtensionMap` で完全URLに復元してから処理
- 同一URL: Set ベースで200ms以内の2発目を抑止

## Test plan
- [x] `pnpm build` 成功（TypeScript / biomeエラーなし）
- [x] `/codex review` 指摘なし
- [ ] E2E: ターミナルにlocalhost URL / 非localhost URL / 折り返しURL を出力してクリックし、それぞれ1window/1ナビゲーションのみ発生することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ターミナルリンク処理における重複実行の問題を修正しました
  * 同一URLが複数回処理されるのを自動的に防止し、より安定した動作を実現しました
  * リンク開く際の処理フローを改善し、信頼性が向上しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->