### PR TITLE
feat: サイドバーからリポジトリを非表示にする機能

### DIFF
--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -6,10 +6,22 @@
  * worktree中心のイテレーション: セッション未起動のworktreeも表示する。
  */
 
-import { FolderOpen, Globe, Plus, Terminal } from "lucide-react";
+import { FolderOpen, Globe, Plus, Terminal, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useGroupedWorktreeItems } from "@/hooks/useGroupedWorktreeItems";
+import { getBaseName } from "@/utils/pathUtils";
 import type { ManagedSession, Worktree } from "../../../shared/types";
 import { SessionCard } from "./SessionCard";
 
@@ -25,6 +37,8 @@ interface SessionSidebarProps {
   onDeleteSession: (sessionId: string, worktree: Worktree | undefined) => void;
   onStartSession: (worktree: Worktree) => void;
   onNewSession: () => void;
+  /** リポジトリをサイドバー一覧から除外する */
+  onRemoveRepo?: (repoPath: string) => void;
   /** ブラウザ選択コールバック（リモートアクセス時のみ使用） */
   onSelectBrowser?: () => void;
   /** ブラウザが選択中か */
@@ -44,6 +58,7 @@ export function SessionSidebar({
   onDeleteSession,
   onStartSession,
   onNewSession,
+  onRemoveRepo,
   onSelectBrowser,
   isBrowserSelected = false,
   isRemote = false,
@@ -53,6 +68,16 @@ export function SessionSidebar({
     sessions,
     repoList
   );
+
+  // basename → repoPath の対応表（同名repoは衝突する点に注意。既存ロジックも同前提）
+  const repoPathByName = useMemo(
+    () => new Map(repoList.map(p => [getBaseName(p), p])),
+    [repoList]
+  );
+
+  const [removeTargetRepoPath, setRemoveTargetRepoPath] = useState<
+    string | null
+  >(null);
 
   return (
     <div className="h-full flex flex-col bg-sidebar">
@@ -101,47 +126,95 @@ export function SessionSidebar({
               <p className="text-xs mt-1">「+」から新規作成</p>
             </div>
           ) : (
-            Array.from(groupedItems.entries()).map(([repoName, items]) => (
-              <div key={repoName} className="mb-3">
-                {/* リポジトリヘッダー */}
-                <div className="flex items-center gap-1.5 px-2 py-1.5">
-                  <FolderOpen className="w-3 h-3 text-muted-foreground" />
-                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate">
-                    {repoName}
-                  </span>
+            Array.from(groupedItems.entries()).map(([repoName, items]) => {
+              const repoPath = repoPathByName.get(repoName);
+              const canRemove = !!onRemoveRepo && !!repoPath;
+              return (
+                <div key={repoName} className="mb-3">
+                  {/* リポジトリヘッダー */}
+                  <div className="sticky left-0 flex items-center gap-1.5 px-2 py-1.5">
+                    <FolderOpen className="w-3 h-3 text-muted-foreground shrink-0" />
+                    <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate">
+                      {repoName}
+                    </span>
+                    {canRemove && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-5 w-5 shrink-0 text-sidebar-foreground/70 hover:text-destructive hover:bg-destructive/15"
+                        onClick={() => setRemoveTargetRepoPath(repoPath)}
+                        aria-label={`${repoName} をサイドバーから除外`}
+                        title="サイドバーから除外"
+                      >
+                        <X className="w-3.5 h-3.5" />
+                      </Button>
+                    )}
+                  </div>
+                  {/* アイテム一覧 */}
+                  <div className="space-y-1">
+                    {items.map(({ worktree: wt, session }) => (
+                      <SessionCard
+                        key={session?.id ?? wt?.id ?? "unknown"}
+                        session={session}
+                        worktree={wt ?? undefined}
+                        repoList={repoList}
+                        isSelected={
+                          session ? selectedSessionId === session.id : false
+                        }
+                        previewText={
+                          session ? sessionPreviews.get(session.id) || "" : ""
+                        }
+                        activityText={
+                          session
+                            ? sessionActivityTexts.get(session.id) || ""
+                            : ""
+                        }
+                        onClick={() => session && onSelectSession(session.id)}
+                        onDelete={() =>
+                          session &&
+                          onDeleteSession(session.id, wt ?? undefined)
+                        }
+                        onStart={() => (wt ? onStartSession(wt) : undefined)}
+                      />
+                    ))}
+                  </div>
                 </div>
-                {/* アイテム一覧 */}
-                <div className="space-y-1">
-                  {items.map(({ worktree: wt, session }) => (
-                    <SessionCard
-                      key={session?.id ?? wt?.id ?? "unknown"}
-                      session={session}
-                      worktree={wt ?? undefined}
-                      repoList={repoList}
-                      isSelected={
-                        session ? selectedSessionId === session.id : false
-                      }
-                      previewText={
-                        session ? sessionPreviews.get(session.id) || "" : ""
-                      }
-                      activityText={
-                        session
-                          ? sessionActivityTexts.get(session.id) || ""
-                          : ""
-                      }
-                      onClick={() => session && onSelectSession(session.id)}
-                      onDelete={() =>
-                        session && onDeleteSession(session.id, wt ?? undefined)
-                      }
-                      onStart={() => (wt ? onStartSession(wt) : undefined)}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))
+              );
+            })
           )}
         </div>
       </ScrollArea>
+
+      <AlertDialog
+        open={removeTargetRepoPath !== null}
+        onOpenChange={open => {
+          if (!open) setRemoveTargetRepoPath(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>リポジトリをサイドバーから除外</AlertDialogTitle>
+            <AlertDialogDescription>
+              {removeTargetRepoPath
+                ? `「${getBaseName(removeTargetRepoPath)}」をサイドバー一覧から非表示にします。Worktreeやセッション、リポジトリ自体は削除されません。再度リポジトリを選択すれば復元できます。`
+                : ""}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (removeTargetRepoPath && onRemoveRepo) {
+                  onRemoveRepo(removeTargetRepoPath);
+                }
+                setRemoveTargetRepoPath(null);
+              }}
+            >
+              除外
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/client/src/hooks/useGroupedWorktreeItems.ts
+++ b/client/src/hooks/useGroupedWorktreeItems.ts
@@ -31,16 +31,24 @@ export function useGroupedWorktreeItems(
     const groups = new Map<string, GroupedItem[]>();
     const worktreeSessionIds = new Set<string>();
 
+    // repoListが空でない場合、リスト外のrepoに属するworktree/sessionは非表示にする
+    // （サイドバーからrepoを除外する操作で利用）
+    const hasFilter = repoList.length > 0;
+
     // worktreePath昇順で処理することでリロード間の並び順を安定させる
     const sortedWorktrees = [...worktrees].sort((a, b) =>
       a.path.localeCompare(b.path)
     );
     for (const wt of sortedWorktrees) {
       const session = sessionByWorktreeId.get(wt.id) ?? null;
+      const matchedRepo = repoList.find(repo => wt.path.startsWith(repo));
+      const sessionRepoMatched = session?.repoPath
+        ? repoList.includes(session.repoPath)
+        : false;
+      if (hasFilter && !matchedRepo && !sessionRepoMatched) continue;
       if (session) worktreeSessionIds.add(session.id);
       const repoName = (() => {
         if (session?.repoPath) return getBaseName(session.repoPath);
-        const matchedRepo = repoList.find(repo => wt.path.startsWith(repo));
         if (matchedRepo) return getBaseName(matchedRepo);
         return getBaseName(wt.path.split("/.worktrees/")[0] || wt.path);
       })();
@@ -55,6 +63,7 @@ export function useGroupedWorktreeItems(
     for (const session of sortedSessions) {
       if (worktreeSessionIds.has(session.id)) continue;
       const repo = session.repoPath ?? findRepoForSession(session, repoList);
+      if (hasFilter && (!repo || !repoList.includes(repo))) continue;
       const repoName = repo ? getBaseName(repo) : "unknown";
       const existing = groups.get(repoName) || [];
       existing.push({ worktree: null, session });

--- a/client/src/hooks/useGroupedWorktreeItems.ts
+++ b/client/src/hooks/useGroupedWorktreeItems.ts
@@ -31,21 +31,23 @@ export function useGroupedWorktreeItems(
     const groups = new Map<string, GroupedItem[]>();
     const worktreeSessionIds = new Set<string>();
 
-    // repoListが空でない場合、リスト外のrepoに属するworktree/sessionは非表示にする
-    // （サイドバーからrepoを除外する操作で利用）
-    const hasFilter = repoList.length > 0;
+    // repoListに含まれるrepoのworktree/sessionのみ表示する。
+    // repoListが空の場合は何も表示しない（「全件表示」にフォールバックすると、
+    // 最後の1件を除外した直後に除外対象が再表示されてしまう）。
+    const repoListEmpty = repoList.length === 0;
 
     // worktreePath昇順で処理することでリロード間の並び順を安定させる
     const sortedWorktrees = [...worktrees].sort((a, b) =>
       a.path.localeCompare(b.path)
     );
     for (const wt of sortedWorktrees) {
+      if (repoListEmpty) break;
       const session = sessionByWorktreeId.get(wt.id) ?? null;
       const matchedRepo = repoList.find(repo => wt.path.startsWith(repo));
       const sessionRepoMatched = session?.repoPath
         ? repoList.includes(session.repoPath)
         : false;
-      if (hasFilter && !matchedRepo && !sessionRepoMatched) continue;
+      if (!matchedRepo && !sessionRepoMatched) continue;
       if (session) worktreeSessionIds.add(session.id);
       const repoName = (() => {
         if (session?.repoPath) return getBaseName(session.repoPath);
@@ -61,10 +63,11 @@ export function useGroupedWorktreeItems(
       a.worktreePath.localeCompare(b.worktreePath)
     );
     for (const session of sortedSessions) {
+      if (repoListEmpty) break;
       if (worktreeSessionIds.has(session.id)) continue;
       const repo = session.repoPath ?? findRepoForSession(session, repoList);
-      if (hasFilter && (!repo || !repoList.includes(repo))) continue;
-      const repoName = repo ? getBaseName(repo) : "unknown";
+      if (!repo || !repoList.includes(repo)) continue;
+      const repoName = getBaseName(repo);
       const existing = groups.get(repoName) || [];
       existing.push({ worktree: null, session });
       groups.set(repoName, existing);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -320,6 +320,21 @@ export default function Dashboard() {
     setIsSelectRepoOpen(true);
   };
 
+  /**
+   * リポジトリをサイドバーから除外する。
+   * 現在選択中のrepoを除外する場合、残りrepoListの先頭に切り替えてから除外することで
+   * 他repoのworktree表示（repoPath選択でのみフェッチされる）が連鎖的に消えないようにする。
+   */
+  const handleRemoveRepo = (path: string) => {
+    if (repoPath === path) {
+      const remaining = repoList.filter(p => p !== path);
+      if (remaining.length > 0) {
+        selectRepo(remaining[0]);
+      }
+    }
+    removeRepo(path);
+  };
+
   return (
     <>
       {isMobile ? (
@@ -364,7 +379,7 @@ export default function Dashboard() {
               onDeleteSession={handleDeleteSession}
               onStartSession={handleStartSession}
               onNewSession={handleNewSession}
-              onRemoveRepo={removeRepo}
+              onRemoveRepo={handleRemoveRepo}
               onSelectBrowser={handleSelectBrowser}
               isBrowserSelected={selectedSessionId === "browser"}
               isRemote={isRemote}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -54,6 +54,7 @@ export default function Dashboard() {
     repoList,
     repoPath,
     selectRepo,
+    removeRepo,
     scannedRepos,
     isScanning,
     scanRepos,
@@ -363,6 +364,7 @@ export default function Dashboard() {
               onDeleteSession={handleDeleteSession}
               onStartSession={handleStartSession}
               onNewSession={handleNewSession}
+              onRemoveRepo={removeRepo}
               onSelectBrowser={handleSelectBrowser}
               isBrowserSelected={selectedSessionId === "browser"}
               isRemote={isRemote}


### PR DESCRIPTION
## 概要

サイドバーのリポジトリヘッダーに×ボタンを追加し、確認ダイアログ経由でリポジトリ単位でサイドバー一覧から非表示にできるようにした。Worktreeやセッション、リポジトリ自体には手を付けず、クライアント側の `repoList`（サーバー永続化された設定）から除外するだけの軽量動作。

## 変更点

### UI (`client/src/components/SessionSidebar.tsx`)
- リポジトリヘッダー（FOLDERNAME表示）の直後に×ボタンを配置
- クリック→AlertDialogで除外確認→`onRemoveRepo` 発火
- ヘッダーに `sticky left-0` を付与して、長いセッション名で横スクロール領域が拡張されてもヘッダーがビューポートから消えないようにした
- 名前の直後にボタンを置くため `flex-1` を外し、`shrink-0` で2要素とも縮まないようにした

### フィルタロジック (`client/src/hooks/useGroupedWorktreeItems.ts`)
- `repoList` に含まれる repo の worktree/session のみ表示するフィルタを追加
- repoList が空の場合は何も表示しない（全件表示フォールバックは、最後の1件を除外した直後に除外対象が再表示されてしまうため廃止）

### 選択中repo除外時のフォールバック (`client/src/pages/Dashboard.tsx`)
- 現選択中の repo を除外する場合、残り repoList の先頭を \`selectRepo\` してから除外
- こうしないと、\`removeRepo\` が \`repoPath=null\` + \`worktrees=[]\` にクリアし、他 repo の worktree 表示（\`repoPath\` 選択でのみフェッチされる）が連鎖的に消える

## 挙動

- リポジトリヘッダーの右端にある × をクリック
- 確認ダイアログ「リポジトリをサイドバーから除外」
- 「除外」で \`repoList\` から当該 path を削除 → サーバー側 settings に永続化
- Worktree / tmuxセッション / Gitリポジトリ自体には一切手を付けない
- 再度 RepoSelectDialog から同じ repo を選べば復活

## 動作確認

- 型チェック通過（\`pnpm tsc --noEmit\`）
- \`pnpm build\` 成功
- pm2再起動済み
- Playwright で実機DOM確認、×ボタンがリポジトリ名直後に表示されることをスクリーンショットで検証

## Test plan

- [ ] サイドバーのリポジトリヘッダー右端に×ボタンが表示されること
- [ ] ×→確認ダイアログ→「除外」で該当 repo がサイドバーから消えること
- [ ] 現選択中の repo を除外しても、他 repo の worktree 表示が維持されること
- [ ] 最後の1件を除外した直後に、除外対象が再表示されないこと
- [ ] リロードしても除外状態が維持されること（サーバー永続化）
- [ ] RepoSelectDialog から同じ repo を再選択すると復活すること