### PR TITLE
feat: Beaconパネルの表示切替とリサイズ機能

### DIFF
--- a/client/src/components/SidebarMainLayout.tsx
+++ b/client/src/components/SidebarMainLayout.tsx
@@ -2,9 +2,10 @@
  * SidebarMainLayout - PC用3カラムレイアウト
  *
  * サイドバー（セッション一覧） + メイン（ttyd 1ペイン） + Beacon（チャット）
- * の3カラム構成。サイドバー幅はドラッグでリサイズ可能。
+ * の3カラム構成。サイドバー・Beacon幅はドラッグでリサイズ可能、Beaconは表示/非表示を切替可能。
  */
 
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import {
   type ReactNode,
   useCallback,
@@ -17,6 +18,10 @@ const SIDEBAR_MIN_WIDTH = 180;
 const SIDEBAR_MAX_WIDTH = 450;
 const SIDEBAR_DEFAULT_WIDTH = 250;
 
+const BEACON_MIN_WIDTH = 280;
+const BEACON_MAX_WIDTH = 700;
+const BEACON_DEFAULT_WIDTH = 350;
+
 interface SidebarMainLayoutProps {
   sidebar: ReactNode;
   main: ReactNode;
@@ -24,6 +29,14 @@ interface SidebarMainLayoutProps {
   initialSidebarWidth?: number;
   onSidebarWidthChange?: (width: number) => void;
   onOpenFrontLine?: () => void;
+  beaconVisible?: boolean;
+  onBeaconVisibleChange?: (visible: boolean) => void;
+  initialBeaconWidth?: number;
+  onBeaconWidthChange?: (width: number) => void;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
 }
 
 export function SidebarMainLayout({
@@ -33,43 +46,60 @@ export function SidebarMainLayout({
   initialSidebarWidth = SIDEBAR_DEFAULT_WIDTH,
   onSidebarWidthChange,
   onOpenFrontLine,
+  beaconVisible = true,
+  onBeaconVisibleChange,
+  initialBeaconWidth = BEACON_DEFAULT_WIDTH,
+  onBeaconWidthChange,
 }: SidebarMainLayoutProps) {
   const [sidebarWidth, setSidebarWidth] = useState(
-    Math.min(
-      SIDEBAR_MAX_WIDTH,
-      Math.max(SIDEBAR_MIN_WIDTH, initialSidebarWidth)
-    )
+    clamp(initialSidebarWidth, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH)
   );
-  const [isResizing, setIsResizing] = useState(false);
-  const widthRef = useRef(sidebarWidth);
+  const [beaconWidth, setBeaconWidth] = useState(
+    clamp(initialBeaconWidth, BEACON_MIN_WIDTH, BEACON_MAX_WIDTH)
+  );
+  const [resizing, setResizing] = useState<"sidebar" | "beacon" | null>(null);
+  const sidebarWidthRef = useRef(sidebarWidth);
+  const beaconWidthRef = useRef(beaconWidth);
   const cleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
-    const clamped = Math.min(
-      SIDEBAR_MAX_WIDTH,
-      Math.max(SIDEBAR_MIN_WIDTH, initialSidebarWidth)
+    const clamped = clamp(
+      initialSidebarWidth,
+      SIDEBAR_MIN_WIDTH,
+      SIDEBAR_MAX_WIDTH
     );
     setSidebarWidth(clamped);
-    widthRef.current = clamped;
+    sidebarWidthRef.current = clamped;
   }, [initialSidebarWidth]);
 
-  const handleResizeStart = useCallback(
+  useEffect(() => {
+    const clamped = clamp(
+      initialBeaconWidth,
+      BEACON_MIN_WIDTH,
+      BEACON_MAX_WIDTH
+    );
+    setBeaconWidth(clamped);
+    beaconWidthRef.current = clamped;
+  }, [initialBeaconWidth]);
+
+  const handleSidebarResizeStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
-      setIsResizing(true);
+      setResizing("sidebar");
 
-      const handleMouseMove = (e: MouseEvent) => {
-        const newWidth = Math.min(
-          SIDEBAR_MAX_WIDTH,
-          Math.max(SIDEBAR_MIN_WIDTH, e.clientX)
+      const handleMouseMove = (ev: MouseEvent) => {
+        const newWidth = clamp(
+          ev.clientX,
+          SIDEBAR_MIN_WIDTH,
+          SIDEBAR_MAX_WIDTH
         );
-        widthRef.current = newWidth;
+        sidebarWidthRef.current = newWidth;
         setSidebarWidth(newWidth);
       };
 
       const handleMouseUp = () => {
-        setIsResizing(false);
-        onSidebarWidthChange?.(widthRef.current);
+        setResizing(null);
+        onSidebarWidthChange?.(sidebarWidthRef.current);
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
         document.body.style.cursor = "";
@@ -92,11 +122,53 @@ export function SidebarMainLayout({
     [onSidebarWidthChange]
   );
 
+  const handleBeaconResizeStart = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      setResizing("beacon");
+
+      const handleMouseMove = (ev: MouseEvent) => {
+        const newWidth = clamp(
+          window.innerWidth - ev.clientX,
+          BEACON_MIN_WIDTH,
+          BEACON_MAX_WIDTH
+        );
+        beaconWidthRef.current = newWidth;
+        setBeaconWidth(newWidth);
+      };
+
+      const handleMouseUp = () => {
+        setResizing(null);
+        onBeaconWidthChange?.(beaconWidthRef.current);
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        cleanupRef.current = null;
+      };
+
+      cleanupRef.current = () => {
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    },
+    [onBeaconWidthChange]
+  );
+
   useEffect(() => {
     return () => {
       cleanupRef.current?.();
     };
   }, []);
+
+  const isResizing = resizing !== null;
 
   return (
     <div className="h-[100dvh] flex relative">
@@ -120,17 +192,64 @@ export function SidebarMainLayout({
         {/* biome-ignore lint/a11y/noStaticElementInteractions: リサイズハンドルはマウス操作専用 */}
         <div
           className={`absolute top-0 -right-1 w-3 h-full cursor-col-resize hover:bg-primary/50 transition-colors ${
-            isResizing ? "bg-primary/50" : "bg-transparent"
+            resizing === "sidebar" ? "bg-primary/50" : "bg-transparent"
           }`}
-          onMouseDown={handleResizeStart}
+          onMouseDown={handleSidebarResizeStart}
         />
       </div>
 
       {/* メインエリア */}
-      <div className="flex-1 min-w-0 flex flex-col">{main}</div>
+      <div className="flex-1 min-w-0 flex flex-col relative">
+        {main}
+        {/* Beacon非表示時の展開ボタン */}
+        {!beaconVisible && onBeaconVisibleChange && (
+          <button
+            type="button"
+            onClick={() => onBeaconVisibleChange(true)}
+            aria-label="Beaconを表示"
+            title="Beaconを表示"
+            className="absolute top-2 right-2 z-10 p-1.5 rounded-md bg-background/80 border border-border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+          >
+            <ChevronLeft className="w-4 h-4" />
+          </button>
+        )}
+      </div>
 
       {/* Beacon */}
-      <div className="w-[350px] shrink-0 border-l border-border">{beacon}</div>
+      {beaconVisible && (
+        <div
+          className="shrink-0 border-l border-border relative"
+          style={{ width: `${beaconWidth}px` }}
+        >
+          {beacon}
+        </div>
+      )}
+
+      {/* Beaconリサイズハンドル（レイアウト直下配置でiframe/内部要素の干渉を回避） */}
+      {beaconVisible && (
+        <>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: リサイズハンドルはマウス操作専用 */}
+          <div
+            className={`absolute top-0 w-3 h-full cursor-col-resize hover:bg-primary/50 transition-colors z-40 ${
+              resizing === "beacon" ? "bg-primary/50" : "bg-transparent"
+            }`}
+            style={{ right: `${beaconWidth - 6}px` }}
+            onMouseDown={handleBeaconResizeStart}
+          />
+          {onBeaconVisibleChange && (
+            <button
+              type="button"
+              onClick={() => onBeaconVisibleChange(false)}
+              aria-label="Beaconを非表示"
+              title="Beaconを非表示"
+              className="absolute top-3 z-40 p-1 rounded-full bg-background border border-border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors shadow-sm"
+              style={{ right: `${beaconWidth - 6}px` }}
+            >
+              <ChevronRight className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </>
+      )}
     </div>
   );
 }

--- a/client/src/components/SidebarMainLayout.tsx
+++ b/client/src/components/SidebarMainLayout.tsx
@@ -22,6 +22,9 @@ const BEACON_MIN_WIDTH = 280;
 const BEACON_MAX_WIDTH = 700;
 const BEACON_DEFAULT_WIDTH = 350;
 
+// メインエリアが最低限保持すべき幅（これ未満には潰れないようBeacon/Sidebarを制限）
+const MAIN_MIN_WIDTH = 320;
+
 interface SidebarMainLayoutProps {
   sidebar: ReactNode;
   main: ReactNode;
@@ -39,6 +42,14 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
+// 現在のサイドバー幅とviewport幅から、Beacon幅の上限を計算する
+function resolveBeaconMax(sidebarWidth: number): number {
+  if (typeof window === "undefined") return BEACON_MAX_WIDTH;
+  const available = window.innerWidth - sidebarWidth - MAIN_MIN_WIDTH;
+  // availableが下限を下回る場合はBEACON_MIN_WIDTHまで許容（main側が潰れてもBeaconはmin死守）
+  return Math.max(BEACON_MIN_WIDTH, Math.min(BEACON_MAX_WIDTH, available));
+}
+
 export function SidebarMainLayout({
   sidebar,
   main,
@@ -51,16 +62,30 @@ export function SidebarMainLayout({
   initialBeaconWidth = BEACON_DEFAULT_WIDTH,
   onBeaconWidthChange,
 }: SidebarMainLayoutProps) {
-  const [sidebarWidth, setSidebarWidth] = useState(
+  const [sidebarWidth, setSidebarWidth] = useState(() =>
     clamp(initialSidebarWidth, SIDEBAR_MIN_WIDTH, SIDEBAR_MAX_WIDTH)
   );
-  const [beaconWidth, setBeaconWidth] = useState(
-    clamp(initialBeaconWidth, BEACON_MIN_WIDTH, BEACON_MAX_WIDTH)
-  );
+  const [beaconWidth, setBeaconWidth] = useState(() => {
+    const initialSb = clamp(
+      initialSidebarWidth,
+      SIDEBAR_MIN_WIDTH,
+      SIDEBAR_MAX_WIDTH
+    );
+    return clamp(
+      initialBeaconWidth,
+      BEACON_MIN_WIDTH,
+      resolveBeaconMax(initialSb)
+    );
+  });
   const [resizing, setResizing] = useState<"sidebar" | "beacon" | null>(null);
   const sidebarWidthRef = useRef(sidebarWidth);
   const beaconWidthRef = useRef(beaconWidth);
   const cleanupRef = useRef<(() => void) | null>(null);
+  const onBeaconWidthChangeRef = useRef(onBeaconWidthChange);
+
+  useEffect(() => {
+    onBeaconWidthChangeRef.current = onBeaconWidthChange;
+  }, [onBeaconWidthChange]);
 
   useEffect(() => {
     const clamped = clamp(
@@ -76,11 +101,25 @@ export function SidebarMainLayout({
     const clamped = clamp(
       initialBeaconWidth,
       BEACON_MIN_WIDTH,
-      BEACON_MAX_WIDTH
+      resolveBeaconMax(sidebarWidthRef.current)
     );
     setBeaconWidth(clamped);
     beaconWidthRef.current = clamped;
   }, [initialBeaconWidth]);
+
+  // ウィンドウリサイズ時にBeaconが新しい上限を超えていたら縮める
+  useEffect(() => {
+    const handleResize = () => {
+      const max = resolveBeaconMax(sidebarWidthRef.current);
+      if (beaconWidthRef.current > max) {
+        beaconWidthRef.current = max;
+        setBeaconWidth(max);
+        onBeaconWidthChangeRef.current?.(max);
+      }
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
 
   const handleSidebarResizeStart = useCallback(
     (e: React.MouseEvent) => {
@@ -95,11 +134,18 @@ export function SidebarMainLayout({
         );
         sidebarWidthRef.current = newWidth;
         setSidebarWidth(newWidth);
+        // サイドバー拡大でBeaconの許容上限を超えたら縮める
+        const beaconMax = resolveBeaconMax(newWidth);
+        if (beaconWidthRef.current > beaconMax) {
+          beaconWidthRef.current = beaconMax;
+          setBeaconWidth(beaconMax);
+        }
       };
 
       const handleMouseUp = () => {
         setResizing(null);
         onSidebarWidthChange?.(sidebarWidthRef.current);
+        onBeaconWidthChangeRef.current?.(beaconWidthRef.current);
         document.removeEventListener("mousemove", handleMouseMove);
         document.removeEventListener("mouseup", handleMouseUp);
         document.body.style.cursor = "";
@@ -131,7 +177,7 @@ export function SidebarMainLayout({
         const newWidth = clamp(
           window.innerWidth - ev.clientX,
           BEACON_MIN_WIDTH,
-          BEACON_MAX_WIDTH
+          resolveBeaconMax(sidebarWidthRef.current)
         );
         beaconWidthRef.current = newWidth;
         setBeaconWidth(newWidth);

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -473,6 +473,10 @@ export default function Dashboard() {
           initialSidebarWidth={getSetting<number>("ark-sidebar-width", 250)}
           onSidebarWidthChange={w => setSetting("ark-sidebar-width", w)}
           onOpenFrontLine={() => setShowFrontLine(true)}
+          beaconVisible={getSetting<boolean>("ark-beacon-visible", true)}
+          onBeaconVisibleChange={v => setSetting("ark-beacon-visible", v)}
+          initialBeaconWidth={getSetting<number>("ark-beacon-width", 350)}
+          onBeaconWidthChange={w => setSetting("ark-beacon-width", w)}
         />
       )}
 


### PR DESCRIPTION
## Summary

- BeaconパネルをShow/Hideトグル可能にし、メインエリアを広く使えるようにした
- Beacon幅をドラッグでリサイズ可能（280〜700px）
- 両方とも`useSettings`で永続化（`ark-beacon-visible` / `ark-beacon-width`）
- Beacon幅はviewport対応でclamp（`main`が320px未満に潰れないよう動的上限算出）

## 実装詳細

- `SidebarMainLayout.tsx`にBeaconリサイズハンドル追加。レイアウト直下配置でttyd iframeへのmousedown吸収を回避（`z-40`）
- 非表示時はメインエリア右上に`<`ボタン、表示時はBeacon左端境界上に`>`ボタン
- sidebar拡大時・windowリサイズ時にも動的にBeacon幅を再clamp

## Test plan

- [ ] Beaconの表示/非表示切替動作
- [ ] Beaconドラッグリサイズ動作（280〜700px範囲）
- [ ] リロード後も幅・表示状態が復元されること
- [ ] 狭いウィンドウ（~1100px）でsidebar+beaconがmainを潰さないこと
- [ ] ブラウザウィンドウを縮小したときにBeaconが自動で縮むこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **New Features**
  * Beaconパネルを独立してドラッグ可能にリサイズできるようになりました
  * Beaconの表示/非表示をワンクリックで切り替え可能に
  * Beaconの幅をカスタマイズでき、設定が自動保存されます
  * ウィンドウサイズの変更に応じてBeacon幅が自動調整されます

<!-- end of auto-generated comment: release notes by coderabbit.ai -->