### PR TITLE
feat: Beacon履歴のDB永続化＋表示順安定化＋repoPath不整合修正

### DIFF
--- a/client/src/hooks/useGroupedWorktreeItems.ts
+++ b/client/src/hooks/useGroupedWorktreeItems.ts
@@ -31,7 +31,11 @@ export function useGroupedWorktreeItems(
     const groups = new Map<string, GroupedItem[]>();
     const worktreeSessionIds = new Set<string>();
 
-    for (const wt of worktrees) {
+    // worktreePath昇順で処理することでリロード間の並び順を安定させる
+    const sortedWorktrees = [...worktrees].sort((a, b) =>
+      a.path.localeCompare(b.path)
+    );
+    for (const wt of sortedWorktrees) {
       const session = sessionByWorktreeId.get(wt.id) ?? null;
       if (session) worktreeSessionIds.add(session.id);
       const repoName = (() => {
@@ -45,7 +49,10 @@ export function useGroupedWorktreeItems(
       groups.set(repoName, existing);
     }
 
-    for (const session of Array.from(sessions.values())) {
+    const sortedSessions = Array.from(sessions.values()).sort((a, b) =>
+      a.worktreePath.localeCompare(b.worktreePath)
+    );
+    for (const session of sortedSessions) {
       if (worktreeSessionIds.has(session.id)) continue;
       const repo = session.repoPath ?? findRepoForSession(session, repoList);
       const repoName = repo ? getBaseName(repo) : "unknown";
@@ -54,7 +61,10 @@ export function useGroupedWorktreeItems(
       groups.set(repoName, existing);
     }
 
-    return groups;
+    // リポジトリ名でも安定ソートする
+    return new Map(
+      Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b))
+    );
   }, [worktrees, sessions, sessionByWorktreeId, repoList]);
 
   return { groupedItems, sessionByWorktreeId };

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -704,8 +704,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   // Beaconメッセージ送信
   const beaconSend = useCallback((message: string) => {
     // 切断時は楽観更新を起こさない（streamingイベントが届かず入力欄が永久ロックされるため）
+    // 無通知で消えるとUX上「送信したのに何も起きない」に見えるのでエラー通知する
     const socket = socketRef.current;
-    if (!socket?.connected) return;
+    if (!socket?.connected) {
+      setError("サーバーに接続していません。再接続後に再送してください。");
+      return;
+    }
     // 楽観的にストリーミング状態を立てる（ツール実行先行ターンは最初のチャンクが遅れるため）
     setBeaconStreaming(true);
     setBeaconStreamText("");

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -703,7 +703,13 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
   // Beaconメッセージ送信
   const beaconSend = useCallback((message: string) => {
-    socketRef.current?.emit("beacon:send", { message });
+    // 切断時は楽観更新を起こさない（streamingイベントが届かず入力欄が永久ロックされるため）
+    const socket = socketRef.current;
+    if (!socket?.connected) return;
+    // 楽観的にストリーミング状態を立てる（ツール実行先行ターンは最初のチャンクが遅れるため）
+    setBeaconStreaming(true);
+    setBeaconStreamText("");
+    socket.emit("beacon:send", { message });
   }, []);
 
   // Beacon履歴取得
@@ -719,8 +725,13 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     setBeaconStreamText("");
   }, []);
 
-  // Beaconチャット履歴クリア（セッションは維持、サーバーには送信しない）
+  // Beaconチャット履歴クリア（サーバー側のセッション・DB履歴も完全にリセット）
+  // 切断時はサーバーに届かないため何もしない（ローカルだけ消すと
+  // 次の再接続時にサーバー履歴が戻ってきて不整合になる）
   const beaconClear = useCallback(() => {
+    const socket = socketRef.current;
+    if (!socket?.connected) return;
+    socket.emit("beacon:clear");
     setBeaconMessages([]);
     setBeaconStreaming(false);
     setBeaconStreamText("");

--- a/server/index.ts
+++ b/server/index.ts
@@ -762,6 +762,9 @@ async function startServer() {
     // Send allowed repos list to client on connection
     socket.emit("repos:list", allowedRepos);
 
+    // Beaconのチャット履歴を接続時に自動送信（クライアント側の取得タイミング問題を回避）
+    socket.emit("beacon:history", { messages: beaconManager.getHistory() });
+
     // ===== Session Orchestrator Event Handlers =====
     // sessionOrchestrator のイベントをそのまま Socket.IO クライアントへ転送する
     // 注意: session:list送信やttyd自動復元より前に登録する必要がある
@@ -1333,6 +1336,13 @@ async function startServer() {
     // Beaconセッション終了
     socket.on("beacon:close", () => {
       beaconManager.closeSession();
+    });
+
+    // Beacon履歴クリア（LLMコンテキスト・DB履歴もリセット）
+    // 履歴は全接続クライアントで共有されるため、broadcastで他タブ・他端末も同期する
+    socket.on("beacon:clear", () => {
+      beaconManager.clearHistory();
+      io.emit("beacon:history", { messages: [] });
     });
 
     // ===== Frontline Commands =====

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -22,6 +22,7 @@ import type {
   ChatMessage,
   SpecialKey,
 } from "../../shared/types.js";
+import { db } from "./database.js";
 import { getErrorMessage } from "./errors.js";
 
 const execFileAsync = promisify(execFile);
@@ -801,11 +802,14 @@ export class BeaconManager extends EventEmitter {
       },
     });
 
+    // DBから既存の履歴をロード（UI表示用・LLMコンテキストは引き継がない）
+    const messages = db.getBeaconMessages();
+
     const session: BeaconSession = {
       queue,
       outputIterator: q[Symbol.asyncIterator](),
       queryInstance: q,
-      messages: [],
+      messages,
       lastActivity: new Date(),
       processing: false,
       abortController,
@@ -841,6 +845,7 @@ export class BeaconManager extends EventEmitter {
       timestamp: new Date(),
     };
     session.messages.push(userMessage);
+    db.addBeaconMessage(userMessage);
     this.emit("beacon:message", userMessage);
 
     // キューにメッセージをpush（query()のAsyncIterableに供給される）
@@ -937,7 +942,9 @@ export class BeaconManager extends EventEmitter {
           }
 
           // 最終的なアシスタントメッセージをチャット履歴に追加
-          if (assistantText) {
+          // clearHistory等でセッションが差し替わっている場合はDB書き込みしない
+          // （消した履歴が in-flight のresult書き込みで復活するのを防ぐ）
+          if (assistantText && this.session === session) {
             const assistantMessage: ChatMessage = {
               id: randomUUID(),
               role: "assistant",
@@ -946,6 +953,7 @@ export class BeaconManager extends EventEmitter {
               toolUse: lastToolUse,
             };
             session.messages.push(assistantMessage);
+            db.addBeaconMessage(assistantMessage);
             this.emit("beacon:message", assistantMessage);
           }
 
@@ -985,9 +993,24 @@ export class BeaconManager extends EventEmitter {
 
   /**
    * チャット履歴を取得する
+   *
+   * セッション未開始時はDBから直接ロードする（サーバー再起動・アイドルタイムアウト後も履歴を保持するため）
    */
   getHistory(): ChatMessage[] {
-    return this.session ? [...this.session.messages] : [];
+    if (this.session) return [...this.session.messages];
+    return db.getBeaconMessages();
+  }
+
+  /**
+   * チャット履歴を全削除する
+   *
+   * サーバー側のセッション（LLMコンテキスト）も閉じてDB履歴もクリアする。
+   * 次のメッセージ送信時に新規セッションが開始される。
+   */
+  clearHistory(): void {
+    this.closeSession();
+    db.clearBeaconMessages();
+    console.log("[BeaconManager] 履歴をクリアしました");
   }
 
   /**

--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -11,6 +11,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import Database from "better-sqlite3";
 import type {
+  ChatMessage,
   FrontlineRecord,
   FrontlineStats,
   Message,
@@ -61,6 +62,28 @@ interface CreateMessageInput {
   readonly role: "user" | "assistant" | "system";
   readonly content: string;
   readonly type?: MessageType;
+  readonly timestamp: Date;
+}
+
+/** Beacon履歴の行データ */
+interface BeaconMessageRow {
+  id: string;
+  role: string;
+  content: string;
+  tool_use_json: string | null;
+  timestamp: string;
+}
+
+/** Beacon履歴追加時の入力データ */
+interface BeaconMessageInput {
+  readonly id: string;
+  readonly role: "user" | "assistant";
+  readonly content: string;
+  readonly toolUse?: {
+    toolName: string;
+    input: string;
+    result?: string;
+  };
   readonly timestamp: Date;
 }
 
@@ -170,6 +193,18 @@ class SessionDatabase {
 
     // 既存のpetsテーブルを破棄（pet機能はサーバー側を廃止済み）
     this.db.exec("DROP TABLE IF EXISTS pets;");
+
+    // Beacon履歴テーブル（グローバルチャット用・1セッションのみ）
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS beacon_messages (
+        id TEXT PRIMARY KEY,
+        role TEXT NOT NULL,
+        content TEXT NOT NULL,
+        tool_use_json TEXT,
+        timestamp TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_beacon_messages_timestamp ON beacon_messages(timestamp);
+    `);
 
     // フロントライン記録テーブル
     this.db.exec(`
@@ -395,6 +430,63 @@ class SessionDatabase {
   clearMessages(sessionId: string): void {
     const stmt = this.db.prepare("DELETE FROM messages WHERE session_id = ?");
     stmt.run(sessionId);
+  }
+
+  // ============================================================
+  // Beacon履歴CRUD操作
+  // ============================================================
+
+  /**
+   * Beaconチャット履歴にメッセージを追加
+   */
+  addBeaconMessage(message: BeaconMessageInput): void {
+    const stmt = this.db.prepare(`
+      INSERT INTO beacon_messages (id, role, content, tool_use_json, timestamp)
+      VALUES (?, ?, ?, ?, ?)
+    `);
+    stmt.run(
+      message.id,
+      message.role,
+      message.content,
+      message.toolUse ? JSON.stringify(message.toolUse) : null,
+      message.timestamp.toISOString()
+    );
+  }
+
+  /**
+   * Beaconチャット履歴を全件取得（タイムスタンプ昇順）
+   */
+  getBeaconMessages(): ChatMessage[] {
+    const stmt = this.db.prepare(
+      "SELECT * FROM beacon_messages ORDER BY timestamp ASC"
+    );
+    const rows = stmt.all() as BeaconMessageRow[];
+    return rows.map(row => {
+      let toolUse: ChatMessage["toolUse"];
+      if (row.tool_use_json) {
+        try {
+          toolUse = JSON.parse(row.tool_use_json);
+        } catch {
+          console.warn(
+            `[DB] Failed to parse beacon_messages.tool_use_json for ${row.id}`
+          );
+        }
+      }
+      return {
+        id: row.id,
+        role: row.role as "user" | "assistant",
+        content: row.content,
+        timestamp: new Date(row.timestamp),
+        toolUse,
+      };
+    });
+  }
+
+  /**
+   * Beaconチャット履歴を全削除
+   */
+  clearBeaconMessages(): void {
+    this.db.exec("DELETE FROM beacon_messages");
   }
 
   // ============================================================

--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -436,8 +436,14 @@ class SessionDatabase {
   // Beacon履歴CRUD操作
   // ============================================================
 
+  /** Beacon履歴の保持上限（UI表示・WebSocket送信のペイロード抑制用） */
+  private static readonly BEACON_MESSAGES_RETENTION = 500;
+
   /**
    * Beaconチャット履歴にメッセージを追加
+   *
+   * 追加後、保持上限 (BEACON_MESSAGES_RETENTION) を超えた古いレコードを
+   * LRU的にトリムしてDB無限成長を防ぐ。
    */
   addBeaconMessage(message: BeaconMessageInput): void {
     const stmt = this.db.prepare(`
@@ -451,27 +457,38 @@ class SessionDatabase {
       message.toolUse ? JSON.stringify(message.toolUse) : null,
       message.timestamp.toISOString()
     );
+
+    // 古いメッセージをトリム（直近 RETENTION 件のみ保持）
+    const trim = this.db.prepare(`
+      DELETE FROM beacon_messages
+      WHERE id NOT IN (
+        SELECT id FROM beacon_messages ORDER BY timestamp DESC LIMIT ?
+      )
+    `);
+    trim.run(SessionDatabase.BEACON_MESSAGES_RETENTION);
   }
 
   /**
-   * Beaconチャット履歴を全件取得（タイムスタンプ昇順）
+   * Beaconチャット履歴を取得（タイムスタンプ昇順、直近 limit 件）
+   *
+   * limit のデフォルトは保持上限と同じ。UI/WebSocket送信で全件返す必要がある想定。
    */
-  getBeaconMessages(): ChatMessage[] {
+  getBeaconMessages(
+    limit: number = SessionDatabase.BEACON_MESSAGES_RETENTION
+  ): ChatMessage[] {
+    // 直近 limit 件を時刻降順で取って、表示用に昇順に戻す
     const stmt = this.db.prepare(
-      "SELECT * FROM beacon_messages ORDER BY timestamp ASC"
+      "SELECT * FROM (SELECT * FROM beacon_messages ORDER BY timestamp DESC LIMIT ?) ORDER BY timestamp ASC"
     );
-    const rows = stmt.all() as BeaconMessageRow[];
+    const rows = stmt.all(limit) as BeaconMessageRow[];
     return rows.map(row => {
-      let toolUse: ChatMessage["toolUse"];
-      if (row.tool_use_json) {
-        try {
-          toolUse = JSON.parse(row.tool_use_json);
-        } catch {
-          console.warn(
-            `[DB] Failed to parse beacon_messages.tool_use_json for ${row.id}`
-          );
-        }
-      }
+      const toolUse = row.tool_use_json
+        ? this.safeJsonParse<ChatMessage["toolUse"]>(
+            row.tool_use_json,
+            undefined,
+            `beacon_messages.tool_use_json[${row.id}]`
+          )
+        : undefined;
       return {
         id: row.id,
         role: row.role as "user" | "assistant",

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -76,11 +76,11 @@ export class SessionOrchestrator extends EventEmitter {
         console.log(
           `[Orchestrator] Restored session: ${tmuxSession.tmuxSessionName} -> ${dbSession.id} (status: ${dbSession.status})`
         );
-        // repoPathが未設定ならgitから導出して保存
-        if (!dbSession.repoPath && tmuxSession.worktreePath) {
-          const repoPath = this.deriveRepoPath(tmuxSession.worktreePath);
-          if (repoPath) {
-            db.updateSessionRepoPath(dbSession.id, repoPath);
+        // DBのrepoPathがworktreePathと不整合なら上書き修正する
+        if (tmuxSession.worktreePath) {
+          const derived = this.deriveRepoPath(tmuxSession.worktreePath);
+          if (derived && dbSession.repoPath !== derived) {
+            db.updateSessionRepoPath(dbSession.id, derived);
           }
         }
       }
@@ -127,13 +127,18 @@ export class SessionOrchestrator extends EventEmitter {
         ? (dbSession?.status as SessionStatus) || "active"
         : this.mapTmuxStatus(tmuxSession.status);
 
-    // repoPathがDBにない場合はgitから導出して保存
-    let repoPath = dbSession?.repoPath;
-    if (!repoPath && tmuxSession.worktreePath) {
-      repoPath = this.deriveRepoPath(tmuxSession.worktreePath);
-      if (repoPath && dbSession) {
-        db.updateSessionRepoPath(dbSession.id, repoPath);
-      }
+    // worktreePathから導出したrepoPathを正として扱い、
+    // DBとの不整合があれば修正する
+    const derivedRepoPath = tmuxSession.worktreePath
+      ? this.deriveRepoPath(tmuxSession.worktreePath)
+      : undefined;
+    const repoPath = derivedRepoPath ?? dbSession?.repoPath;
+    if (
+      derivedRepoPath &&
+      dbSession &&
+      dbSession.repoPath !== derivedRepoPath
+    ) {
+      db.updateSessionRepoPath(dbSession.id, derivedRepoPath);
     }
 
     return {
@@ -195,14 +200,19 @@ export class SessionOrchestrator extends EventEmitter {
     worktreePath: string,
     repoPath?: string
   ): Promise<ManagedSession> {
+    // worktreePathから導出したrepoPathを優先する。
+    // 呼び出し側の `currentRepoPath` はソケット状態に依存するため、
+    // 別リポジトリのworktreeに対して誤った値が渡るケースがある。
+    const resolvedRepoPath = this.deriveRepoPath(worktreePath) ?? repoPath;
+
     // 既存セッションがあれば再利用
     const existingTmux = tmuxManager.getSessionByWorktree(worktreePath);
     if (existingTmux) {
-      // repoPathが渡された場合はDBを更新（既存セッションにrepoPath情報を補完）
-      if (repoPath) {
+      // repoPathが解決できた場合はDBを更新（既存セッションにrepoPath情報を補完）
+      if (resolvedRepoPath) {
         const dbSession = db.getSessionByWorktreePath(worktreePath);
-        if (dbSession && !dbSession.repoPath) {
-          db.updateSessionRepoPath(dbSession.id, repoPath);
+        if (dbSession && dbSession.repoPath !== resolvedRepoPath) {
+          db.updateSessionRepoPath(dbSession.id, resolvedRepoPath);
         }
       }
 
@@ -234,7 +244,7 @@ export class SessionOrchestrator extends EventEmitter {
       id: tmuxSession.id,
       worktreeId,
       worktreePath,
-      repoPath,
+      repoPath: resolvedRepoPath,
       status: "active",
     });
 
@@ -242,7 +252,7 @@ export class SessionOrchestrator extends EventEmitter {
       id: tmuxSession.id,
       worktreeId,
       worktreePath,
-      repoPath,
+      repoPath: resolvedRepoPath,
       status: "active",
       createdAt: tmuxSession.createdAt,
       tmuxSessionName: tmuxSession.tmuxSessionName,

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -21,6 +21,16 @@ import { ttydManager } from "./ttyd-manager.js";
 export type { ManagedSession };
 
 export class SessionOrchestrator extends EventEmitter {
+  /**
+   * worktreePath → repoPath のキャッシュ
+   *
+   * deriveRepoPath() は execFileSync(git) で同期子プロセスを起動するため、
+   * getAllSessions/toManagedSession のhot pathでN回呼ばれると接続時応答が遅れる。
+   * worktreeは削除イベント時のみ変更されるので、生存期間中はキャッシュして良い。
+   * stopSession / 孤立セッションクリーンアップ時に invalidate する。
+   */
+  private repoPathCache = new Map<string, string | undefined>();
+
   constructor() {
     super();
     this.setupEventForwarding();
@@ -67,22 +77,18 @@ export class SessionOrchestrator extends EventEmitter {
         if (dbSession) {
           db.deleteSession(dbSession.id);
         }
+        this.repoPathCache.delete(tmuxSession.worktreePath);
         continue;
       }
 
       // DBにセッション情報があればstatusを尊重（idle等の永続化された状態を維持）
+      // repoPathの不整合はttyd起動完了時のtoManagedSession()が修正するので
+      // ここで二度execFileSyncを走らせない
       const dbSession = db.getSessionByWorktreePath(tmuxSession.worktreePath);
       if (dbSession) {
         console.log(
           `[Orchestrator] Restored session: ${tmuxSession.tmuxSessionName} -> ${dbSession.id} (status: ${dbSession.status})`
         );
-        // DBのrepoPathがworktreePathと不整合なら上書き修正する
-        if (tmuxSession.worktreePath) {
-          const derived = this.deriveRepoPath(tmuxSession.worktreePath);
-          if (derived && dbSession.repoPath !== derived) {
-            db.updateSessionRepoPath(dbSession.id, derived);
-          }
-        }
       }
 
       // ttydも自動起動（起動完了後にクライアントへ通知）
@@ -154,8 +160,16 @@ export class SessionOrchestrator extends EventEmitter {
     };
   }
 
-  /** worktreePathからメインリポジトリのパスを導出 */
+  /**
+   * worktreePathからメインリポジトリのパスを導出
+   *
+   * `repoPathCache` でメモ化する。ヒット時はgitプロセスを起動しない。
+   * 失敗結果 (undefined) も再試行を避けるためキャッシュする。
+   */
   private deriveRepoPath(worktreePath: string): string | undefined {
+    if (this.repoPathCache.has(worktreePath)) {
+      return this.repoPathCache.get(worktreePath);
+    }
     try {
       const gitCommonDir = execFileSync(
         "git",
@@ -168,8 +182,11 @@ export class SessionOrchestrator extends EventEmitter {
         ],
         { encoding: "utf-8" }
       ).trim();
-      return gitCommonDir.replace(/\/\.git\/?$/, "") || undefined;
+      const repo = gitCommonDir.replace(/\/\.git\/?$/, "") || undefined;
+      this.repoPathCache.set(worktreePath, repo);
+      return repo;
     } catch {
+      this.repoPathCache.set(worktreePath, undefined);
       return undefined;
     }
   }
@@ -303,6 +320,9 @@ export class SessionOrchestrator extends EventEmitter {
     ttydManager.stopInstance(sessionId);
     tmuxManager.killSession(sessionId);
     db.deleteSession(sessionId);
+    if (worktreePath) {
+      this.repoPathCache.delete(worktreePath);
+    }
     this.emit("session:stopped", sessionId);
 
     return worktreePath ? { worktreePath, repoPath } : null;
@@ -378,6 +398,7 @@ export class SessionOrchestrator extends EventEmitter {
         if (dbSession) {
           db.deleteSession(dbSession.id);
         }
+        this.repoPathCache.delete(s.worktreePath);
         this.emit("session:stopped", s.id);
       }
     }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -253,6 +253,7 @@ export interface ClientToServerEvents {
   "beacon:send": (data: { message: string }) => void;
   "beacon:history": () => void;
   "beacon:close": () => void;
+  "beacon:clear": () => void;
 
   // ファイルビューワー
   "file:read": (data: { sessionId: string; filePath: string }) => void;


### PR DESCRIPTION
## 概要

3つの独立した改善を1つのPRにまとめる:

1. **Beaconチャット履歴のDB永続化** — サーバー再起動・アイドルタイムアウト後も履歴を保持
2. **Worktree一覧の表示順安定化** — リロードのたびに並びがブレる問題を修正
3. **Session の repoPath 不整合修正** — DB に誤った repoPath が残るのを防止

## 1. Beacon履歴のDB永続化

`beacon_messages` テーブルを追加し、`BeaconManager` でユーザー/アシスタントメッセージを DB に保存するようにした。これまでは `BeaconManager.session` のインメモリ配列でしか保持されていなかったため、サーバー再起動・30分アイドルタイムアウトで全履歴が失われていた。

- \`server/lib/database.ts\` — \`beacon_messages\` テーブル + \`addBeaconMessage\` / \`getBeaconMessages\` / \`clearBeaconMessages\` CRUD
- \`server/lib/beacon-manager.ts\` — \`startSession\` 時に DB から履歴をロード (LLMコンテキストには引き継がない、UI表示用)、メッセージ追加時に DB 書き込み、\`clearHistory\` でセッション閉鎖+DB削除
- \`server/index.ts\` — 接続時に \`beacon:history\` を自動送信 (クライアント側の取得タイミング問題を回避)、\`beacon:clear\` ハンドラ追加 (履歴は全接続クライアントで共有されるため \`io.emit\` で broadcast)
- \`shared/types.ts\` — \`beacon:clear\` イベント定義追加
- \`client/src/hooks/useSocket.ts\` — \`beaconSend\` / \`beaconClear\` に Socket.IO 切断ガードを追加 (切断時に楽観UI更新すると \`beacon:stream\` が届かず入力欄が永久ロックされる/履歴がサーバーと乖離する)

### Codex レビュー指摘対応

レビューで挙がった2件のレース条件も同コミットで修正:

- **[MEDIUM]** \`processOutput()\` で \`msg.type === \"result\"\` 時に DB 書き込み直前 \`this.session === session\` をチェック。\`clearHistory\` で差し替わっていたら書き込まずスキップ (消した履歴が in-flight のresult書き込みで復活するのを防ぐ)
- **[LOW]** \`beaconClear()\` を切断時は no-op に (ローカル state だけ消えてサーバーに届かず、再接続で旧履歴が戻る不整合を防ぐ)

## 2. 表示順の安定化

\`useGroupedWorktreeItems\` で worktree/セッション/リポジトリの全てを昇順ソート。Map のinsertion order依存でリロードごとに並びがブレていたのを修正。

## 3. repoPath不整合修正

\`SessionOrchestrator.startSession\` で worktreePath から導出した repoPath を優先して DB に書き込む。呼び出し側の \`currentRepoPath\` はソケット状態に依存するため、別リポジトリの worktree を開くケースで誤った値がDBに入ることがあった。既存DB行との不整合がある場合も上書き修正する。

## 動作確認

- \`pnpm tsc --noEmit\`: pass
- \`pnpm build\`: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ビーコンチャット履歴の永続化に対応しました
  * ビーコンチャット履歴をクリアする機能を追加しました。全クライアントに同期されます

* **改善**
  * ワークツリーアイテムのグループ化順序が確定的になり、より安定した表示順序を実現しました
  * ビーコン接続時にチャット履歴が自動的に復元されるようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->