### PR TITLE
feat: スキャンパス選択をフォルダ選択ダイアログ化

### DIFF
--- a/client/src/components/FolderBrowserDialog.tsx
+++ b/client/src/components/FolderBrowserDialog.tsx
@@ -86,8 +86,12 @@ function FolderBrowserContent({
     e => showHidden || !e.isHidden
   );
 
+  // エラー発生時はconfirm不可。listingは前回値が残るため
+  // pathDraft（テキスト欄表示）と乖離したまま誤選択するのを防ぐ。
+  const isConfirmDisabled = !listing || error !== null;
+
   const handleConfirm = () => {
-    if (!listing) return;
+    if (isConfirmDisabled || !listing) return;
     onConfirm(listing.path);
     onClose();
   };
@@ -211,7 +215,7 @@ function FolderBrowserContent({
           <Button
             type="button"
             onClick={handleConfirm}
-            disabled={!listing}
+            disabled={isConfirmDisabled}
             className="glow-green h-12"
           >
             <FolderOpen className="mr-2 h-4 w-4" />
@@ -234,7 +238,7 @@ function FolderBrowserContent({
           <Button
             type="button"
             onClick={handleConfirm}
-            disabled={!listing}
+            disabled={isConfirmDisabled}
             className="glow-green"
           >
             <FolderOpen className="mr-2 h-4 w-4" />

--- a/client/src/components/FolderBrowserDialog.tsx
+++ b/client/src/components/FolderBrowserDialog.tsx
@@ -1,5 +1,5 @@
 import { ArrowUp, Folder, FolderOpen, Loader2, RefreshCw } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -60,19 +60,26 @@ function FolderBrowserContent({
   // パス入力は編集中のdraftを別持ちし、keystrokeごとにloadしない。
   // Enter / blurで確定したときだけload。中間パスの解決失敗でスナップバックを防ぐ。
   const [pathDraft, setPathDraft] = useState("");
+  // load()の重複呼び出しでレスポンス順序が前後しても、最新のリクエスト結果のみを反映するための世代番号
+  const generationRef = useRef(0);
 
   const load = useCallback(
     async (targetPath?: string) => {
+      const myGeneration = ++generationRef.current;
       setError(null);
       setIsLoading(true);
       try {
         const res = await listDirectory(targetPath);
+        if (myGeneration !== generationRef.current) return;
         setListing(res);
         setPathDraft(res.path);
       } catch (err) {
+        if (myGeneration !== generationRef.current) return;
         setError(err instanceof Error ? err.message : String(err));
       } finally {
-        setIsLoading(false);
+        if (myGeneration === generationRef.current) {
+          setIsLoading(false);
+        }
       }
     },
     [listDirectory]

--- a/client/src/components/FolderBrowserDialog.tsx
+++ b/client/src/components/FolderBrowserDialog.tsx
@@ -1,0 +1,301 @@
+import { ArrowUp, Folder, FolderOpen, Loader2, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useIsMobile } from "@/hooks/useMobile";
+import type { FsListResult } from "../../../shared/types";
+
+interface FolderBrowserDialogProps {
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 初期表示パス（未指定時はサーバー側でホームディレクトリ） */
+  initialPath?: string;
+  /** ダイアログタイトル */
+  title?: string;
+  /** ダイアログの説明 */
+  description?: string;
+  /** ディレクトリ列挙関数（useSocket.listDirectory） */
+  listDirectory: (path?: string) => Promise<FsListResult>;
+  /** 「選択」押下時のコールバック */
+  onConfirm: (path: string) => void;
+}
+
+function FolderBrowserContent({
+  variant,
+  initialPath,
+  description,
+  listDirectory,
+  onConfirm,
+  onClose,
+}: {
+  variant: "dialog" | "drawer";
+  initialPath?: string;
+  description?: string;
+  listDirectory: (path?: string) => Promise<FsListResult>;
+  onConfirm: (path: string) => void;
+  onClose: () => void;
+}) {
+  const [listing, setListing] = useState<FsListResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showHidden, setShowHidden] = useState(false);
+  // パス入力は編集中のdraftを別持ちし、keystrokeごとにloadしない。
+  // Enter / blurで確定したときだけload。中間パスの解決失敗でスナップバックを防ぐ。
+  const [pathDraft, setPathDraft] = useState("");
+
+  const load = useCallback(
+    async (targetPath?: string) => {
+      setError(null);
+      setIsLoading(true);
+      try {
+        const res = await listDirectory(targetPath);
+        setListing(res);
+        setPathDraft(res.path);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [listDirectory]
+  );
+
+  useEffect(() => {
+    void load(initialPath);
+  }, [load, initialPath]);
+
+  const visibleEntries = (listing?.entries ?? []).filter(
+    e => showHidden || !e.isHidden
+  );
+
+  const handleConfirm = () => {
+    if (!listing) return;
+    onConfirm(listing.path);
+    onClose();
+  };
+
+  const isDrawer = variant === "drawer";
+
+  return (
+    <div className="flex flex-1 flex-col gap-3 overflow-hidden px-1 py-2">
+      {description && (
+        <p className="px-1 text-xs text-muted-foreground">{description}</p>
+      )}
+
+      {/* パス入力 + 親ディレクトリへ移動 */}
+      <div className="flex gap-2 px-1">
+        <Input
+          value={pathDraft}
+          onChange={e => setPathDraft(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              void load(pathDraft);
+            } else if (e.key === "Escape") {
+              setPathDraft(listing?.path ?? "");
+            }
+          }}
+          onBlur={() => {
+            if (pathDraft && pathDraft !== listing?.path) {
+              void load(pathDraft);
+            }
+          }}
+          placeholder="/path/to/directory"
+          className="h-12 flex-1 font-mono text-base md:h-10 md:text-sm"
+          aria-label="現在のパス"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => listing?.parent && void load(listing.parent)}
+          disabled={isLoading || !listing || listing.parent === null}
+          className="h-12 shrink-0 md:h-10"
+          aria-label="親ディレクトリへ移動"
+        >
+          <ArrowUp className="h-4 w-4" />
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => void load(listing?.path)}
+          disabled={isLoading}
+          className="h-12 shrink-0 md:h-10"
+          aria-label="再読み込み"
+        >
+          <RefreshCw className={`h-4 w-4 ${isLoading ? "animate-spin" : ""}`} />
+        </Button>
+      </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="mx-1 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        >
+          {error}
+        </div>
+      )}
+
+      {/* ディレクトリ一覧 */}
+      <div
+        className={`mx-1 flex-1 overflow-y-auto rounded-md border ${
+          isDrawer ? "min-h-[200px]" : "min-h-[260px] max-h-[360px]"
+        } ${isLoading ? "opacity-50" : ""}`}
+      >
+        <div className="space-y-0.5 p-2">
+          {listing === null && isLoading ? (
+            <div className="flex items-center justify-center gap-2 px-3 py-8 text-xs text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              読み込み中…
+            </div>
+          ) : visibleEntries.length === 0 ? (
+            <div className="px-3 py-8 text-center text-xs text-muted-foreground">
+              {(listing?.entries.length ?? 0) > 0
+                ? "隠しフォルダのみ（下のチェックボックスで表示）"
+                : "サブフォルダなし"}
+            </div>
+          ) : (
+            visibleEntries.map(entry => (
+              <button
+                key={entry.path}
+                type="button"
+                onClick={() => void load(entry.path)}
+                disabled={isLoading}
+                className={`flex w-full items-center gap-2 rounded-md text-left transition-colors hover:bg-accent ${
+                  isDrawer ? "min-h-[44px] p-3" : "p-2"
+                }`}
+              >
+                <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="truncate text-sm">{entry.name}</span>
+              </button>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* 隠しフォルダ表示トグル */}
+      <div className="flex items-center gap-2 px-2">
+        <Checkbox
+          id="folder-browser-show-hidden"
+          checked={showHidden}
+          onCheckedChange={checked => setShowHidden(checked === true)}
+        />
+        <Label
+          htmlFor="folder-browser-show-hidden"
+          className="cursor-pointer text-xs text-muted-foreground"
+        >
+          隠しフォルダを表示
+        </Label>
+      </div>
+
+      {/* フッター */}
+      {isDrawer ? (
+        <DrawerFooter className="px-1 pb-2">
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!listing}
+            className="glow-green h-12"
+          >
+            <FolderOpen className="mr-2 h-4 w-4" />
+            このフォルダを選択
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            className="h-12"
+          >
+            キャンセル
+          </Button>
+        </DrawerFooter>
+      ) : (
+        <DialogFooter className="px-1 pt-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            キャンセル
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!listing}
+            className="glow-green"
+          >
+            <FolderOpen className="mr-2 h-4 w-4" />
+            このフォルダを選択
+          </Button>
+        </DialogFooter>
+      )}
+    </div>
+  );
+}
+
+function FolderBrowserDesktop(props: FolderBrowserDialogProps) {
+  return (
+    <Dialog open={props.isOpen} onOpenChange={props.onOpenChange}>
+      <DialogContent className="mx-auto flex max-h-[85vh] w-[calc(100%-2rem)] max-w-2xl flex-col bg-card">
+        <DialogHeader>
+          <DialogTitle>{props.title ?? "フォルダを選択"}</DialogTitle>
+          <DialogDescription>
+            {props.description ??
+              "ディレクトリを移動して、選択したいフォルダを開いた状態で「このフォルダを選択」を押してください。"}
+          </DialogDescription>
+        </DialogHeader>
+        <FolderBrowserContent
+          variant="dialog"
+          initialPath={props.initialPath}
+          listDirectory={props.listDirectory}
+          onConfirm={props.onConfirm}
+          onClose={() => props.onOpenChange(false)}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function FolderBrowserMobile(props: FolderBrowserDialogProps) {
+  return (
+    <Drawer open={props.isOpen} onOpenChange={props.onOpenChange}>
+      <DrawerContent className="flex max-h-[90dvh] flex-col">
+        <DrawerHeader>
+          <DrawerTitle>{props.title ?? "フォルダを選択"}</DrawerTitle>
+          <DrawerDescription>
+            {props.description ??
+              "ディレクトリを移動して、選択したいフォルダを開いた状態で「このフォルダを選択」を押してください。"}
+          </DrawerDescription>
+        </DrawerHeader>
+        <div className="flex flex-1 flex-col overflow-hidden px-4">
+          <FolderBrowserContent
+            variant="drawer"
+            initialPath={props.initialPath}
+            listDirectory={props.listDirectory}
+            onConfirm={props.onConfirm}
+            onClose={() => props.onOpenChange(false)}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+export function FolderBrowserDialog(props: FolderBrowserDialogProps) {
+  const isMobile = useIsMobile();
+  if (isMobile) return <FolderBrowserMobile {...props} />;
+  return <FolderBrowserDesktop {...props} />;
+}

--- a/client/src/components/FolderBrowserDialog.tsx
+++ b/client/src/components/FolderBrowserDialog.tsx
@@ -86,9 +86,15 @@ function FolderBrowserContent({
     e => showHidden || !e.isHidden
   );
 
-  // エラー発生時はconfirm不可。listingは前回値が残るため
-  // pathDraft（テキスト欄表示）と乖離したまま誤選択するのを防ぐ。
-  const isConfirmDisabled = !listing || error !== null;
+  // confirm 不可条件:
+  // - listing 未取得 / エラー発生中 → 状態が不確定、または前回値が残っている
+  // - ロード中 → 別のパスへ遷移途中、結果が確定していない
+  // - pathDraft が listing.path と乖離 → ユーザーが編集中で未確定
+  const isConfirmDisabled =
+    !listing ||
+    error !== null ||
+    isLoading ||
+    pathDraft.trim() !== listing.path;
 
   const handleConfirm = () => {
     if (isConfirmDisabled || !listing) return;

--- a/client/src/components/RepoSelectDialog.tsx
+++ b/client/src/components/RepoSelectDialog.tsx
@@ -19,7 +19,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Separator } from "@/components/ui/separator";
 import { useIsMobile } from "@/hooks/useMobile";
-import type { RepoInfo } from "../../../shared/types";
+import type { FsListResult, RepoInfo } from "../../../shared/types";
+import { FolderBrowserDialog } from "./FolderBrowserDialog";
 
 interface RepoSelectDialogProps {
   isOpen: boolean;
@@ -28,6 +29,11 @@ interface RepoSelectDialogProps {
   isScanning: boolean;
   onScanRepos: (basePath: string) => void;
   onSelectRepo: (path: string) => void;
+  listDirectory: (path?: string) => Promise<FsListResult>;
+  /** 前回スキャンしたパス（サーバーDB由来、クロスデバイス共有） */
+  initialScanBasePath: string;
+  /** スキャン実行時にサーバーDBへ永続化するためのコールバック */
+  onScanBasePathChange: (path: string) => void;
 }
 
 // --- 共通コンテンツ ---
@@ -38,6 +44,9 @@ function RepoSelectContent({
   onScanRepos,
   onSelectRepo,
   onOpenChange,
+  listDirectory,
+  initialScanBasePath,
+  onScanBasePathChange,
 }: {
   variant: "dialog" | "drawer";
   scannedRepos: RepoInfo[];
@@ -45,12 +54,19 @@ function RepoSelectContent({
   onScanRepos: (basePath: string) => void;
   onSelectRepo: (path: string) => void;
   onOpenChange: (open: boolean) => void;
+  listDirectory: (path?: string) => Promise<FsListResult>;
+  initialScanBasePath: string;
+  onScanBasePathChange: (path: string) => void;
 }) {
-  const [scanBasePath, setScanBasePath] = useState(() => {
-    return localStorage.getItem("scanBasePath") || "";
-  });
+  const [scanBasePath, setScanBasePath] = useState(initialScanBasePath);
   const [repoInput, setRepoInput] = useState("");
   const [filterQuery, setFilterQuery] = useState("");
+  const [isFolderBrowserOpen, setIsFolderBrowserOpen] = useState(false);
+
+  // ダイアログを開き直したときに最新のサーバー値を反映
+  useEffect(() => {
+    setScanBasePath(initialScanBasePath);
+  }, [initialScanBasePath]);
 
   const filteredRepos = useMemo(() => {
     if (!filterQuery.trim()) {
@@ -64,55 +80,41 @@ function RepoSelectContent({
     );
   }, [scannedRepos, filterQuery]);
 
-  useEffect(() => {
-    if (scanBasePath) {
-      localStorage.setItem("scanBasePath", scanBasePath);
-    }
-  }, [scanBasePath]);
-
-  const handleScanRepos = () => {
-    if (!scanBasePath.trim()) return;
-    onScanRepos(scanBasePath.trim());
-  };
-
   const handleSelectRepo = () => {
     if (!repoInput.trim()) return;
     onSelectRepo(repoInput.trim());
     onOpenChange(false);
   };
 
+  const handleFolderConfirm = (path: string) => {
+    setScanBasePath(path);
+    onScanBasePathChange(path);
+    onScanRepos(path);
+  };
+
   const isDrawer = variant === "drawer";
 
   return (
     <div className="space-y-4 py-4 flex-1 overflow-hidden flex flex-col">
-      {/* スキャン用入力 */}
+      {/* スキャンパス選択 */}
       <div className="space-y-2 px-1">
-        <Label htmlFor="scanPath">スキャンするパス</Label>
-        <div className="flex gap-2">
-          <Input
-            id="scanPath"
-            placeholder="/Users/username/dev"
-            value={scanBasePath}
-            onChange={e => setScanBasePath(e.target.value)}
-            autoFocus={!isDrawer}
-            onKeyDown={e => {
-              if (e.key === "Enter") handleScanRepos();
-            }}
-            className="font-mono h-12 md:h-10 text-base md:text-sm flex-1"
-          />
-          <Button
-            type="button"
-            onClick={handleScanRepos}
-            disabled={isScanning}
-            className="h-12 md:h-10 shrink-0"
-          >
-            {isScanning ? (
-              <RefreshCw className="w-4 h-4 animate-spin" />
-            ) : (
-              "スキャン"
-            )}
-          </Button>
-        </div>
+        <Label>スキャンするパス</Label>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setIsFolderBrowserOpen(true)}
+          disabled={isScanning}
+          className="w-full justify-start gap-2 h-12 md:h-10 font-mono text-base md:text-sm"
+        >
+          {isScanning ? (
+            <RefreshCw className="w-4 h-4 animate-spin shrink-0" />
+          ) : (
+            <FolderOpen className="w-4 h-4 shrink-0" />
+          )}
+          <span className="truncate flex-1 text-left">
+            {scanBasePath || "フォルダを選択..."}
+          </span>
+        </Button>
       </div>
 
       {/* スキャン結果リスト */}
@@ -231,6 +233,17 @@ function RepoSelectContent({
           </Button>
         </div>
       )}
+
+      {/* フォルダ選択ダイアログ */}
+      <FolderBrowserDialog
+        isOpen={isFolderBrowserOpen}
+        onOpenChange={setIsFolderBrowserOpen}
+        initialPath={scanBasePath || undefined}
+        title="スキャンするフォルダを選択"
+        description="このフォルダ配下のGitリポジトリをスキャンします。"
+        listDirectory={listDirectory}
+        onConfirm={handleFolderConfirm}
+      />
     </div>
   );
 }
@@ -243,6 +256,9 @@ function RepoSelectDialogDesktop({
   isScanning,
   onScanRepos,
   onSelectRepo,
+  listDirectory,
+  initialScanBasePath,
+  onScanBasePathChange,
 }: RepoSelectDialogProps) {
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -250,7 +266,7 @@ function RepoSelectDialogDesktop({
         <DialogHeader>
           <DialogTitle>リポジトリを選択</DialogTitle>
           <DialogDescription>
-            ディレクトリパスを入力してスキャンするか、直接リポジトリパスを入力してください。
+            スキャンするフォルダを選択するか、直接リポジトリパスを入力してください。
           </DialogDescription>
         </DialogHeader>
         <RepoSelectContent
@@ -260,6 +276,9 @@ function RepoSelectDialogDesktop({
           onScanRepos={onScanRepos}
           onSelectRepo={onSelectRepo}
           onOpenChange={onOpenChange}
+          listDirectory={listDirectory}
+          initialScanBasePath={initialScanBasePath}
+          onScanBasePathChange={onScanBasePathChange}
         />
       </DialogContent>
     </Dialog>
@@ -274,6 +293,9 @@ function RepoSelectDrawerMobile({
   isScanning,
   onScanRepos,
   onSelectRepo,
+  listDirectory,
+  initialScanBasePath,
+  onScanBasePathChange,
 }: RepoSelectDialogProps) {
   return (
     <Drawer open={isOpen} onOpenChange={onOpenChange}>
@@ -281,7 +303,7 @@ function RepoSelectDrawerMobile({
         <DrawerHeader>
           <DrawerTitle>リポジトリを選択</DrawerTitle>
           <DrawerDescription>
-            ディレクトリパスを入力してスキャンするか、直接リポジトリパスを入力してください。
+            スキャンするフォルダを選択するか、直接リポジトリパスを入力してください。
           </DrawerDescription>
         </DrawerHeader>
         <div className="flex-1 overflow-hidden flex flex-col px-4">
@@ -292,6 +314,9 @@ function RepoSelectDrawerMobile({
             onScanRepos={onScanRepos}
             onSelectRepo={onSelectRepo}
             onOpenChange={onOpenChange}
+            listDirectory={listDirectory}
+            initialScanBasePath={initialScanBasePath}
+            onScanBasePathChange={onScanBasePathChange}
           />
         </div>
       </DrawerContent>

--- a/client/src/components/RepoSelectDialog.tsx
+++ b/client/src/components/RepoSelectDialog.tsx
@@ -32,10 +32,11 @@ interface RepoSelectDialogProps {
   onScanRepos: (basePath: string) => void;
   onSelectRepo: (path: string) => void;
   listDirectory: (path?: string) => Promise<FsListResult>;
-  /** 前回スキャンしたパス（サーバーDB由来、クロスデバイス共有） */
+  /**
+   * 前回スキャンしたパス（サーバーDB由来、クロスデバイス共有）。
+   * 失敗パスを保存しないため、保存はサーバー側のスキャン成功時のみで行われる。
+   */
   initialScanBasePath: string;
-  /** スキャン実行時にサーバーDBへ永続化するためのコールバック */
-  onScanBasePathChange: (path: string) => void;
 }
 
 // --- 共通コンテンツ ---
@@ -49,7 +50,6 @@ function RepoSelectContent({
   onOpenChange,
   listDirectory,
   initialScanBasePath,
-  onScanBasePathChange,
 }: {
   variant: "dialog" | "drawer";
   allowedRepos: string[];
@@ -60,7 +60,6 @@ function RepoSelectContent({
   onOpenChange: (open: boolean) => void;
   listDirectory: (path?: string) => Promise<FsListResult>;
   initialScanBasePath: string;
-  onScanBasePathChange: (path: string) => void;
 }) {
   const [scanBasePath, setScanBasePath] = useState(initialScanBasePath);
   const [repoInput, setRepoInput] = useState("");
@@ -106,9 +105,10 @@ function RepoSelectContent({
     onOpenChange(false);
   };
 
+  // scanBasePath はサーバー側のスキャン成功時のみDBに永続化される（失敗パスを残さないため）。
+  // クライアント側ではローカルstateだけ更新し、本セッション中の表示用に保持する。
   const handleFolderConfirm = (path: string) => {
     setScanBasePath(path);
-    onScanBasePathChange(path);
     onScanRepos(path);
   };
 
@@ -283,7 +283,6 @@ function RepoSelectDialogDesktop({
   onSelectRepo,
   listDirectory,
   initialScanBasePath,
-  onScanBasePathChange,
 }: RepoSelectDialogProps) {
   const isAllowlistMode = allowedRepos.length > 0;
   return (
@@ -307,7 +306,6 @@ function RepoSelectDialogDesktop({
           onOpenChange={onOpenChange}
           listDirectory={listDirectory}
           initialScanBasePath={initialScanBasePath}
-          onScanBasePathChange={onScanBasePathChange}
         />
       </DialogContent>
     </Dialog>
@@ -325,7 +323,6 @@ function RepoSelectDrawerMobile({
   onSelectRepo,
   listDirectory,
   initialScanBasePath,
-  onScanBasePathChange,
 }: RepoSelectDialogProps) {
   const isAllowlistMode = allowedRepos.length > 0;
   return (
@@ -350,7 +347,6 @@ function RepoSelectDrawerMobile({
             onOpenChange={onOpenChange}
             listDirectory={listDirectory}
             initialScanBasePath={initialScanBasePath}
-            onScanBasePathChange={onScanBasePathChange}
           />
         </div>
       </DrawerContent>

--- a/client/src/components/RepoSelectDialog.tsx
+++ b/client/src/components/RepoSelectDialog.tsx
@@ -25,6 +25,8 @@ import { FolderBrowserDialog } from "./FolderBrowserDialog";
 interface RepoSelectDialogProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
+  /** `--repos` 起動オプション由来の許可リポジトリ一覧。空配列なら制限なし */
+  allowedRepos: string[];
   scannedRepos: RepoInfo[];
   isScanning: boolean;
   onScanRepos: (basePath: string) => void;
@@ -39,6 +41,7 @@ interface RepoSelectDialogProps {
 // --- 共通コンテンツ ---
 function RepoSelectContent({
   variant,
+  allowedRepos,
   scannedRepos,
   isScanning,
   onScanRepos,
@@ -49,6 +52,7 @@ function RepoSelectContent({
   onScanBasePathChange,
 }: {
   variant: "dialog" | "drawer";
+  allowedRepos: string[];
   scannedRepos: RepoInfo[];
   isScanning: boolean;
   onScanRepos: (basePath: string) => void;
@@ -68,17 +72,33 @@ function RepoSelectContent({
     setScanBasePath(initialScanBasePath);
   }, [initialScanBasePath]);
 
+  // allowlistモード: --reposで起動したサーバーは任意ディレクトリ列挙を拒否するため、
+  // フォルダ選択UIを非表示にし、許可リポジトリ一覧のみ提示する
+  const isAllowlistMode = allowedRepos.length > 0;
+
+  // 表示するリポジトリ一覧: allowlistモードでは許可リポジトリ、通常モードではスキャン結果
+  const displayRepos = useMemo<RepoInfo[]>(() => {
+    if (isAllowlistMode) {
+      return allowedRepos.map(p => ({
+        path: p,
+        name: p.split("/").filter(Boolean).pop() ?? p,
+        branch: "",
+      }));
+    }
+    return scannedRepos;
+  }, [isAllowlistMode, allowedRepos, scannedRepos]);
+
   const filteredRepos = useMemo(() => {
     if (!filterQuery.trim()) {
-      return scannedRepos;
+      return displayRepos;
     }
     const query = filterQuery.toLowerCase();
-    return scannedRepos.filter(
+    return displayRepos.filter(
       repo =>
         repo.name.toLowerCase().includes(query) ||
         repo.path.toLowerCase().includes(query)
     );
-  }, [scannedRepos, filterQuery]);
+  }, [displayRepos, filterQuery]);
 
   const handleSelectRepo = () => {
     if (!repoInput.trim()) return;
@@ -96,35 +116,39 @@ function RepoSelectContent({
 
   return (
     <div className="space-y-4 py-4 flex-1 overflow-hidden flex flex-col">
-      {/* スキャンパス選択 */}
-      <div className="space-y-2 px-1">
-        <Label>スキャンするパス</Label>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => setIsFolderBrowserOpen(true)}
-          disabled={isScanning}
-          className="w-full justify-start gap-2 h-12 md:h-10 font-mono text-base md:text-sm"
-        >
-          {isScanning ? (
-            <RefreshCw className="w-4 h-4 animate-spin shrink-0" />
-          ) : (
-            <FolderOpen className="w-4 h-4 shrink-0" />
-          )}
-          <span className="truncate flex-1 text-left">
-            {scanBasePath || "フォルダを選択..."}
-          </span>
-        </Button>
-      </div>
+      {/* スキャンパス選択（allowlistモード時は任意パス列挙が拒否されるため非表示） */}
+      {!isAllowlistMode && (
+        <div className="space-y-2 px-1">
+          <Label>スキャンするパス</Label>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setIsFolderBrowserOpen(true)}
+            disabled={isScanning}
+            className="w-full justify-start gap-2 h-12 md:h-10 font-mono text-base md:text-sm"
+          >
+            {isScanning ? (
+              <RefreshCw className="w-4 h-4 animate-spin shrink-0" />
+            ) : (
+              <FolderOpen className="w-4 h-4 shrink-0" />
+            )}
+            <span className="truncate flex-1 text-left">
+              {scanBasePath || "フォルダを選択..."}
+            </span>
+          </Button>
+        </div>
+      )}
 
-      {/* スキャン結果リスト */}
+      {/* リポジトリ一覧 */}
       <div className="space-y-2 flex-1 overflow-hidden flex flex-col px-1">
         <Label>
-          {isScanning
-            ? "スキャン中..."
-            : scannedRepos.length > 0
-              ? `検出されたリポジトリ (${filteredRepos.length}/${scannedRepos.length})`
-              : "検出されたリポジトリ"}
+          {isAllowlistMode
+            ? `許可されたリポジトリ (${filteredRepos.length}/${displayRepos.length})`
+            : isScanning
+              ? "スキャン中..."
+              : displayRepos.length > 0
+                ? `検出されたリポジトリ (${filteredRepos.length}/${displayRepos.length})`
+                : "検出されたリポジトリ"}
         </Label>
         {/* 検索ボックス */}
         <div className="relative">
@@ -134,7 +158,7 @@ function RepoSelectContent({
             value={filterQuery}
             onChange={e => setFilterQuery(e.target.value)}
             className="pl-9 h-10"
-            disabled={isScanning || scannedRepos.length === 0}
+            disabled={isScanning || displayRepos.length === 0}
           />
         </div>
         <div
@@ -252,6 +276,7 @@ function RepoSelectContent({
 function RepoSelectDialogDesktop({
   isOpen,
   onOpenChange,
+  allowedRepos,
   scannedRepos,
   isScanning,
   onScanRepos,
@@ -260,17 +285,21 @@ function RepoSelectDialogDesktop({
   initialScanBasePath,
   onScanBasePathChange,
 }: RepoSelectDialogProps) {
+  const isAllowlistMode = allowedRepos.length > 0;
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-lg mx-auto max-h-[80vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>リポジトリを選択</DialogTitle>
           <DialogDescription>
-            スキャンするフォルダを選択するか、直接リポジトリパスを入力してください。
+            {isAllowlistMode
+              ? "許可されたリポジトリ一覧から選択するか、直接リポジトリパスを入力してください。"
+              : "スキャンするフォルダを選択するか、直接リポジトリパスを入力してください。"}
           </DialogDescription>
         </DialogHeader>
         <RepoSelectContent
           variant="dialog"
+          allowedRepos={allowedRepos}
           scannedRepos={scannedRepos}
           isScanning={isScanning}
           onScanRepos={onScanRepos}
@@ -289,6 +318,7 @@ function RepoSelectDialogDesktop({
 function RepoSelectDrawerMobile({
   isOpen,
   onOpenChange,
+  allowedRepos,
   scannedRepos,
   isScanning,
   onScanRepos,
@@ -297,18 +327,22 @@ function RepoSelectDrawerMobile({
   initialScanBasePath,
   onScanBasePathChange,
 }: RepoSelectDialogProps) {
+  const isAllowlistMode = allowedRepos.length > 0;
   return (
     <Drawer open={isOpen} onOpenChange={onOpenChange}>
       <DrawerContent className="max-h-[85dvh] flex flex-col">
         <DrawerHeader>
           <DrawerTitle>リポジトリを選択</DrawerTitle>
           <DrawerDescription>
-            スキャンするフォルダを選択するか、直接リポジトリパスを入力してください。
+            {isAllowlistMode
+              ? "許可されたリポジトリ一覧から選択するか、直接リポジトリパスを入力してください。"
+              : "スキャンするフォルダを選択するか、直接リポジトリパスを入力してください。"}
           </DrawerDescription>
         </DrawerHeader>
         <div className="flex-1 overflow-hidden flex flex-col px-4">
           <RepoSelectContent
             variant="drawer"
+            allowedRepos={allowedRepos}
             scannedRepos={scannedRepos}
             isScanning={isScanning}
             onScanRepos={onScanRepos}

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -14,6 +14,7 @@ import type {
   BrowserSession,
   ChatMessage,
   ClientToServerEvents,
+  FsListResult,
   ManagedSession,
   Profile,
   RepoInfo,
@@ -53,6 +54,9 @@ interface UseSocketReturn {
   scannedRepos: RepoInfo[];
   isScanning: boolean;
   scanRepos: (basePath: string) => void;
+
+  // Folder browser
+  listDirectory: (path?: string) => Promise<FsListResult>;
 
   // Repository
   repoList: string[];
@@ -640,6 +644,28 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     socketRef.current?.emit("repo:scan", basePath);
   }, []);
 
+  // フォルダ選択ダイアログ用: 指定パス配下のサブディレクトリを取得
+  const listDirectory = useCallback((path?: string): Promise<FsListResult> => {
+    return new Promise((resolve, reject) => {
+      const socket = socketRef.current;
+      if (!socket?.connected) {
+        reject(new Error("ソケットが切断されています"));
+        return;
+      }
+      const timeoutId = window.setTimeout(() => {
+        reject(new Error("ディレクトリ取得がタイムアウトしました"));
+      }, 10000);
+      socket.emit("fs:list", { path }, response => {
+        window.clearTimeout(timeoutId);
+        if (response.result) {
+          resolve(response.result);
+        } else {
+          reject(new Error(response.error ?? "ディレクトリ取得に失敗しました"));
+        }
+      });
+    });
+  }, []);
+
   // Worktree actions
   const createWorktree = useCallback(
     (branchName: string, baseBranch?: string) => {
@@ -902,6 +928,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     scannedRepos,
     isScanning,
     scanRepos,
+    listDirectory,
     repoList,
     repoPath,
     selectRepo,

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -746,7 +746,6 @@ export default function Dashboard() {
         onSelectRepo={handleSelectRepo}
         listDirectory={listDirectory}
         initialScanBasePath={savedScanBasePath}
-        onScanBasePathChange={path => setSetting("scanBasePath", path)}
       />
 
       {/* Worktree作成ダイアログ */}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -47,6 +47,7 @@ export default function Dashboard() {
 
   const savedRepoList = getSetting<string[]>("repoList", []);
   const savedRepoPath = getSetting<string | null>("selectedRepoPath", null);
+  const savedScanBasePath = getSetting<string>("scanBasePath", "");
 
   const {
     socket,
@@ -59,6 +60,7 @@ export default function Dashboard() {
     scannedRepos,
     isScanning,
     scanRepos,
+    listDirectory,
     worktrees,
     createWorktree,
     deleteWorktree,
@@ -740,6 +742,9 @@ export default function Dashboard() {
         isScanning={isScanning}
         onScanRepos={scanRepos}
         onSelectRepo={handleSelectRepo}
+        listDirectory={listDirectory}
+        initialScanBasePath={savedScanBasePath}
+        onScanBasePathChange={path => setSetting("scanBasePath", path)}
       />
 
       {/* Worktree作成ダイアログ */}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -53,6 +53,7 @@ export default function Dashboard() {
     socket,
     isConnected,
     error,
+    allowedRepos,
     repoList,
     repoPath,
     selectRepo,
@@ -738,6 +739,7 @@ export default function Dashboard() {
       <RepoSelectDialog
         isOpen={isSelectRepoOpen}
         onOpenChange={setIsSelectRepoOpen}
+        allowedRepos={allowedRepos}
         scannedRepos={scannedRepos}
         isScanning={isScanning}
         onScanRepos={scanRepos}

--- a/server/index.ts
+++ b/server/index.ts
@@ -886,7 +886,17 @@ async function startServer() {
     });
 
     // フォルダ選択ダイアログ用: 指定パス配下のサブディレクトリを返却（コールバックパターン）
+    // --repos で許可リポジトリが指定されている場合、フォルダブラウザは
+    // allowlistをバイパスして任意のディレクトリを列挙できてしまうため無効化する。
+    // 許可リポジトリは `repos:list` で既に提供されているのでブラウザは不要。
     socket.on("fs:list", async (data, callback) => {
+      if (allowedRepos.length > 0) {
+        callback({
+          error:
+            "このサーバーでは許可リポジトリのみ利用可能なためフォルダ参照は無効です",
+        });
+        return;
+      }
       try {
         const result = await listDirectory(data?.path);
         callback({ result });

--- a/server/index.ts
+++ b/server/index.ts
@@ -44,6 +44,7 @@ import {
   fileUploadManager,
 } from "./lib/file-upload-manager.js";
 import { frontlineManager } from "./lib/frontline-manager.js";
+import { listDirectory } from "./lib/fs-browser.js";
 import {
   createWorktree,
   deleteWorktree,
@@ -881,6 +882,16 @@ async function startServer() {
           status: "error",
           error: getErrorMessage(error),
         });
+      }
+    });
+
+    // フォルダ選択ダイアログ用: 指定パス配下のサブディレクトリを返却（コールバックパターン）
+    socket.on("fs:list", async (data, callback) => {
+      try {
+        const result = await listDirectory(data?.path);
+        callback({ result });
+      } catch (error) {
+        callback({ error: getErrorMessage(error) });
       }
     });
 

--- a/server/lib/fs-browser.ts
+++ b/server/lib/fs-browser.ts
@@ -1,0 +1,92 @@
+/**
+ * フォルダ選択ダイアログ用のディレクトリ列挙ユーティリティ
+ *
+ * 指定パス配下のサブディレクトリを返却する。シンボリックリンクは実体を辿り、
+ * ディレクトリのみを結果に含める。`fs.readdir` がEACCESで失敗した場合は
+ * 空のentriesを返却し、UI側で表示できるようにする。
+ */
+
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { FsEntry, FsListResult } from "../../shared/types.js";
+
+/**
+ * 指定パス配下のサブディレクトリを列挙する。
+ * @param targetPath 絶対パス。未指定時はホームディレクトリ
+ */
+export async function listDirectory(
+  targetPath?: string
+): Promise<FsListResult> {
+  const target = targetPath ?? os.homedir();
+  if (!path.isAbsolute(target)) {
+    throw new Error("pathは絶対パスのみ指定可能");
+  }
+  const normalized = path.resolve(target);
+
+  let stat: Awaited<ReturnType<typeof fs.stat>>;
+  try {
+    stat = await fs.stat(normalized);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new Error("ディレクトリが存在しません");
+    }
+    if (code === "EACCES") {
+      throw new Error("権限がありません");
+    }
+    throw err;
+  }
+  if (!stat.isDirectory()) {
+    throw new Error("ディレクトリではありません");
+  }
+
+  const parent = path.dirname(normalized);
+  const parentResolved = parent === normalized ? null : parent;
+
+  let rawEntries: import("node:fs").Dirent[];
+  try {
+    rawEntries = await fs.readdir(normalized, { withFileTypes: true });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "EACCES") {
+      // 権限がない場合は空のentriesで返却（UI側で「中身なし」表示）
+      return {
+        path: normalized,
+        parent: parentResolved,
+        entries: [],
+      };
+    }
+    throw err;
+  }
+
+  // シンボリックリンクも含めてディレクトリエントリを解決する
+  const dirEntries = await Promise.all(
+    rawEntries
+      .filter(e => e.isDirectory() || e.isSymbolicLink())
+      .map(async (e): Promise<FsEntry | null> => {
+        const childPath = path.join(normalized, e.name);
+        try {
+          const s = await fs.stat(childPath);
+          if (!s.isDirectory()) return null;
+        } catch {
+          // リンク切れ等はスキップ
+          return null;
+        }
+        return {
+          name: e.name,
+          path: childPath,
+          isHidden: e.name.startsWith("."),
+        };
+      })
+  );
+  const entries = dirEntries
+    .filter((e): e is FsEntry => e !== null)
+    .sort((a, b) => a.name.localeCompare(b.name, "ja"));
+
+  return {
+    path: normalized,
+    parent: parentResolved,
+    entries,
+  };
+}

--- a/server/lib/fs-browser.ts
+++ b/server/lib/fs-browser.ts
@@ -4,6 +4,10 @@
  * 指定パス配下のサブディレクトリを返却する。シンボリックリンクは実体を辿り、
  * ディレクトリのみを結果に含める。`fs.readdir` がEACCESで失敗した場合は
  * 空のentriesを返却し、UI側で表示できるようにする。
+ *
+ * 返却するパスは `fs.realpath()` で実体パスに正規化する。これは後続の
+ * `scanRepositories()` が `find <basePath>` をsymlink追跡なしで実行するため、
+ * symlinkパスのままだとスキャン結果が空になる問題を防ぐ目的。
  */
 
 import { promises as fs } from "node:fs";
@@ -22,7 +26,22 @@ export async function listDirectory(
   if (!path.isAbsolute(target)) {
     throw new Error("pathは絶対パスのみ指定可能");
   }
-  const normalized = path.resolve(target);
+
+  // realpathでsymlinkを実体パスに解決（後続のscanRepositoriesが
+  // find <basePath> でsymlinkを辿らないため、symlinkパスのままだと空結果になる）
+  let normalized: string;
+  try {
+    normalized = await fs.realpath(path.resolve(target));
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new Error("ディレクトリが存在しません");
+    }
+    if (code === "EACCES") {
+      throw new Error("権限がありません");
+    }
+    throw err;
+  }
 
   let stat: Awaited<ReturnType<typeof fs.stat>>;
   try {
@@ -66,16 +85,19 @@ export async function listDirectory(
       .filter(e => e.isDirectory() || e.isSymbolicLink())
       .map(async (e): Promise<FsEntry | null> => {
         const childPath = path.join(normalized, e.name);
+        let realChildPath: string;
         try {
           const s = await fs.stat(childPath);
           if (!s.isDirectory()) return null;
+          // symlinkの場合に実体パスへ正規化（リンク先がディレクトリと確認後）
+          realChildPath = await fs.realpath(childPath);
         } catch {
           // リンク切れ等はスキップ
           return null;
         }
         return {
           name: e.name,
-          path: childPath,
+          path: realChildPath,
           isHidden: e.name.startsWith("."),
         };
       })

--- a/server/lib/fs-browser.ts
+++ b/server/lib/fs-browser.ts
@@ -5,9 +5,9 @@
  * ディレクトリのみを結果に含める。`fs.readdir` がEACCESで失敗した場合は
  * 空のentriesを返却し、UI側で表示できるようにする。
  *
- * 返却するパスは `fs.realpath()` で実体パスに正規化する。これは後続の
- * `scanRepositories()` が `find <basePath>` をsymlink追跡なしで実行するため、
- * symlinkパスのままだとスキャン結果が空になる問題を防ぐ目的。
+ * パスはユーザーが入力したsymlinkのまま返却する（realpath()で実体パスに変換しない）。
+ * 実体パスにすると`'` `!` 等を含む path（例: `/Volumes/John's SSD/dev`）に変換され、
+ * 後続の `scanRepositories()` が `validatePath()` で拒否してしまうため。
  */
 
 import { promises as fs } from "node:fs";
@@ -26,22 +26,7 @@ export async function listDirectory(
   if (!path.isAbsolute(target)) {
     throw new Error("pathは絶対パスのみ指定可能");
   }
-
-  // realpathでsymlinkを実体パスに解決（後続のscanRepositoriesが
-  // find <basePath> でsymlinkを辿らないため、symlinkパスのままだと空結果になる）
-  let normalized: string;
-  try {
-    normalized = await fs.realpath(path.resolve(target));
-  } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") {
-      throw new Error("ディレクトリが存在しません");
-    }
-    if (code === "EACCES") {
-      throw new Error("権限がありません");
-    }
-    throw err;
-  }
+  const normalized = path.resolve(target);
 
   let stat: Awaited<ReturnType<typeof fs.stat>>;
   try {
@@ -85,19 +70,17 @@ export async function listDirectory(
       .filter(e => e.isDirectory() || e.isSymbolicLink())
       .map(async (e): Promise<FsEntry | null> => {
         const childPath = path.join(normalized, e.name);
-        let realChildPath: string;
         try {
+          // stat でリンク先の実体がディレクトリか確認
           const s = await fs.stat(childPath);
           if (!s.isDirectory()) return null;
-          // symlinkの場合に実体パスへ正規化（リンク先がディレクトリと確認後）
-          realChildPath = await fs.realpath(childPath);
         } catch {
           // リンク切れ等はスキップ
           return null;
         }
         return {
           name: e.name,
-          path: realChildPath,
+          path: childPath,
           isHidden: e.name.startsWith("."),
         };
       })

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -22,6 +22,26 @@ export interface RepoInfo {
   branch: string;
 }
 
+/** フォルダブラウザ: ディレクトリエントリ */
+export interface FsEntry {
+  /** ディレクトリ名 */
+  name: string;
+  /** 絶対パス */
+  path: string;
+  /** `.` 始まりかどうか */
+  isHidden: boolean;
+}
+
+/** フォルダブラウザ: ディレクトリ一覧結果 */
+export interface FsListResult {
+  /** 正規化済みの現在パス */
+  path: string;
+  /** 親ディレクトリパス（ルート時はnull） */
+  parent: string | null;
+  /** サブディレクトリ一覧 */
+  entries: FsEntry[];
+}
+
 export interface Session {
   id: string;
   worktreeId: string;
@@ -285,6 +305,12 @@ export interface ClientToServerEvents {
   "repo:scan": (basePath: string) => void;
   "repo:select": (path: string) => void;
   "repo:browse": () => void;
+
+  // ファイルシステムブラウザ（フォルダ選択ダイアログ用）
+  "fs:list": (
+    data: { path?: string },
+    callback: (response: { result?: FsListResult; error?: string }) => void
+  ) => void;
 
   // Tunnel commands
   "tunnel:start": (data?: { port?: number }) => void;


### PR DESCRIPTION
## Summary
- スキャン対象パスのテキスト入力をフォルダ選択ダイアログに完全置換
- サーバー側に Socket.IO `fs:list` イベント＋`server/lib/fs-browser.ts` を追加してディレクトリ列挙API化
- shadcn/ui Dialog/Drawer ベースの `FolderBrowserDialog` を実装（デスクトップ・モバイル両対応、親移動・隠しフォルダトグル・再読み込み・パス直接入力対応）
- `scanBasePath` の初期値を localStorage から サーバーDB（`useSettings`）に移行してクロスデバイス共有

## 主な動作仕様
- 初期パス優先順位: サーバーDB `scanBasePath`（クロスデバイス共有） → なければサーバー側 `os.homedir()` フォールバック
- スキャン成功時のみサーバーがDB保存（失敗パスは永続化しない）
- 同一サーバーが `--repos` で起動されている場合: `fs:list` を拒否し、許可リポジトリ一覧を表示するUIに切替
- `load()` は generation tracking で重複ナビゲーション時の古いレスポンス上書きを防止
- confirm ボタンは「listing 未取得 / エラー / ロード中 / pathDraft != listing.path」のいずれかで無効化

## Codexレビュー対応履歴
- round1: `fs:list` の allowlist バイパス修正、symlink 正規化、エラー時の listing 状態整合
- round2: allowlist時の許可リポジトリ表示UI、confirm無効化条件の補強、realpath撤回（`'!`を含む実体パスがvalidatePath()で拒否されるため）
- round3: クライアント即保存の撤回（失敗パス永続化問題）、generation tracking 追加（レース条件解消）
- 最終: 指摘なし

## Test plan
- [ ] デスクトップ: フォルダブラウザで親/サブディレクトリ移動、隠しフォルダ表示、パス直接入力（Enter / Escape / blur）
- [ ] モバイル: Drawer版で同様の動作確認
- [ ] スキャン成功後にサーバーDB `scanBasePath` が更新されることを確認
- [ ] 別ブラウザ/シークレットウィンドウで初期パスが共有されることを確認
- [ ] 存在しないパスを入力 → エラー表示、confirmボタン無効化、listing維持で「↑ 親」で復帰可能なこと
- [ ] `--repos` 起動時に許可リポジトリ一覧が表示され、フォルダ選択ボタンが非表示なこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フォルダ参照ダイアログを追加。デスクトップとモバイルの両方に対応した、レスポンシブなフォルダピッカーを実装しました。
  * フォルダ参照UI経由でスキャンパスを選択できるようになり、利便性が向上しました。
  * ディレクトリ参照と一覧表示機能をサーバーサイドに追加。隠しファイルの表示切り替えに対応しています。
  * スキャンパス設定の永続化に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->