### PR TITLE
fix: BrowserManager起動時に孤立Xvfb/x11vnc/websockify/Chromiumを掃除

### DIFF
--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -570,6 +570,201 @@ export class BrowserManager extends EventEmitter {
   }
 
   /**
+   * 自身のpidfileに記録された pid のうち、現在の sessions Map で管理されて
+   * いない（過去の killProcess timeout/start失敗で残った）pid を再 kill する。
+   *
+   * cleanupOrphanedProcesses は自身の serverPid を skip するため、同一プロセス
+   * 内の leak はここで処理する必要がある。start() の各回前に呼び出すことで、
+   * 次セッションが leaked DISPLAY/CDPポートと衝突するのを防ぐ。
+   */
+  private reapOwnSurvivors(): void {
+    let entries: PidEntry[] = [];
+    try {
+      const content = fs.readFileSync(this.ownPidFile(), "utf-8");
+      entries = this.parsePidEntries(content);
+    } catch {
+      return; // ファイル未作成
+    }
+    if (entries.length === 0) return;
+
+    // 現在の sessions Map のpid（=管理中で触ってはいけない）を集める
+    const activePids = new Set<number>();
+    for (const session of this.sessions.values()) {
+      for (const child of [
+        session.xvfb,
+        session.chromium,
+        session.x11vnc,
+        session.websockify,
+      ]) {
+        if (child.pid !== undefined) activePids.add(child.pid);
+      }
+    }
+    const survivorEntries = entries.filter(e => !activePids.has(e.pid));
+    if (survivorEntries.length === 0) return;
+
+    const minDisplay = DISPLAY_START;
+    const maxDisplay = DISPLAY_START + 100;
+
+    // ps で対象pidのcmdを取得
+    const candidatePids = survivorEntries.map(e => e.pid);
+    const pidToCmd = new Map<number, string>();
+    try {
+      const psOutput = execFileSync(
+        "ps",
+        ["-o", "pid=,cmd=", "-p", candidatePids.join(",")],
+        { encoding: "utf-8" }
+      );
+      for (const line of psOutput.split("\n")) {
+        const m = line.trim().match(/^(\d+)\s+(.*)$/);
+        if (!m) continue;
+        pidToCmd.set(Number.parseInt(m[1], 10), m[2]);
+      }
+    } catch {
+      // 全pid死亡 → display情報のあるpidについてはソケット削除して、pidfile再sync
+      const deadDisplays = new Set<number>();
+      for (const e of survivorEntries) {
+        if (
+          e.display !== undefined &&
+          e.display >= minDisplay &&
+          e.display <= maxDisplay
+        ) {
+          deadDisplays.add(e.display);
+        }
+      }
+      for (const display of deadDisplays) {
+        try {
+          fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
+        } catch {
+          // 残存しない/権限なしは無視
+        }
+      }
+      this.syncPidFile();
+      return;
+    }
+
+    const reapPids: number[] = [];
+    const reapDisplays = new Set<number>();
+
+    for (const e of survivorEntries) {
+      const cmd = pidToCmd.get(e.pid);
+      if (!cmd) {
+        // 死亡pid → display情報があればソケット削除候補
+        if (
+          e.display !== undefined &&
+          e.display >= minDisplay &&
+          e.display <= maxDisplay
+        ) {
+          reapDisplays.add(e.display);
+        }
+        continue;
+      }
+
+      const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
+      if (xvfbMatch && cmd.includes(XVFB_FB_DIR)) {
+        const display = Number.parseInt(xvfbMatch[1], 10);
+        if (display >= minDisplay && display <= maxDisplay) {
+          reapPids.push(e.pid);
+          reapDisplays.add(display);
+        }
+        continue;
+      }
+
+      const x11vncMatch = cmd.match(/\bx11vnc\b.*?-display\s+:(\d+)\b/);
+      if (x11vncMatch && cmd.includes(`-desktop ${ARK_DESKTOP}`)) {
+        const display = Number.parseInt(x11vncMatch[1], 10);
+        if (display >= minDisplay && display <= maxDisplay) {
+          reapPids.push(e.pid);
+        }
+        continue;
+      }
+
+      if (
+        /\bwebsockify\b/.test(cmd) &&
+        /127\.0\.0\.1:\d+\s+127\.0\.0\.1:\d+/.test(cmd)
+      ) {
+        reapPids.push(e.pid);
+        continue;
+      }
+
+      if (
+        /\b(chrome|chromium)\b/.test(cmd) &&
+        cmd.includes(`--remote-debugging-port=${CDP_PORT}`)
+      ) {
+        reapPids.push(e.pid);
+      }
+    }
+
+    if (reapPids.length > 0) {
+      console.log(
+        `[BrowserManager] 自プロセスsurvivorを掃除: pids=${reapPids.join(",")}`
+      );
+      for (const pid of reapPids) {
+        try {
+          process.kill(pid, "SIGTERM");
+        } catch {
+          // 既に終了済み
+        }
+      }
+      const remaining = new Set(reapPids);
+      const deadline = Date.now() + ORPHAN_TERM_TIMEOUT_MS;
+      while (remaining.size > 0 && Date.now() < deadline) {
+        for (const pid of Array.from(remaining)) {
+          try {
+            process.kill(pid, 0);
+          } catch {
+            remaining.delete(pid);
+          }
+        }
+        if (remaining.size > 0) {
+          try {
+            execFileSync("sleep", ["0.1"]);
+          } catch {
+            break;
+          }
+        }
+      }
+      if (remaining.size > 0) {
+        for (const pid of remaining) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // 既に終了済み
+          }
+        }
+        const killDeadline = Date.now() + ORPHAN_TERM_TIMEOUT_MS;
+        while (remaining.size > 0 && Date.now() < killDeadline) {
+          for (const pid of Array.from(remaining)) {
+            try {
+              process.kill(pid, 0);
+            } catch {
+              remaining.delete(pid);
+            }
+          }
+          if (remaining.size > 0) {
+            try {
+              execFileSync("sleep", ["0.1"]);
+            } catch {
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    // killしたXvfbのソケット削除
+    for (const display of reapDisplays) {
+      try {
+        fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
+      } catch {
+        // 残存しない/権限なしは無視
+      }
+    }
+
+    // pidfileを再sync。生存中pidがあれば pidfile に survivor として残る
+    this.syncPidFile();
+  }
+
+  /**
    * 依存コマンド・パスの存在チェック
    * 不足時はavailable=falseにしてログ警告（Ark全体の起動は妨げない）
    */
@@ -848,6 +1043,11 @@ export class BrowserManager extends EventEmitter {
     if (this.pendingStart) {
       return this.pendingStart;
     }
+
+    // 過去のkillProcess timeoutで残った自プロセス内のleakを掃除する。
+    // 自身のpidfile由来のsurvivorsは cleanupOrphanedProcesses が
+    // 自serverPidをskipするため、別経路で再killしないとDISPLAY/CDP衝突が残る。
+    this.reapOwnSurvivors();
 
     const promise = this._startInternal(initialUrl);
     this.pendingStart = promise;

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -168,7 +168,7 @@ export class BrowserManager extends EventEmitter {
         return; // pidfile未作成 = 過去にArkが起動していない
       }
       if (candidatePids.length === 0) {
-        this.clearPidFile();
+        this.writePidFile([]);
         return;
       }
 
@@ -187,7 +187,7 @@ export class BrowserManager extends EventEmitter {
         }
       } catch {
         // 全pidが既に死んでいると ps は非0を返すことがある → pidfileのみクリア
-        this.clearPidFile();
+        this.writePidFile([]);
         return;
       }
 
@@ -240,7 +240,7 @@ export class BrowserManager extends EventEmitter {
       }
 
       if (orphanPids.length === 0) {
-        this.clearPidFile();
+        this.writePidFile([]);
         return;
       }
 
@@ -303,17 +303,27 @@ export class BrowserManager extends EventEmitter {
         }
       }
 
-      // プロセスが消えたことを確認した後でX11ソケット残骸を削除する
-      for (const display of orphanDisplays) {
-        try {
-          fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
-        } catch {
-          // 残存しない/権限なしは無視
+      const survivors = Array.from(remainingPids);
+      if (survivors.length === 0) {
+        // 全プロセスが終了した → ソケット残骸を削除し、pidfileをクリア
+        for (const display of orphanDisplays) {
+          try {
+            fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
+          } catch {
+            // 残存しない/権限なしは無視
+          }
         }
+        this.writePidFile([]);
+      } else {
+        // SIGKILL後も生存しているpidがある → 次回起動時の再試行候補として
+        // pidfileに残存pidだけを書き戻す。ソケット削除も生存Xvfbが所有して
+        // いる可能性があるためスキップする（findAvailableDisplay() の誤判定防止）
+        console.warn(
+          `[BrowserManager] 一部の孤立プロセスが終了しませんでした: pids=${survivors.join(",")} ` +
+            "（次回起動時に再試行します）"
+        );
+        this.writePidFile(survivors);
       }
-
-      // 掃除完了 → 古い候補を流すためpidfileを空にする
-      this.clearPidFile();
     } catch (err) {
       console.warn(
         `[BrowserManager] 孤立プロセス掃除に失敗: ${getErrorMessage(err)}`
@@ -322,25 +332,36 @@ export class BrowserManager extends EventEmitter {
   }
 
   /**
-   * 起動した子プロセスのpidをBROWSER_PIDFILEに追記する。
-   * 次回起動時の cleanupOrphanedProcesses() がこのpidを候補として読む。
+   * 現在アクティブなセッションのpidをBROWSER_PIDFILEに書き戻す。
+   * sessions Mapが「現在管理中のArkプロセス」の単一の真実なので、
+   * stop/cleanup/start_internal完了時にこれを呼べばpidfileが常に同期する。
    */
-  private recordPid(pid: number | undefined): void {
-    if (pid === undefined) return;
-    try {
-      fs.mkdirSync(path.dirname(BROWSER_PIDFILE), { recursive: true });
-      fs.appendFileSync(BROWSER_PIDFILE, `${pid}\n`);
-    } catch (err) {
-      console.warn(`[BrowserManager] pidfile記録失敗: ${getErrorMessage(err)}`);
+  private syncPidFile(): void {
+    const activePids: number[] = [];
+    for (const session of this.sessions.values()) {
+      const pids = [
+        session.xvfb.pid,
+        session.chromium.pid,
+        session.x11vnc.pid,
+        session.websockify.pid,
+      ];
+      for (const pid of pids) {
+        if (pid !== undefined) activePids.push(pid);
+      }
     }
+    this.writePidFile(activePids);
   }
 
-  /** BROWSER_PIDFILEを空にする（cleanup完了時に呼ぶ） */
-  private clearPidFile(): void {
+  /** BROWSER_PIDFILEに任意のpid配列を書き戻す */
+  private writePidFile(pids: number[]): void {
     try {
-      fs.writeFileSync(BROWSER_PIDFILE, "");
-    } catch {
-      // ファイル未作成等は無視
+      fs.mkdirSync(path.dirname(BROWSER_PIDFILE), { recursive: true });
+      const content = pids.length === 0 ? "" : `${pids.join("\n")}\n`;
+      fs.writeFileSync(BROWSER_PIDFILE, content);
+    } catch (err) {
+      console.warn(
+        `[BrowserManager] pidfile書き込み失敗: ${getErrorMessage(err)}`
+      );
     }
   }
 
@@ -669,7 +690,6 @@ export class BrowserManager extends EventEmitter {
         { stdio: ["ignore", "pipe", "pipe"], detached: false }
       );
       startedProcesses.push(xvfb);
-      this.recordPid(xvfb.pid);
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -720,7 +740,6 @@ export class BrowserManager extends EventEmitter {
         },
       });
       startedProcesses.push(chromium);
-      this.recordPid(chromium.pid);
 
       // CDPエンドポイントが応答するまでポーリングしてChromium readinessを検出
       // 早期exitやerrorも検出してreject
@@ -795,7 +814,6 @@ export class BrowserManager extends EventEmitter {
         { stdio: ["ignore", "pipe", "pipe"], detached: false }
       );
       startedProcesses.push(x11vnc);
-      this.recordPid(x11vnc.pid);
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -864,7 +882,6 @@ export class BrowserManager extends EventEmitter {
         { stdio: ["ignore", "pipe", "pipe"], detached: false }
       );
       startedProcesses.push(websockify);
-      this.recordPid(websockify.pid);
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -942,6 +959,9 @@ export class BrowserManager extends EventEmitter {
         createdAt: new Date(),
       };
       this.sessions.set(id, processSet);
+      // pidfileを最新のアクティブセッション一覧で更新
+      // （次回起動時のcleanupOrphanedProcesses()がこれを参照する）
+      this.syncPidFile();
 
       // プロセスの異常終了監視: いずれかが終了したらセッション全体をstop
       const processNames = [
@@ -1067,6 +1087,8 @@ export class BrowserManager extends EventEmitter {
 
     // 先にMapから削除して、異常終了監視のハンドラが再度stopを呼ばないようにする
     this.sessions.delete(browserId);
+    // pidfileから当該セッションのpidを除去（古いpidの累積を防ぐ）
+    this.syncPidFile();
 
     // シングルトンセッションをクリア
     if (this.singletonSession?.id === browserId) {

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -36,6 +36,16 @@ const KILL_GRACE_PERIOD = 3000;
 const ORPHAN_TERM_TIMEOUT_MS = 1500;
 
 /**
+ * 起動後の孤立プロセス再掃除までの遅延（ミリ秒）。
+ *
+ * pm2 reload 等で旧サーバーが新サーバー起動と一定期間共存するケースに対応する。
+ * 初回 cleanup では旧 serverPid が「生存中」として skip されるが、reload 完了
+ * (旧プロセス終了) 後に再 cleanup を走らせることで、旧サーバーの管理対象だった
+ * 孤立子プロセスを次回restartを待たずに回収する。
+ */
+const ORPHAN_RECLEAN_DELAY_MS = 10000;
+
+/**
  * Ark識別マーカー: Xvfbのフレームバッファ保存ディレクトリ
  * cleanupOrphanedProcesses() でこの文字列を含むXvfbのみをArk由来と判定する
  */
@@ -124,6 +134,12 @@ export class BrowserManager extends EventEmitter {
         );
       }
       this.cleanupOrphanedProcesses();
+      // pm2 reload等で旧サーバーが起動直後にはまだ生存中の場合、初回cleanup
+      // ではそのpidfileがskipされる。一定遅延後に再実行して旧サーバー死亡後の
+      // 孤立を回収する。unref()でevent loopをブロックしないようにする。
+      setTimeout(() => {
+        this.cleanupOrphanedProcesses();
+      }, ORPHAN_RECLEAN_DELAY_MS).unref();
     }
   }
 
@@ -1084,6 +1100,21 @@ export class BrowserManager extends EventEmitter {
           // 失敗は無視（既に死んでいる可能性）
         });
       }
+      // killProcessが殺しきれず生き残った子pidを survivors として pidfile に
+      // 残し、次回起動時のcleanup候補とする（startup失敗で孤立が永続化するのを防ぐ）
+      const partialSurvivors: number[] = [];
+      for (const child of startedProcesses) {
+        if (child.pid === undefined) continue;
+        try {
+          process.kill(child.pid, 0);
+          partialSurvivors.push(child.pid);
+        } catch {
+          // 死亡 → 含めない
+        }
+      }
+      if (partialSurvivors.length > 0) {
+        this.syncPidFile(partialSurvivors);
+      }
       throw error;
     }
   }
@@ -1092,7 +1123,9 @@ export class BrowserManager extends EventEmitter {
    * プロセスを安全に停止（SIGTERM→待機→SIGKILL→再待機）
    */
   private async killProcess(proc: ChildProcess, name: string): Promise<void> {
-    if (proc.exitCode !== null || proc.killed) {
+    // proc.killed はsignal送信済み(=killメソッド呼出済み)を示すだけで、
+    // 実プロセス終了とは無関係なので exitCode のみで判定する。
+    if (proc.exitCode !== null) {
       // 既に終了している
       return;
     }
@@ -1104,9 +1137,9 @@ export class BrowserManager extends EventEmitter {
       return;
     }
 
-    // SIGTERM後の猶予時間を待つ
+    // SIGTERM後の猶予時間を待つ（実プロセス終了まで）
     const exited = await new Promise<boolean>(resolve => {
-      if (proc.exitCode !== null || proc.killed) {
+      if (proc.exitCode !== null) {
         resolve(true);
         return;
       }
@@ -1129,7 +1162,7 @@ export class BrowserManager extends EventEmitter {
       }
       // SIGKILL後もexitを待つ（プロセステーブルからの削除確認）
       await new Promise<void>(resolve => {
-        if (proc.exitCode !== null || proc.killed) {
+        if (proc.exitCode !== null) {
           resolve();
           return;
         }

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -268,9 +268,12 @@ export class BrowserManager extends EventEmitter {
         // 使えなくなるが、誤動作よりは安全側を優先）
         if (!cmd) continue;
 
-        // Xvfb: マーカー(-fbdir XVFB_FB_DIR)とdisplayレンジで判定
+        // Xvfb: pidfile経由でArk由来と確認済み。cmd binary名と
+        // displayレンジでpid再利用を検知する（マーカー -fbdir は信頼度を
+        // 上げるが、旧版でマーカー無しに起動された残留プロセスも回収できる
+        // よう必須にはしない）
         const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
-        if (xvfbMatch && cmd.includes(XVFB_FB_DIR)) {
+        if (xvfbMatch) {
           const display = Number.parseInt(xvfbMatch[1], 10);
           if (display >= minDisplay && display <= maxDisplay) {
             orphanPids.push(c.pid);
@@ -279,9 +282,11 @@ export class BrowserManager extends EventEmitter {
           continue;
         }
 
-        // x11vnc: マーカー(-desktop ARK_DESKTOP)とdisplayレンジで判定
+        // x11vnc: pidfile経由でArk由来と確認済み。cmd binary名と
+        // displayレンジでpid再利用を検知する（マーカー -desktop ARK_DESKTOP
+        // は任意で旧版互換を保つ）
         const x11vncMatch = cmd.match(/\bx11vnc\b.*?-display\s+:(\d+)\b/);
-        if (x11vncMatch && cmd.includes(`-desktop ${ARK_DESKTOP}`)) {
+        if (x11vncMatch) {
           const display = Number.parseInt(x11vncMatch[1], 10);
           if (display >= minDisplay && display <= maxDisplay) {
             orphanPids.push(c.pid);
@@ -614,8 +619,10 @@ export class BrowserManager extends EventEmitter {
       // サーバーの live socket を破壊するリスクがあるため）
       if (!cmd) continue;
 
+      // Xvfb/x11vnc: pidfile経由でArk由来と確認済み。cmd binary名と
+      // displayレンジでpid再利用を検知（マーカー -fbdir/-desktop は任意）
       const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
-      if (xvfbMatch && cmd.includes(XVFB_FB_DIR)) {
+      if (xvfbMatch) {
         const display = Number.parseInt(xvfbMatch[1], 10);
         if (display >= minDisplay && display <= maxDisplay) {
           reapPids.push(e.pid);
@@ -625,7 +632,7 @@ export class BrowserManager extends EventEmitter {
       }
 
       const x11vncMatch = cmd.match(/\bx11vnc\b.*?-display\s+:(\d+)\b/);
-      if (x11vncMatch && cmd.includes(`-desktop ${ARK_DESKTOP}`)) {
+      if (x11vncMatch) {
         const display = Number.parseInt(x11vncMatch[1], 10);
         if (display >= minDisplay && display <= maxDisplay) {
           reapPids.push(e.pid);

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -433,7 +433,11 @@ export class BrowserManager extends EventEmitter {
    * 指定pidが「Arkサーバープロセスとして生存しているか」を判定する。
    * 単なる kill -0 だけだとpid再利用された別プロセスを「生存」と誤判定して
    * 旧サーバーのpidfileがcleanup対象から永久に漏れる。ps cmd でArkサーバー
-   * のentry point (`dist/index.js`) パターンを確認する。
+   * のentry point パターンを確認する。
+   *
+   * 対応する起動モード:
+   * - 本番 (pm2 fork): `node /path/to/dist/index.js [args]`
+   * - 開発 (pnpm dev:server / dev:remote 等): `tsx /path/to/server/index.ts`
    */
   private isArkServerAlive(serverPid: number): boolean {
     try {
@@ -441,8 +445,9 @@ export class BrowserManager extends EventEmitter {
         encoding: "utf-8",
       }).trim();
       if (!cmd) return false;
-      // pm2 fork mode: `node /path/to/dist/index.js [args]`
-      return /\bnode\b/.test(cmd) && /\bdist\/index\.js\b/.test(cmd);
+      const hasEntry = /\b(dist\/index\.js|server\/index\.ts)\b/.test(cmd);
+      const hasRuntime = /\b(node|tsx)\b/.test(cmd);
+      return hasEntry && hasRuntime;
     } catch {
       // ps失敗（pid死亡またはpermission denied）
       return false;

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -31,6 +31,22 @@ const WEBSOCKIFY_TIMEOUT = 5000;
 /** stop時のSIGTERM→SIGKILL待機時間（ミリ秒） */
 const KILL_GRACE_PERIOD = 3000;
 
+/** 孤立プロセス掃除時のSIGTERM→SIGKILL待機時間（ミリ秒） */
+const ORPHAN_TERM_TIMEOUT_MS = 1500;
+
+/**
+ * Ark識別マーカー: Xvfbのフレームバッファ保存ディレクトリ
+ * cleanupOrphanedProcesses() でこの文字列を含むXvfbのみをArk由来と判定する
+ */
+const XVFB_FB_DIR = "/tmp/.ark-xvfb-fb";
+
+/**
+ * Ark識別マーカー: x11vncのデスクトップ名
+ * cleanupOrphanedProcesses() でこの値を `-desktop` 引数に持つx11vncのみを
+ * Ark由来と判定する
+ */
+const ARK_DESKTOP = "ark-browser";
+
 /** Xvfb仮想ディスプレイの解像度 */
 const DISPLAY_RESOLUTION = "1280x900x24";
 
@@ -90,25 +106,50 @@ export class BrowserManager extends EventEmitter {
     this.nextDisplay = DISPLAY_START;
     this.checkDependencies();
     if (this.available) {
+      try {
+        fs.mkdirSync(XVFB_FB_DIR, { recursive: true });
+      } catch (err) {
+        console.warn(
+          `[BrowserManager] ${XVFB_FB_DIR} 作成失敗: ${getErrorMessage(err)}`
+        );
+      }
       this.cleanupOrphanedProcesses();
     }
   }
 
   /**
-   * 過去のArkプロセスが残した孤立Xvfb/x11vnc/websockifyを掃除する。
+   * 過去のArkプロセスが残した孤立Xvfb/x11vnc/websockify/Chromiumを掃除する。
    *
    * pm2 restart 等でサーバーが再起動するとシングルトンは消えるが、
    * Xvfb等の子プロセスは生存し続ける。次回起動時 findAvailableDisplay() が
    * 残存ディスプレイを避けて :100 等に逃げる一方、Chromium readiness 判定は
    * 固定CDPポート(9222)を fetch するため、既存 :99 Chromiumのレスポンスを
    * 自プロセスのreadinessと誤認 → Chromiumのいない空ディスプレイが量産される。
-   * 起動時にArk管理範囲のXvfb系を一掃して再発を防ぐ。
+   * 起動時にArk由来プロセスを一掃して再発を防ぐ。
+   *
+   * 識別方針:
+   * - 同一uidのプロセスのみ対象（クロスユーザーで他サービスを誤killしない）
+   * - Xvfb: 起動時に付与する `-fbdir XVFB_FB_DIR` をマーカーとする
+   * - x11vnc: 起動時に付与する `-desktop ARK_DESKTOP` をマーカーとする
+   * - Chromium: Ark専用固定CDPポート(`--remote-debugging-port=9222`)で識別
+   * - websockify: uid限定 + Ark管理ポート範囲で識別
+   *
+   * 終了確認:
+   * - SIGTERM後、最大 ORPHAN_TERM_TIMEOUT_MS まで `kill -0` で終了をポーリング
+   * - 残存プロセスは SIGKILL で強制終了
+   * - 全プロセスが消えたことを確認した後で X11 ソケットを削除する
+   *   （Xvfb生存中にソケットを消すと findAvailableDisplay() が誤判定する）
    */
   private cleanupOrphanedProcesses(): void {
     try {
-      const psOutput = execFileSync("ps", ["-eo", "pid=,cmd="], {
-        encoding: "utf-8",
-      });
+      const ownUid = process.getuid?.();
+      if (ownUid === undefined) return; // POSIX外環境では何もしない
+
+      const psOutput = execFileSync(
+        "ps",
+        ["-o", "pid=,cmd=", "-u", String(ownUid)],
+        { encoding: "utf-8" }
+      );
       const orphanPids: number[] = [];
       const orphanDisplays: number[] = [];
       const minDisplay = DISPLAY_START;
@@ -120,8 +161,9 @@ export class BrowserManager extends EventEmitter {
         const pid = Number.parseInt(m[1], 10);
         const cmd = m[2];
 
+        // Xvfb: Ark識別マーカー(-fbdir XVFB_FB_DIR)とdisplayレンジで判定
         const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
-        if (xvfbMatch) {
+        if (xvfbMatch && cmd.includes(XVFB_FB_DIR)) {
           const display = Number.parseInt(xvfbMatch[1], 10);
           if (display >= minDisplay && display <= maxDisplay) {
             orphanPids.push(pid);
@@ -130,8 +172,9 @@ export class BrowserManager extends EventEmitter {
           continue;
         }
 
-        const x11vncMatch = cmd.match(/\bx11vnc\b.*-display\s+:(\d+)\b/);
-        if (x11vncMatch) {
+        // x11vnc: Ark識別マーカー(-desktop ARK_DESKTOP)とdisplayレンジで判定
+        const x11vncMatch = cmd.match(/\bx11vnc\b.*?-display\s+:(\d+)\b/);
+        if (x11vncMatch && cmd.includes(`-desktop ${ARK_DESKTOP}`)) {
           const display = Number.parseInt(x11vncMatch[1], 10);
           if (display >= minDisplay && display <= maxDisplay) {
             orphanPids.push(pid);
@@ -139,6 +182,7 @@ export class BrowserManager extends EventEmitter {
           continue;
         }
 
+        // websockify: uid限定済みなのでArk管理ポート範囲のみで判定
         const wsMatch = cmd.match(
           /\bwebsockify\b.*?127\.0\.0\.1:(\d+)\s+127\.0\.0\.1:(\d+)/
         );
@@ -151,6 +195,15 @@ export class BrowserManager extends EventEmitter {
           ) {
             orphanPids.push(pid);
           }
+          continue;
+        }
+
+        // Chromium: Ark固定CDPポートを使うものはArk由来とみなす
+        if (
+          /\b(chrome|chromium)\b/.test(cmd) &&
+          cmd.includes(`--remote-debugging-port=${CDP_PORT}`)
+        ) {
+          orphanPids.push(pid);
         }
       }
 
@@ -167,8 +220,55 @@ export class BrowserManager extends EventEmitter {
         }
       }
 
-      // Xvfbを停止しても /tmp/.X11-unix/X<num> ソケットが残ると
-      // findAvailableDisplay() が誤って「使用中」と判定するので削除する
+      // SIGTERM後、終了をポーリング待機（最大ORPHAN_TERM_TIMEOUT_MS）
+      const remainingPids = new Set(orphanPids);
+      const deadline = Date.now() + ORPHAN_TERM_TIMEOUT_MS;
+      while (remainingPids.size > 0 && Date.now() < deadline) {
+        for (const pid of Array.from(remainingPids)) {
+          try {
+            process.kill(pid, 0); // 存在確認のみ
+          } catch {
+            remainingPids.delete(pid); // ESRCH → 既に終了
+          }
+        }
+        if (remainingPids.size > 0) {
+          try {
+            execFileSync("sleep", ["0.1"]);
+          } catch {
+            break;
+          }
+        }
+      }
+
+      // 残ったプロセスはSIGKILLで強制終了し、消えるまで再待機
+      if (remainingPids.size > 0) {
+        for (const pid of remainingPids) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {
+            // 既に終了済み
+          }
+        }
+        const killDeadline = Date.now() + ORPHAN_TERM_TIMEOUT_MS;
+        while (remainingPids.size > 0 && Date.now() < killDeadline) {
+          for (const pid of Array.from(remainingPids)) {
+            try {
+              process.kill(pid, 0);
+            } catch {
+              remainingPids.delete(pid);
+            }
+          }
+          if (remainingPids.size > 0) {
+            try {
+              execFileSync("sleep", ["0.1"]);
+            } catch {
+              break;
+            }
+          }
+        }
+      }
+
+      // プロセスが消えたことを確認した後でX11ソケット残骸を削除する
       for (const display of orphanDisplays) {
         try {
           fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
@@ -494,9 +594,17 @@ export class BrowserManager extends EventEmitter {
 
     try {
       // 1. Xvfb起動
+      // -fbdir はArk由来プロセス識別マーカーを兼ねる（cleanupOrphanedProcesses 参照）
       const xvfb = spawn(
         "Xvfb",
-        [`:${displayNum}`, "-screen", "0", DISPLAY_RESOLUTION],
+        [
+          `:${displayNum}`,
+          "-screen",
+          "0",
+          DISPLAY_RESOLUTION,
+          "-fbdir",
+          XVFB_FB_DIR,
+        ],
         { stdio: ["ignore", "pipe", "pipe"], detached: false }
       );
       startedProcesses.push(xvfb);
@@ -604,6 +712,7 @@ export class BrowserManager extends EventEmitter {
       );
 
       // 3. x11vnc起動
+      // -desktop はArk由来プロセス識別マーカーを兼ねる（cleanupOrphanedProcesses 参照）
       const x11vnc = spawn(
         "x11vnc",
         [
@@ -617,6 +726,8 @@ export class BrowserManager extends EventEmitter {
           "-forever",
           "-nopw",
           "-noxdamage",
+          "-desktop",
+          ARK_DESKTOP,
         ],
         { stdio: ["ignore", "pipe", "pipe"], detached: false }
       );

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -89,6 +89,98 @@ export class BrowserManager extends EventEmitter {
     this.nextWsPort = WS_PORT_START;
     this.nextDisplay = DISPLAY_START;
     this.checkDependencies();
+    if (this.available) {
+      this.cleanupOrphanedProcesses();
+    }
+  }
+
+  /**
+   * 過去のArkプロセスが残した孤立Xvfb/x11vnc/websockifyを掃除する。
+   *
+   * pm2 restart 等でサーバーが再起動するとシングルトンは消えるが、
+   * Xvfb等の子プロセスは生存し続ける。次回起動時 findAvailableDisplay() が
+   * 残存ディスプレイを避けて :100 等に逃げる一方、Chromium readiness 判定は
+   * 固定CDPポート(9222)を fetch するため、既存 :99 Chromiumのレスポンスを
+   * 自プロセスのreadinessと誤認 → Chromiumのいない空ディスプレイが量産される。
+   * 起動時にArk管理範囲のXvfb系を一掃して再発を防ぐ。
+   */
+  private cleanupOrphanedProcesses(): void {
+    try {
+      const psOutput = execFileSync("ps", ["-eo", "pid=,cmd="], {
+        encoding: "utf-8",
+      });
+      const orphanPids: number[] = [];
+      const orphanDisplays: number[] = [];
+      const minDisplay = DISPLAY_START;
+      const maxDisplay = DISPLAY_START + 100;
+
+      for (const line of psOutput.split("\n")) {
+        const m = line.trim().match(/^(\d+)\s+(.*)$/);
+        if (!m) continue;
+        const pid = Number.parseInt(m[1], 10);
+        const cmd = m[2];
+
+        const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
+        if (xvfbMatch) {
+          const display = Number.parseInt(xvfbMatch[1], 10);
+          if (display >= minDisplay && display <= maxDisplay) {
+            orphanPids.push(pid);
+            orphanDisplays.push(display);
+          }
+          continue;
+        }
+
+        const x11vncMatch = cmd.match(/\bx11vnc\b.*-display\s+:(\d+)\b/);
+        if (x11vncMatch) {
+          const display = Number.parseInt(x11vncMatch[1], 10);
+          if (display >= minDisplay && display <= maxDisplay) {
+            orphanPids.push(pid);
+          }
+          continue;
+        }
+
+        const wsMatch = cmd.match(
+          /\bwebsockify\b.*?127\.0\.0\.1:(\d+)\s+127\.0\.0\.1:(\d+)/
+        );
+        if (wsMatch) {
+          const wsPort = Number.parseInt(wsMatch[1], 10);
+          const vncPort = Number.parseInt(wsMatch[2], 10);
+          if (
+            (wsPort >= WS_PORT_START && wsPort <= WS_PORT_END) ||
+            (vncPort >= VNC_PORT_START && vncPort <= VNC_PORT_END)
+          ) {
+            orphanPids.push(pid);
+          }
+        }
+      }
+
+      if (orphanPids.length === 0) return;
+
+      console.log(
+        `[BrowserManager] 孤立プロセスを掃除: pids=${orphanPids.join(",")}`
+      );
+      for (const pid of orphanPids) {
+        try {
+          process.kill(pid, "SIGTERM");
+        } catch {
+          // 既に終了済み
+        }
+      }
+
+      // Xvfbを停止しても /tmp/.X11-unix/X<num> ソケットが残ると
+      // findAvailableDisplay() が誤って「使用中」と判定するので削除する
+      for (const display of orphanDisplays) {
+        try {
+          fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
+        } catch {
+          // 残存しない/権限なしは無視
+        }
+      }
+    } catch (err) {
+      console.warn(
+        `[BrowserManager] 孤立プロセス掃除に失敗: ${getErrorMessage(err)}`
+      );
+    }
   }
 
   /**

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -49,12 +49,13 @@ const XVFB_FB_DIR = "/tmp/.ark-xvfb-fb";
 const ARK_DESKTOP = "ark-browser";
 
 /**
- * Arkが起動したブラウザ関連子プロセスのpidを記録するファイル
- * cleanupOrphanedProcesses() がこのpidfileを読み、現存しArk的cmdを持つものだけを
- * 掃除対象とする。マーカー引数を付けられないwebsockify/Chromiumを
- * 安全に識別するため。
+ * Arkが起動したブラウザ関連子プロセスのpidを記録するディレクトリ。
+ * 各Arkサーバーインスタンスは自身のpidをファイル名にしたファイル
+ * (`<dir>/<serverPid>`) に子pidを書き込む。cleanupOrphanedProcesses()
+ * は「ファイル名のserverPidが現存していない」ファイルだけを孤立扱いし、
+ * 別の生存中サーバー（pm2 reload等での旧インスタンス）の子は触らない。
  */
-const BROWSER_PIDFILE = path.join("data", "browser-pids");
+const BROWSER_PIDFILE_DIR = path.join("data", "browser-pids");
 
 /** Xvfb仮想ディスプレイの解像度 */
 const DISPLAY_RESOLUTION = "1280x900x24";
@@ -136,43 +137,75 @@ export class BrowserManager extends EventEmitter {
    * 自プロセスのreadinessと誤認 → Chromiumのいない空ディスプレイが量産される。
    * 起動時にArk由来プロセスを一掃して再発を防ぐ。
    *
-   * 識別方針（誤kill防止のため pidfile + cmd検証 の両方を必須とする）:
-   * - Arkが起動したpidは BROWSER_PIDFILE に記録される
-   * - 起動時にpidfileを読み、現存pidの cmd を ps で確認
-   * - cmd が Ark系のいずれか（マーカー付きXvfb/x11vnc、Ark固定CDPポートの
-   *   Chromium、websockify）にマッチしたものだけを掃除対象とする
-   * - pidfile に記録されていない他サービスや、pid再利用で別cmdになった
-   *   プロセスは安全に無視される
+   * 識別方針（誤kill防止のため pidfile + cmd検証 + サーバーownership の三段階）:
+   * - 各Arkサーバーは自身のpidをファイル名にしたpidfileに子pidを記録する
+   *   (`<BROWSER_PIDFILE_DIR>/<serverPid>`)
+   * - 起動時にディレクトリをスキャンし、ファイル名のserverPidが現存しない
+   *   （=死亡サーバー）ファイルだけを孤立扱いする。生存中の他サーバー
+   *   インスタンス（pm2 reload等）の子は触らない
+   * - 候補pidは ps -p で cmd を取得し、Ark由来cmd（マーカー付きXvfb/x11vnc、
+   *   Ark固定CDPポートのChromium、websockify）にマッチしたものだけkill対象
+   * - pid再利用で別cmdになったプロセスは無視される
    *
    * 終了確認:
    * - SIGTERM後、最大 ORPHAN_TERM_TIMEOUT_MS まで `kill -0` で終了をポーリング
    * - 残存プロセスは SIGKILL で強制終了
    * - 全プロセスが消えたことを確認した後で X11 ソケットを削除する
-   *   （Xvfb生存中にソケットを消すと findAvailableDisplay() が誤判定する）
+   * - 残存pidが残った場合: 最初のorphanFileに残存pidを書き戻し、ソケット削除は
+   *   スキップする（findAvailableDisplay() の誤判定防止 + 次回起動時の再試行）
    */
   private cleanupOrphanedProcesses(): void {
     try {
-      // pidfile から Ark 由来候補 pid を読み込む。なければ掃除対象なし。
-      let candidatePids: number[];
+      let entries: string[];
       try {
-        const content = fs.readFileSync(BROWSER_PIDFILE, "utf-8");
-        candidatePids = Array.from(
-          new Set(
-            content
-              .split("\n")
-              .map(s => Number.parseInt(s.trim(), 10))
-              .filter(n => Number.isFinite(n) && n > 0)
-          )
-        );
+        entries = fs.readdirSync(BROWSER_PIDFILE_DIR);
       } catch {
-        return; // pidfile未作成 = 過去にArkが起動していない
+        return; // ディレクトリ未作成 = 過去にArkが起動していない
       }
+
+      // 死亡サーバー(=自分以外で生存していないserverPid)のファイルだけ集める
+      const orphanFiles: string[] = [];
+      for (const entry of entries) {
+        const serverPid = Number.parseInt(entry, 10);
+        if (!Number.isFinite(serverPid) || serverPid <= 0) continue;
+        if (serverPid === process.pid) continue; // 自分のファイルは触らない
+        let alive = false;
+        try {
+          process.kill(serverPid, 0);
+          alive = true;
+        } catch {
+          alive = false;
+        }
+        if (!alive) orphanFiles.push(entry);
+      }
+
+      if (orphanFiles.length === 0) return;
+
+      // 候補pidを集める
+      const candidatePidSet = new Set<number>();
+      for (const file of orphanFiles) {
+        try {
+          const content = fs.readFileSync(
+            path.join(BROWSER_PIDFILE_DIR, file),
+            "utf-8"
+          );
+          for (const line of content.split("\n")) {
+            const pid = Number.parseInt(line.trim(), 10);
+            if (Number.isFinite(pid) && pid > 0) candidatePidSet.add(pid);
+          }
+        } catch {
+          // ファイル読めない場合は無視
+        }
+      }
+      const candidatePids = Array.from(candidatePidSet);
+
       if (candidatePids.length === 0) {
-        this.writePidFile([]);
+        // 空のorphanFileは削除して終了
+        this.deleteOrphanFiles(orphanFiles);
         return;
       }
 
-      // ps で対象pidのcmdを取得（pid再利用や別プロセス摩り替わりを検知）
+      // ps で対象pidのcmdを取得（pid再利用検知）
       const pidToCmd = new Map<number, string>();
       try {
         const psOutput = execFileSync(
@@ -186,8 +219,8 @@ export class BrowserManager extends EventEmitter {
           pidToCmd.set(Number.parseInt(m[1], 10), m[2]);
         }
       } catch {
-        // 全pidが既に死んでいると ps は非0を返すことがある → pidfileのみクリア
-        this.writePidFile([]);
+        // 全pidが既に死んでいると ps は非0を返す → orphanFiles削除のみ
+        this.deleteOrphanFiles(orphanFiles);
         return;
       }
 
@@ -240,7 +273,7 @@ export class BrowserManager extends EventEmitter {
       }
 
       if (orphanPids.length === 0) {
-        this.writePidFile([]);
+        this.deleteOrphanFiles(orphanFiles);
         return;
       }
 
@@ -305,7 +338,7 @@ export class BrowserManager extends EventEmitter {
 
       const survivors = Array.from(remainingPids);
       if (survivors.length === 0) {
-        // 全プロセスが終了した → ソケット残骸を削除し、pidfileをクリア
+        // 全プロセスが終了した → ソケット残骸を削除し、orphan files削除
         for (const display of orphanDisplays) {
           try {
             fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
@@ -313,16 +346,32 @@ export class BrowserManager extends EventEmitter {
             // 残存しない/権限なしは無視
           }
         }
-        this.writePidFile([]);
+        this.deleteOrphanFiles(orphanFiles);
       } else {
-        // SIGKILL後も生存しているpidがある → 次回起動時の再試行候補として
-        // pidfileに残存pidだけを書き戻す。ソケット削除も生存Xvfbが所有して
-        // いる可能性があるためスキップする（findAvailableDisplay() の誤判定防止）
+        // SIGKILL後も生存pidあり → 最初のorphan fileに残存pidを書き戻し、
+        // 他は削除。ソケット削除は生存Xvfb所有の可能性があるためスキップ
+        // （findAvailableDisplay()の誤判定防止）。次回起動時に再試行される。
         console.warn(
           `[BrowserManager] 一部の孤立プロセスが終了しませんでした: pids=${survivors.join(",")} ` +
             "（次回起動時に再試行します）"
         );
-        this.writePidFile(survivors);
+        try {
+          fs.writeFileSync(
+            path.join(BROWSER_PIDFILE_DIR, orphanFiles[0]),
+            `${survivors.join("\n")}\n`
+          );
+        } catch (err) {
+          console.warn(
+            `[BrowserManager] survivors書き込み失敗: ${getErrorMessage(err)}`
+          );
+        }
+        for (let i = 1; i < orphanFiles.length; i++) {
+          try {
+            fs.unlinkSync(path.join(BROWSER_PIDFILE_DIR, orphanFiles[i]));
+          } catch {
+            // 既に削除されているなどは無視
+          }
+        }
       }
     } catch (err) {
       console.warn(
@@ -331,12 +380,30 @@ export class BrowserManager extends EventEmitter {
     }
   }
 
+  /** orphan扱いのpidfileを一括削除する */
+  private deleteOrphanFiles(orphanFiles: string[]): void {
+    for (const file of orphanFiles) {
+      try {
+        fs.unlinkSync(path.join(BROWSER_PIDFILE_DIR, file));
+      } catch {
+        // 既に削除されているなどは無視
+      }
+    }
+  }
+
+  /** 自身のpidfileのパス */
+  private ownPidFile(): string {
+    return path.join(BROWSER_PIDFILE_DIR, String(process.pid));
+  }
+
   /**
-   * 現在アクティブなセッションのpidをBROWSER_PIDFILEに書き戻す。
-   * sessions Mapが「現在管理中のArkプロセス」の単一の真実なので、
-   * stop/cleanup/start_internal完了時にこれを呼べばpidfileが常に同期する。
+   * 現在アクティブなセッションのpidを自身のpidfileに書き戻す。
+   * sessions Map が「現在管理中のArkプロセス」の単一の真実だが、
+   * stop()でkillProcess()がtimeoutして子が残るケースに備え、survivors
+   * パラメータで「終了確認できなかったpid」も併せてpidfileに残せる。
+   * その残存pidは自分が死亡した際の次回cleanup候補となる。
    */
-  private syncPidFile(): void {
+  private syncPidFile(survivors: number[] = []): void {
     const activePids: number[] = [];
     for (const session of this.sessions.values()) {
       const pids = [
@@ -349,15 +416,13 @@ export class BrowserManager extends EventEmitter {
         if (pid !== undefined) activePids.push(pid);
       }
     }
-    this.writePidFile(activePids);
-  }
+    activePids.push(...survivors);
 
-  /** BROWSER_PIDFILEに任意のpid配列を書き戻す */
-  private writePidFile(pids: number[]): void {
     try {
-      fs.mkdirSync(path.dirname(BROWSER_PIDFILE), { recursive: true });
-      const content = pids.length === 0 ? "" : `${pids.join("\n")}\n`;
-      fs.writeFileSync(BROWSER_PIDFILE, content);
+      fs.mkdirSync(BROWSER_PIDFILE_DIR, { recursive: true });
+      const content =
+        activePids.length === 0 ? "" : `${activePids.join("\n")}\n`;
+      fs.writeFileSync(this.ownPidFile(), content);
     } catch (err) {
       console.warn(
         `[BrowserManager] pidfile書き込み失敗: ${getErrorMessage(err)}`
@@ -1087,8 +1152,6 @@ export class BrowserManager extends EventEmitter {
 
     // 先にMapから削除して、異常終了監視のハンドラが再度stopを呼ばないようにする
     this.sessions.delete(browserId);
-    // pidfileから当該セッションのpidを除去（古いpidの累積を防ぐ）
-    this.syncPidFile();
 
     // シングルトンセッションをクリア
     if (this.singletonSession?.id === browserId) {
@@ -1104,6 +1167,25 @@ export class BrowserManager extends EventEmitter {
       this.killProcess(processSet.chromium, "chromium"),
       this.killProcess(processSet.xvfb, "xvfb"),
     ]);
+
+    // killProcess() がtimeout等で殺しきれず残ったpidを集めて pidfile に残す。
+    // これらは自分が死亡した際に次回起動時のcleanup候補となる。
+    const survivors: number[] = [];
+    for (const child of [
+      processSet.websockify,
+      processSet.x11vnc,
+      processSet.chromium,
+      processSet.xvfb,
+    ]) {
+      if (child.pid === undefined) continue;
+      try {
+        process.kill(child.pid, 0);
+        survivors.push(child.pid); // まだ生きている
+      } catch {
+        // ESRCH → 死亡 → pidfileに残さない
+      }
+    }
+    this.syncPidFile(survivors);
 
     this.emit("session:stopped", browserId);
     console.log(`[BrowserManager] ブラウザセッション停止完了: ${browserId}`);

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -64,8 +64,16 @@ const ARK_DESKTOP = "ark-browser";
  * (`<dir>/<serverPid>`) に子pidを書き込む。cleanupOrphanedProcesses()
  * は「ファイル名のserverPidが現存していない」ファイルだけを孤立扱いし、
  * 別の生存中サーバー（pm2 reload等での旧インスタンス）の子は触らない。
+ *
+ * ファイル形式: 1行1エントリ。`<pid>` または `<pid>:<display>`。
+ * Xvfbのみdisplay情報を併記してプロセス死亡後もソケット残骸を回収できる。
  */
 const BROWSER_PIDFILE_DIR = path.join("data", "browser-pids");
+
+interface PidEntry {
+  pid: number;
+  display?: number;
+}
 
 /** Xvfb仮想ディスプレイの解像度 */
 const DISPLAY_RESOLUTION = "1280x900x24";
@@ -197,26 +205,32 @@ export class BrowserManager extends EventEmitter {
 
       if (orphanFiles.length === 0) return;
 
-      // 候補pidを集める
-      const candidatePidSet = new Set<number>();
+      // 候補エントリを集める。pid重複時はdisplay情報のあるエントリを優先
+      const entryByPid = new Map<number, PidEntry>();
       for (const file of orphanFiles) {
         try {
           const content = fs.readFileSync(
             path.join(BROWSER_PIDFILE_DIR, file),
             "utf-8"
           );
-          for (const line of content.split("\n")) {
-            const pid = Number.parseInt(line.trim(), 10);
-            if (Number.isFinite(pid) && pid > 0) candidatePidSet.add(pid);
+          for (const e of this.parsePidEntries(content)) {
+            const existing = entryByPid.get(e.pid);
+            if (
+              !existing ||
+              (existing.display === undefined && e.display !== undefined)
+            ) {
+              entryByPid.set(e.pid, e);
+            }
           }
         } catch {
           // ファイル読めない場合は無視
         }
       }
-      const candidatePids = Array.from(candidatePidSet);
+      const candidates = Array.from(entryByPid.values());
+      const minDisplay = DISPLAY_START;
+      const maxDisplay = DISPLAY_START + 100;
 
-      if (candidatePids.length === 0) {
-        // 空のorphanFileは削除して終了
+      if (candidates.length === 0) {
         this.deleteOrphanFiles(orphanFiles);
         return;
       }
@@ -226,7 +240,7 @@ export class BrowserManager extends EventEmitter {
       try {
         const psOutput = execFileSync(
           "ps",
-          ["-o", "pid=,cmd=", "-p", candidatePids.join(",")],
+          ["-o", "pid=,cmd=", "-p", candidates.map(c => c.pid).join(",")],
           { encoding: "utf-8" }
         );
         for (const line of psOutput.split("\n")) {
@@ -235,27 +249,54 @@ export class BrowserManager extends EventEmitter {
           pidToCmd.set(Number.parseInt(m[1], 10), m[2]);
         }
       } catch {
-        // 全pidが既に死んでいると ps は非0を返す → orphanFiles削除のみ
+        // 全pidが既に死んでいる → display情報のあるpidについてはX11ソケット
+        // 残骸を削除してからorphanFilesを削除する
+        // （crashed Xvfbがソケットだけ残しているケース対応）
+        const deadDisplays = new Set<number>();
+        for (const c of candidates) {
+          if (
+            c.display !== undefined &&
+            c.display >= minDisplay &&
+            c.display <= maxDisplay
+          ) {
+            deadDisplays.add(c.display);
+          }
+        }
+        for (const display of deadDisplays) {
+          try {
+            fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
+          } catch {
+            // 残存しない/権限なしは無視
+          }
+        }
         this.deleteOrphanFiles(orphanFiles);
         return;
       }
 
       const orphanPids: number[] = [];
-      const orphanDisplays: number[] = [];
-      const minDisplay = DISPLAY_START;
-      const maxDisplay = DISPLAY_START + 100;
+      const orphanDisplays = new Set<number>();
 
-      for (const pid of candidatePids) {
-        const cmd = pidToCmd.get(pid);
-        if (!cmd) continue; // pid既に終了済み
+      for (const c of candidates) {
+        const cmd = pidToCmd.get(c.pid);
+        if (!cmd) {
+          // pid既に終了済み → 紐づくdisplay情報があればソケット削除候補に
+          if (
+            c.display !== undefined &&
+            c.display >= minDisplay &&
+            c.display <= maxDisplay
+          ) {
+            orphanDisplays.add(c.display);
+          }
+          continue;
+        }
 
         // Xvfb: マーカー(-fbdir XVFB_FB_DIR)とdisplayレンジで判定
         const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
         if (xvfbMatch && cmd.includes(XVFB_FB_DIR)) {
           const display = Number.parseInt(xvfbMatch[1], 10);
           if (display >= minDisplay && display <= maxDisplay) {
-            orphanPids.push(pid);
-            orphanDisplays.push(display);
+            orphanPids.push(c.pid);
+            orphanDisplays.add(display);
           }
           continue;
         }
@@ -265,7 +306,7 @@ export class BrowserManager extends EventEmitter {
         if (x11vncMatch && cmd.includes(`-desktop ${ARK_DESKTOP}`)) {
           const display = Number.parseInt(x11vncMatch[1], 10);
           if (display >= minDisplay && display <= maxDisplay) {
-            orphanPids.push(pid);
+            orphanPids.push(c.pid);
           }
           continue;
         }
@@ -275,7 +316,7 @@ export class BrowserManager extends EventEmitter {
           /\bwebsockify\b/.test(cmd) &&
           /127\.0\.0\.1:\d+\s+127\.0\.0\.1:\d+/.test(cmd)
         ) {
-          orphanPids.push(pid);
+          orphanPids.push(c.pid);
           continue;
         }
 
@@ -284,11 +325,19 @@ export class BrowserManager extends EventEmitter {
           /\b(chrome|chromium)\b/.test(cmd) &&
           cmd.includes(`--remote-debugging-port=${CDP_PORT}`)
         ) {
-          orphanPids.push(pid);
+          orphanPids.push(c.pid);
         }
       }
 
       if (orphanPids.length === 0) {
+        // kill対象pidなしだが、死亡Xvfbのソケット残骸があれば削除
+        for (const display of orphanDisplays) {
+          try {
+            fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
+          } catch {
+            // 残存しない/権限なしは無視
+          }
+        }
         this.deleteOrphanFiles(orphanFiles);
         return;
       }
@@ -367,14 +416,19 @@ export class BrowserManager extends EventEmitter {
         // SIGKILL後も生存pidあり → 最初のorphan fileに残存pidを書き戻し、
         // 他は削除。ソケット削除は生存Xvfb所有の可能性があるためスキップ
         // （findAvailableDisplay()の誤判定防止）。次回起動時に再試行される。
+        // display情報は元のorphan fileから引き継いで再起動時のソケット回収に活用。
         console.warn(
           `[BrowserManager] 一部の孤立プロセスが終了しませんでした: pids=${survivors.join(",")} ` +
             "（次回起動時に再試行します）"
         );
+        const survivorEntries: PidEntry[] = survivors.map(pid => ({
+          pid,
+          display: entryByPid.get(pid)?.display,
+        }));
         try {
           fs.writeFileSync(
             path.join(BROWSER_PIDFILE_DIR, orphanFiles[0]),
-            `${survivors.join("\n")}\n`
+            this.serializePidEntries(survivorEntries)
           );
         } catch (err) {
           console.warn(
@@ -413,32 +467,101 @@ export class BrowserManager extends EventEmitter {
   }
 
   /**
+   * pidfile内容をPidEntry配列にパースする。
+   * 1行 = `<pid>` または `<pid>:<display>`
+   */
+  private parsePidEntries(content: string): PidEntry[] {
+    const entries: PidEntry[] = [];
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const [pidStr, displayStr] = trimmed.split(":");
+      const pid = Number.parseInt(pidStr, 10);
+      if (!Number.isFinite(pid) || pid <= 0) continue;
+      const display =
+        displayStr !== undefined ? Number.parseInt(displayStr, 10) : Number.NaN;
+      entries.push({
+        pid,
+        display: Number.isFinite(display) ? display : undefined,
+      });
+    }
+    return entries;
+  }
+
+  /** PidEntry配列をpidfileテキスト形式にシリアライズする */
+  private serializePidEntries(entries: PidEntry[]): string {
+    if (entries.length === 0) return "";
+    return `${entries
+      .map(e =>
+        e.display !== undefined ? `${e.pid}:${e.display}` : String(e.pid)
+      )
+      .join("\n")}\n`;
+  }
+
+  /**
    * 現在アクティブなセッションのpidを自身のpidfileに書き戻す。
+   *
    * sessions Map が「現在管理中のArkプロセス」の単一の真実だが、
-   * stop()でkillProcess()がtimeoutして子が残るケースに備え、survivors
-   * パラメータで「終了確認できなかったpid」も併せてpidfileに残せる。
-   * その残存pidは自分が死亡した際の次回cleanup候補となる。
+   * 次の点も考慮する必要がある:
+   * - 過去のstop()/start失敗で `survivors` として記録されたpidが、新しい
+   *   session start/stop で素朴な書き戻しによって失われると、自分が死亡時に
+   *   次回起動が孤立を発見できない。既存pidfileから「sessions管理外で
+   *   生存中のpid」を読み込んで保持する。
+   * - Xvfbのdisplay情報を `pid:display` 形式で記録し、プロセス死亡後の
+   *   ソケット残骸回収に活用する。
    */
   private syncPidFile(survivors: number[] = []): void {
-    const activePids: number[] = [];
+    const entries: PidEntry[] = [];
+    const activePids = new Set<number>();
+
+    // sessions Mapから現在のpidを集める。Xvfbのみdisplay情報を併記
     for (const session of this.sessions.values()) {
-      const pids = [
-        session.xvfb.pid,
-        session.chromium.pid,
-        session.x11vnc.pid,
-        session.websockify.pid,
-      ];
-      for (const pid of pids) {
-        if (pid !== undefined) activePids.push(pid);
+      if (session.xvfb.pid !== undefined) {
+        entries.push({ pid: session.xvfb.pid, display: session.displayNum });
+        activePids.add(session.xvfb.pid);
+      }
+      for (const child of [
+        session.chromium,
+        session.x11vnc,
+        session.websockify,
+      ]) {
+        if (child.pid !== undefined) {
+          entries.push({ pid: child.pid });
+          activePids.add(child.pid);
+        }
       }
     }
-    activePids.push(...survivors);
+
+    // 既存pidfileから「sessions管理外で生存中のpid（過去のsurvivors）」を保持
+    let priorEntries: PidEntry[] = [];
+    try {
+      const content = fs.readFileSync(this.ownPidFile(), "utf-8");
+      priorEntries = this.parsePidEntries(content);
+    } catch {
+      // ファイル未作成は無視
+    }
+    for (const e of priorEntries) {
+      if (activePids.has(e.pid)) continue;
+      try {
+        process.kill(e.pid, 0);
+        entries.push(e); // 生存中の過去survivor → display情報も含めて保持
+        activePids.add(e.pid);
+      } catch {
+        // 死亡 → 含めない
+      }
+    }
+
+    // 今回新たに発生した survivors（display情報なし）
+    for (const pid of survivors) {
+      if (!activePids.has(pid)) {
+        entries.push({ pid });
+        activePids.add(pid);
+      }
+    }
 
     try {
       fs.mkdirSync(BROWSER_PIDFILE_DIR, { recursive: true });
-      const content =
-        activePids.length === 0 ? "" : `${activePids.join("\n")}\n`;
-      fs.writeFileSync(this.ownPidFile(), content);
+      fs.writeFileSync(this.ownPidFile(), this.serializePidEntries(entries));
     } catch (err) {
       console.warn(
         `[BrowserManager] pidfile書き込み失敗: ${getErrorMessage(err)}`

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -12,6 +12,7 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
+import path from "node:path";
 import type { BrowserSession } from "../../shared/types.js";
 import {
   CDP_PORT,
@@ -46,6 +47,14 @@ const XVFB_FB_DIR = "/tmp/.ark-xvfb-fb";
  * Ark由来と判定する
  */
 const ARK_DESKTOP = "ark-browser";
+
+/**
+ * Arkが起動したブラウザ関連子プロセスのpidを記録するファイル
+ * cleanupOrphanedProcesses() がこのpidfileを読み、現存しArk的cmdを持つものだけを
+ * 掃除対象とする。マーカー引数を付けられないwebsockify/Chromiumを
+ * 安全に識別するため。
+ */
+const BROWSER_PIDFILE = path.join("data", "browser-pids");
 
 /** Xvfb仮想ディスプレイの解像度 */
 const DISPLAY_RESOLUTION = "1280x900x24";
@@ -127,12 +136,13 @@ export class BrowserManager extends EventEmitter {
    * 自プロセスのreadinessと誤認 → Chromiumのいない空ディスプレイが量産される。
    * 起動時にArk由来プロセスを一掃して再発を防ぐ。
    *
-   * 識別方針:
-   * - 同一uidのプロセスのみ対象（クロスユーザーで他サービスを誤killしない）
-   * - Xvfb: 起動時に付与する `-fbdir XVFB_FB_DIR` をマーカーとする
-   * - x11vnc: 起動時に付与する `-desktop ARK_DESKTOP` をマーカーとする
-   * - Chromium: Ark専用固定CDPポート(`--remote-debugging-port=9222`)で識別
-   * - websockify: uid限定 + Ark管理ポート範囲で識別
+   * 識別方針（誤kill防止のため pidfile + cmd検証 の両方を必須とする）:
+   * - Arkが起動したpidは BROWSER_PIDFILE に記録される
+   * - 起動時にpidfileを読み、現存pidの cmd を ps で確認
+   * - cmd が Ark系のいずれか（マーカー付きXvfb/x11vnc、Ark固定CDPポートの
+   *   Chromium、websockify）にマッチしたものだけを掃除対象とする
+   * - pidfile に記録されていない他サービスや、pid再利用で別cmdになった
+   *   プロセスは安全に無視される
    *
    * 終了確認:
    * - SIGTERM後、最大 ORPHAN_TERM_TIMEOUT_MS まで `kill -0` で終了をポーリング
@@ -142,26 +152,55 @@ export class BrowserManager extends EventEmitter {
    */
   private cleanupOrphanedProcesses(): void {
     try {
-      const ownUid = process.getuid?.();
-      if (ownUid === undefined) return; // POSIX外環境では何もしない
+      // pidfile から Ark 由来候補 pid を読み込む。なければ掃除対象なし。
+      let candidatePids: number[];
+      try {
+        const content = fs.readFileSync(BROWSER_PIDFILE, "utf-8");
+        candidatePids = Array.from(
+          new Set(
+            content
+              .split("\n")
+              .map(s => Number.parseInt(s.trim(), 10))
+              .filter(n => Number.isFinite(n) && n > 0)
+          )
+        );
+      } catch {
+        return; // pidfile未作成 = 過去にArkが起動していない
+      }
+      if (candidatePids.length === 0) {
+        this.clearPidFile();
+        return;
+      }
 
-      const psOutput = execFileSync(
-        "ps",
-        ["-o", "pid=,cmd=", "-u", String(ownUid)],
-        { encoding: "utf-8" }
-      );
+      // ps で対象pidのcmdを取得（pid再利用や別プロセス摩り替わりを検知）
+      const pidToCmd = new Map<number, string>();
+      try {
+        const psOutput = execFileSync(
+          "ps",
+          ["-o", "pid=,cmd=", "-p", candidatePids.join(",")],
+          { encoding: "utf-8" }
+        );
+        for (const line of psOutput.split("\n")) {
+          const m = line.trim().match(/^(\d+)\s+(.*)$/);
+          if (!m) continue;
+          pidToCmd.set(Number.parseInt(m[1], 10), m[2]);
+        }
+      } catch {
+        // 全pidが既に死んでいると ps は非0を返すことがある → pidfileのみクリア
+        this.clearPidFile();
+        return;
+      }
+
       const orphanPids: number[] = [];
       const orphanDisplays: number[] = [];
       const minDisplay = DISPLAY_START;
       const maxDisplay = DISPLAY_START + 100;
 
-      for (const line of psOutput.split("\n")) {
-        const m = line.trim().match(/^(\d+)\s+(.*)$/);
-        if (!m) continue;
-        const pid = Number.parseInt(m[1], 10);
-        const cmd = m[2];
+      for (const pid of candidatePids) {
+        const cmd = pidToCmd.get(pid);
+        if (!cmd) continue; // pid既に終了済み
 
-        // Xvfb: Ark識別マーカー(-fbdir XVFB_FB_DIR)とdisplayレンジで判定
+        // Xvfb: マーカー(-fbdir XVFB_FB_DIR)とdisplayレンジで判定
         const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
         if (xvfbMatch && cmd.includes(XVFB_FB_DIR)) {
           const display = Number.parseInt(xvfbMatch[1], 10);
@@ -172,7 +211,7 @@ export class BrowserManager extends EventEmitter {
           continue;
         }
 
-        // x11vnc: Ark識別マーカー(-desktop ARK_DESKTOP)とdisplayレンジで判定
+        // x11vnc: マーカー(-desktop ARK_DESKTOP)とdisplayレンジで判定
         const x11vncMatch = cmd.match(/\bx11vnc\b.*?-display\s+:(\d+)\b/);
         if (x11vncMatch && cmd.includes(`-desktop ${ARK_DESKTOP}`)) {
           const display = Number.parseInt(x11vncMatch[1], 10);
@@ -182,23 +221,16 @@ export class BrowserManager extends EventEmitter {
           continue;
         }
 
-        // websockify: uid限定済みなのでArk管理ポート範囲のみで判定
-        const wsMatch = cmd.match(
-          /\bwebsockify\b.*?127\.0\.0\.1:(\d+)\s+127\.0\.0\.1:(\d+)/
-        );
-        if (wsMatch) {
-          const wsPort = Number.parseInt(wsMatch[1], 10);
-          const vncPort = Number.parseInt(wsMatch[2], 10);
-          if (
-            (wsPort >= WS_PORT_START && wsPort <= WS_PORT_END) ||
-            (vncPort >= VNC_PORT_START && vncPort <= VNC_PORT_END)
-          ) {
-            orphanPids.push(pid);
-          }
+        // websockify: pidfile経由でArk由来と確認できているのでcmd形状のみ確認
+        if (
+          /\bwebsockify\b/.test(cmd) &&
+          /127\.0\.0\.1:\d+\s+127\.0\.0\.1:\d+/.test(cmd)
+        ) {
+          orphanPids.push(pid);
           continue;
         }
 
-        // Chromium: Ark固定CDPポートを使うものはArk由来とみなす
+        // Chromium: pidfile経由 + Ark固定CDPポートの両方でArk由来と確認
         if (
           /\b(chrome|chromium)\b/.test(cmd) &&
           cmd.includes(`--remote-debugging-port=${CDP_PORT}`)
@@ -207,7 +239,10 @@ export class BrowserManager extends EventEmitter {
         }
       }
 
-      if (orphanPids.length === 0) return;
+      if (orphanPids.length === 0) {
+        this.clearPidFile();
+        return;
+      }
 
       console.log(
         `[BrowserManager] 孤立プロセスを掃除: pids=${orphanPids.join(",")}`
@@ -276,10 +311,36 @@ export class BrowserManager extends EventEmitter {
           // 残存しない/権限なしは無視
         }
       }
+
+      // 掃除完了 → 古い候補を流すためpidfileを空にする
+      this.clearPidFile();
     } catch (err) {
       console.warn(
         `[BrowserManager] 孤立プロセス掃除に失敗: ${getErrorMessage(err)}`
       );
+    }
+  }
+
+  /**
+   * 起動した子プロセスのpidをBROWSER_PIDFILEに追記する。
+   * 次回起動時の cleanupOrphanedProcesses() がこのpidを候補として読む。
+   */
+  private recordPid(pid: number | undefined): void {
+    if (pid === undefined) return;
+    try {
+      fs.mkdirSync(path.dirname(BROWSER_PIDFILE), { recursive: true });
+      fs.appendFileSync(BROWSER_PIDFILE, `${pid}\n`);
+    } catch (err) {
+      console.warn(`[BrowserManager] pidfile記録失敗: ${getErrorMessage(err)}`);
+    }
+  }
+
+  /** BROWSER_PIDFILEを空にする（cleanup完了時に呼ぶ） */
+  private clearPidFile(): void {
+    try {
+      fs.writeFileSync(BROWSER_PIDFILE, "");
+    } catch {
+      // ファイル未作成等は無視
     }
   }
 
@@ -608,6 +669,7 @@ export class BrowserManager extends EventEmitter {
         { stdio: ["ignore", "pipe", "pipe"], detached: false }
       );
       startedProcesses.push(xvfb);
+      this.recordPid(xvfb.pid);
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -658,6 +720,7 @@ export class BrowserManager extends EventEmitter {
         },
       });
       startedProcesses.push(chromium);
+      this.recordPid(chromium.pid);
 
       // CDPエンドポイントが応答するまでポーリングしてChromium readinessを検出
       // 早期exitやerrorも検出してreject
@@ -732,6 +795,7 @@ export class BrowserManager extends EventEmitter {
         { stdio: ["ignore", "pipe", "pipe"], detached: false }
       );
       startedProcesses.push(x11vnc);
+      this.recordPid(x11vnc.pid);
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {
@@ -800,6 +864,7 @@ export class BrowserManager extends EventEmitter {
         { stdio: ["ignore", "pipe", "pipe"], detached: false }
       );
       startedProcesses.push(websockify);
+      this.recordPid(websockify.pid);
 
       await new Promise<void>((resolve, reject) => {
         const timeout = setTimeout(() => {

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -187,20 +187,17 @@ export class BrowserManager extends EventEmitter {
         return; // ディレクトリ未作成 = 過去にArkが起動していない
       }
 
-      // 死亡サーバー(=自分以外で生存していないserverPid)のファイルだけ集める
+      // 死亡サーバー(=自分以外でArkサーバーとして生存していないserverPid)の
+      // ファイルだけ集める。pid再利用で別プロセスがそのpidを取っているケース
+      // を `isArkServerAlive` で識別する（kill -0 だけだと永久に skip される）
       const orphanFiles: string[] = [];
       for (const entry of entries) {
         const serverPid = Number.parseInt(entry, 10);
         if (!Number.isFinite(serverPid) || serverPid <= 0) continue;
         if (serverPid === process.pid) continue; // 自分のファイルは触らない
-        let alive = false;
-        try {
-          process.kill(serverPid, 0);
-          alive = true;
-        } catch {
-          alive = false;
+        if (!this.isArkServerAlive(serverPid)) {
+          orphanFiles.push(entry);
         }
-        if (!alive) orphanFiles.push(entry);
       }
 
       if (orphanFiles.length === 0) return;
@@ -432,6 +429,49 @@ export class BrowserManager extends EventEmitter {
     }
   }
 
+  /**
+   * 指定pidが「Arkサーバープロセスとして生存しているか」を判定する。
+   * 単なる kill -0 だけだとpid再利用された別プロセスを「生存」と誤判定して
+   * 旧サーバーのpidfileがcleanup対象から永久に漏れる。ps cmd でArkサーバー
+   * のentry point (`dist/index.js`) パターンを確認する。
+   */
+  private isArkServerAlive(serverPid: number): boolean {
+    try {
+      const cmd = execFileSync("ps", ["-o", "cmd=", "-p", String(serverPid)], {
+        encoding: "utf-8",
+      }).trim();
+      if (!cmd) return false;
+      // pm2 fork mode: `node /path/to/dist/index.js [args]`
+      return /\bnode\b/.test(cmd) && /\bdist\/index\.js\b/.test(cmd);
+    } catch {
+      // ps失敗（pid死亡またはpermission denied）
+      return false;
+    }
+  }
+
+  /**
+   * cmd行が Ark由来のブラウザヘルパープロセスのパターンにマッチするかを判定する。
+   * pidfileに記録されたpidをsurvivorとして保持/kill対象にする前に、pid再利用で
+   * 別プロセスにすり替わっていないかを確認するために使う。
+   */
+  private isArkBrowserCmd(cmd: string): boolean {
+    if (/^Xvfb\s+:\d+\b/.test(cmd)) return true;
+    if (/\bx11vnc\b/.test(cmd) && /-display\s+:\d+/.test(cmd)) return true;
+    if (
+      /\bwebsockify\b/.test(cmd) &&
+      /127\.0\.0\.1:\d+\s+127\.0\.0\.1:\d+/.test(cmd)
+    ) {
+      return true;
+    }
+    if (
+      /\b(chrome|chromium)\b/.test(cmd) &&
+      cmd.includes(`--remote-debugging-port=${CDP_PORT}`)
+    ) {
+      return true;
+    }
+    return false;
+  }
+
   /** orphan扱いのpidfileを一括削除する */
   private deleteOrphanFiles(orphanFiles: string[]): void {
     for (const file of orphanFiles) {
@@ -514,7 +554,9 @@ export class BrowserManager extends EventEmitter {
       }
     }
 
-    // 既存pidfileから「sessions管理外で生存中のpid（過去のsurvivors）」を保持
+    // 既存pidfileから「sessions管理外で生存中のpid（過去のsurvivors）」を保持。
+    // pid再利用で別プロセスが同じpidを取っているケースを排除するため、
+    // ps cmd を取得してArk由来binary形状にマッチするものだけを残す。
     let priorEntries: PidEntry[] = [];
     try {
       const content = fs.readFileSync(this.ownPidFile(), "utf-8");
@@ -522,14 +564,29 @@ export class BrowserManager extends EventEmitter {
     } catch {
       // ファイル未作成は無視
     }
-    for (const e of priorEntries) {
-      if (activePids.has(e.pid)) continue;
+    const candidatePriors = priorEntries.filter(e => !activePids.has(e.pid));
+    if (candidatePriors.length > 0) {
+      const priorPidToCmd = new Map<number, string>();
       try {
-        process.kill(e.pid, 0);
-        entries.push(e); // 生存中の過去survivor → display情報も含めて保持
-        activePids.add(e.pid);
+        const psOutput = execFileSync(
+          "ps",
+          ["-o", "pid=,cmd=", "-p", candidatePriors.map(e => e.pid).join(",")],
+          { encoding: "utf-8" }
+        );
+        for (const line of psOutput.split("\n")) {
+          const m = line.trim().match(/^(\d+)\s+(.*)$/);
+          if (!m) continue;
+          priorPidToCmd.set(Number.parseInt(m[1], 10), m[2]);
+        }
       } catch {
-        // 死亡 → 含めない
+        // 全pid死亡 → priorPidToCmd空のまま、誰も保持されない
+      }
+      for (const e of candidatePriors) {
+        const cmd = priorPidToCmd.get(e.pid);
+        if (!cmd) continue; // pid既に死亡
+        if (!this.isArkBrowserCmd(cmd)) continue; // pid再利用で別プロセス
+        entries.push(e); // 生存中のArk由来survivor → display情報も含めて保持
+        activePids.add(e.pid);
       }
     }
 

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -249,46 +249,24 @@ export class BrowserManager extends EventEmitter {
           pidToCmd.set(Number.parseInt(m[1], 10), m[2]);
         }
       } catch {
-        // 全pidが既に死んでいる → display情報のあるpidについてはX11ソケット
-        // 残骸を削除してからorphanFilesを削除する
-        // （crashed Xvfbがソケットだけ残しているケース対応）
-        const deadDisplays = new Set<number>();
-        for (const c of candidates) {
-          if (
-            c.display !== undefined &&
-            c.display >= minDisplay &&
-            c.display <= maxDisplay
-          ) {
-            deadDisplays.add(c.display);
-          }
-        }
-        for (const display of deadDisplays) {
-          try {
-            fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
-          } catch {
-            // 残存しない/権限なしは無視
-          }
-        }
+        // 全pidが既に死んでいる → orphanFiles削除のみ。
+        // ソケット残骸の削除は行わない（pid死亡後にdisplay番号を別の
+        // X11サーバーが再利用している場合に live socket を破壊する恐れ）
         this.deleteOrphanFiles(orphanFiles);
         return;
       }
 
       const orphanPids: number[] = [];
-      const orphanDisplays = new Set<number>();
+      // pid → display のマップ。kill成功確認後にXvfbソケットを削除するため
+      const pidToOrphanDisplay = new Map<number, number>();
 
       for (const c of candidates) {
         const cmd = pidToCmd.get(c.pid);
-        if (!cmd) {
-          // pid既に終了済み → 紐づくdisplay情報があればソケット削除候補に
-          if (
-            c.display !== undefined &&
-            c.display >= minDisplay &&
-            c.display <= maxDisplay
-          ) {
-            orphanDisplays.add(c.display);
-          }
-          continue;
-        }
+        // pid既に終了済みの場合はskip（display単独でのソケット削除はlive socket
+        // 破壊リスクがあるため触らない。crashed Xvfbのソケット残骸は
+        // findAvailableDisplay()側が「使用中」とみなして100displays中1つ
+        // 使えなくなるが、誤動作よりは安全側を優先）
+        if (!cmd) continue;
 
         // Xvfb: マーカー(-fbdir XVFB_FB_DIR)とdisplayレンジで判定
         const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
@@ -296,7 +274,7 @@ export class BrowserManager extends EventEmitter {
           const display = Number.parseInt(xvfbMatch[1], 10);
           if (display >= minDisplay && display <= maxDisplay) {
             orphanPids.push(c.pid);
-            orphanDisplays.add(display);
+            pidToOrphanDisplay.set(c.pid, display);
           }
           continue;
         }
@@ -330,14 +308,6 @@ export class BrowserManager extends EventEmitter {
       }
 
       if (orphanPids.length === 0) {
-        // kill対象pidなしだが、死亡Xvfbのソケット残骸があれば削除
-        for (const display of orphanDisplays) {
-          try {
-            fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
-          } catch {
-            // 残存しない/権限なしは無視
-          }
-        }
         this.deleteOrphanFiles(orphanFiles);
         return;
       }
@@ -402,15 +372,22 @@ export class BrowserManager extends EventEmitter {
       }
 
       const survivors = Array.from(remainingPids);
-      if (survivors.length === 0) {
-        // 全プロセスが終了した → ソケット残骸を削除し、orphan files削除
-        for (const display of orphanDisplays) {
-          try {
-            fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
-          } catch {
-            // 残存しない/権限なしは無視
-          }
+      // kill成功(=remainingPidsに無い)pidのdisplayのみソケット削除する。
+      // remainingに残るpid（SIGKILLでも消えなかった）のソケットは
+      // 触らない（live socket破壊で次のセッションが衝突するのを避ける）
+      for (const pid of orphanPids) {
+        if (remainingPids.has(pid)) continue;
+        const display = pidToOrphanDisplay.get(pid);
+        if (display === undefined) continue;
+        try {
+          fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
+        } catch {
+          // 残存しない/権限なしは無視
         }
+      }
+
+      if (survivors.length === 0) {
+        // 全プロセス終了 → orphan files削除
         this.deleteOrphanFiles(orphanFiles);
       } else {
         // SIGKILL後も生存pidあり → 最初のorphan fileに残存pidを書き戻し、
@@ -620,51 +597,29 @@ export class BrowserManager extends EventEmitter {
         pidToCmd.set(Number.parseInt(m[1], 10), m[2]);
       }
     } catch {
-      // 全pid死亡 → display情報のあるpidについてはソケット削除して、pidfile再sync
-      const deadDisplays = new Set<number>();
-      for (const e of survivorEntries) {
-        if (
-          e.display !== undefined &&
-          e.display >= minDisplay &&
-          e.display <= maxDisplay
-        ) {
-          deadDisplays.add(e.display);
-        }
-      }
-      for (const display of deadDisplays) {
-        try {
-          fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
-        } catch {
-          // 残存しない/権限なしは無視
-        }
-      }
+      // 全pid死亡 → pidfile再syncのみ（ソケット削除はlive socket破壊リスクが
+      // あるためスキップ。crashed Xvfbのソケット残骸は findAvailableDisplay
+      // 側が「使用中」扱いするため、安全側の挙動を優先する）
       this.syncPidFile();
       return;
     }
 
     const reapPids: number[] = [];
-    const reapDisplays = new Set<number>();
+    // pid → display のマップ。kill成功確認後にソケット削除するため
+    const pidToReapDisplay = new Map<number, number>();
 
     for (const e of survivorEntries) {
       const cmd = pidToCmd.get(e.pid);
-      if (!cmd) {
-        // 死亡pid → display情報があればソケット削除候補
-        if (
-          e.display !== undefined &&
-          e.display >= minDisplay &&
-          e.display <= maxDisplay
-        ) {
-          reapDisplays.add(e.display);
-        }
-        continue;
-      }
+      // 死亡pidのソケットは触らない（display単独でのソケット削除は別X11
+      // サーバーの live socket を破壊するリスクがあるため）
+      if (!cmd) continue;
 
       const xvfbMatch = cmd.match(/^Xvfb\s+:(\d+)\b/);
       if (xvfbMatch && cmd.includes(XVFB_FB_DIR)) {
         const display = Number.parseInt(xvfbMatch[1], 10);
         if (display >= minDisplay && display <= maxDisplay) {
           reapPids.push(e.pid);
-          reapDisplays.add(display);
+          pidToReapDisplay.set(e.pid, display);
         }
         continue;
       }
@@ -749,14 +704,19 @@ export class BrowserManager extends EventEmitter {
           }
         }
       }
-    }
 
-    // killしたXvfbのソケット削除
-    for (const display of reapDisplays) {
-      try {
-        fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
-      } catch {
-        // 残存しない/権限なしは無視
+      // kill成功(=remainingにいない)pidのXvfbソケットのみ削除する。
+      // remainingに残るpid（SIGKILLでも消えなかった）のソケットは
+      // 触らない（live socket破壊で次のセッションが衝突するのを避ける）
+      for (const pid of reapPids) {
+        if (remaining.has(pid)) continue;
+        const display = pidToReapDisplay.get(pid);
+        if (display === undefined) continue;
+        try {
+          fs.unlinkSync(`/tmp/.X11-unix/X${display}`);
+        } catch {
+          // 残存しない/権限なしは無視
+        }
       }
     }
 

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -68,7 +68,7 @@ const ARK_DESKTOP = "ark-browser";
  * ファイル形式: 1行1エントリ。`<pid>` または `<pid>:<display>`。
  * Xvfbのみdisplay情報を併記してプロセス死亡後もソケット残骸を回収できる。
  */
-const BROWSER_PIDFILE_DIR = path.join("data", "browser-pids");
+const BROWSER_PIDFILE_DIR = path.join(process.cwd(), "data", "browser-pids");
 
 interface PidEntry {
   pid: number;
@@ -135,7 +135,7 @@ export class BrowserManager extends EventEmitter {
     this.checkDependencies();
     if (this.available) {
       try {
-        fs.mkdirSync(XVFB_FB_DIR, { recursive: true });
+        fs.mkdirSync(XVFB_FB_DIR, { recursive: true, mode: 0o700 });
       } catch (err) {
         console.warn(
           `[BrowserManager] ${XVFB_FB_DIR} 作成失敗: ${getErrorMessage(err)}`
@@ -237,7 +237,13 @@ export class BrowserManager extends EventEmitter {
       try {
         const psOutput = execFileSync(
           "ps",
-          ["-o", "pid=,cmd=", "-p", candidates.map(c => c.pid).join(",")],
+          [
+            "-ww",
+            "-o",
+            "pid=,cmd=",
+            "-p",
+            candidates.map(c => c.pid).join(","),
+          ],
           { encoding: "utf-8" }
         );
         for (const line of psOutput.split("\n")) {
@@ -441,9 +447,11 @@ export class BrowserManager extends EventEmitter {
    */
   private isArkServerAlive(serverPid: number): boolean {
     try {
-      const cmd = execFileSync("ps", ["-o", "cmd=", "-p", String(serverPid)], {
-        encoding: "utf-8",
-      }).trim();
+      const cmd = execFileSync(
+        "ps",
+        ["-ww", "-o", "cmd=", "-p", String(serverPid)],
+        { encoding: "utf-8" }
+      ).trim();
       if (!cmd) return false;
       const hasEntry = /\b(dist\/index\.js|server\/index\.ts)\b/.test(cmd);
       const hasRuntime = /\b(node|tsx)\b/.test(cmd);
@@ -575,7 +583,13 @@ export class BrowserManager extends EventEmitter {
       try {
         const psOutput = execFileSync(
           "ps",
-          ["-o", "pid=,cmd=", "-p", candidatePriors.map(e => e.pid).join(",")],
+          [
+            "-ww",
+            "-o",
+            "pid=,cmd=",
+            "-p",
+            candidatePriors.map(e => e.pid).join(","),
+          ],
           { encoding: "utf-8" }
         );
         for (const line of psOutput.split("\n")) {
@@ -655,7 +669,7 @@ export class BrowserManager extends EventEmitter {
     try {
       const psOutput = execFileSync(
         "ps",
-        ["-o", "pid=,cmd=", "-p", candidatePids.join(",")],
+        ["-ww", "-o", "pid=,cmd=", "-p", candidatePids.join(",")],
         { encoding: "utf-8" }
       );
       for (const line of psOutput.split("\n")) {


### PR DESCRIPTION
## Summary

- pm2 restart 後に noVNC で繋いでも画面が真っ黒になるバグを修正
- 原因は孤立した Xvfb/x11vnc/websockify が残留し、新規ブラウザ起動時に Chromium readiness 判定が既存 :99 Chromium のレスポンスを誤検出していたこと
- BrowserManager の起動時/start() 前/stop() 後に複数経路で孤立プロセスを安全に掃除する仕組みを追加

## 根本原因

1. pm2 restart で `BrowserManager` シングルトンは消えるが、Xvfb/x11vnc/websockify/Chromium は生存し続ける
2. 次回起動時 `findAvailableDisplay()` が残存ディスプレイ(:99)を避けて :100 を選ぶ
3. 新Chromium起動が固定CDPポート(9222)で既存:99 Chromiumと衝突して失敗
4. しかし readiness 判定は `fetch http://127.0.0.1:9222/json/version` だけ見るため、既存 :99 Chromium のレスポンスを誤検出 → resolve
5. 結果として「Xvfb/x11vnc/websockify は :100 で動くが Chromium がいない」黒画面ディスプレイが量産される

## 主な変更

- **pidfile管理**: `data/browser-pids/<serverPid>` 形式でArkサーバーごとに子pidを記録（pm2 reload safe）
- **マーカー識別**: Xvfb に `-fbdir /tmp/.ark-xvfb-fb`、x11vnc に `-desktop ark-browser` を起動引数に追加
- **cleanupOrphanedProcesses**: 起動時に死亡サーバー由来の pidfile から候補pidを集めSIGTERM/SIGKILL → X11ソケット削除
- **reapOwnSurvivors**: start() 前に自プロセスの leak 子（killProcess timeout残）を再kill
- **isArkServerAlive / isArkBrowserCmd**: pid再利用時に別プロセスへの誤kill を防ぐためのcmd検証ヘルパー
- **遅延retry**: pm2 reload で旧サーバーが一時生存中のケースに対応するため、起動10秒後に再cleanup
- **survivors保持**: stop()/起動失敗時にkillきれなかった子pidを pidfile に残し、次回起動時の cleanup 候補にする
- **live socket 防護**: SIGKILL後も生存中のXvfbのソケットは削除しない（live socket破壊で次セッションが衝突するのを避ける）

## Test plan

- [x] `pm2 restart` 後にArkサーバーが正常起動し既存セッションが影響を受けないこと
- [x] 死亡サーバー由来の `<dir>/<dummy_pid>` ファイルからの孤立Xvfb/x11vncが正しくkillされ、X11ソケットも削除されること
- [x] マーカー無し（旧版を模した）Xvfbも識別されkillされること（旧版互換性）
- [x] 自シェルpid由来の生存pidfileは保護されること（pm2 reload safe）
- [x] `pid:display` 形式のpidfileから crashed Xvfb のソケット残骸が回収されること
- [ ] 実際にブラウザ機能を起動 → pm2 restart → 再度ブラウザ起動して黒画面にならないことの End-to-End 確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* 再起動時に遺留されたヘルパープロセスの自動クリーンアップを改善しました
* アプリケーション停止時のプロセス管理の信頼性が向上し、システムリソースの効率的な利用が実現しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->