### PR TITLE
feat: サイドバーのリポジトリヘッダーから直接Worktreeを追加

### DIFF
--- a/client/src/components/MobileSessionList.tsx
+++ b/client/src/components/MobileSessionList.tsx
@@ -107,18 +107,26 @@ export function MobileSessionList({
             ワークツリーがありません
           </div>
         ) : (
-          Array.from(groupedItems.entries()).map(([repoPath, items]) => (
+          Array.from(groupedItems.entries()).map(([repoPath, group]) => (
             <div key={repoPath}>
               {/* リポジトリヘッダー（PC版SessionSidebarと同じFolderOpenアイコン付き） */}
               <div className="flex items-center gap-1.5 px-1 py-1.5 mb-2">
                 <FolderOpen className="w-3 h-3 text-muted-foreground" />
-                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate">
-                  {getBaseName(repoPath)}
+                <span
+                  className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate"
+                  title={repoPath}
+                >
+                  {group.repoName}
+                  {group.disambiguator && (
+                    <span className="ml-1 text-muted-foreground/70 normal-case">
+                      ({group.disambiguator})
+                    </span>
+                  )}
                 </span>
               </div>
               {/* アイテム一覧 */}
               <div className="space-y-3">
-                {items.map(({ worktree, session }) => {
+                {group.items.map(({ worktree, session }) => {
                   // worktreeがあるアイテム
                   if (worktree) {
                     return (

--- a/client/src/components/RepoProfileMenu.tsx
+++ b/client/src/components/RepoProfileMenu.tsx
@@ -1,21 +1,29 @@
 /**
- * RepoProfileMenu - リポジトリ右クリックメニュー内に表示する
+ * RepoProfileMenu - リポジトリ右クリック / ⋮ メニュー内に表示する
  * 「プロファイルを変更」サブメニューのコンテンツ
  *
  * - 登録プロファイル一覧
  * - 既定 (~/.claude) で紐付け解除
  * - プロファイル管理ダイアログを開く
  *
- * NOTE: ContextMenuSubContentにラップする内側のItem群のみを描画する。
+ * NOTE: ContextMenu / DropdownMenu のどちらにも組み込めるよう、Item/Label/Separator
+ *       コンポーネントをpropで受け取る（Radixはmenuタイプ毎に内部スコープが分離されるため、
+ *       ContextMenuItemをDropdownMenu内で使うと動作しない）。
  *       SubTriggerは呼び出し側 (SessionSidebar) が担う。
  */
 
 import { Check, Settings } from "lucide-react";
+import type { ComponentType } from "react";
 import {
   ContextMenuItem,
   ContextMenuLabel,
   ContextMenuSeparator,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import type { Profile } from "../../../shared/types";
 
 /** プロファイルバッジのカラーパレット (5色) */
@@ -49,26 +57,50 @@ interface RepoProfileMenuProps {
   currentProfileId: string | null;
   onSelect: (profileId: string | null) => void;
   onOpenManager: () => void;
+  /** どのメニューに組み込むか。デフォルトは context */
+  variant?: "context" | "dropdown";
 }
+
+// 各variantで使用するMenu primitiveの組
+type MenuPrimitives = {
+  Item: ComponentType<React.ComponentProps<typeof ContextMenuItem>>;
+  Label: ComponentType<React.ComponentProps<typeof ContextMenuLabel>>;
+  Separator: ComponentType<React.ComponentProps<typeof ContextMenuSeparator>>;
+};
+
+const PRIMITIVES_BY_VARIANT: Record<"context" | "dropdown", MenuPrimitives> = {
+  context: {
+    Item: ContextMenuItem,
+    Label: ContextMenuLabel,
+    Separator: ContextMenuSeparator,
+  },
+  dropdown: {
+    Item: DropdownMenuItem as MenuPrimitives["Item"],
+    Label: DropdownMenuLabel as MenuPrimitives["Label"],
+    Separator: DropdownMenuSeparator as MenuPrimitives["Separator"],
+  },
+};
 
 export function RepoProfileMenu({
   profiles,
   currentProfileId,
   onSelect,
   onOpenManager,
+  variant = "context",
 }: RepoProfileMenuProps) {
+  const { Item, Label, Separator } = PRIMITIVES_BY_VARIANT[variant];
   return (
     <>
-      <ContextMenuLabel className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+      <Label className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
         プロファイル
-      </ContextMenuLabel>
+      </Label>
       {profiles.map(profile => {
         const isCurrent = profile.id === currentProfileId;
         const colorClass = colorFor(profile.id);
         const label = badgeLabel(profile.name);
 
         return (
-          <ContextMenuItem
+          <Item
             key={profile.id}
             onSelect={() => onSelect(profile.id)}
             className="flex items-center justify-between gap-2"
@@ -86,29 +118,26 @@ export function RepoProfileMenu({
             >
               {label}
             </span>
-          </ContextMenuItem>
+          </Item>
         );
       })}
-      <ContextMenuSeparator />
-      <ContextMenuItem
-        onSelect={() => onSelect(null)}
-        className="flex items-center gap-2"
-      >
+      <Separator />
+      <Item onSelect={() => onSelect(null)} className="flex items-center gap-2">
         {currentProfileId === null ? (
           <Check className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
         ) : (
           <span className="w-3.5 h-3.5 shrink-0" aria-hidden />
         )}
         <span className="truncate text-muted-foreground">既定 (~/.claude)</span>
-      </ContextMenuItem>
-      <ContextMenuSeparator />
-      <ContextMenuItem
+      </Item>
+      <Separator />
+      <Item
         onSelect={() => onOpenManager()}
         className="flex items-center gap-2"
       >
         <Settings className="w-3.5 h-3.5" />
         <span>プロファイル管理を開く...</span>
-      </ContextMenuItem>
+      </Item>
     </>
   );
 }

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -15,6 +15,7 @@ import {
   AlertTriangle,
   FolderOpen,
   Globe,
+  MoreVertical,
   Plus,
   RotateCw,
   Terminal,
@@ -42,6 +43,16 @@ import {
   ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Tooltip,
@@ -286,7 +297,7 @@ export function SessionSidebar({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="h-5 w-5 shrink-0 ml-auto text-sidebar-foreground/70 hover:text-foreground hover:bg-sidebar-accent"
+                      className="h-5 w-5 shrink-0 ml-auto text-primary hover:text-primary hover:bg-primary/15"
                       onClick={() => onCreateWorktreeForRepo?.(repoPath)}
                       aria-label={`${repoName} に新規Worktreeを作成`}
                       title="新規Worktreeを作成"
@@ -298,13 +309,74 @@ export function SessionSidebar({
                     <Button
                       variant="ghost"
                       size="icon"
-                      className={`h-5 w-5 shrink-0 ${canCreateWorktree ? "" : "ml-auto"} text-sidebar-foreground/70 hover:text-destructive hover:bg-destructive/15`}
+                      className={`h-5 w-5 shrink-0 ${canCreateWorktree ? "" : "ml-auto"} text-destructive hover:text-destructive hover:bg-destructive/15`}
                       onClick={() => setRemoveTargetRepoPath(repoPath)}
                       aria-label={`${repoName} をサイドバーから除外`}
                       title="サイドバーから除外"
                     >
                       <X className="w-3.5 h-3.5" />
                     </Button>
+                  )}
+                  {showRepoContextMenu && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className={`h-5 w-5 shrink-0 ${canCreateWorktree || canRemove ? "" : "ml-auto"} text-sidebar-foreground/70 hover:text-foreground hover:bg-sidebar-accent`}
+                          aria-label={`${repoName} のメニュー`}
+                          title="メニュー"
+                        >
+                          <MoreVertical className="w-3.5 h-3.5" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end" className="w-56">
+                        {canCreateWorktree && (
+                          <>
+                            <DropdownMenuItem
+                              onSelect={() =>
+                                onCreateWorktreeForRepo?.(repoPath)
+                              }
+                            >
+                              <Plus className="w-3.5 h-3.5 mr-2" />
+                              新規Worktreeを作成
+                            </DropdownMenuItem>
+                            {(showProfileSubmenu || canRemove) && (
+                              <DropdownMenuSeparator />
+                            )}
+                          </>
+                        )}
+                        {showProfileSubmenu && (
+                          <>
+                            <DropdownMenuSub>
+                              <DropdownMenuSubTrigger>
+                                プロファイルを変更
+                              </DropdownMenuSubTrigger>
+                              <DropdownMenuSubContent className="w-56">
+                                <RepoProfileMenu
+                                  variant="dropdown"
+                                  profiles={profileList}
+                                  currentProfileId={currentLinkId}
+                                  onSelect={profileId =>
+                                    onSetRepoProfile?.(repoPath, profileId)
+                                  }
+                                  onOpenManager={() => onOpenProfileManager?.()}
+                                />
+                              </DropdownMenuSubContent>
+                            </DropdownMenuSub>
+                            {canRemove && <DropdownMenuSeparator />}
+                          </>
+                        )}
+                        {canRemove && (
+                          <DropdownMenuItem
+                            onSelect={() => setRemoveTargetRepoPath(repoPath)}
+                          >
+                            <X className="w-3.5 h-3.5 mr-2" />
+                            サイドバーから除外
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
                   )}
                 </div>
               );

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -253,8 +253,8 @@ export function SessionSidebar({
               <p className="text-xs mt-1">「+」から新規作成</p>
             </div>
           ) : (
-            Array.from(groupedItems.entries()).map(([repoPath, items]) => {
-              const repoName = getBaseName(repoPath);
+            Array.from(groupedItems.entries()).map(([repoPath, group]) => {
+              const { repoName, disambiguator, items } = group;
               const canRemove = !!onRemoveRepo;
               const currentLinkId = repoProfileLinks?.get(repoPath) ?? null;
               const showProfileSubmenu =
@@ -270,8 +270,16 @@ export function SessionSidebar({
               const repoHeader = (
                 <div className="sticky left-0 flex items-center gap-1.5 px-2 py-1.5">
                   <FolderOpen className="w-3 h-3 text-muted-foreground shrink-0" />
-                  <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate">
+                  <span
+                    className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate"
+                    title={repoPath}
+                  >
                     {repoName}
+                    {disambiguator && (
+                      <span className="ml-1 text-muted-foreground/70 normal-case">
+                        ({disambiguator})
+                      </span>
+                    )}
                   </span>
                   {renderRepoProfileBadge(repoPath)}
                   {canCreateWorktree && (

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -280,57 +280,20 @@ export function SessionSidebar({
 
               const repoHeader = (
                 <div className="sticky left-0 flex items-center gap-1.5 px-2 py-1.5">
-                  <FolderOpen className="w-3 h-3 text-muted-foreground shrink-0" />
-                  <span
-                    className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate"
-                    title={repoPath}
-                  >
-                    {repoName}
-                    {disambiguator && (
-                      <span className="ml-1 text-muted-foreground/70 normal-case">
-                        ({disambiguator})
-                      </span>
-                    )}
-                  </span>
-                  {renderRepoProfileBadge(repoPath)}
-                  {canCreateWorktree && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-5 w-5 shrink-0 ml-auto text-primary hover:text-primary hover:bg-primary/15"
-                      onClick={() => onCreateWorktreeForRepo?.(repoPath)}
-                      aria-label={`${repoName} に新規Worktreeを作成`}
-                      title="新規Worktreeを作成"
-                    >
-                      <Plus className="w-3.5 h-3.5" />
-                    </Button>
-                  )}
-                  {canRemove && (
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className={`h-5 w-5 shrink-0 ${canCreateWorktree ? "" : "ml-auto"} text-destructive hover:text-destructive hover:bg-destructive/15`}
-                      onClick={() => setRemoveTargetRepoPath(repoPath)}
-                      aria-label={`${repoName} をサイドバーから除外`}
-                      title="サイドバーから除外"
-                    >
-                      <X className="w-3.5 h-3.5" />
-                    </Button>
-                  )}
-                  {showRepoContextMenu && (
+                  {showRepoContextMenu ? (
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <Button
                           variant="ghost"
                           size="icon"
-                          className={`h-5 w-5 shrink-0 ${canCreateWorktree || canRemove ? "" : "ml-auto"} text-sidebar-foreground/70 hover:text-foreground hover:bg-sidebar-accent`}
+                          className="h-5 w-5 shrink-0 text-muted-foreground hover:text-foreground hover:bg-sidebar-accent"
                           aria-label={`${repoName} のメニュー`}
                           title="メニュー"
                         >
                           <MoreVertical className="w-3.5 h-3.5" />
                         </Button>
                       </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end" className="w-56">
+                      <DropdownMenuContent align="start" className="w-56">
                         {canCreateWorktree && (
                           <>
                             <DropdownMenuItem
@@ -377,7 +340,21 @@ export function SessionSidebar({
                         )}
                       </DropdownMenuContent>
                     </DropdownMenu>
+                  ) : (
+                    <FolderOpen className="w-3 h-3 text-muted-foreground shrink-0" />
                   )}
+                  <span
+                    className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate"
+                    title={repoPath}
+                  >
+                    {repoName}
+                    {disambiguator && (
+                      <span className="ml-1 text-muted-foreground/70 normal-case">
+                        ({disambiguator})
+                      </span>
+                    )}
+                  </span>
+                  {renderRepoProfileBadge(repoPath)}
                 </div>
               );
 

--- a/client/src/hooks/useGroupedWorktreeItems.ts
+++ b/client/src/hooks/useGroupedWorktreeItems.ts
@@ -5,7 +5,8 @@
  *
  * グループキーは絶対パス (repoPath)。同じbasenameのリポジトリ（例:
  * `/work/a/app` と `/work/b/app`）が衝突しないようにするため、
- * UIで表示する短縮名はキーから getBaseName で都度導出する。
+ * UIで表示する短縮名は repoName を用い、basenameが他repoと重複する場合は
+ * 親ディレクトリsegmentを末尾から付与した disambiguator を併記する。
  */
 
 import { useMemo } from "react";
@@ -16,6 +17,24 @@ export type GroupedItem = {
   worktree: Worktree | null;
   session: ManagedSession | null;
 };
+
+export type RepoGroup = {
+  /** 表示用のリポジトリ名（basename） */
+  repoName: string;
+  /**
+   * 同じbasenameの他repoが存在する場合の区別用ヒント（親ディレクトリ名等）。
+   * 重複がない場合はnull。UI側でrepoName横に括弧書きで表示する想定。
+   */
+  disambiguator: string | null;
+  /** グループ配下のworktree/sessionアイテム */
+  items: GroupedItem[];
+};
+
+function getBaseName(repoPath: string): string {
+  const trimmed = repoPath.replace(/\/+$/, "");
+  const idx = trimmed.lastIndexOf("/");
+  return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+}
 
 export function useGroupedWorktreeItems(
   worktrees: Worktree[],
@@ -31,13 +50,25 @@ export function useGroupedWorktreeItems(
   }, [sessions]);
 
   const groupedItems = useMemo(() => {
-    const groups = new Map<string, GroupedItem[]>();
+    const groups = new Map<string, RepoGroup>();
     const worktreeSessionIds = new Set<string>();
 
     // repoListに含まれるrepoのworktree/sessionのみ表示する。
     // repoListが空の場合は何も表示しない（「全件表示」にフォールバックすると、
     // 最後の1件を除外した直後に除外対象が再表示されてしまう）。
     const repoListEmpty = repoList.length === 0;
+
+    const ensureGroup = (repoPath: string): RepoGroup => {
+      const existing = groups.get(repoPath);
+      if (existing) return existing;
+      const created: RepoGroup = {
+        repoName: getBaseName(repoPath),
+        disambiguator: null,
+        items: [],
+      };
+      groups.set(repoPath, created);
+      return created;
+    };
 
     // worktreePath昇順で処理することでリロード間の並び順を安定させる
     const sortedWorktrees = [...worktrees].sort((a, b) =>
@@ -57,9 +88,7 @@ export function useGroupedWorktreeItems(
         if (matchedRepo) return matchedRepo;
         return wt.path.split("/.worktrees/")[0] || wt.path;
       })();
-      const existing = groups.get(repoPath) || [];
-      existing.push({ worktree: wt, session });
-      groups.set(repoPath, existing);
+      ensureGroup(repoPath).items.push({ worktree: wt, session });
     }
 
     const sortedSessions = Array.from(sessions.values()).sort((a, b) =>
@@ -70,14 +99,50 @@ export function useGroupedWorktreeItems(
       if (worktreeSessionIds.has(session.id)) continue;
       const repo = session.repoPath ?? findRepoForSession(session, repoList);
       if (!repo || !repoList.includes(repo)) continue;
-      const existing = groups.get(repo) || [];
-      existing.push({ worktree: null, session });
-      groups.set(repo, existing);
+      ensureGroup(repo).items.push({ worktree: null, session });
     }
 
-    // repoPathでも安定ソートする
+    // 同じbasenameが複数repoで使われている場合、先祖ディレクトリを必要分付与して一意にする。
+    // 例: /a/services/api と /b/services/api → "api (a/services)" / "api (b/services)"
+    const nameBuckets = new Map<string, string[]>();
+    for (const [repoPath, group] of groups.entries()) {
+      const arr = nameBuckets.get(group.repoName) ?? [];
+      arr.push(repoPath);
+      nameBuckets.set(group.repoName, arr);
+    }
+    for (const [name, paths] of nameBuckets.entries()) {
+      if (paths.length < 2) continue;
+      // 各pathの親部分（basenameを除く）をsegment配列に分解。末尾側から追加していく。
+      const parentSegments = paths.map(p => {
+        const parent = p.replace(/\/+[^/]+\/?$/, "");
+        return parent.split("/").filter(Boolean);
+      });
+      // 一意になるまで末尾segment数を増やす
+      let suffixLen = 1;
+      while (suffixLen <= Math.max(...parentSegments.map(s => s.length))) {
+        const suffixes = parentSegments.map(s =>
+          s.slice(Math.max(0, s.length - suffixLen)).join("/")
+        );
+        if (new Set(suffixes).size === suffixes.length) break;
+        suffixLen++;
+      }
+      paths.forEach((p, i) => {
+        const group = groups.get(p);
+        if (!group) return;
+        const segs = parentSegments[i];
+        const suffix = segs
+          .slice(Math.max(0, segs.length - suffixLen))
+          .join("/");
+        group.disambiguator = suffix || name; // 最悪fallbackで同名のまま
+      });
+    }
+
+    // リポジトリ名(basename)→ full pathで安定ソートする
     return new Map(
-      Array.from(groups.entries()).sort(([a], [b]) => a.localeCompare(b))
+      Array.from(groups.entries()).sort(([pathA, a], [pathB, b]) => {
+        const byName = a.repoName.localeCompare(b.repoName);
+        return byName !== 0 ? byName : pathA.localeCompare(pathB);
+      })
     );
   }, [worktrees, sessions, sessionByWorktreeId, repoList]);
 

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -175,6 +175,11 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   );
   // 再接続時に最新のrepoPathを参照するためのref
   const repoPathRef = useRef(options.initialRepoPath ?? null);
+  /**
+   * 直近のクライアント選択。`repo:set` 応答の out-of-order 適用を抑制するのに使う。
+   * selectRepoで更新し、repo:set受信時に一致しなければ無視する（stale応答）。
+   */
+  const pendingRepoPathRef = useRef<string | null>(null);
 
   const [worktrees, setWorktrees] = useState<Worktree[]>([]);
   const [deletedWorktreeId, setDeletedWorktreeId] = useState<string | null>(
@@ -309,6 +314,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
     // Repository events
     socket.on("repo:set", path => {
+      // stale応答を無視: 直近の selectRepo 呼び出しの期待pathと一致しない場合、
+      // これはより古い selectRepo の遅延応答なのでスキップする。
+      // pendingは一致してもクリアしない（後から到着する古い応答で上書きされないようにするため）。
+      const pending = pendingRepoPathRef.current;
+      if (pending !== null && pending !== path) return;
+
       setRepoPath(path);
 
       // リポジトリリストに追加（重複しない場合）
@@ -321,8 +332,17 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       setError(null);
     });
 
-    socket.on("repo:error", err => {
-      setError(err);
+    socket.on("repo:error", ({ repoPath: errorRepoPath, error: errMsg }) => {
+      // stale error: 新しい選択がすでに成功している場合、古いエラーのロールバックを適用しない
+      const pending = pendingRepoPathRef.current;
+      if (
+        errorRepoPath !== null &&
+        pending !== null &&
+        errorRepoPath !== pending
+      ) {
+        return;
+      }
+      setError(errMsg);
       // 楽観的更新のロールバック（selectRepoで先行設定したrepoPathを戻す）
       setRepoPath(null);
     });
@@ -346,17 +366,24 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     });
 
     // Worktree events
-    socket.on("worktree:list", wts => {
+    socket.on("worktree:list", ({ repoPath: listRepoPath, worktrees: wts }) => {
+      // rapidなselectRepoによるout-of-order応答で他repoのworktreesに上書きされないよう、
+      // 自分が現在選択中のrepoと一致しない場合は無視する
+      if (listRepoPath !== repoPathRef.current) return;
       setWorktrees(wts);
     });
 
-    socket.on("worktree:created", wt => {
-      setWorktrees(prev => [...prev, wt]);
+    socket.on("worktree:created", ({ repoPath: eventRepoPath, worktree }) => {
+      // 他repoに対する作成通知は無視する（broadcast対策）
+      if (eventRepoPath !== repoPathRef.current) return;
+      setWorktrees(prev => [...prev, worktree]);
     });
 
-    socket.on("worktree:deleted", wtId => {
-      setWorktrees(prev => prev.filter(w => w.id !== wtId));
-      setDeletedWorktreeId(wtId);
+    socket.on("worktree:deleted", ({ repoPath: eventRepoPath, worktreeId }) => {
+      // 他repoに対する削除通知は無視する（broadcast対策）
+      if (eventRepoPath !== repoPathRef.current) return;
+      setWorktrees(prev => prev.filter(w => w.id !== worktreeId));
+      setDeletedWorktreeId(worktreeId);
     });
 
     socket.on("worktree:error", err => {
@@ -622,6 +649,10 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
   // Repository actions
   const selectRepo = useCallback((path: string) => {
+    // worktree:listハンドラでの即時判定用に、refもsetStateと同時に同期更新する
+    repoPathRef.current = path;
+    // repo:setハンドラがstale応答を無視できるよう、直近の期待pathを記録する
+    pendingRepoPathRef.current = path;
     setRepoPath(path);
     socketRef.current?.emit("repo:select", path);
   }, []);

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -180,6 +180,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
    * selectRepoで更新し、repo:set受信時に一致しなければ無視する（stale応答）。
    */
   const pendingRepoPathRef = useRef<string | null>(null);
+  /**
+   * server側が確認(`repo:set`)を返したrepoPath。
+   * 同一pathの重複selectで一方が失敗してもロールバックしないよう、
+   * `repo:error` のロールバック判定で「確認済みstate」と「楽観state」を区別するために使う。
+   */
+  const confirmedRepoPathRef = useRef<string | null>(null);
 
   const [worktrees, setWorktrees] = useState<Worktree[]>([]);
   const [deletedWorktreeId, setDeletedWorktreeId] = useState<string | null>(
@@ -320,6 +326,11 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       const pending = pendingRepoPathRef.current;
       if (pending !== null && pending !== path) return;
 
+      // server側で repo:set 直後に worktree:list が emit されるため、refをuseEffect待たず
+      // 同期更新する。これがないと続く worktree:list が古いrefと比較されdropされる。
+      repoPathRef.current = path;
+      // server確認済みstateを記録（重複selectの後続エラーでロールバックしないために使用）
+      confirmedRepoPathRef.current = path;
       setRepoPath(path);
 
       // リポジトリリストに追加（重複しない場合）
@@ -342,8 +353,25 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       ) {
         return;
       }
+      // 同一pathに対する重複selectで、既にserver確認済み（confirmedRepoPathRef==errorRepoPath）の
+      // 場合は後続エラーをロールバックしない。repoPathRefは楽観更新値も含むため、
+      // 確認済みstateを表す confirmedRepoPathRef で判定する必要がある。
+      if (
+        errorRepoPath !== null &&
+        errorRepoPath === confirmedRepoPathRef.current
+      ) {
+        setError(errMsg);
+        // server側がrepo:set後にworktree取得で失敗するケース（listWorktrees throw 等）。
+        // worktreesは前repoのstaleデータが残るため、確認済みrepoには有効データがない事を表すため空にする。
+        setWorktrees([]);
+        return;
+      }
       setError(errMsg);
       // 楽観的更新のロールバック（selectRepoで先行設定したrepoPathを戻す）
+      // pendingもクリアし以降のworktreeイベントをデフォルト判定（refベース）に戻す
+      repoPathRef.current = null;
+      pendingRepoPathRef.current = null;
+      confirmedRepoPathRef.current = null;
       setRepoPath(null);
     });
 
@@ -365,23 +393,31 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       }
     });
 
+    /**
+     * worktree系イベントの受け入れ判定。
+     * ユーザーの最新意図 (pendingRepoPathRef) を最優先で使用し、未設定時は確認済み (repoPathRef) で判定する。
+     * pendingベースで判定する理由: 直前のselectRepo(B)後にA向け遅延応答が届いた場合、
+     * refはまだAだが意図はBなので、Aのlistを誤って適用しないようにする。
+     */
+    const eventTargetRepoPath = (): string | null =>
+      pendingRepoPathRef.current ?? repoPathRef.current;
+
     // Worktree events
     socket.on("worktree:list", ({ repoPath: listRepoPath, worktrees: wts }) => {
-      // rapidなselectRepoによるout-of-order応答で他repoのworktreesに上書きされないよう、
-      // 自分が現在選択中のrepoと一致しない場合は無視する
-      if (listRepoPath !== repoPathRef.current) return;
+      const target = eventTargetRepoPath();
+      if (target !== null && listRepoPath !== target) return;
       setWorktrees(wts);
     });
 
     socket.on("worktree:created", ({ repoPath: eventRepoPath, worktree }) => {
-      // 他repoに対する作成通知は無視する（broadcast対策）
-      if (eventRepoPath !== repoPathRef.current) return;
+      const target = eventTargetRepoPath();
+      if (target !== null && eventRepoPath !== target) return;
       setWorktrees(prev => [...prev, worktree]);
     });
 
     socket.on("worktree:deleted", ({ repoPath: eventRepoPath, worktreeId }) => {
-      // 他repoに対する削除通知は無視する（broadcast対策）
-      if (eventRepoPath !== repoPathRef.current) return;
+      const target = eventTargetRepoPath();
+      if (target !== null && eventRepoPath !== target) return;
       setWorktrees(prev => prev.filter(w => w.id !== worktreeId));
       setDeletedWorktreeId(worktreeId);
     });
@@ -649,9 +685,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
   // Repository actions
   const selectRepo = useCallback((path: string) => {
-    // worktree:listハンドラでの即時判定用に、refもsetStateと同時に同期更新する
-    repoPathRef.current = path;
-    // repo:setハンドラがstale応答を無視できるよう、直近の期待pathを記録する
+    // repo:setハンドラがstale応答を無視できるよう、直近の期待pathを記録する。
+    // repoPathRef は repo:set 確定時に useEffect 経由で同期する（楽観更新しない理由は、
+    // 切り替えが拒否された場合に古いrepoのworktree更新を誤って捨てないため）。
     pendingRepoPathRef.current = path;
     setRepoPath(path);
     socketRef.current?.emit("repo:select", path);
@@ -664,6 +700,10 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
       // 削除したリポジトリが選択中の場合はクリア
       if (repoPath === path) {
+        // 全refを同期クリア（pendingが残ると以降のworktree:listが古いpathで誤フィルタされる）
+        repoPathRef.current = null;
+        pendingRepoPathRef.current = null;
+        confirmedRepoPathRef.current = null;
         setRepoPath(null);
         setWorktrees([]);
       }

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -297,6 +297,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
       // 保存されたリポジトリを自動復元（再接続時は最新のrepoPathRefを使用）
       if (repoPathRef.current) {
+        // 切断中に未確定のpendingが残っているとre-emit後の repo:set を stale 判定で
+        // 落としてしまうため、pendingを復元対象pathに揃える
+        pendingRepoPathRef.current = repoPathRef.current;
         socket.emit("repo:select", repoPathRef.current);
       }
     });
@@ -344,22 +347,21 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     });
 
     socket.on("repo:error", ({ repoPath: errorRepoPath, error: errMsg }) => {
+      // 全般エラー(repoに紐付かないerror)は選択状態に触らずエラー表示のみ。
+      // selectRepo楽観更新のロールバックは特定repoに対するerrorに限定する
+      if (errorRepoPath === null) {
+        setError(errMsg);
+        return;
+      }
       // stale error: 新しい選択がすでに成功している場合、古いエラーのロールバックを適用しない
       const pending = pendingRepoPathRef.current;
-      if (
-        errorRepoPath !== null &&
-        pending !== null &&
-        errorRepoPath !== pending
-      ) {
+      if (pending !== null && errorRepoPath !== pending) {
         return;
       }
       // 同一pathに対する重複selectで、既にserver確認済み（confirmedRepoPathRef==errorRepoPath）の
       // 場合は後続エラーをロールバックしない。repoPathRefは楽観更新値も含むため、
       // 確認済みstateを表す confirmedRepoPathRef で判定する必要がある。
-      if (
-        errorRepoPath !== null &&
-        errorRepoPath === confirmedRepoPathRef.current
-      ) {
+      if (errorRepoPath === confirmedRepoPathRef.current) {
         setError(errMsg);
         // server側がrepo:set後にworktree取得で失敗するケース（listWorktrees throw 等）。
         // worktreesは前repoのstaleデータが残るため、確認済みrepoには有効データがない事を表すため空にする。

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -207,6 +207,12 @@ export default function Dashboard() {
   }, [selectedSessionId, activeBrowserSession, isRemote, startBrowser]);
 
   const [isCreateWorktreeOpen, setIsCreateWorktreeOpen] = useState(false);
+  /**
+   * サイドバー+ボタンで他repoに切り替えた際の元repoPath。
+   * ダイアログキャンセル時に元に戻すために保持する。
+   * 作成確定時はnullにしてリセットし、新しいrepoに留まらせる。
+   */
+  const [previousRepoPath, setPreviousRepoPath] = useState<string | null>(null);
   const [isSelectRepoOpen, setIsSelectRepoOpen] = useState(false);
   const [showFrontLine, setShowFrontLine] = useState(false);
   const [showTunnelDialog, setShowTunnelDialog] = useState(false);
@@ -356,6 +362,8 @@ export default function Dashboard() {
   const handleCreateWorktree = (branchName: string, baseBranch?: string) => {
     createWorktree(branchName, baseBranch);
     setIsCreateWorktreeOpen(false);
+    // 作成確定時は元repoへの復元をキャンセルし、作成先repoに留まる
+    setPreviousRepoPath(null);
     toast.success(`Creating worktree: ${branchName}`);
   };
 
@@ -416,13 +424,32 @@ export default function Dashboard() {
     setIsSelectRepoOpen(true);
   };
 
-  /** 既存リポジトリの右クリック等から直接Worktree作成 */
+  /**
+   * 既存リポジトリの右クリック / +ボタンから直接Worktree作成。
+   * server側の worktree:list 配信が repoを問わず worktrees stateを上書きするため、
+   * 作成前にrepoPathを切り替えておく必要がある。
+   * キャンセル時は元のrepoに戻すため previousRepoPath を保存しておく。
+   */
   const handleCreateWorktreeForRepo = (path: string) => {
-    selectRepo(path);
-    // selectRepo の反映を待ってから作成ダイアログを開く
-    setTimeout(() => {
+    if (repoPath !== path) {
+      setPreviousRepoPath(repoPath);
+      selectRepo(path);
+      // selectRepo の反映を待ってから作成ダイアログを開く
+      setTimeout(() => {
+        setIsCreateWorktreeOpen(true);
+      }, 50);
+    } else {
       setIsCreateWorktreeOpen(true);
-    }, 50);
+    }
+  };
+
+  /** Worktree作成ダイアログの open/close ハンドラ。close時にrepo復元する */
+  const handleCreateWorktreeOpenChange = (open: boolean) => {
+    setIsCreateWorktreeOpen(open);
+    if (!open && previousRepoPath) {
+      selectRepo(previousRepoPath);
+      setPreviousRepoPath(null);
+    }
   };
 
   /**
@@ -751,7 +778,7 @@ export default function Dashboard() {
       {/* Worktree作成ダイアログ */}
       <CreateWorktreeDialog
         open={isCreateWorktreeOpen}
-        onOpenChange={setIsCreateWorktreeOpen}
+        onOpenChange={handleCreateWorktreeOpenChange}
         selectedRepoPath={repoPath}
         onCreateWorktree={handleCreateWorktree}
       />

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -211,6 +211,8 @@ export default function Dashboard() {
    * サイドバー+ボタンで他repoに切り替えた際の元repoPath。
    * ダイアログキャンセル時に元に戻すために保持する。
    * 作成確定時はnullにしてリセットし、新しいrepoに留まらせる。
+   * （未選択状態 repoPath===null からの+クリックは「単純選択」として扱い、
+   *   復元対象とせず previousRepoPath は更新しない）
    */
   const [previousRepoPath, setPreviousRepoPath] = useState<string | null>(null);
   const [isSelectRepoOpen, setIsSelectRepoOpen] = useState(false);
@@ -431,6 +433,14 @@ export default function Dashboard() {
    * キャンセル時は元のrepoに戻すため previousRepoPath を保存しておく。
    */
   const handleCreateWorktreeForRepo = (path: string) => {
+    if (repoPath === null) {
+      // 未選択状態からの+クリック: 単純選択として扱う（復元なし）
+      selectRepo(path);
+      setTimeout(() => {
+        setIsCreateWorktreeOpen(true);
+      }, 50);
+      return;
+    }
     if (repoPath !== path) {
       setPreviousRepoPath(repoPath);
       selectRepo(path);
@@ -446,7 +456,7 @@ export default function Dashboard() {
   /** Worktree作成ダイアログの open/close ハンドラ。close時にrepo復元する */
   const handleCreateWorktreeOpenChange = (open: boolean) => {
     setIsCreateWorktreeOpen(open);
-    if (!open && previousRepoPath) {
+    if (!open && previousRepoPath !== null) {
       selectRepo(previousRepoPath);
       setPreviousRepoPath(null);
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -265,9 +265,9 @@ async function startServer() {
       const worktree = await createWorktree(repoPath, branchName, baseBranch);
       // 通知は操作の成否に影響させない
       try {
-        io.emit("worktree:created", worktree);
+        io.emit("worktree:created", { repoPath, worktree });
         const worktrees = await listWorktrees(repoPath);
-        io.emit("worktree:list", worktrees);
+        io.emit("worktree:list", { repoPath, worktrees });
       } catch {
         console.error("[Beacon] worktree通知に失敗しました");
       }
@@ -286,9 +286,12 @@ async function startServer() {
       await deleteWorktree(repoPath, worktreePath);
       // 通知は操作の成否に影響させない
       try {
-        io.emit("worktree:deleted", deletedWorktreeId);
+        io.emit("worktree:deleted", {
+          repoPath,
+          worktreeId: deletedWorktreeId,
+        });
         const worktrees = await listWorktrees(repoPath);
-        io.emit("worktree:list", worktrees);
+        io.emit("worktree:list", { repoPath, worktrees });
       } catch {
         console.error("[Beacon] worktree通知に失敗しました");
       }
@@ -908,13 +911,19 @@ async function startServer() {
     socket.on("repo:select", async repoPath => {
       try {
         if (allowedRepos.length > 0 && !allowedRepos.includes(repoPath)) {
-          socket.emit("repo:error", "Repository not in allowed list");
+          socket.emit("repo:error", {
+            repoPath,
+            error: "Repository not in allowed list",
+          });
           return;
         }
 
         const isRepo = await isGitRepository(repoPath);
         if (!isRepo) {
-          socket.emit("repo:error", "Not a valid git repository");
+          socket.emit("repo:error", {
+            repoPath,
+            error: "Not a valid git repository",
+          });
           return;
         }
         socket.emit("repo:set", repoPath);
@@ -922,9 +931,9 @@ async function startServer() {
         knownRepos.add(repoPath);
 
         const worktrees = await listWorktrees(repoPath);
-        socket.emit("worktree:list", worktrees);
+        socket.emit("worktree:list", { repoPath, worktrees });
       } catch (error) {
-        socket.emit("repo:error", getErrorMessage(error));
+        socket.emit("repo:error", { repoPath, error: getErrorMessage(error) });
       }
     });
 
@@ -933,7 +942,7 @@ async function startServer() {
     socket.on("worktree:list", async repoPath => {
       try {
         const worktrees = await listWorktrees(repoPath);
-        socket.emit("worktree:list", worktrees);
+        socket.emit("worktree:list", { repoPath, worktrees });
       } catch (error) {
         socket.emit("worktree:error", getErrorMessage(error));
       }
@@ -945,7 +954,7 @@ async function startServer() {
         let worktree: Awaited<ReturnType<typeof createWorktree>>;
         try {
           worktree = await createWorktree(repoPath, branchName, baseBranch);
-          io.emit("worktree:created", worktree);
+          io.emit("worktree:created", { repoPath, worktree });
         } catch (error) {
           socket.emit("worktree:error", getErrorMessage(error));
           return;
@@ -953,7 +962,7 @@ async function startServer() {
 
         try {
           const worktrees = await listWorktrees(repoPath);
-          io.emit("worktree:list", worktrees);
+          io.emit("worktree:list", { repoPath, worktrees });
         } catch {
           // worktree一覧の更新失敗はセッション起動をブロックしない
         }
@@ -990,10 +999,13 @@ async function startServer() {
         await deleteWorktree(repoPath, worktreePath);
 
         // 削除成功を通知
-        io.emit("worktree:deleted", deletedWorktreeId);
+        io.emit("worktree:deleted", {
+          repoPath,
+          worktreeId: deletedWorktreeId,
+        });
 
         const worktrees = await listWorktrees(repoPath);
-        io.emit("worktree:list", worktrees);
+        io.emit("worktree:list", { repoPath, worktrees });
       } catch (error) {
         socket.emit("worktree:error", getErrorMessage(error));
       }
@@ -1050,7 +1062,10 @@ async function startServer() {
                 .toString("base64")
                 .replace(/[/+=]/g, "");
               await deleteWorktree(result.repoPath, result.worktreePath);
-              socket.emit("worktree:deleted", deletedWorktreeId);
+              socket.emit("worktree:deleted", {
+                repoPath: result.repoPath,
+                worktreeId: deletedWorktreeId,
+              });
             } catch (wtError) {
               console.error(
                 `[Session] Worktree削除に失敗（セッションは削除済み）: ${getErrorMessage(wtError)}`
@@ -1064,7 +1079,10 @@ async function startServer() {
 
             try {
               const worktrees = await listWorktrees(result.repoPath);
-              socket.emit("worktree:list", worktrees);
+              socket.emit("worktree:list", {
+                repoPath: result.repoPath,
+                worktrees,
+              });
             } catch {
               // worktree一覧の更新失敗は無視
             }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -171,9 +171,27 @@ export interface ServerToClientEvents {
   }) => void;
 
   // Worktree events
-  "worktree:list": (worktrees: Worktree[]) => void;
-  "worktree:created": (worktree: Worktree) => void;
-  "worktree:deleted": (worktreeId: string) => void;
+  /**
+   * 対象repoのworktree一覧を通知する。
+   * クライアントは repoPath と自分が選択中のrepoPathを比較し、mismatchなら無視する
+   * （rapid selectRepoによるout-of-order応答でworktrees stateが取り違えられるのを防ぐ）。
+   */
+  "worktree:list": (payload: {
+    repoPath: string;
+    worktrees: Worktree[];
+  }) => void;
+  /**
+   * worktree:created / worktree:deleted は io.emit で全クライアントにブロードキャストされるため、
+   * 別repoのクライアントで誤適用されないよう repoPath を添付する（クライアントで完全一致判定）。
+   */
+  "worktree:created": (payload: {
+    repoPath: string;
+    worktree: Worktree;
+  }) => void;
+  "worktree:deleted": (payload: {
+    repoPath: string;
+    worktreeId: string;
+  }) => void;
   "worktree:error": (error: string) => void;
 
   // Session events（ManagedSessionを使用）
@@ -210,7 +228,11 @@ export interface ServerToClientEvents {
 
   // Repository events
   "repo:set": (path: string) => void;
-  "repo:error": (error: string) => void;
+  /**
+   * repo選択エラーの通知。クライアントはrepoPathを見てstale応答を判定する。
+   * repoPathがnullのエラー（repoに紐付かない全般エラー）もあり得る。
+   */
+  "repo:error": (payload: { repoPath: string | null; error: string }) => void;
 
   // Tunnel events
   "tunnel:started": (data: { url: string; token: string }) => void;


### PR DESCRIPTION
## 概要

サイドバーの各リポジトリヘッダーに `+` ボタンを追加。クリックすると対象repoに切り替えて既存の Create Worktree ダイアログを開き、そのrepo配下に直接Worktreeを作成できる。

- `+`（primary色） / `X`（destructive色）の並びで色付きアイコンに統一
- ダイアログをキャンセルした場合は元の選択中repoに復元（`previousRepoPath` で追跡）

## 副次修正（codexレビューで顕在化した既存race/不整合）

`+`ボタンの実装過程で、複数repo間のSocket.IOイベントが状態を不整合に上書きする既存問題が露呈したため併せて修正:

- `worktree:list` / `worktree:created` / `worktree:deleted` / `repo:error` イベントに `repoPath` を含め、クライアント側で完全一致判定。out-of-order応答や別repoへのbroadcastで他repoのworktree stateを誤って上書きする問題を解消
- `repo:set` のstale応答も `pendingRepoPathRef` で抑制
- `useGroupedWorktreeItems` のグループキーをfull pathに変更し、同名basenameのrepoを別グループとして扱う
- basename衝突時は祖先segmentを必要分付与した `disambiguator` をUI表示
- worktreeCreate時のpath prefix判定を厳密化

## Test plan

- [ ] 単一repo: ヘッダーの `+` クリック → Create Worktreeダイアログが開く
- [ ] 複数repo: 別repoのヘッダー `+` クリック → そのrepoに切り替わってダイアログ表示
- [ ] ダイアログCancel → 元のrepoに戻る
- [ ] ダイアログSubmit → 作成先repoに留まる
- [ ] 同名basenameの2repoがある場合、ヘッダーが識別可能（disambiguator表示）
- [ ] 別タブで他repoにworktreeを作成しても、現在表示中のrepo一覧に紛れ込まない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * サイドバーのリポジトリ見出しに明示名とホバーの識別情報を表示。リポジトリごとのアクションメニューを追加。
  * プロフィールメニューがドロップダウンとコンテキストの両方に対応。

* **Bug Fixes**
  * ワークツリー/リポジトリのリアルタイム通知で順序や誤配信を抑制。切替時の状態混在を防止。
  * 別名が必要な重複リポジトリに識別子を付与。
* **Other**
  * 作成処理後に前回選択リポジトリを自動復元。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->