### PR TITLE
feat: 全プロファイル Claude Code 使用量サマリ機能 (Linux限定)

### DIFF
--- a/client/src/components/MobileChatView.tsx
+++ b/client/src/components/MobileChatView.tsx
@@ -29,7 +29,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import type { ChatMessage } from "../../../shared/types";
+import type { ChatMessage, UsageProgress } from "../../../shared/types";
 import { useComposition } from "../hooks/useComposition";
 import { useVisualViewport } from "../hooks/useVisualViewport";
 
@@ -48,13 +48,20 @@ interface MobileChatViewProps {
   onBack?: () => void;
   /** チャットクリアコールバック */
   onClear?: () => void;
+  /** Usage取得（Linux + multiProfileSupported のみ表示） */
+  onRequestUsage?: () => void;
+  /** Usage取得中フラグ（ボタンdisable + ローディング） */
+  usageRequesting?: boolean;
+  /** Usage取得進捗（取得中のみ非null） */
+  usageProgress?: UsageProgress | null;
+  /** プロファイル機能が有効か（falseならUsageボタン非表示） */
+  multiProfileSupported?: boolean;
 }
 
 /** クイックコマンドの定義 */
-interface QuickCommand {
-  label: string;
-  message: string;
-}
+type QuickCommand =
+  | { kind?: "send"; label: string; message: string }
+  | { kind: "usage"; label: string };
 
 /** パース済みマークダウンの各セグメント */
 type MarkdownSegment =
@@ -86,6 +93,7 @@ const QUICK_COMMANDS: QuickCommand[] = [
   { label: "判断", message: "判断" },
   { label: "タスク着手", message: "タスク着手" },
   { label: "PR URL", message: "PR URL" },
+  { kind: "usage", label: "Usage" },
 ];
 
 // --- 簡易マークダウンパーサー ---
@@ -433,6 +441,10 @@ export function MobileChatView({
   onSendMessage,
   onBack,
   onClear,
+  onRequestUsage,
+  usageRequesting = false,
+  usageProgress = null,
+  multiProfileSupported = false,
 }: MobileChatViewProps) {
   const { height: viewportHeight, isKeyboardVisible } = useVisualViewport();
   const [inputValue, setInputValue] = useState("");
@@ -592,19 +604,49 @@ export function MobileChatView({
       {/* クイックコマンド */}
       {QUICK_COMMANDS.length > 0 && (
         <div className="flex items-center gap-1.5 px-3 py-1.5 border-t border-border/30 bg-sidebar overflow-x-auto select-none scrollbar-none">
-          {QUICK_COMMANDS.map(cmd => (
-            <Button
-              key={cmd.label}
-              type="button"
-              variant="outline"
-              size="sm"
-              className="h-7 px-3 text-xs shrink-0 rounded-full border-border/50 text-muted-foreground hover:text-primary hover:border-primary/40 transition-colors"
-              disabled={isInputDisabled}
-              onClick={() => handleQuickCommand(cmd.message)}
-            >
-              {cmd.label}
-            </Button>
-          ))}
+          {QUICK_COMMANDS.map(cmd => {
+            // Usageボタン: multiProfileSupported のときのみ表示
+            if (cmd.kind === "usage") {
+              if (!multiProfileSupported || !onRequestUsage) return null;
+              // 進捗中のラベル: 「取得中 (1/2 personal)」のように表示
+              const progressLabel = usageProgress
+                ? `${usageProgress.completed + 1}/${usageProgress.total} ${usageProgress.currentProfileName}`
+                : "取得中";
+              return (
+                <Button
+                  key={cmd.label}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-7 px-3 text-xs shrink-0 rounded-full border-border/50 text-muted-foreground hover:text-primary hover:border-primary/40 transition-colors"
+                  disabled={isInputDisabled || usageRequesting}
+                  onClick={onRequestUsage}
+                >
+                  {usageRequesting ? (
+                    <>
+                      <Loader2 className="w-3 h-3 mr-1 animate-spin" />
+                      {progressLabel}
+                    </>
+                  ) : (
+                    cmd.label
+                  )}
+                </Button>
+              );
+            }
+            return (
+              <Button
+                key={cmd.label}
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-7 px-3 text-xs shrink-0 rounded-full border-border/50 text-muted-foreground hover:text-primary hover:border-primary/40 transition-colors"
+                disabled={isInputDisabled}
+                onClick={() => handleQuickCommand(cmd.message)}
+              >
+                {cmd.label}
+              </Button>
+            );
+          })}
         </div>
       )}
 

--- a/client/src/components/MobileChatView.tsx
+++ b/client/src/components/MobileChatView.tsx
@@ -608,10 +608,17 @@ export function MobileChatView({
             // Usageボタン: multiProfileSupported のときのみ表示
             if (cmd.kind === "usage") {
               if (!multiProfileSupported || !onRequestUsage) return null;
-              // 進捗中のラベル: 「取得中 (1/2 personal)」のように表示
+              // 進捗中のラベル: 「取得中 (1/2 personal)」のように表示。
+              // completed=N (=total) は最後の取得完了直後にのみ届くため、
+              // ここでは「処理中の index = completed + 1」で表示する
+              const currentIdx = usageProgress
+                ? Math.min(usageProgress.completed + 1, usageProgress.total)
+                : 0;
               const progressLabel = usageProgress
-                ? `${usageProgress.completed + 1}/${usageProgress.total} ${usageProgress.currentProfileName}`
+                ? `${currentIdx}/${usageProgress.total} ${usageProgress.currentProfileName}`
                 : "取得中";
+              // Beacon streaming 中でも Usage は実行可能 (server側で
+              // beacon:external-message を queue 制御し streaming を阻害しない)
               return (
                 <Button
                   key={cmd.label}
@@ -619,7 +626,7 @@ export function MobileChatView({
                   variant="outline"
                   size="sm"
                   className="h-7 px-3 text-xs shrink-0 rounded-full border-border/50 text-muted-foreground hover:text-primary hover:border-primary/40 transition-colors"
-                  disabled={isInputDisabled || usageRequesting}
+                  disabled={usageRequesting}
                   onClick={onRequestUsage}
                 >
                   {usageRequesting ? (

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -22,6 +22,7 @@ import type {
   ManagedSession,
   ServerToClientEvents,
   SpecialKey,
+  UsageProgress,
   Worktree,
 } from "../../../shared/types";
 import { useViewerTabs } from "../hooks/useViewerTabs";
@@ -66,6 +67,11 @@ interface MobileLayoutProps {
   beaconStreamText: string;
   onBeaconSend: (message: string) => void;
   onBeaconClear?: () => void;
+  // Usage取得（Linux + multiProfileSupported のみ）
+  onRequestUsage?: () => void;
+  usageRequesting?: boolean;
+  usageProgress?: UsageProgress | null;
+  multiProfileSupported?: boolean;
   // ブラウザ（noVNC）
   activeBrowserSession: BrowserSession | null;
   onSelectBrowser: () => void;
@@ -95,6 +101,10 @@ export function MobileLayout({
   beaconStreamText,
   onBeaconSend,
   onBeaconClear,
+  onRequestUsage,
+  usageRequesting,
+  usageProgress,
+  multiProfileSupported,
   activeBrowserSession,
   onSelectBrowser,
   navigateBrowser,
@@ -280,6 +290,10 @@ export function MobileLayout({
           streamingText={beaconStreamText}
           onSendMessage={onBeaconSend}
           onClear={onBeaconClear}
+          onRequestUsage={onRequestUsage}
+          usageRequesting={usageRequesting}
+          usageProgress={usageProgress}
+          multiProfileSupported={multiProfileSupported}
         />
       </div>
 

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -648,8 +648,14 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       setUsageReport(report);
       setUsageRequesting(false);
       setUsageProgress(null);
-      // 取得結果はBeaconメッセージとしてpostExternalMessage経由で配信されるため、
-      // ここでは toast を出さない (Beacon履歴に出る通知でユーザーに伝わる)
+      // 取得結果は通常 Beacon履歴に投稿されるが、Beacon履歴がクリア
+      // された場合などで投稿が skip されるケースもあるため、要求元には
+      // 必ず toast で完了通知する。Beacon に出ている時は二重通知になるが、
+      // 短い情報のみで邪魔にならない。
+      const okCount = report.entries.filter(e => e.status === "ok").length;
+      toast.success(
+        `Usage取得完了: ${okCount}/${report.entries.length} プロファイル`
+      );
     });
 
     socket.on("usage:error", ({ message }) => {

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -646,16 +646,20 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
     socket.on("usage:complete", report => {
       setUsageReport(report);
-      setUsageRequesting(false);
       setUsageProgress(null);
-      // 取得結果は通常 Beacon履歴に投稿されるが、Beacon履歴がクリア
-      // された場合などで投稿が skip されるケースもあるため、要求元には
-      // 必ず toast で完了通知する。Beacon に出ている時は二重通知になるが、
-      // 短い情報のみで邪魔にならない。
-      const okCount = report.entries.filter(e => e.status === "ok").length;
-      toast.success(
-        `Usage取得完了: ${okCount}/${report.entries.length} プロファイル`
-      );
+      // 完了 toast は要求元クライアントだけに出す。
+      // server は io.emit でブロードキャストしているため、別タブ/別デバイス
+      // にも届くが、それらは usageRequesting=false なので toast を出さない。
+      // (functional setState で前値を読み取り、true→false 遷移時のみ通知)
+      setUsageRequesting(prev => {
+        if (prev) {
+          const okCount = report.entries.filter(e => e.status === "ok").length;
+          toast.success(
+            `Usage取得完了: ${okCount}/${report.entries.length} プロファイル`
+          );
+        }
+        return false;
+      });
     });
 
     socket.on("usage:error", ({ message }) => {

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -970,10 +970,18 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   // Usage取得
   const requestUsage = useCallback(() => {
     if (usageRequesting) return;
+    // 未接続でemitすると永遠に応答が返らず、ボタンがリロードまでdisabledになる。
+    // socket未確立 or 切断中なら何もせずユーザに通知する。
+    if (!socketRef.current?.connected) {
+      toast.error(
+        "サーバーに接続されていません。少し待ってから再試行してください"
+      );
+      return;
+    }
     setUsageError(null);
     setUsageRequesting(true);
     setUsageProgress(null);
-    socketRef.current?.emit("usage:request");
+    socketRef.current.emit("usage:request");
     toast.info("Usage取得を開始しました（数十秒かかります）");
   }, [usageRequesting]);
 

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -21,6 +21,8 @@ import type {
   ServerToClientEvents,
   SpecialKey,
   SystemCapabilities,
+  UsageProgress,
+  UsageReport,
   Worktree,
 } from "../../../shared/types";
 
@@ -155,6 +157,20 @@ interface UseSocketReturn {
   deleteProfile: (id: string) => void;
   setRepoProfile: (repoPath: string, profileId: string | null) => void;
   restartSessionWithProfile: (sessionId: string) => void;
+
+  // Usage取得 (Linux + multiProfileSupported 限定)
+  /** /usage 取得が進行中か（全クライアント横断ではなく、自身が依頼中の状態） */
+  usageRequesting: boolean;
+  /** 直近の取得進捗（取得開始まで null） */
+  usageProgress: UsageProgress | null;
+  /** 直近の取得結果（成功時のみ更新） */
+  usageReport: UsageReport | null;
+  /** 直近の usage:error メッセージ */
+  usageError: string | null;
+  /** Usage取得を要求する */
+  requestUsage: () => void;
+  /** UI側で表示済みのusageErrorをクリア */
+  clearUsageError: () => void;
 }
 
 export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
@@ -232,6 +248,14 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   const [capabilities, setCapabilities] = useState<SystemCapabilities>({
     multiProfileSupported: false,
   });
+
+  // Usage取得
+  const [usageRequesting, setUsageRequesting] = useState(false);
+  const [usageProgress, setUsageProgress] = useState<UsageProgress | null>(
+    null
+  );
+  const [usageReport, setUsageReport] = useState<UsageReport | null>(null);
+  const [usageError, setUsageError] = useState<string | null>(null);
 
   // repoPathRefをrepoPathの変化に同期させる
   useEffect(() => {
@@ -604,6 +628,26 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       setRepoProfileLinks(next);
     });
 
+    // Usage取得イベント
+    socket.on("usage:progress", progress => {
+      setUsageProgress(progress);
+    });
+
+    socket.on("usage:complete", report => {
+      setUsageReport(report);
+      setUsageRequesting(false);
+      setUsageProgress(null);
+      // 取得結果はBeaconメッセージとしてpostExternalMessage経由で配信されるため、
+      // ここでは toast を出さない (Beacon履歴に出る通知でユーザーに伝わる)
+    });
+
+    socket.on("usage:error", ({ message }) => {
+      setUsageError(message);
+      setUsageRequesting(false);
+      setUsageProgress(null);
+      toast.error(`Usage取得に失敗: ${message}`);
+    });
+
     // Cleanup on unmount
     return () => {
       socket.off("ports:list");
@@ -616,6 +660,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       socket.off("browser:started");
       socket.off("browser:stopped");
       socket.off("browser:error");
+      socket.off("usage:progress");
+      socket.off("usage:complete");
+      socket.off("usage:error");
       socket.disconnect();
     };
   }, [enabled]);
@@ -920,6 +967,20 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     socketRef.current?.emit("session:restart-with-profile", { sessionId });
   }, []);
 
+  // Usage取得
+  const requestUsage = useCallback(() => {
+    if (usageRequesting) return;
+    setUsageError(null);
+    setUsageRequesting(true);
+    setUsageProgress(null);
+    socketRef.current?.emit("usage:request");
+    toast.info("Usage取得を開始しました（数十秒かかります）");
+  }, [usageRequesting]);
+
+  const clearUsageError = useCallback(() => {
+    setUsageError(null);
+  }, []);
+
   return {
     socket: socketRef.current,
     isConnected,
@@ -990,5 +1051,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     deleteProfile,
     setRepoProfile,
     restartSessionWithProfile,
+    // Usage取得
+    usageRequesting,
+    usageProgress,
+    usageReport,
+    usageError,
+    requestUsage,
+    clearUsageError,
   };
 }

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -317,6 +317,11 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     socket.on("disconnect", () => {
       console.log("Socket disconnected");
       setIsConnected(false);
+      // 切断中に usage:complete/usage:error を受け損ねるとボタンが永遠に
+      // disabled になるため、進行中フラグもリセットする。
+      // (再接続後に再度 requestUsage を呼べる状態に戻す)
+      setUsageRequesting(false);
+      setUsageProgress(null);
     });
 
     socket.on("connect_error", err => {
@@ -506,6 +511,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       }
     });
 
+    // 外部メッセージ (Usage取得結果など)。streaming state には影響させない
+    // (LLM応答 streaming 中に到着しても応答を切り捨てない)。
+    socket.on("beacon:external-message", (message: ChatMessage) => {
+      setBeaconMessages(prev => [...prev, message]);
+    });
+
     socket.on("beacon:stream", (data: BeaconStreamChunk) => {
       if (data.done) {
         setBeaconStreaming(false);
@@ -653,6 +664,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       socket.off("ports:list");
       socket.off("file:content");
       socket.off("beacon:message");
+      socket.off("beacon:external-message");
       socket.off("beacon:stream");
       socket.off("beacon:history");
       socket.off("beacon:error");

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -104,6 +104,9 @@ export default function Dashboard() {
     deleteProfile,
     setRepoProfile,
     restartSessionWithProfile,
+    usageRequesting,
+    usageProgress,
+    requestUsage,
   } = useSocket({
     enabled: !isSettingsLoading,
     initialRepoList: savedRepoList,
@@ -465,6 +468,10 @@ export default function Dashboard() {
           beaconStreamText={beaconStreamText}
           onBeaconSend={beaconSend}
           onBeaconClear={beaconClear}
+          onRequestUsage={requestUsage}
+          usageRequesting={usageRequesting}
+          usageProgress={usageProgress}
+          multiProfileSupported={capabilities.multiProfileSupported}
           activeBrowserSession={activeBrowserSession}
           onSelectBrowser={handleSelectBrowser}
           navigateBrowser={navigateBrowser}
@@ -580,6 +587,10 @@ export default function Dashboard() {
               streamingText={beaconStreamText}
               onSendMessage={beaconSend}
               onClear={beaconClear}
+              onRequestUsage={requestUsage}
+              usageRequesting={usageRequesting}
+              usageProgress={usageProgress}
+              multiProfileSupported={capabilities.multiProfileSupported}
             />
           }
           initialSidebarWidth={getSetting<number>("ark-sidebar-width", 250)}

--- a/server/index.ts
+++ b/server/index.ts
@@ -220,12 +220,37 @@ function formatResetTimestamp(resets: string): string {
     }
   }
 
+  // 時刻のみのケース (例 "8:20pm") は日付情報が無いので、JST 現在時刻と
+  // 比較して today/tomorrow を判定し、`M/D HH:MM` 形式に揃える。
+  // (週次リセットの "M/D HH:MM" 形式とカラムを揃えるため)
   const timeOnly = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(stripped);
   if (timeOnly) {
-    return to24Hour(timeOnly[1], timeOnly[2], timeOnly[3]);
+    const time24 = to24Hour(timeOnly[1], timeOnly[2], timeOnly[3]);
+    return appendJstDate(time24);
   }
 
   return stripped;
+}
+
+/**
+ * `HH:MM` 形式の時刻に JST の日付を補って `M/D HH:MM` を返す。
+ * 現在 JST 時刻と比較し、与えられた時刻が今日中ならtoday、過ぎていれば
+ * tomorrow を採用する (claude /usage が示す reset は常に「次回」)。
+ */
+function appendJstDate(time24: string): string {
+  const [hStr, mStr] = time24.split(":");
+  const targetH = Number.parseInt(hStr, 10);
+  const targetM = Number.parseInt(mStr, 10);
+  const targetMinutes = targetH * 60 + targetM;
+
+  const jstNow = new Date(
+    new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" })
+  );
+  const nowMinutes = jstNow.getHours() * 60 + jstNow.getMinutes();
+  const isTomorrow = targetMinutes <= nowMinutes;
+  const target = new Date(jstNow);
+  if (isTomorrow) target.setDate(target.getDate() + 1);
+  return `${target.getMonth() + 1}/${target.getDate()} ${time24}`;
 }
 
 function to24Hour(

--- a/server/index.ts
+++ b/server/index.ts
@@ -139,10 +139,24 @@ function loadTunnelState(): { active: boolean; port: number } | null {
   }
 }
 
+/** 進捗バーの幅 (文字数) */
+const USAGE_BAR_WIDTH = 24;
+
+/**
+ * 0-100 の percent から `█████░░░░░...` 形式のバー文字列を生成する。
+ * モバイル幅を考慮して 24 文字幅 (= 約4%/char)。
+ */
+function renderUsageBar(percent: number): string {
+  const clamped = Math.max(0, Math.min(100, percent));
+  const filled = Math.round((clamped / 100) * USAGE_BAR_WIDTH);
+  return "█".repeat(filled) + "░".repeat(USAGE_BAR_WIDTH - filled);
+}
+
 /**
  * UsageReport をBeaconチャットに表示するMarkdownへ変換する。
- * 既存のBeacon Markdownレンダラはテーブル非対応の可能性があるため、
- * 見出し + ビュレットリスト形式で出力する。
+ *
+ * code block (monospace) でバーを描画してプロファイル間の使用率を視覚的に
+ * 比較できるようにする。週次 (Sonnetのみ) は省略 (主要シグナルのみ表示)。
  */
 function formatUsageMarkdown(report: UsageReport): string {
   const lines: string[] = ["## Claude Code 使用量サマリ", ""];
@@ -164,20 +178,18 @@ function formatUsageMarkdown(report: UsageReport): string {
 function formatUsageEntryLines(entry: UsageEntry): string[] {
   if (entry.status === "ok" && entry.parsed) {
     const p = entry.parsed;
-    // Sonnet only は Team プランで 0% 時に Resets が無い → "Resets ..." を省略
-    const sonnetSuffix = p.weeklySonnetResets
-      ? ` (Resets ${p.weeklySonnetResets})`
-      : "";
-    const out = [
-      `- セッション: ${p.sessionPercent}% (Resets ${p.sessionResets})`,
-      `- 週次 (全モデル): ${p.weeklyAllPercent}% (Resets ${p.weeklyAllResets})`,
-      `- 週次 (Sonnetのみ): ${p.weeklySonnetPercent}%${sonnetSuffix}`,
+    const sessionPct = p.sessionPercent.toString().padStart(3, " ");
+    const weeklyPct = p.weeklyAllPercent.toString().padStart(3, " ");
+    // code block でバー表示 (monospace で揃える)
+    const bars = [
+      "```",
+      `セッション   ${renderUsageBar(p.sessionPercent)} ${sessionPct}%`,
+      `週次(全)     ${renderUsageBar(p.weeklyAllPercent)} ${weeklyPct}%`,
+      "```",
     ];
-    if (p.totalCost || p.wallDuration) {
-      const cost = p.totalCost ?? "-";
-      const dur = p.wallDuration ?? "-";
-      out.push(`- コスト: ${cost} / 経過時間: ${dur}`);
-    }
+    const out = [...bars];
+    out.push(`- セッションリセット: ${p.sessionResets}`);
+    out.push(`- 週次リセット: ${p.weeklyAllResets}`);
     return out;
   }
   if (entry.status === "unauthenticated") {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1992,19 +1992,9 @@ async function startServer() {
         // アントへブロードキャストする (live UI と DB reload の順序を一致)。
         // expectedVersion を渡すことで、開始後に clearHistory された場合は
         // 投稿スキップ (cleared chat 復活防止)。
-        const posted = beaconManager.postExternalMessage(
-          markdown,
-          beaconVersionAtStart
-        );
-        if (!posted) {
-          // 投稿は skip されたが、要求元クライアントには結果が見えなくなる
-          // ので usage:report-text で markdown を直接返してフォールバック表示
-          // (clearHistory レース時のみ。通常パスには影響しない)
-          socket.emit("usage:error", {
-            message:
-              "Beacon履歴がクリアされたためチャットには投稿しませんでした。取得結果は usage:complete を参照してください",
-          });
-        }
+        // null が返っても client は usage:complete + toast.success で結果を
+        // 認識できるので、ここでエラー扱いはしない。
+        beaconManager.postExternalMessage(markdown, beaconVersionAtStart);
         io.emit("usage:complete", report);
         console.log(
           `[UsageCollector] 完了: ok=${report.entries.filter(e => e.status === "ok").length}/${report.entries.length}`

--- a/server/index.ts
+++ b/server/index.ts
@@ -396,6 +396,12 @@ async function startServer() {
       activeBeaconSocket.emit("beacon:error", data);
     }
   });
+  // 外部メッセージ (Usage取得結果など) は LLM streaming 中の場合に
+  // BeaconManager 側で flush タイミングを制御してから emit する。
+  // ここで全クライアントへブロードキャスト (Beacon利用状況に関わらず共有)。
+  beaconManager.on("beacon:external-message", message => {
+    io.emit("beacon:external-message", message);
+  });
 
   /**
    * Quick Tunnelを起動する共通関数
@@ -1849,12 +1855,11 @@ async function startServer() {
       try {
         const report = await usageCollector.collect(profiles);
         const markdown = formatUsageMarkdown(report);
-        const message = beaconManager.postExternalMessage(markdown);
-        // 専用の `beacon:external-message` イベントで全クライアントに配信する。
-        // 通常の `beacon:message` を使うと、Beacon が LLM応答を streaming 中に
-        // 到着した場合に client 側の assistant-message ハンドラが
-        // beaconStreamText を強制クリアし、進行中の応答が切り捨てられるため。
-        io.emit("beacon:external-message", message);
+        // postExternalMessage は LLM streaming 中なら pending queue に入れ、
+        // turn 完了 / セッション close 時に "beacon:external-message" を emit
+        // する。emit を購読する beaconManager.on(...) → io.emit が全クライ
+        // アントへブロードキャストする (live UI と DB reload の順序を一致)。
+        beaconManager.postExternalMessage(markdown);
         io.emit("usage:complete", report);
         console.log(
           `[UsageCollector] 完了: ok=${report.entries.filter(e => e.status === "ok").length}/${report.entries.length}`

--- a/server/index.ts
+++ b/server/index.ts
@@ -1850,10 +1850,11 @@ async function startServer() {
         const report = await usageCollector.collect(profiles);
         const markdown = formatUsageMarkdown(report);
         const message = beaconManager.postExternalMessage(markdown);
-        // postExternalMessage は activeBeaconSocket にのみemitするため、
-        // 全クライアントに向けて明示的にbroadcastする
-        // (Usage取得結果はBeacon利用状況に関わらず全タブで共有される)
-        io.emit("beacon:message", message);
+        // 専用の `beacon:external-message` イベントで全クライアントに配信する。
+        // 通常の `beacon:message` を使うと、Beacon が LLM応答を streaming 中に
+        // 到着した場合に client 側の assistant-message ハンドラが
+        // beaconStreamText を強制クリアし、進行中の応答が切り捨てられるため。
+        io.emit("beacon:external-message", message);
         io.emit("usage:complete", report);
         console.log(
           `[UsageCollector] 完了: ok=${report.entries.filter(e => e.status === "ok").length}/${report.entries.length}`

--- a/server/index.ts
+++ b/server/index.ts
@@ -23,6 +23,9 @@ import type {
   ClientToServerEvents,
   ServerToClientEvents,
   SystemCapabilities,
+  UsageEntry,
+  UsageProgress,
+  UsageReport,
 } from "../shared/types.js";
 import { authManager } from "./lib/auth.js";
 import { beaconManager } from "./lib/beacon-manager.js";
@@ -58,6 +61,7 @@ import { sessionOrchestrator } from "./lib/session-orchestrator.js";
 import { detectMultiProfileSupported } from "./lib/system.js";
 import { tmuxManager } from "./lib/tmux-manager.js";
 import { TunnelManager } from "./lib/tunnel.js";
+import { UsageCollector } from "./lib/usage-collector.js";
 
 // Parse command line arguments
 const args = process.argv.slice(2);
@@ -135,6 +139,56 @@ function loadTunnelState(): { active: boolean; port: number } | null {
   }
 }
 
+/**
+ * UsageReport をBeaconチャットに表示するMarkdownへ変換する。
+ * 既存のBeacon Markdownレンダラはテーブル非対応の可能性があるため、
+ * 見出し + ビュレットリスト形式で出力する。
+ */
+function formatUsageMarkdown(report: UsageReport): string {
+  const lines: string[] = ["## Claude Code 使用量サマリ", ""];
+  for (const entry of report.entries) {
+    lines.push(`### ${entry.profileName}`);
+    lines.push(...formatUsageEntryLines(entry));
+    lines.push("");
+  }
+  const collected = new Date(report.collectedAt).toLocaleString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+  });
+  const okCount = report.entries.filter(e => e.status === "ok").length;
+  lines.push(
+    `取得時刻: ${collected} (${report.entries.length}件中${okCount}件取得成功)`
+  );
+  return lines.join("\n");
+}
+
+function formatUsageEntryLines(entry: UsageEntry): string[] {
+  if (entry.status === "ok" && entry.parsed) {
+    const p = entry.parsed;
+    // Sonnet only は Team プランで 0% 時に Resets が無い → "Resets ..." を省略
+    const sonnetSuffix = p.weeklySonnetResets
+      ? ` (Resets ${p.weeklySonnetResets})`
+      : "";
+    const out = [
+      `- セッション: ${p.sessionPercent}% (Resets ${p.sessionResets})`,
+      `- 週次 (全モデル): ${p.weeklyAllPercent}% (Resets ${p.weeklyAllResets})`,
+      `- 週次 (Sonnetのみ): ${p.weeklySonnetPercent}%${sonnetSuffix}`,
+    ];
+    if (p.totalCost || p.wallDuration) {
+      const cost = p.totalCost ?? "-";
+      const dur = p.wallDuration ?? "-";
+      out.push(`- コスト: ${cost} / 経過時間: ${dur}`);
+    }
+    return out;
+  }
+  if (entry.status === "unauthenticated") {
+    return ["- 状態: 未認証 (オンボーディング画面)"];
+  }
+  if (entry.status === "timeout") {
+    return ["- 状態: タイムアウト"];
+  }
+  return [`- 状態: エラー (${entry.errorMessage ?? "詳細不明"})`];
+}
+
 async function startServer() {
   const app = express();
   const server = createServer(app);
@@ -155,6 +209,11 @@ async function startServer() {
   console.log(
     `[Capabilities] multiProfileSupported = ${capabilities.multiProfileSupported}`
   );
+
+  // ===== Usage取得 =====
+  const usageCollector = new UsageCollector();
+  // 全クライアント横断で同時実行を1件に制限する
+  let usageInFlight = false;
 
   // Create proxy for ttyd WebSocket connections
   const ttydProxy = httpProxy.createProxyServer({
@@ -1728,6 +1787,76 @@ async function startServer() {
           sessionId,
           error: getErrorMessage(e),
         });
+      }
+    });
+
+    socket.on("usage:request", async () => {
+      if (!capabilities.multiProfileSupported) {
+        socket.emit("usage:error", {
+          message: "この環境ではプロファイル機能が使えません",
+        });
+        return;
+      }
+      if (usageInFlight) {
+        socket.emit("usage:error", {
+          message: "Usage取得が既に進行中です",
+        });
+        return;
+      }
+      const registeredProfiles = db.listProfiles();
+      // デフォルトアカウント (CLAUDE_CONFIG_DIR を設定しないときの ~/.claude) も
+      // 集計対象に含める。既存プロファイルが ~/.claude を指している場合は重複を
+      // 避ける (configDir 空文字 = デフォルト指定として UsageCollector 側で扱う)。
+      const defaultConfigDir = path.join(os.homedir(), ".claude");
+      const hasDefaultProfile = registeredProfiles.some(
+        p => p.configDir === defaultConfigDir
+      );
+      const profiles = hasDefaultProfile
+        ? registeredProfiles
+        : [
+            {
+              id: "__default__",
+              name: "デフォルト",
+              configDir: "",
+              createdAt: 0,
+              updatedAt: 0,
+            },
+            ...registeredProfiles,
+          ];
+
+      if (profiles.length === 0) {
+        socket.emit("usage:error", {
+          message: "プロファイルが登録されていません",
+        });
+        return;
+      }
+
+      usageInFlight = true;
+      const onProgress = (data: UsageProgress) => {
+        io.emit("usage:progress", data);
+      };
+      usageCollector.on("usage:progress", onProgress);
+      console.log(
+        `[UsageCollector] 開始: ${profiles.length} プロファイル (要求元: ${socket.id})`
+      );
+
+      try {
+        const report = await usageCollector.collect(profiles);
+        const markdown = formatUsageMarkdown(report);
+        const message = beaconManager.postExternalMessage(markdown);
+        // postExternalMessage は activeBeaconSocket にのみemitするため、
+        // 全クライアントに向けて明示的にbroadcastする
+        // (Usage取得結果はBeacon利用状況に関わらず全タブで共有される)
+        io.emit("beacon:message", message);
+        io.emit("usage:complete", report);
+        console.log(
+          `[UsageCollector] 完了: ok=${report.entries.filter(e => e.status === "ok").length}/${report.entries.length}`
+        );
+      } catch (e) {
+        socket.emit("usage:error", { message: getErrorMessage(e) });
+      } finally {
+        usageCollector.off("usage:progress", onProgress);
+        usageInFlight = false;
       }
     });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -176,11 +176,72 @@ function formatUsageMarkdown(report: UsageReport): string {
 }
 
 /**
- * `8:20pm (Asia/Tokyo)` のような Resets 文字列から JST 表示部分を除去して
- * `8:20pm` のように簡潔化する。Ark は JST 前提のため明示は不要。
+ * Claude /usage の Resets 文字列を `M/D HH:MM` (時刻のみなら `HH:MM`)
+ * の 24時間表記に変換する。Ark は JST 前提のため `(Asia/Tokyo)` は除去。
+ *
+ * 入力例:
+ *   `8:20pm (Asia/Tokyo)`         -> `20:20`
+ *   `3am (Asia/Tokyo)`            -> `03:00`
+ *   `May 4, 1pm (Asia/Tokyo)`     -> `5/4 13:00`
+ *   `May 4, 11:30am (Asia/Tokyo)` -> `5/4 11:30`
+ *
+ * パース不能なものは `(Asia/Tokyo)` だけ除いて返す (フォールバック)。
  */
-function trimTimezone(resets: string): string {
-  return resets.replace(/\s*\(Asia\/Tokyo\)\s*$/, "").trim();
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+function formatResetTimestamp(resets: string): string {
+  const stripped = resets.replace(/\s*\(Asia\/Tokyo\)\s*$/, "").trim();
+
+  const dated =
+    /^([A-Za-z]+)\s+(\d{1,2}),\s+(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(
+      stripped
+    );
+  if (dated) {
+    const monthIdx = MONTH_NAMES.findIndex(
+      m => m.toLowerCase() === dated[1].slice(0, 3).toLowerCase()
+    );
+    if (monthIdx >= 0) {
+      const day = Number.parseInt(dated[2], 10);
+      const time24 = to24Hour(dated[3], dated[4], dated[5]);
+      return `${monthIdx + 1}/${day} ${time24}`;
+    }
+  }
+
+  const timeOnly = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(stripped);
+  if (timeOnly) {
+    return to24Hour(timeOnly[1], timeOnly[2], timeOnly[3]);
+  }
+
+  return stripped;
+}
+
+function to24Hour(
+  hourStr: string,
+  minuteStr: string | undefined,
+  ampm: string
+): string {
+  let h = Number.parseInt(hourStr, 10);
+  const m = minuteStr ? Number.parseInt(minuteStr, 10) : 0;
+  const isPm = ampm.toLowerCase() === "pm";
+  if (h === 12) {
+    h = isPm ? 12 : 0;
+  } else if (isPm) {
+    h += 12;
+  }
+  return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
 }
 
 function formatUsageEntryLines(entry: UsageEntry): string[] {
@@ -188,13 +249,17 @@ function formatUsageEntryLines(entry: UsageEntry): string[] {
     const p = entry.parsed;
     const sessionPct = p.sessionPercent.toString().padStart(3, " ");
     const weeklyPct = p.weeklyAllPercent.toString().padStart(3, " ");
-    const sessionReset = trimTimezone(p.sessionResets);
-    const weeklyReset = trimTimezone(p.weeklyAllResets);
-    // code block でバー表示 (monospace で揃える)。Reset時刻もインラインで表示
+    const sessionReset = formatResetTimestamp(p.sessionResets);
+    const weeklyReset = formatResetTimestamp(p.weeklyAllResets);
+    // ラベルとバーを別行に分け、バーは常に column 0 から開始する。
+    // (Japanese fullwidth と halfwidth の混在で renderer によって幅が
+    //  揃わないのを回避)
     return [
       "```",
-      `セッション ${renderUsageBar(p.sessionPercent)} ${sessionPct}%  ↻ ${sessionReset}`,
-      `週次       ${renderUsageBar(p.weeklyAllPercent)} ${weeklyPct}%  ↻ ${weeklyReset}`,
+      `セッション ${sessionPct}%  ↻ ${sessionReset}`,
+      renderUsageBar(p.sessionPercent),
+      `週次       ${weeklyPct}%  ↻ ${weeklyReset}`,
+      renderUsageBar(p.weeklyAllPercent),
       "```",
     ];
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -162,7 +162,7 @@ function formatUsageMarkdown(report: UsageReport): string {
   const lines: string[] = ["## Claude Code 使用量サマリ", ""];
   for (const entry of report.entries) {
     lines.push(`### ${entry.profileName}`);
-    lines.push(...formatUsageEntryLines(entry));
+    lines.push(...formatUsageEntryLines(entry, report.collectedAt));
     lines.push("");
   }
   const collected = new Date(report.collectedAt).toLocaleString("ja-JP", {
@@ -202,7 +202,7 @@ const MONTH_NAMES = [
   "Dec",
 ];
 
-function formatResetTimestamp(resets: string): string {
+function formatResetTimestamp(resets: string, refMs: number): string {
   const stripped = resets.replace(/\s*\(Asia\/Tokyo\)\s*$/, "").trim();
 
   const dated =
@@ -220,13 +220,13 @@ function formatResetTimestamp(resets: string): string {
     }
   }
 
-  // 時刻のみのケース (例 "8:20pm") は日付情報が無いので、JST 現在時刻と
-  // 比較して today/tomorrow を判定し、`M/D HH:MM` 形式に揃える。
-  // (週次リセットの "M/D HH:MM" 形式とカラムを揃えるため)
+  // 時刻のみのケース (例 "8:20pm") は日付情報が無いので、refMs 時点の JST
+  // 時刻と比較して today/tomorrow を判定し、`M/D HH:MM` 形式に揃える。
+  // refMs には report.collectedAt を渡すことで深夜跨ぎ時の整合性を担保。
   const timeOnly = /^(\d{1,2})(?::(\d{2}))?\s*(am|pm)$/i.exec(stripped);
   if (timeOnly) {
     const time24 = to24Hour(timeOnly[1], timeOnly[2], timeOnly[3]);
-    return appendJstDate(time24);
+    return appendJstDate(time24, refMs);
   }
 
   return stripped;
@@ -234,14 +234,18 @@ function formatResetTimestamp(resets: string): string {
 
 /**
  * `HH:MM` 形式の時刻に JST の日付を補って `M/D HH:MM` を返す。
- * 現在 JST 時刻と比較し、与えられた時刻が今日中ならtoday、過ぎていれば
- * tomorrow を採用する (claude /usage が示す reset は常に「次回」)。
+ * `refMs` 時点 (collectedAt) の JST と比較し、与えられた時刻が refMs 以後
+ * 今日中ならtoday、過ぎていれば tomorrow を採用する (claude /usage が示す
+ * reset は常に「次回」)。
+ *
+ * refMs を引数で受け取ることで、render 時刻ではなく capture 時刻を基準に
+ * できる (深夜跨ぎ時の整合性確保)。
  *
  * 注: host TZ に依存しないよう Intl.DateTimeFormat.formatToParts で
  * JST の年/月/日/時/分を直接取得する。`new Date(toLocaleString)` 経由だと
  * UTC コンテナ等で再パース時に host TZ で解釈され翌日判定がズレる。
  */
-function appendJstDate(time24: string): string {
+function appendJstDate(time24: string, refMs: number): string {
   const [hStr, mStr] = time24.split(":");
   const targetH = Number.parseInt(hStr, 10);
   const targetM = Number.parseInt(mStr, 10);
@@ -255,7 +259,7 @@ function appendJstDate(time24: string): string {
     hour: "numeric",
     minute: "numeric",
     hour12: false,
-  }).formatToParts(new Date());
+  }).formatToParts(new Date(refMs));
   const getPart = (type: string) =>
     Number.parseInt(parts.find(p => p.type === type)?.value ?? "0", 10);
   // hour=24 になるケース (formatToParts の en-US 仕様) を 0 に補正
@@ -290,13 +294,13 @@ function to24Hour(
   return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
 }
 
-function formatUsageEntryLines(entry: UsageEntry): string[] {
+function formatUsageEntryLines(entry: UsageEntry, refMs: number): string[] {
   if (entry.status === "ok" && entry.parsed) {
     const p = entry.parsed;
     const sessionPct = p.sessionPercent.toString().padStart(3, " ");
     const weeklyPct = p.weeklyAllPercent.toString().padStart(3, " ");
-    const sessionReset = formatResetTimestamp(p.sessionResets);
-    const weeklyReset = formatResetTimestamp(p.weeklyAllResets);
+    const sessionReset = formatResetTimestamp(p.sessionResets, refMs);
+    const weeklyReset = formatResetTimestamp(p.weeklyAllResets, refMs);
     // ラベル / バー / % / リセット時刻 を 1 行に並べる。
     // 「セ」「週」は両方 1 文字 (ほとんどの monospace 環境で同じセル幅で
     // 描画される) なので column 整列が壊れない。

--- a/server/index.ts
+++ b/server/index.ts
@@ -1805,14 +1805,20 @@ async function startServer() {
       }
       const registeredProfiles = db.listProfiles();
       // デフォルトアカウント (CLAUDE_CONFIG_DIR を設定しないときの ~/.claude) も
-      // 集計対象に含める。既存プロファイルが ~/.claude を指している場合は重複を
-      // 避ける (configDir 空文字 = デフォルト指定として UsageCollector 側で扱う)。
+      // 集計対象に含める。configDir 空文字 = デフォルト指定として UsageCollector
+      // 側で「CLAUDE_CONFIG_DIR を渡さない」分岐を選ぶ。
+      // 注: ユーザが ~/.claude を明示プロファイル登録している場合、そのまま
+      // CLAUDE_CONFIG_DIR=~/.claude で起動するとオンボーディング画面に詰まるため
+      // (UsageCollector のコメント参照)、ここで configDir を空に正規化する。
       const defaultConfigDir = path.join(os.homedir(), ".claude");
-      const hasDefaultProfile = registeredProfiles.some(
-        p => p.configDir === defaultConfigDir
+      const normalizedRegistered = registeredProfiles.map(p =>
+        p.configDir === defaultConfigDir ? { ...p, configDir: "" } : p
+      );
+      const hasDefaultProfile = normalizedRegistered.some(
+        p => p.configDir === ""
       );
       const profiles = hasDefaultProfile
-        ? registeredProfiles
+        ? normalizedRegistered
         : [
             {
               id: "__default__",
@@ -1821,7 +1827,7 @@ async function startServer() {
               createdAt: 0,
               updatedAt: 0,
             },
-            ...registeredProfiles,
+            ...normalizedRegistered,
           ];
 
       if (profiles.length === 0) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1943,9 +1943,25 @@ async function startServer() {
       // 注: ユーザが ~/.claude を明示プロファイル登録している場合、そのまま
       // CLAUDE_CONFIG_DIR=~/.claude で起動するとオンボーディング画面に詰まるため
       // (UsageCollector のコメント参照)、ここで configDir を空に正規化する。
+      // 比較は fs.realpathSync で canonical 化して symlink / bind mount 経由で
+      // 同じ実体を指す経路でも検出できるようにする。
       const defaultConfigDir = path.join(os.homedir(), ".claude");
+      let canonicalDefaultDir = defaultConfigDir;
+      try {
+        canonicalDefaultDir = fs.realpathSync(defaultConfigDir);
+      } catch {
+        // ~/.claude が無い環境ではそのまま使う (どのプロファイルとも一致しない)
+      }
+      const isDefaultPath = (configDir: string): boolean => {
+        if (configDir === defaultConfigDir) return true;
+        try {
+          return fs.realpathSync(configDir) === canonicalDefaultDir;
+        } catch {
+          return false;
+        }
+      };
       const normalizedRegistered = registeredProfiles.map(p =>
-        p.configDir === defaultConfigDir ? { ...p, configDir: "" } : p
+        isDefaultPath(p.configDir) ? { ...p, configDir: "" } : p
       );
       const hasDefaultProfile = normalizedRegistered.some(
         p => p.configDir === ""

--- a/server/index.ts
+++ b/server/index.ts
@@ -236,6 +236,10 @@ function formatResetTimestamp(resets: string): string {
  * `HH:MM` 形式の時刻に JST の日付を補って `M/D HH:MM` を返す。
  * 現在 JST 時刻と比較し、与えられた時刻が今日中ならtoday、過ぎていれば
  * tomorrow を採用する (claude /usage が示す reset は常に「次回」)。
+ *
+ * 注: host TZ に依存しないよう Intl.DateTimeFormat.formatToParts で
+ * JST の年/月/日/時/分を直接取得する。`new Date(toLocaleString)` 経由だと
+ * UTC コンテナ等で再パース時に host TZ で解釈され翌日判定がズレる。
  */
 function appendJstDate(time24: string): string {
   const [hStr, mStr] = time24.split(":");
@@ -243,14 +247,31 @@ function appendJstDate(time24: string): string {
   const targetM = Number.parseInt(mStr, 10);
   const targetMinutes = targetH * 60 + targetM;
 
-  const jstNow = new Date(
-    new Date().toLocaleString("en-US", { timeZone: "Asia/Tokyo" })
-  );
-  const nowMinutes = jstNow.getHours() * 60 + jstNow.getMinutes();
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: "Asia/Tokyo",
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    hour12: false,
+  }).formatToParts(new Date());
+  const getPart = (type: string) =>
+    Number.parseInt(parts.find(p => p.type === type)?.value ?? "0", 10);
+  // hour=24 になるケース (formatToParts の en-US 仕様) を 0 に補正
+  const nowH = getPart("hour") % 24;
+  const nowM = getPart("minute");
+  const nowMinutes = nowH * 60 + nowM;
   const isTomorrow = targetMinutes <= nowMinutes;
-  const target = new Date(jstNow);
-  if (isTomorrow) target.setDate(target.getDate() + 1);
-  return `${target.getMonth() + 1}/${target.getDate()} ${time24}`;
+
+  // JST のローカル年/月/日 として扱える Date を構築 (UTC 値で持ちながら
+  // 表示時は JST 換算ではなく getMonth/getDate で参照する。
+  // ※ Date.UTC で組み立てることで host TZ に依存しない)
+  const target = new Date(
+    Date.UTC(getPart("year"), getPart("month") - 1, getPart("day"))
+  );
+  if (isTomorrow) target.setUTCDate(target.getUTCDate() + 1);
+  return `${target.getUTCMonth() + 1}/${target.getUTCDate()} ${time24}`;
 }
 
 function to24Hour(
@@ -276,15 +297,13 @@ function formatUsageEntryLines(entry: UsageEntry): string[] {
     const weeklyPct = p.weeklyAllPercent.toString().padStart(3, " ");
     const sessionReset = formatResetTimestamp(p.sessionResets);
     const weeklyReset = formatResetTimestamp(p.weeklyAllResets);
-    // ラベル行は単独 (Japanese 幅依存なし)、バー + % + リセット は同じ行に
-    // 並べる。バー は monospace 24 cells で固定なので % の column が両行で
-    // 揃う。Japanese label の幅で % がズレることはない。
+    // ラベル / バー / % / リセット時刻 を 1 行に並べる。
+    // 「セ」「週」は両方 1 文字 (ほとんどの monospace 環境で同じセル幅で
+    // 描画される) なので column 整列が壊れない。
     return [
       "```",
-      "セッション",
-      `${renderUsageBar(p.sessionPercent)} ${sessionPct}% ↻ ${sessionReset}`,
-      "週次",
-      `${renderUsageBar(p.weeklyAllPercent)} ${weeklyPct}% ↻ ${weeklyReset}`,
+      `セ ${renderUsageBar(p.sessionPercent)} ${sessionPct}% ${sessionReset}`,
+      `週 ${renderUsageBar(p.weeklyAllPercent)} ${weeklyPct}% ${weeklyReset}`,
       "```",
     ];
   }
@@ -1973,7 +1992,19 @@ async function startServer() {
         // アントへブロードキャストする (live UI と DB reload の順序を一致)。
         // expectedVersion を渡すことで、開始後に clearHistory された場合は
         // 投稿スキップ (cleared chat 復活防止)。
-        beaconManager.postExternalMessage(markdown, beaconVersionAtStart);
+        const posted = beaconManager.postExternalMessage(
+          markdown,
+          beaconVersionAtStart
+        );
+        if (!posted) {
+          // 投稿は skip されたが、要求元クライアントには結果が見えなくなる
+          // ので usage:report-text で markdown を直接返してフォールバック表示
+          // (clearHistory レース時のみ。通常パスには影響しない)
+          socket.emit("usage:error", {
+            message:
+              "Beacon履歴がクリアされたためチャットには投稿しませんでした。取得結果は usage:complete を参照してください",
+          });
+        }
         io.emit("usage:complete", report);
         console.log(
           `[UsageCollector] 完了: ok=${report.entries.filter(e => e.status === "ok").length}/${report.entries.length}`

--- a/server/index.ts
+++ b/server/index.ts
@@ -175,22 +175,28 @@ function formatUsageMarkdown(report: UsageReport): string {
   return lines.join("\n");
 }
 
+/**
+ * `8:20pm (Asia/Tokyo)` のような Resets 文字列から JST 表示部分を除去して
+ * `8:20pm` のように簡潔化する。Ark は JST 前提のため明示は不要。
+ */
+function trimTimezone(resets: string): string {
+  return resets.replace(/\s*\(Asia\/Tokyo\)\s*$/, "").trim();
+}
+
 function formatUsageEntryLines(entry: UsageEntry): string[] {
   if (entry.status === "ok" && entry.parsed) {
     const p = entry.parsed;
     const sessionPct = p.sessionPercent.toString().padStart(3, " ");
     const weeklyPct = p.weeklyAllPercent.toString().padStart(3, " ");
-    // code block でバー表示 (monospace で揃える)
-    const bars = [
+    const sessionReset = trimTimezone(p.sessionResets);
+    const weeklyReset = trimTimezone(p.weeklyAllResets);
+    // code block でバー表示 (monospace で揃える)。Reset時刻もインラインで表示
+    return [
       "```",
-      `セッション   ${renderUsageBar(p.sessionPercent)} ${sessionPct}%`,
-      `週次(全)     ${renderUsageBar(p.weeklyAllPercent)} ${weeklyPct}%`,
+      `セッション ${renderUsageBar(p.sessionPercent)} ${sessionPct}%  ↻ ${sessionReset}`,
+      `週次       ${renderUsageBar(p.weeklyAllPercent)} ${weeklyPct}%  ↻ ${weeklyReset}`,
       "```",
     ];
-    const out = [...bars];
-    out.push(`- セッションリセット: ${p.sessionResets}`);
-    out.push(`- 週次リセット: ${p.weeklyAllResets}`);
-    return out;
   }
   if (entry.status === "unauthenticated") {
     return ["- 状態: 未認証 (オンボーディング画面)"];

--- a/server/index.ts
+++ b/server/index.ts
@@ -251,15 +251,15 @@ function formatUsageEntryLines(entry: UsageEntry): string[] {
     const weeklyPct = p.weeklyAllPercent.toString().padStart(3, " ");
     const sessionReset = formatResetTimestamp(p.sessionResets);
     const weeklyReset = formatResetTimestamp(p.weeklyAllResets);
-    // ラベルとバーを別行に分け、バーは常に column 0 から開始する。
-    // (Japanese fullwidth と halfwidth の混在で renderer によって幅が
-    //  揃わないのを回避)
+    // ラベル行は単独 (Japanese 幅依存なし)、バー + % + リセット は同じ行に
+    // 並べる。バー は monospace 24 cells で固定なので % の column が両行で
+    // 揃う。Japanese label の幅で % がズレることはない。
     return [
       "```",
-      `セッション ${sessionPct}%  ↻ ${sessionReset}`,
-      renderUsageBar(p.sessionPercent),
-      `週次       ${weeklyPct}%  ↻ ${weeklyReset}`,
-      renderUsageBar(p.weeklyAllPercent),
+      "セッション",
+      `${renderUsageBar(p.sessionPercent)} ${sessionPct}% ↻ ${sessionReset}`,
+      "週次",
+      `${renderUsageBar(p.weeklyAllPercent)} ${weeklyPct}% ↻ ${weeklyReset}`,
       "```",
     ];
   }
@@ -1935,6 +1935,10 @@ async function startServer() {
         `[UsageCollector] 開始: ${profiles.length} プロファイル (要求元: ${socket.id})`
       );
 
+      // 完了時に Beacon履歴がクリアされていないか判定するため、開始時の
+      // 世代をcaptureする。背景処理 (~30s) 中に clearHistory されていたら
+      // postExternalMessage は no-op になり、新しい transcript を汚染しない。
+      const beaconVersionAtStart = beaconManager.getHistoryVersion();
       try {
         const report = await usageCollector.collect(profiles);
         const markdown = formatUsageMarkdown(report);
@@ -1942,7 +1946,9 @@ async function startServer() {
         // turn 完了 / セッション close 時に "beacon:external-message" を emit
         // する。emit を購読する beaconManager.on(...) → io.emit が全クライ
         // アントへブロードキャストする (live UI と DB reload の順序を一致)。
-        beaconManager.postExternalMessage(markdown);
+        // expectedVersion を渡すことで、開始後に clearHistory された場合は
+        // 投稿スキップ (cleared chat 復活防止)。
+        beaconManager.postExternalMessage(markdown, beaconVersionAtStart);
         io.emit("usage:complete", report);
         console.log(
           `[UsageCollector] 完了: ok=${report.entries.filter(e => e.status === "ok").length}/${report.entries.length}`

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -1029,46 +1029,48 @@ export class BeaconManager extends EventEmitter {
       content,
       timestamp: new Date(),
     };
-    // 要求元クライアントに即座に結果を表示するため、live emit は常に行う。
-    // (Beacon turn streaming 中でもユーザに「結果が来た」ことを伝える)
-    this.emit("beacon:external-message", message);
-
     if (this.session?.processing) {
-      // LLM が応答 streaming 中の場合、assistantMessage の DB 永続化は
-      // turn 完了時に行われる。ここで即座に DB 保存すると次回履歴ロード時に
-      // 「assistant より前に external が出る」順序逆転が起きる。
-      // pending queue に入れて、turn 完了後に timestamp を更新して保存する。
+      // LLM が応答 streaming 中の場合、live emit と DB 永続化を両方 defer する。
+      // 即時 live emit すると「live UI: external→assistant」「DB reload:
+      // assistant→external」と順序が食い違うため、turn 完了後にまとめて行う。
+      // 要求元クライアントは数秒〜turn完了まで待つが、順序整合性を優先する。
       this.pendingExternalMessages.push(message);
     } else {
-      this.persistExternal(message);
+      this.persistAndEmitExternal(message);
     }
     return message;
   }
 
   /**
-   * 外部メッセージを DB / session.messages に保存する (live emit はしない)。
+   * 外部メッセージを DB / session.messages へ保存し、
+   * `beacon:external-message` イベントで通知する。
    */
-  private persistExternal(message: ChatMessage): void {
+  private persistAndEmitExternal(message: ChatMessage): void {
     db.addBeaconMessage(message);
     if (this.session) {
       this.session.messages.push(message);
     }
+    this.emit("beacon:external-message", message);
   }
 
   /**
-   * postExternalMessage で待機中の外部メッセージを DB と session.messages に
-   * 反映する。LLM turn 完了時 / セッション close 時 / エラー時に呼び出す。
-   * live emit は postExternalMessage 時点で既に行っているため再emitしない。
+   * postExternalMessage で待機中の外部メッセージを DB / session.messages に
+   * 反映し、`beacon:external-message` を emit する。
+   * LLM turn 完了時 / セッション close 時 / エラー時に呼び出す。
+   *
+   * 確実に assistantMessage より後で、互いも strict ordering になるよう
+   * `Date.now() + 1` を起点に index 毎に +1ms ずらした timestamp を設定する。
+   * (同一ミリ秒に着地して timestamp ソートが不安定になるのを回避)
    */
   private flushPendingExternalMessages(): void {
     if (this.pendingExternalMessages.length === 0) return;
     const queued = this.pendingExternalMessages;
     this.pendingExternalMessages = [];
-    for (const message of queued) {
-      // 確実に assistantMessage より後の timestamp になるよう更新
-      message.timestamp = new Date();
-      this.persistExternal(message);
-    }
+    const baseMs = Date.now() + 1;
+    queued.forEach((message, i) => {
+      message.timestamp = new Date(baseMs + i);
+      this.persistAndEmitExternal(message);
+    });
   }
 
   /**

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -1026,6 +1026,11 @@ export class BeaconManager extends EventEmitter {
     } finally {
       if (session) {
         session.processing = false;
+        // activeTurn は通常 result message 受信時に false になるが、
+        // query() throw / abort / iterator 終了などでそこへ到達できない
+        // ケースもある。finally で必ず false に戻し、後続 postExternalMessage
+        // が「streaming中」と誤判定して queue 滞留しないようにする。
+        session.activeTurn = false;
       }
       // エラー / 中断パスでも pending external messages が滞留しないよう
       // 必ず flush。assistant 応答が無くても外部メッセージはユーザに届ける。

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -990,10 +990,12 @@ export class BeaconManager extends EventEmitter {
             this.emit("beacon:message", assistantMessage);
           }
 
-          // turn 終了後に pending external メッセージを flush。
-          // assistant text の有無に関わらず flush することで、tool-only turn
-          // (text無し) でも queue 滞留を解消する。
-          this.flushPendingExternalMessages();
+          // turn 終了後、活性 turn がもう無くなった場合のみ flush。
+          // 複数 turn が queue されている場合は次の result まで保留する
+          // (multi-client で external message が途中で挟まらないように)。
+          if (this.session === session && session.activeTurnCount === 0) {
+            this.flushPendingExternalMessages();
+          }
 
           // 完了チャンクを送信
           const doneChunk: BeaconStreamChunk = {

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -1150,15 +1150,22 @@ export class BeaconManager extends EventEmitter {
    *
    * サーバー側のセッション（LLMコンテキスト）も閉じてDB履歴もクリアする。
    * 次のメッセージ送信時に新規セッションが開始される。
-   * historyVersion を増やすことで、進行中の /usage 等が完了時に
-   * postExternalMessage で履歴を復活させないようにする。
+   *
+   * 順序が重要:
+   * 1. historyVersion を先に上げる
+   *    → 進行中の /usage が postExternalMessage を呼んでも version mismatch
+   *      で skip される。
+   * 2. pendingExternalMessages を捨てる
+   *    → closeSession 内の flushPendingExternalMessages が emit/persist しない
+   *      ようにする (= cleared chat への stale message 復活を防ぐ)。
+   * 3. closeSession (LLMコンテキスト中断、queue空なので flush は no-op)。
+   * 4. DB クリア。
    */
   clearHistory(): void {
+    this.historyVersion += 1;
+    this.pendingExternalMessages = [];
     this.closeSession();
     db.clearBeaconMessages();
-    this.historyVersion += 1;
-    // pending の外部メッセージも捨てる (clearHistory で消したい意図と一致)
-    this.pendingExternalMessages = [];
     console.log("[BeaconManager] 履歴をクリアしました");
   }
 

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -990,13 +990,6 @@ export class BeaconManager extends EventEmitter {
             this.emit("beacon:message", assistantMessage);
           }
 
-          // turn 終了後、活性 turn がもう無くなった場合のみ flush。
-          // 複数 turn が queue されている場合は次の result まで保留する
-          // (multi-client で external message が途中で挟まらないように)。
-          if (this.session === session && session.activeTurnCount === 0) {
-            this.flushPendingExternalMessages();
-          }
-
           // 完了チャンクを送信
           const doneChunk: BeaconStreamChunk = {
             chunk: "",
@@ -1004,12 +997,17 @@ export class BeaconManager extends EventEmitter {
           };
           this.emit("beacon:stream", doneChunk);
 
-          // turn 完了 → activeTurnCount を 1 減らす。multi-client で複数
-          // turn が queue されている場合、最後の result が来るまで count > 0
-          // のままなので、後続 turn 中の postExternalMessage は引き続き
-          // pending queue に入る (順序保護)。
+          // turn 完了 → activeTurnCount を 1 減らす。decrement 後に 0 なら
+          // flushPendingExternalMessages を呼ぶ。順序が逆だと 1→0 遷移時に
+          // flush されず pending が滞留する (CodeRabbit 指摘)。
+          // multi-client で複数 turn が queue されている場合、最後の
+          // result まで count > 0 のままなので、後続 turn 中の
+          // postExternalMessage は引き続き pending queue に入る (順序保護)。
           if (this.session === session) {
             session.activeTurnCount = Math.max(0, session.activeTurnCount - 1);
+            if (session.activeTurnCount === 0) {
+              this.flushPendingExternalMessages();
+            }
           }
 
           // このターンの処理完了。ループを継続して次のターンの出力を待つ

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -286,8 +286,18 @@ interface BeaconSession {
   messages: ChatMessage[];
   /** 最終アクティビティ時刻 */
   lastActivity: Date;
-  /** 出力処理が進行中かどうか */
+  /**
+   * 出力処理ループが起動中かどうか (processOutput の再入防止用)。
+   * Beacon セッションが生きている間はずっと true。
+   * postExternalMessage の defer 判定には使えない (常時 true のため queue が
+   * 永遠に flush されない) → activeTurn を見ること。
+   */
   processing: boolean;
+  /**
+   * ユーザメッセージ送信後、assistant の `result` が来るまで true。
+   * postExternalMessage はこのフラグを見て LLM streaming 中か判定する。
+   */
+  activeTurn: boolean;
   /** AbortController（セッション終了時にquery()を中断するため） */
   abortController: AbortController;
 }
@@ -825,6 +835,7 @@ export class BeaconManager extends EventEmitter {
       messages,
       lastActivity: new Date(),
       processing: false,
+      activeTurn: false,
       abortController,
     };
 
@@ -863,6 +874,10 @@ export class BeaconManager extends EventEmitter {
 
     // キューにメッセージをpush（query()のAsyncIterableに供給される）
     session.queue.push(message);
+
+    // この turn が完了 (result message 受信) するまで activeTurn=true。
+    // postExternalMessage はこれを見て LLM streaming 中なら queue する。
+    session.activeTurn = true;
 
     // 出力の処理を開始
     await this.processOutput();
@@ -982,6 +997,12 @@ export class BeaconManager extends EventEmitter {
           };
           this.emit("beacon:stream", doneChunk);
 
+          // turn 完了 → activeTurn=false。次の sendMessage で再び true になる。
+          // (この期間中に postExternalMessage が来たら即時に persistAndEmit する)
+          if (this.session === session) {
+            session.activeTurn = false;
+          }
+
           // このターンの処理完了。ループを継続して次のターンの出力を待つ
           // （キューに新しいメッセージがpushされるとquery()が新しい出力を生成する）
           assistantText = "";
@@ -1063,11 +1084,13 @@ export class BeaconManager extends EventEmitter {
       content,
       timestamp: new Date(),
     };
-    if (this.session?.processing) {
-      // LLM が応答 streaming 中の場合、live emit と DB 永続化を両方 defer する。
-      // 即時 live emit すると「live UI: external→assistant」「DB reload:
-      // assistant→external」と順序が食い違うため、turn 完了後にまとめて行う。
-      // 要求元クライアントは数秒〜turn完了まで待つが、順序整合性を優先する。
+    if (this.session?.activeTurn) {
+      // LLM が応答 streaming 中 (= activeTurn) の場合、live emit と DB
+      // 永続化を両方 defer する。即時 live emit すると「live UI: external
+      // →assistant」「DB reload: assistant→external」と順序が食い違うため、
+      // turn 完了後にまとめて行う。
+      // ※ session.processing は session 生存期間中ずっと true のため判定に
+      //   使えない。activeTurn が「現在 LLM が応答中か」の正確なシグナル。
       this.pendingExternalMessages.push(message);
     } else {
       this.persistAndEmitExternal(message);

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -1000,6 +1000,9 @@ export class BeaconManager extends EventEmitter {
       if (session) {
         session.processing = false;
       }
+      // エラー / 中断パスでも pending external messages が滞留しないよう
+      // 必ず flush。assistant 応答が無くても外部メッセージはユーザに届ける。
+      this.flushPendingExternalMessages();
     }
   }
 
@@ -1028,21 +1031,32 @@ export class BeaconManager extends EventEmitter {
     };
     // LLM が応答 streaming 中の場合、assistantMessage の timestamp は turn
     // 完了時に設定されるため、ここで先に DB 保存すると履歴順序が逆転する。
-    // pending queue に入れて turn 完了後に flush する。
+    // pending queue に入れて turn 完了後に flush する。emit も遅延させて
+    // live UI と DB reload で順序が一致するようにする。
     if (this.session?.processing) {
       this.pendingExternalMessages.push(message);
     } else {
-      db.addBeaconMessage(message);
-      if (this.session) {
-        this.session.messages.push(message);
-      }
+      this.persistAndEmitExternal(message);
     }
     return message;
   }
 
   /**
+   * 外部メッセージを DB / session.messages へ保存し、
+   * `beacon:external-message` イベントで通知する。
+   */
+  private persistAndEmitExternal(message: ChatMessage): void {
+    db.addBeaconMessage(message);
+    if (this.session) {
+      this.session.messages.push(message);
+    }
+    this.emit("beacon:external-message", message);
+  }
+
+  /**
    * postExternalMessage で待機中の外部メッセージを DB と session.messages に
-   * 反映する。LLM turn 完了時に呼び出す。
+   * 反映し、`beacon:external-message` イベントで配信する。
+   * LLM turn 完了時 / セッション close 時 / エラー時に呼び出す。
    */
   private flushPendingExternalMessages(): void {
     if (this.pendingExternalMessages.length === 0) return;
@@ -1051,10 +1065,7 @@ export class BeaconManager extends EventEmitter {
     for (const message of queued) {
       // 確実に assistantMessage より後の timestamp になるよう更新
       message.timestamp = new Date();
-      db.addBeaconMessage(message);
-      if (this.session) {
-        this.session.messages.push(message);
-      }
+      this.persistAndEmitExternal(message);
     }
   }
 
@@ -1094,6 +1105,10 @@ export class BeaconManager extends EventEmitter {
     if (!this.session) return;
 
     console.log("[BeaconManager] セッション終了");
+
+    // 滞留中の外部メッセージを必ず DB に確定させる
+    // (idle close / clearHistory 経由でも消失しないように)
+    this.flushPendingExternalMessages();
 
     // query()を中断する
     this.session.abortController.abort();

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -322,6 +322,13 @@ export class BeaconManager extends EventEmitter {
   private session: BeaconSession | null = null;
   private idleCheckTimer: ReturnType<typeof setInterval> | null = null;
   private deps: BeaconDeps | null = null;
+  /**
+   * Beacon が assistant 応答を streaming 中に postExternalMessage が呼ばれた場合
+   * のキュー。LLM turn の timestamp は完了時に確定するため、turn 完了前に
+   * 外部メッセージを保存すると DB 上の順序が逆転する。turn 完了後にまとめて
+   * flush する。
+   */
+  private pendingExternalMessages: ChatMessage[] = [];
 
   constructor() {
     super();
@@ -955,6 +962,11 @@ export class BeaconManager extends EventEmitter {
             session.messages.push(assistantMessage);
             db.addBeaconMessage(assistantMessage);
             this.emit("beacon:message", assistantMessage);
+
+            // turn 終了後に pending external メッセージを flush。
+            // ここで保存することで assistantMessage よりも timestamp が後に
+            // なり、次回履歴取得時の順序が「assistant → external」になる。
+            this.flushPendingExternalMessages();
           }
 
           // 完了チャンクを送信
@@ -1014,11 +1026,36 @@ export class BeaconManager extends EventEmitter {
       content,
       timestamp: new Date(),
     };
-    db.addBeaconMessage(message);
-    if (this.session) {
-      this.session.messages.push(message);
+    // LLM が応答 streaming 中の場合、assistantMessage の timestamp は turn
+    // 完了時に設定されるため、ここで先に DB 保存すると履歴順序が逆転する。
+    // pending queue に入れて turn 完了後に flush する。
+    if (this.session?.processing) {
+      this.pendingExternalMessages.push(message);
+    } else {
+      db.addBeaconMessage(message);
+      if (this.session) {
+        this.session.messages.push(message);
+      }
     }
     return message;
+  }
+
+  /**
+   * postExternalMessage で待機中の外部メッセージを DB と session.messages に
+   * 反映する。LLM turn 完了時に呼び出す。
+   */
+  private flushPendingExternalMessages(): void {
+    if (this.pendingExternalMessages.length === 0) return;
+    const queued = this.pendingExternalMessages;
+    this.pendingExternalMessages = [];
+    for (const message of queued) {
+      // 確実に assistantMessage より後の timestamp になるよう更新
+      message.timestamp = new Date();
+      db.addBeaconMessage(message);
+      if (this.session) {
+        this.session.messages.push(message);
+      }
+    }
   }
 
   /**

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -1029,34 +1029,36 @@ export class BeaconManager extends EventEmitter {
       content,
       timestamp: new Date(),
     };
-    // LLM が応答 streaming 中の場合、assistantMessage の timestamp は turn
-    // 完了時に設定されるため、ここで先に DB 保存すると履歴順序が逆転する。
-    // pending queue に入れて turn 完了後に flush する。emit も遅延させて
-    // live UI と DB reload で順序が一致するようにする。
+    // 要求元クライアントに即座に結果を表示するため、live emit は常に行う。
+    // (Beacon turn streaming 中でもユーザに「結果が来た」ことを伝える)
+    this.emit("beacon:external-message", message);
+
     if (this.session?.processing) {
+      // LLM が応答 streaming 中の場合、assistantMessage の DB 永続化は
+      // turn 完了時に行われる。ここで即座に DB 保存すると次回履歴ロード時に
+      // 「assistant より前に external が出る」順序逆転が起きる。
+      // pending queue に入れて、turn 完了後に timestamp を更新して保存する。
       this.pendingExternalMessages.push(message);
     } else {
-      this.persistAndEmitExternal(message);
+      this.persistExternal(message);
     }
     return message;
   }
 
   /**
-   * 外部メッセージを DB / session.messages へ保存し、
-   * `beacon:external-message` イベントで通知する。
+   * 外部メッセージを DB / session.messages に保存する (live emit はしない)。
    */
-  private persistAndEmitExternal(message: ChatMessage): void {
+  private persistExternal(message: ChatMessage): void {
     db.addBeaconMessage(message);
     if (this.session) {
       this.session.messages.push(message);
     }
-    this.emit("beacon:external-message", message);
   }
 
   /**
    * postExternalMessage で待機中の外部メッセージを DB と session.messages に
-   * 反映し、`beacon:external-message` イベントで配信する。
-   * LLM turn 完了時 / セッション close 時 / エラー時に呼び出す。
+   * 反映する。LLM turn 完了時 / セッション close 時 / エラー時に呼び出す。
+   * live emit は postExternalMessage 時点で既に行っているため再emitしない。
    */
   private flushPendingExternalMessages(): void {
     if (this.pendingExternalMessages.length === 0) return;
@@ -1065,7 +1067,7 @@ export class BeaconManager extends EventEmitter {
     for (const message of queued) {
       // 確実に assistantMessage より後の timestamp になるよう更新
       message.timestamp = new Date();
-      this.persistAndEmitExternal(message);
+      this.persistExternal(message);
     }
   }
 

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -992,6 +992,36 @@ export class BeaconManager extends EventEmitter {
   }
 
   /**
+   * 外部システム（Usage取得など）からassistantメッセージを投稿する。
+   *
+   * 用途: LLM経由ではなく、Arkの内部処理結果（例: 全プロファイル使用量サマリ）を
+   * Beaconの履歴UIに表示するためのバイパスAPI。
+   *
+   * 注意1: このメソッドで投稿したメッセージは LLMコンテキストには注入されない。
+   * BeaconManagerは履歴UIをDBから読み出すので、このメッセージは履歴画面には残るが、
+   * 次回のBeacon会話で参照されることはない（履歴をリセットして新規セッションを
+   * 開始する設計のため）。
+   *
+   * 注意2: `beacon:message` イベントは emit しない。BeaconManagerの通常emitは
+   * activeBeaconSocket にしか転送されないため、Usage取得時のように Beacon未利用
+   * 状態でも全クライアントに届けたい用途では呼び出し側が io.emit で broadcast
+   * する責務を持つ。返り値の ChatMessage を使って呼び出し側で配信すること。
+   */
+  postExternalMessage(content: string): ChatMessage {
+    const message: ChatMessage = {
+      id: randomUUID(),
+      role: "assistant",
+      content,
+      timestamp: new Date(),
+    };
+    db.addBeaconMessage(message);
+    if (this.session) {
+      this.session.messages.push(message);
+    }
+    return message;
+  }
+
+  /**
    * チャット履歴を取得する
    *
    * セッション未開始時はDBから直接ロードする（サーバー再起動・アイドルタイムアウト後も履歴を保持するため）

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -983,12 +983,12 @@ export class BeaconManager extends EventEmitter {
             session.messages.push(assistantMessage);
             db.addBeaconMessage(assistantMessage);
             this.emit("beacon:message", assistantMessage);
-
-            // turn 終了後に pending external メッセージを flush。
-            // ここで保存することで assistantMessage よりも timestamp が後に
-            // なり、次回履歴取得時の順序が「assistant → external」になる。
-            this.flushPendingExternalMessages();
           }
+
+          // turn 終了後に pending external メッセージを flush。
+          // assistant text の有無に関わらず flush することで、tool-only turn
+          // (text無し) でも queue 滞留を解消する。
+          this.flushPendingExternalMessages();
 
           // 完了チャンクを送信
           const doneChunk: BeaconStreamChunk = {

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -294,10 +294,14 @@ interface BeaconSession {
    */
   processing: boolean;
   /**
-   * ユーザメッセージ送信後、assistant の `result` が来るまで true。
-   * postExternalMessage はこのフラグを見て LLM streaming 中か判定する。
+   * 進行中の turn 数 (queue+streaming中の合計)。
+   * sendMessage で +1、processOutput の result message ごとに -1。
+   * 多数 turn が queue されているケース (multi-client) でも、count > 0 の
+   * 間は postExternalMessage を defer する必要がある。boolean では
+   * 1回目の result で false になってしまい、後続 turn 中の usage 投稿が
+   * 即時 emit/persist されて順序崩壊するため counter を使う。
    */
-  activeTurn: boolean;
+  activeTurnCount: number;
   /** AbortController（セッション終了時にquery()を中断するため） */
   abortController: AbortController;
 }
@@ -835,7 +839,7 @@ export class BeaconManager extends EventEmitter {
       messages,
       lastActivity: new Date(),
       processing: false,
-      activeTurn: false,
+      activeTurnCount: 0,
       abortController,
     };
 
@@ -875,9 +879,10 @@ export class BeaconManager extends EventEmitter {
     // キューにメッセージをpush（query()のAsyncIterableに供給される）
     session.queue.push(message);
 
-    // この turn が完了 (result message 受信) するまで activeTurn=true。
-    // postExternalMessage はこれを見て LLM streaming 中なら queue する。
-    session.activeTurn = true;
+    // この turn が完了 (result message 受信) するまで activeTurnCount を
+    // 増やす。multi-client で複数 turn が queue されると count が積まれ、
+    // 全 turn の result が揃って 0 に戻るまで postExternalMessage は defer。
+    session.activeTurnCount += 1;
 
     // 出力の処理を開始
     await this.processOutput();
@@ -997,10 +1002,12 @@ export class BeaconManager extends EventEmitter {
           };
           this.emit("beacon:stream", doneChunk);
 
-          // turn 完了 → activeTurn=false。次の sendMessage で再び true になる。
-          // (この期間中に postExternalMessage が来たら即時に persistAndEmit する)
+          // turn 完了 → activeTurnCount を 1 減らす。multi-client で複数
+          // turn が queue されている場合、最後の result が来るまで count > 0
+          // のままなので、後続 turn 中の postExternalMessage は引き続き
+          // pending queue に入る (順序保護)。
           if (this.session === session) {
-            session.activeTurn = false;
+            session.activeTurnCount = Math.max(0, session.activeTurnCount - 1);
           }
 
           // このターンの処理完了。ループを継続して次のターンの出力を待つ
@@ -1026,11 +1033,11 @@ export class BeaconManager extends EventEmitter {
     } finally {
       if (session) {
         session.processing = false;
-        // activeTurn は通常 result message 受信時に false になるが、
+        // activeTurnCount は通常 result message 受信時に decrement するが、
         // query() throw / abort / iterator 終了などでそこへ到達できない
-        // ケースもある。finally で必ず false に戻し、後続 postExternalMessage
+        // ケースもある。finally で必ず 0 に戻し、後続 postExternalMessage
         // が「streaming中」と誤判定して queue 滞留しないようにする。
-        session.activeTurn = false;
+        session.activeTurnCount = 0;
       }
       // エラー / 中断パスでも pending external messages が滞留しないよう
       // 必ず flush。assistant 応答が無くても外部メッセージはユーザに届ける。
@@ -1089,13 +1096,14 @@ export class BeaconManager extends EventEmitter {
       content,
       timestamp: new Date(),
     };
-    if (this.session?.activeTurn) {
-      // LLM が応答 streaming 中 (= activeTurn) の場合、live emit と DB
-      // 永続化を両方 defer する。即時 live emit すると「live UI: external
+    if (this.session && this.session.activeTurnCount > 0) {
+      // LLM が応答 streaming 中 (= activeTurnCount > 0) の場合、live emit と
+      // DB 永続化を両方 defer する。即時 live emit すると「live UI: external
       // →assistant」「DB reload: assistant→external」と順序が食い違うため、
       // turn 完了後にまとめて行う。
       // ※ session.processing は session 生存期間中ずっと true のため判定に
-      //   使えない。activeTurn が「現在 LLM が応答中か」の正確なシグナル。
+      //   使えない。activeTurnCount が「現在進行中の turn 数」の正確な
+      //   シグナル (multi-client で複数 turn が queue されていても安全)。
       this.pendingExternalMessages.push(message);
     } else {
       this.persistAndEmitExternal(message);

--- a/server/lib/beacon-manager.ts
+++ b/server/lib/beacon-manager.ts
@@ -329,6 +329,12 @@ export class BeaconManager extends EventEmitter {
    * flush する。
    */
   private pendingExternalMessages: ChatMessage[] = [];
+  /**
+   * 履歴の世代カウンタ。clearHistory で +1 する。
+   * /usage のような長時間バックグラウンド処理が、終了時点で
+   * 履歴がクリア済みかを判定するために使う (capture → complete 時に比較)。
+   */
+  private historyVersion = 0;
 
   constructor() {
     super();
@@ -1022,7 +1028,35 @@ export class BeaconManager extends EventEmitter {
    * 状態でも全クライアントに届けたい用途では呼び出し側が io.emit で broadcast
    * する責務を持つ。返り値の ChatMessage を使って呼び出し側で配信すること。
    */
-  postExternalMessage(content: string): ChatMessage {
+  /**
+   * 現在の履歴世代を取得する。
+   * /usage のような長時間バックグラウンド処理は開始時にこの値を capture
+   * しておき、完了時に `postExternalMessage(content, expectedVersion)` を
+   * 呼ぶことで、その間に clearHistory された場合の汚染を回避できる。
+   */
+  getHistoryVersion(): number {
+    return this.historyVersion;
+  }
+
+  /**
+   * 外部メッセージを Beacon 履歴に投稿する。
+   * @param expectedVersion 開始時の `getHistoryVersion()` 値。指定時、現在の
+   *   世代と異なれば (= clearHistory 経由で履歴がリセット済み) 何もせず null
+   *   を返す。指定なしなら無条件で投稿する (旧API互換)。
+   */
+  postExternalMessage(
+    content: string,
+    expectedVersion?: number
+  ): ChatMessage | null {
+    if (
+      expectedVersion !== undefined &&
+      expectedVersion !== this.historyVersion
+    ) {
+      console.log(
+        `[BeaconManager] postExternalMessage skipped (history reset during background task: expected v${expectedVersion}, current v${this.historyVersion})`
+      );
+      return null;
+    }
     const message: ChatMessage = {
       id: randomUUID(),
       role: "assistant",
@@ -1088,10 +1122,15 @@ export class BeaconManager extends EventEmitter {
    *
    * サーバー側のセッション（LLMコンテキスト）も閉じてDB履歴もクリアする。
    * 次のメッセージ送信時に新規セッションが開始される。
+   * historyVersion を増やすことで、進行中の /usage 等が完了時に
+   * postExternalMessage で履歴を復活させないようにする。
    */
   clearHistory(): void {
     this.closeSession();
     db.clearBeaconMessages();
+    this.historyVersion += 1;
+    // pending の外部メッセージも捨てる (clearHistory で消したい意図と一致)
+    this.pendingExternalMessages = [];
     console.log("[BeaconManager] 履歴をクリアしました");
   }
 

--- a/server/lib/system.ts
+++ b/server/lib/system.ts
@@ -121,6 +121,10 @@ export function checkClaudeCommandExists(): boolean {
 
 /**
  * `tmux` コマンドが利用可能か。
+ * 1. `which tmux` (PATH チェック)
+ * 2. process.env.PATH を分解して各 dir で確認
+ *    (pm2 等で which が機能しない / login PATH と異なる場合をカバー)
+ * 3. 既知の候補ディレクトリ
  */
 export function checkTmuxCommandExists(): boolean {
   try {
@@ -129,7 +133,20 @@ export function checkTmuxCommandExists(): boolean {
   } catch {
     // fallthrough
   }
-  // 既知の場所も確認
+
+  // process.env.PATH を辿る (which が使えない環境向けの補完)
+  const envPath = process.env.PATH ?? "";
+  for (const dir of envPath.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, "tmux");
+    try {
+      if (existsSync(candidate)) return true;
+    } catch {
+      // ignore
+    }
+  }
+
+  // 既知の候補ディレクトリ
   const candidates = [
     "/usr/bin/tmux",
     "/usr/local/bin/tmux",

--- a/server/lib/system.ts
+++ b/server/lib/system.ts
@@ -248,6 +248,7 @@ export function resolveTmuxPath(): string | null {
   const candidates = [
     "/usr/bin/tmux",
     "/usr/local/bin/tmux",
+    "/bin/tmux",
     "/opt/homebrew/bin/tmux",
     "/home/linuxbrew/.linuxbrew/bin/tmux",
   ];

--- a/server/lib/system.ts
+++ b/server/lib/system.ts
@@ -120,27 +120,36 @@ export function checkClaudeCommandExists(): boolean {
 }
 
 /**
- * `tmux` コマンドが利用可能か。
+ * `tmux` コマンドの絶対パスを解決する。利用不可なら null。
  * 1. `which tmux` (PATH チェック)
  * 2. process.env.PATH を分解して各 dir で確認
  *    (pm2 等で which が機能しない / login PATH と異なる場合をカバー)
  * 3. 既知の候補ディレクトリ
+ *
+ * 子プロセス起動時に絶対パスを使うと、pm2/systemd で PATH に tmux が
+ * 含まれていない環境でも spawnSync が ENOENT にならない。
  */
-export function checkTmuxCommandExists(): boolean {
+export function resolveTmuxPath(): string | null {
   try {
-    const r = spawnSync("which", ["tmux"], { stdio: "pipe" });
-    if (r.status === 0) return true;
+    const r = spawnSync("which", ["tmux"], {
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
+    if (r.status === 0 && r.stdout) {
+      const resolved = r.stdout.trim();
+      if (resolved) return resolved;
+    }
   } catch {
     // fallthrough
   }
 
-  // process.env.PATH を辿る (which が使えない環境向けの補完)
+  // process.env.PATH を辿る
   const envPath = process.env.PATH ?? "";
   for (const dir of envPath.split(path.delimiter)) {
     if (!dir) continue;
     const candidate = path.join(dir, "tmux");
     try {
-      if (existsSync(candidate)) return true;
+      if (existsSync(candidate)) return candidate;
     } catch {
       // ignore
     }
@@ -153,13 +162,19 @@ export function checkTmuxCommandExists(): boolean {
     "/opt/homebrew/bin/tmux",
     "/home/linuxbrew/.linuxbrew/bin/tmux",
   ];
-  return candidates.some(p => {
+  for (const p of candidates) {
     try {
-      return existsSync(p);
+      if (existsSync(p)) return p;
     } catch {
-      return false;
+      // ignore
     }
-  });
+  }
+  return null;
+}
+
+/** `tmux` コマンドが利用可能か。 */
+export function checkTmuxCommandExists(): boolean {
+  return resolveTmuxPath() !== null;
 }
 
 /**

--- a/server/lib/system.ts
+++ b/server/lib/system.ts
@@ -120,10 +120,37 @@ export function checkClaudeCommandExists(): boolean {
 }
 
 /**
+ * `tmux` コマンドが利用可能か。
+ */
+export function checkTmuxCommandExists(): boolean {
+  try {
+    const r = spawnSync("which", ["tmux"], { stdio: "pipe" });
+    if (r.status === 0) return true;
+  } catch {
+    // fallthrough
+  }
+  // 既知の場所も確認
+  const candidates = [
+    "/usr/bin/tmux",
+    "/usr/local/bin/tmux",
+    "/opt/homebrew/bin/tmux",
+    "/home/linuxbrew/.linuxbrew/bin/tmux",
+  ];
+  return candidates.some(p => {
+    try {
+      return existsSync(p);
+    } catch {
+      return false;
+    }
+  });
+}
+
+/**
  * プロファイル切替機能のサポート判定。
- * Linux + claude CLI が両方揃った時のみ true。
+ * Linux + claude CLI + tmux が3つ揃った時のみ true。
+ * (UsageCollector も tmux を必要とするため tmux チェックも含める)
  */
 export function detectMultiProfileSupported(): boolean {
   if (process.platform !== "linux") return false;
-  return checkClaudeCommandExists();
+  return checkClaudeCommandExists() && checkTmuxCommandExists();
 }

--- a/server/lib/system.ts
+++ b/server/lib/system.ts
@@ -42,6 +42,95 @@ function existsInVersionedDirs(baseDir: string, suffix: string): boolean {
 }
 
 /**
+ * `claude` コマンドの絶対パスを解決する。利用不可なら null。
+ * 解決ロジックは checkClaudeCommandExists と同じ順序。tmux send-keys に
+ * 絶対パスで claude を送ることで、pm2/systemd の PATH に claude が無い
+ * 環境でも「command not found」にならないようにする。
+ */
+export function resolveClaudePath(): string | null {
+  try {
+    const r = spawnSync("which", ["claude"], {
+      stdio: "pipe",
+      encoding: "utf-8",
+    });
+    if (r.status === 0 && r.stdout) {
+      const resolved = r.stdout.trim();
+      if (resolved) return resolved;
+    }
+  } catch {
+    // fallthrough
+  }
+
+  const envPath = process.env.PATH ?? "";
+  for (const dir of envPath.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, "claude");
+    try {
+      if (existsSync(candidate)) return candidate;
+    } catch {
+      // ignore
+    }
+  }
+
+  const home = os.homedir();
+  const candidates = [
+    path.join(home, ".local/bin/claude"),
+    path.join(home, ".local/share/mise/shims/claude"),
+    path.join(home, ".npm-global/bin/claude"),
+    path.join(home, ".volta/bin/claude"),
+    "/usr/local/bin/claude",
+    "/usr/bin/claude",
+    "/usr/sbin/claude",
+    "/opt/claude/bin/claude",
+    "/home/linuxbrew/.linuxbrew/bin/claude",
+  ];
+  for (const p of candidates) {
+    try {
+      if (existsSync(p)) return p;
+    } catch {
+      // ignore
+    }
+  }
+
+  // nvm / fnm: 各 version 配下を走査
+  const nvm = scanVersionedDir(
+    path.join(home, ".nvm/versions/node"),
+    "bin/claude"
+  );
+  if (nvm) return nvm;
+  const fnmShare = scanVersionedDir(
+    path.join(home, ".local/share/fnm/node-versions"),
+    "installation/bin/claude"
+  );
+  if (fnmShare) return fnmShare;
+  const fnm = scanVersionedDir(
+    path.join(home, ".fnm/node-versions"),
+    "bin/claude"
+  );
+  if (fnm) return fnm;
+
+  return null;
+}
+
+/** versioned dir 配下から最初に見つかった絶対パスを返す */
+function scanVersionedDir(baseDir: string, suffix: string): string | null {
+  try {
+    const entries = readdirSync(baseDir);
+    for (const entry of entries) {
+      const candidate = path.join(baseDir, entry, suffix);
+      try {
+        if (existsSync(candidate)) return candidate;
+      } catch {
+        // ignore
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+/**
  * `claude` コマンドが利用可能か。
  * 1. `which claude` (PATH チェック)
  * 2. process.env.PATH を分解して各 dir で確認

--- a/server/lib/tmux-manager.ts
+++ b/server/lib/tmux-manager.ts
@@ -111,8 +111,19 @@ export class TmuxManager extends EventEmitter {
       for (const name of sessionNames) {
         if (name.startsWith(this.SESSION_PREFIX)) {
           // ark-usage-* は UsageCollector が一時的に作る短命セッション。
-          // 起動時に拾うとttydを起動しようとして競合する。
-          if (name.startsWith("ark-usage-")) continue;
+          // サーバ crash/restart で finally の kill-session が走らずに残った
+          // 場合、claude プロセスごと永遠に残留するため、起動時に kill する。
+          if (name.startsWith("ark-usage-")) {
+            const killResult = spawnSync("tmux", ["kill-session", "-t", name], {
+              stdio: "pipe",
+            });
+            if (killResult.status === 0) {
+              console.log(
+                `[TmuxManager] Cleaned up orphan usage session: ${name}`
+              );
+            }
+            continue;
+          }
           const id = name.replace(this.SESSION_PREFIX, "");
           const cwd = this.getTmuxSessionCwd(name);
 

--- a/server/lib/tmux-manager.ts
+++ b/server/lib/tmux-manager.ts
@@ -5,7 +5,7 @@
  * 各セッションはattach/detach可能で、サーバー再起動後も維持される。
  */
 
-import { execSync, spawnSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { nanoid } from "nanoid";
 import type { SpecialKey } from "../../shared/types.js";
@@ -81,19 +81,23 @@ export class TmuxManager extends EventEmitter {
    */
   private setCopyCommand(): void {
     try {
-      execSync('tmux set-option -s copy-command "pbcopy"', { stdio: "pipe" });
+      spawnSync(
+        TMUX_BINARY_PATH,
+        ["set-option", "-s", "copy-command", "pbcopy"],
+        { stdio: "pipe" }
+      );
     } catch {
       // tmuxサーバーが起動していない場合は設定不要
     }
   }
 
   /**
-   * tmuxがインストールされているか確認
+   * tmuxがインストールされているか確認 (起動時にログ出すだけ)
+   * 実際の解決パスは TMUX_BINARY_PATH (resolveTmuxPath) で取得済み。
    */
   private checkTmuxInstalled(): void {
-    try {
-      execSync("which tmux", { stdio: "pipe" });
-    } catch {
+    if (TMUX_BINARY_PATH === "tmux") {
+      // resolveTmuxPath が解決できなかった (= 多くの環境で見つからない)
       console.error(
         "[TmuxManager] tmux not found. Install it:\n" +
           "  macOS: brew install tmux\n" +
@@ -107,10 +111,13 @@ export class TmuxManager extends EventEmitter {
    */
   private discoverExistingSessions(): void {
     try {
-      const output = execSync('tmux list-sessions -F "#{session_name}"', {
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      const result = spawnSync(
+        TMUX_BINARY_PATH,
+        ["list-sessions", "-F", "#{session_name}"],
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+      );
+      if (result.status !== 0) return;
+      const output = result.stdout ?? "";
       const sessionNames = output.trim().split("\n").filter(Boolean);
 
       for (const name of sessionNames) {
@@ -145,9 +152,11 @@ export class TmuxManager extends EventEmitter {
 
           // マウスモードを有効化（再起動時に設定を再適用）
           try {
-            execSync(`tmux set-option -t "${name}" mouse on`, {
-              stdio: "pipe",
-            });
+            spawnSync(
+              TMUX_BINARY_PATH,
+              ["set-option", "-t", name, "mouse", "on"],
+              { stdio: "pipe" }
+            );
           } catch {
             // セッションが利用不可の場合は無視
           }
@@ -165,10 +174,13 @@ export class TmuxManager extends EventEmitter {
    */
   private getTmuxSessionCwd(sessionName: string): string | null {
     try {
-      return execSync(
-        `tmux display-message -p -t "${sessionName}" "#{pane_current_path}"`,
+      const result = spawnSync(
+        TMUX_BINARY_PATH,
+        ["display-message", "-p", "-t", sessionName, "#{pane_current_path}"],
         { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-      ).trim();
+      );
+      if (result.status !== 0) return null;
+      return (result.stdout ?? "").trim();
     } catch {
       return null;
     }
@@ -259,7 +271,7 @@ export class TmuxManager extends EventEmitter {
     } catch (error) {
       // 作成済みのtmuxセッションをクリーンアップ
       if (tmuxCreated) {
-        spawnSync("tmux", ["kill-session", "-t", tmuxSessionName], {
+        spawnSync(TMUX_BINARY_PATH, ["kill-session", "-t", tmuxSessionName], {
           stdio: "pipe",
         });
       }
@@ -360,14 +372,12 @@ export class TmuxManager extends EventEmitter {
     const session = this.sessions.get(sessionId);
     if (!session) return false;
 
-    try {
-      execSync(`tmux has-session -t "${session.tmuxSessionName}"`, {
-        stdio: "pipe",
-      });
-      return true;
-    } catch {
-      return false;
-    }
+    const result = spawnSync(
+      TMUX_BINARY_PATH,
+      ["has-session", "-t", session.tmuxSessionName],
+      { stdio: "pipe" }
+    );
+    return result.status === 0;
   }
 
   /**
@@ -377,13 +387,13 @@ export class TmuxManager extends EventEmitter {
     const session = this.sessions.get(sessionId);
     if (!session) return;
 
-    try {
-      execSync(`tmux kill-session -t "${session.tmuxSessionName}"`, {
-        stdio: "pipe",
-      });
+    const result = spawnSync(
+      TMUX_BINARY_PATH,
+      ["kill-session", "-t", session.tmuxSessionName],
+      { stdio: "pipe" }
+    );
+    if (result.status === 0) {
       console.log(`[TmuxManager] Killed session: ${session.tmuxSessionName}`);
-    } catch {
-      // セッションが既に終了している場合
     }
 
     session.status = "stopped";
@@ -397,14 +407,12 @@ export class TmuxManager extends EventEmitter {
   getBuffer(sessionId: string): string | null {
     const session = this.sessions.get(sessionId);
     if (!session) return null;
-    try {
-      return execSync(`tmux show-buffer`, {
-        encoding: "utf-8",
-        stdio: ["pipe", "pipe", "pipe"],
-      }).trimEnd();
-    } catch {
-      return null;
-    }
+    const result = spawnSync(TMUX_BINARY_PATH, ["show-buffer"], {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    if (result.status !== 0) return null;
+    return (result.stdout ?? "").trimEnd();
   }
 
   /**

--- a/server/lib/tmux-manager.ts
+++ b/server/lib/tmux-manager.ts
@@ -221,7 +221,7 @@ export class TmuxManager extends EventEmitter {
       // CLAUDECODE を空にしてネストされたセッション検出を回避
       // CLAUDE_CODE_NO_FLICKER=1 でttydフリッカー抑制
       const newSessionResult = spawnSync(
-        "tmux",
+        TMUX_BINARY_PATH,
         [
           "new-session",
           "-d",
@@ -246,7 +246,7 @@ export class TmuxManager extends EventEmitter {
 
       // マウスモードを有効化
       const setOptionResult = spawnSync(
-        "tmux",
+        TMUX_BINARY_PATH,
         ["set-option", "-t", tmuxSessionName, "mouse", "on"],
         { stdio: "pipe" }
       );
@@ -259,7 +259,7 @@ export class TmuxManager extends EventEmitter {
       // claudeコマンド（または options.commandLine）を送信
       // 終了後もシェルが残るのでvimなども使える
       const sendKeysResult = spawnSync(
-        "tmux",
+        TMUX_BINARY_PATH,
         ["send-keys", "-t", tmuxSessionName, claudeCmd, "Enter"],
         { stdio: "pipe" }
       );
@@ -309,7 +309,7 @@ export class TmuxManager extends EventEmitter {
 
     // send-keys -l でリテラル送信（spawnSyncなのでシェルエスケープ不要）
     const literalResult = spawnSync(
-      "tmux",
+      TMUX_BINARY_PATH,
       ["send-keys", "-t", session.tmuxSessionName, "-l", input],
       { stdio: "pipe" }
     );
@@ -321,7 +321,7 @@ export class TmuxManager extends EventEmitter {
 
     // Enterキーを別途送信
     const enterResult = spawnSync(
-      "tmux",
+      TMUX_BINARY_PATH,
       ["send-keys", "-t", session.tmuxSessionName, "Enter"],
       { stdio: "pipe" }
     );
@@ -354,7 +354,7 @@ export class TmuxManager extends EventEmitter {
     };
     const tmuxKey = keyMap[key] ?? key;
     const result = spawnSync(
-      "tmux",
+      TMUX_BINARY_PATH,
       ["send-keys", "-t", session.tmuxSessionName, tmuxKey],
       { stdio: "pipe" }
     );
@@ -426,7 +426,7 @@ export class TmuxManager extends EventEmitter {
     try {
       // -p: stdoutに出力、-S: 開始行（負数で過去の行）
       const result = spawnSync(
-        "tmux",
+        TMUX_BINARY_PATH,
         [
           "capture-pane",
           "-t",

--- a/server/lib/tmux-manager.ts
+++ b/server/lib/tmux-manager.ts
@@ -9,6 +9,11 @@ import { execSync, spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { nanoid } from "nanoid";
 import type { SpecialKey } from "../../shared/types.js";
+import { resolveTmuxPath } from "./system.js";
+
+// tmux 絶対パス (pm2/systemd で PATH に tmux が無くても動作させるため)。
+// 解決不能なら "tmux" にフォールバック (PATH依存)。
+const TMUX_BINARY_PATH = resolveTmuxPath() ?? "tmux";
 
 /** 送信を許可する特殊キーのホワイトリスト */
 const ALLOWED_SPECIAL_KEYS = new Set<SpecialKey>([
@@ -114,9 +119,11 @@ export class TmuxManager extends EventEmitter {
           // サーバ crash/restart で finally の kill-session が走らずに残った
           // 場合、claude プロセスごと永遠に残留するため、起動時に kill する。
           if (name.startsWith("ark-usage-")) {
-            const killResult = spawnSync("tmux", ["kill-session", "-t", name], {
-              stdio: "pipe",
-            });
+            const killResult = spawnSync(
+              TMUX_BINARY_PATH,
+              ["kill-session", "-t", name],
+              { stdio: "pipe" }
+            );
             if (killResult.status === 0) {
               console.log(
                 `[TmuxManager] Cleaned up orphan usage session: ${name}`

--- a/server/lib/tmux-manager.ts
+++ b/server/lib/tmux-manager.ts
@@ -110,6 +110,9 @@ export class TmuxManager extends EventEmitter {
 
       for (const name of sessionNames) {
         if (name.startsWith(this.SESSION_PREFIX)) {
+          // ark-usage-* は UsageCollector が一時的に作る短命セッション。
+          // 起動時に拾うとttydを起動しようとして競合する。
+          if (name.startsWith("ark-usage-")) continue;
           const id = name.replace(this.SESSION_PREFIX, "");
           const cwd = this.getTmuxSessionCwd(name);
 

--- a/server/lib/usage-collector.test.ts
+++ b/server/lib/usage-collector.test.ts
@@ -403,6 +403,7 @@ describe("UsageCollector.collectOne", () => {
           return {
             status: 0,
             stdout: "Quick safety check: Is this a project you trust?",
+            stderr: "",
           };
         if (captureCount === 3)
           return { status: 0, stdout: "? for shortcuts", stderr: "" };

--- a/server/lib/usage-collector.test.ts
+++ b/server/lib/usage-collector.test.ts
@@ -563,9 +563,13 @@ describe("UsageCollector.collect", () => {
 
     await collector.collect([profileA, profileB]);
 
+    // 各プロファイルで「開始時 (completed=i)」と「完了時 (completed=i+1)」の
+    // 2回 progress を emit する。最後に completed=total が必ず届く
     expect(progressEvents).toEqual([
       { name: "personal", completed: 0 },
+      { name: "personal", completed: 1 },
       { name: "work", completed: 1 },
+      { name: "work", completed: 2 },
     ]);
   });
 });

--- a/server/lib/usage-collector.test.ts
+++ b/server/lib/usage-collector.test.ts
@@ -563,13 +563,12 @@ describe("UsageCollector.collect", () => {
 
     await collector.collect([profileA, profileB]);
 
-    // 各プロファイルで「開始時 (completed=i)」と「完了時 (completed=i+1)」の
-    // 2回 progress を emit する。最後に completed=total が必ず届く
+    // 各プロファイルで「開始時 (completed=i)」のみ emit。
+    // 「completed=total」の完了通知は usage:complete に集約 (UI の先取り
+    // 表示問題を避けるため AFTER emit は廃止)。
     expect(progressEvents).toEqual([
       { name: "personal", completed: 0 },
-      { name: "personal", completed: 1 },
       { name: "work", completed: 1 },
-      { name: "work", completed: 2 },
     ]);
   });
 });

--- a/server/lib/usage-collector.test.ts
+++ b/server/lib/usage-collector.test.ts
@@ -1,0 +1,571 @@
+/**
+ * UsageCollector ユニットテスト
+ *
+ * tmuxコマンドの実行は `UsageCollectorDeps.tmuxExec` をモックして検証する。
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { Profile } from "../../shared/types.js";
+import {
+  hasUsageResult,
+  isOnboardingScreen,
+  isReadyScreen,
+  isTrustDialog,
+  parseUsage,
+  UsageCollector,
+} from "./usage-collector.js";
+
+// ---------------------------------------------------------------------------
+// 実機調査済みサンプル（2026-04-27 取得・Maxプラン認証済み）
+// ---------------------------------------------------------------------------
+
+const REAL_USAGE_OUTPUT = `    Status   Config   Usage   Stats
+
+   Session
+   Total cost:            $0.0000
+   Total duration (API):  0s
+   Total duration (wall): 7s
+   Total code changes:    0 lines added, 0 lines removed
+   Usage:                 0 input, 0 output, 0 cache read, 0 cache write
+
+   Current session
+   ██                                                 4% used
+   Resets 8:20pm (Asia/Tokyo)
+
+   Current week (all models)
+   ███████████████▌                                   31% used
+   Resets 3am (Asia/Tokyo)
+
+   Current week (Sonnet only)
+                                                      0% used
+   Resets 3am (Asia/Tokyo)
+`;
+
+const ONBOARDING_OUTPUT = `Welcome to Claude Code
+
+  Let's get started
+
+  Choose the text style that looks best with your terminal:
+`;
+
+const ANSI_USAGE_OUTPUT = `\x1b[2J\x1b[H\x1b[1m   Current session\x1b[0m
+   \x1b[36m██\x1b[0m                                                 4% used
+   Resets 8:20pm (Asia/Tokyo)
+
+   \x1b[1mCurrent week (all models)\x1b[0m
+   \x1b[33m███\x1b[0m                                                31% used
+   Resets 3am (Asia/Tokyo)
+
+   \x1b[1mCurrent week (Sonnet only)\x1b[0m
+                                                      0% used
+   Resets 3am (Asia/Tokyo)
+`;
+
+// ---------------------------------------------------------------------------
+// パーサのテスト
+// ---------------------------------------------------------------------------
+
+describe("parseUsage", () => {
+  it("実機サンプル（Maxプラン）から3つのセクションを抽出する", () => {
+    const parsed = parseUsage(REAL_USAGE_OUTPUT);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.sessionPercent).toBe(4);
+    expect(parsed?.weeklyAllPercent).toBe(31);
+    expect(parsed?.weeklySonnetPercent).toBe(0);
+    expect(parsed?.sessionResets).toBe("8:20pm (Asia/Tokyo)");
+    expect(parsed?.weeklyAllResets).toBe("3am (Asia/Tokyo)");
+    expect(parsed?.weeklySonnetResets).toBe("3am (Asia/Tokyo)");
+  });
+
+  it("totalCost / wallDuration を抽出する", () => {
+    const parsed = parseUsage(REAL_USAGE_OUTPUT);
+    expect(parsed?.totalCost).toBe("$0.0000");
+    expect(parsed?.wallDuration).toBe("7s");
+  });
+
+  it("ANSIエスケープ混入版もパースできる", () => {
+    const parsed = parseUsage(ANSI_USAGE_OUTPUT);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.sessionPercent).toBe(4);
+    expect(parsed?.weeklyAllPercent).toBe(31);
+    expect(parsed?.weeklySonnetPercent).toBe(0);
+  });
+
+  it("セクション欠落時は null を返す", () => {
+    const incomplete = `Current session
+    4% used
+    Resets 8:20pm (Asia/Tokyo)
+`;
+    expect(parseUsage(incomplete)).toBeNull();
+  });
+
+  it("オンボーディング画面では null を返す", () => {
+    expect(parseUsage(ONBOARDING_OUTPUT)).toBeNull();
+  });
+
+  it("Team プラン (Sonnet 0% で Resets行欠落) も Sonnet resets を空文字でパース成功", () => {
+    const teamPlanOutput = `    Status   Config   Usage   Stats
+
+   Session
+   Total cost:            $0.0000
+   Total duration (wall): 8s
+   Usage:                 0 input, 0 output, 0 cache read, 0 cache write
+
+   Current session
+   ██████████████████████████████████████▌            77% used
+   Resets 8:40pm (Asia/Tokyo)
+
+   Current week (all models)
+   ███████                                            14% used
+   Resets May 4, 1pm (Asia/Tokyo)
+
+   Current week (Sonnet only)
+                                                      0% used
+
+`;
+    const parsed = parseUsage(teamPlanOutput);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.sessionPercent).toBe(77);
+    expect(parsed?.weeklyAllPercent).toBe(14);
+    expect(parsed?.weeklySonnetPercent).toBe(0);
+    expect(parsed?.sessionResets).toBe("8:40pm (Asia/Tokyo)");
+    expect(parsed?.weeklyAllResets).toBe("May 4, 1pm (Asia/Tokyo)");
+    expect(parsed?.weeklySonnetResets).toBe("");
+  });
+});
+
+describe("isOnboardingScreen", () => {
+  it("Welcome to Claude Code を含む場合 true", () => {
+    expect(isOnboardingScreen(ONBOARDING_OUTPUT)).toBe(true);
+  });
+
+  it("通常の/usage出力では false", () => {
+    expect(isOnboardingScreen(REAL_USAGE_OUTPUT)).toBe(false);
+  });
+
+  it("Choose the text style 単独でも検出する", () => {
+    expect(isOnboardingScreen("Choose the text style that looks best")).toBe(
+      true
+    );
+  });
+});
+
+describe("isReadyScreen", () => {
+  it("? for shortcuts のヘルプ表記で true", () => {
+    expect(isReadyScreen("? for shortcuts")).toBe(true);
+  });
+
+  it("プロンプト記号 ❯ 単独では false (trust dialog の誤検出を避けるため)", () => {
+    expect(isReadyScreen("❯ ")).toBe(false);
+    // trust dialog のサンプル
+    expect(isReadyScreen("❯ 1. Yes, I trust this folder")).toBe(false);
+  });
+
+  it("起動中の空画面では false", () => {
+    expect(isReadyScreen("")).toBe(false);
+  });
+});
+
+describe("isTrustDialog", () => {
+  it("trust this folder のテキストで true", () => {
+    expect(
+      isTrustDialog(
+        "Quick safety check: Is this a project you created or one you trust?"
+      )
+    ).toBe(true);
+    expect(isTrustDialog("Yes, I trust this folder")).toBe(true);
+  });
+
+  it("通常画面では false", () => {
+    expect(isTrustDialog(REAL_USAGE_OUTPUT)).toBe(false);
+    expect(isTrustDialog("? for shortcuts")).toBe(false);
+  });
+});
+
+describe("hasUsageResult", () => {
+  it("'% used' 3つ + Resets 3つ + Sonnet only 見出し → true", () => {
+    expect(hasUsageResult(REAL_USAGE_OUTPUT)).toBe(true);
+  });
+
+  it("'% used' が2回以下なら false", () => {
+    const partial = "Current session\n4% used\nResets later\n";
+    expect(hasUsageResult(partial)).toBe(false);
+  });
+
+  it("Team プラン Sonnet 0% (Resets行欠落) でも true", () => {
+    const teamPlanOutput = `Current session
+77% used
+Resets 8:40pm (Asia/Tokyo)
+
+Current week (all models)
+14% used
+Resets May 4, 1pm (Asia/Tokyo)
+
+Current week (Sonnet only)
+0% used
+`;
+    expect(hasUsageResult(teamPlanOutput)).toBe(true);
+  });
+
+  it("Sonnet only 見出しがない描画途中の画面では false", () => {
+    const midRender = `Current session
+4% used
+Resets 8:00pm
+Current week (all models)
+31% used
+Resets 3am
+`;
+    expect(hasUsageResult(midRender)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// UsageCollector のテスト
+// ---------------------------------------------------------------------------
+
+interface FakeTmuxState {
+  sessions: Map<string, string>;
+  killCount: number;
+}
+
+/**
+ * tmuxの状態を模倣するfake。
+ * `scenario` で各セッションが返す出力を制御する。
+ */
+function createFakeTmux(scenario: {
+  /** セッションごとに返す capture-pane 出力（複数回呼ばれることがある） */
+  outputs: Map<string, string[]>;
+  /** new-session を失敗させる場合 true */
+  failNewSession?: boolean;
+}): {
+  tmuxExec: (args: string[]) => {
+    status: number;
+    stdout: string;
+    stderr: string;
+  };
+  state: FakeTmuxState;
+} {
+  const state: FakeTmuxState = {
+    sessions: new Map(),
+    killCount: 0,
+  };
+  const callCounts: Map<string, number> = new Map();
+
+  const tmuxExec = (
+    args: string[]
+  ): { status: number; stdout: string; stderr: string } => {
+    const subcmd = args[0];
+    if (subcmd === "new-session") {
+      if (scenario.failNewSession) return { status: 1, stdout: "", stderr: "" };
+      // -s <name> を取り出す
+      const sIdx = args.indexOf("-s");
+      const name = args[sIdx + 1];
+      state.sessions.set(name, name);
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    if (subcmd === "send-keys") {
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    if (subcmd === "capture-pane") {
+      const tIdx = args.indexOf("-t");
+      const name = args[tIdx + 1];
+      const outputs = scenario.outputs.get(name) ?? [""];
+      const count = callCounts.get(name) ?? 0;
+      const stdout = outputs[Math.min(count, outputs.length - 1)];
+      callCounts.set(name, count + 1);
+      return { status: 0, stdout, stderr: "" };
+    }
+    if (subcmd === "kill-session") {
+      const tIdx = args.indexOf("-t");
+      const name = args[tIdx + 1];
+      state.sessions.delete(name);
+      state.killCount += 1;
+      return { status: 0, stdout: "", stderr: "" };
+    }
+    return { status: 1, stdout: "", stderr: "" };
+  };
+
+  return { tmuxExec, state };
+}
+
+const profileA: Profile = {
+  id: "profA",
+  name: "personal",
+  configDir: "/home/user/.claude-personal",
+  createdAt: 1,
+  updatedAt: 1,
+};
+const profileB: Profile = {
+  id: "profB",
+  name: "work",
+  configDir: "/home/user/.claude-work",
+  createdAt: 2,
+  updatedAt: 2,
+};
+
+describe("UsageCollector.collectOne", () => {
+  let nowValue: number;
+  beforeEach(() => {
+    nowValue = 1000;
+  });
+
+  it("認証済みプロファイルから ok を返す", async () => {
+    const sessionPattern = "ark-usage-profA-1000";
+    const { tmuxExec, state } = createFakeTmux({
+      outputs: new Map([
+        [
+          sessionPattern,
+          [
+            "", // 起動中
+            "❯ for shortcuts", // ready
+            REAL_USAGE_OUTPUT, // /usage 結果
+          ],
+        ],
+      ]),
+    });
+
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {
+        nowValue += 200;
+      },
+    });
+
+    const entry = await collector.collectOne(profileA);
+
+    expect(entry.status).toBe("ok");
+    expect(entry.profileId).toBe("profA");
+    expect(entry.parsed?.sessionPercent).toBe(4);
+    expect(entry.parsed?.weeklyAllPercent).toBe(31);
+    // セッションがkillされている
+    expect(state.killCount).toBe(1);
+    expect(state.sessions.size).toBe(0);
+  });
+
+  it("オンボーディング画面なら unauthenticated を返す", async () => {
+    const sessionName = "ark-usage-profA-1000";
+    const { tmuxExec, state } = createFakeTmux({
+      outputs: new Map([[sessionName, ["", ONBOARDING_OUTPUT]]]),
+    });
+
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {
+        nowValue += 200;
+      },
+    });
+
+    const entry = await collector.collectOne(profileA);
+    expect(entry.status).toBe("unauthenticated");
+    expect(state.killCount).toBe(1);
+  });
+
+  it("readyにならない場合 timeout", async () => {
+    const sessionName = "ark-usage-profA-1000";
+    const { tmuxExec, state } = createFakeTmux({
+      outputs: new Map([[sessionName, [""]]]),
+    });
+
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {
+        nowValue += 500;
+      },
+    });
+
+    const entry = await collector.collectOne(profileA);
+    expect(entry.status).toBe("timeout");
+    expect(state.killCount).toBe(1);
+  });
+
+  it("trust dialog が出たら自動承諾し、最終的にokになる", async () => {
+    const sentKeys: string[][] = [];
+    let captureCount = 0;
+
+    const tmuxExec = (
+      args: string[]
+    ): { status: number; stdout: string; stderr: string } => {
+      const subcmd = args[0];
+      if (subcmd === "new-session")
+        return { status: 0, stdout: "", stderr: "" };
+      if (subcmd === "send-keys") {
+        sentKeys.push(args);
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (subcmd === "capture-pane") {
+        captureCount += 1;
+        // 1回目: 起動中, 2回目: trust dialog, 3回目以降: ready
+        if (captureCount === 1) return { status: 0, stdout: "", stderr: "" };
+        if (captureCount === 2)
+          return {
+            status: 0,
+            stdout: "Quick safety check: Is this a project you trust?",
+          };
+        if (captureCount === 3)
+          return { status: 0, stdout: "? for shortcuts", stderr: "" };
+        return { status: 0, stdout: REAL_USAGE_OUTPUT, stderr: "" };
+      }
+      if (subcmd === "kill-session")
+        return { status: 0, stdout: "", stderr: "" };
+      return { status: 1, stdout: "", stderr: "" };
+    };
+
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {
+        nowValue += 200;
+      },
+    });
+
+    const entry = await collector.collectOne(profileA);
+    expect(entry.status).toBe("ok");
+    // trust dialog で 1 + Enter が送られていること
+    const trustAccept = sentKeys.find(
+      args => args.includes("1") && args.includes("Enter")
+    );
+    expect(trustAccept).toBeDefined();
+    expect(trustAccept?.[3]).toBe("1");
+    // 同じ trust dialog 検出で連打しないこと（trustAcceptは1回のみ）
+    const trustAccepts = sentKeys.filter(
+      args => args[3] === "1" && args.includes("Enter")
+    );
+    expect(trustAccepts).toHaveLength(1);
+  });
+
+  it("new-session失敗時は error", async () => {
+    const { tmuxExec, state } = createFakeTmux({
+      outputs: new Map(),
+      failNewSession: true,
+    });
+
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {
+        nowValue += 200;
+      },
+    });
+
+    const entry = await collector.collectOne(profileA);
+    expect(entry.status).toBe("error");
+    // new-sessionが失敗してもkillSessionはfinallyで呼ばれる
+    expect(state.killCount).toBe(1);
+  });
+});
+
+describe("UsageCollector.collect", () => {
+  let nowValue: number;
+  beforeEach(() => {
+    nowValue = 1000;
+  });
+
+  it("空配列なら空のreport", async () => {
+    const { tmuxExec } = createFakeTmux({ outputs: new Map() });
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {},
+    });
+
+    const report = await collector.collect([]);
+    expect(report.entries).toEqual([]);
+    expect(report.collectedAt).toBe(nowValue);
+  });
+
+  it("1件目がtimeoutでも2件目を実行する（直列実行・継続）", async () => {
+    const sessionA = "ark-usage-profA-1000";
+    // 2件目のセッション名は1件目処理中にnowが進むので動的に決まる
+    // テストでは sleep で 500ms 進むので、1件目のreadyタイムアウト = 5000ms
+    // 起動～timeout処理～killまでの過程でnowが進む
+    const outputs = new Map<string, string[]>();
+    outputs.set(sessionA, [""]); // 全部空 → timeout
+    // 2件目: 仮にnowが xxx になっていても、必ず最終的にOK出力を返すように
+    // ワイルドカードで全セッションに同じ出力を返す方式に変更
+    const callCounts: Map<string, number> = new Map();
+    let killCount = 0;
+    const sessions: Set<string> = new Set();
+
+    const tmuxExec = (
+      args: string[]
+    ): { status: number; stdout: string; stderr: string } => {
+      const subcmd = args[0];
+      if (subcmd === "new-session") {
+        const sIdx = args.indexOf("-s");
+        const name = args[sIdx + 1];
+        sessions.add(name);
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      if (subcmd === "send-keys") return { status: 0, stdout: "", stderr: "" };
+      if (subcmd === "capture-pane") {
+        const tIdx = args.indexOf("-t");
+        const name = args[tIdx + 1];
+        const count = callCounts.get(name) ?? 0;
+        callCounts.set(name, count + 1);
+        // profA のセッション名は固定で空応答
+        if (name.startsWith("ark-usage-profA-")) {
+          return { status: 0, stdout: "", stderr: "" };
+        }
+        // profB は ready → /usage結果 の順
+        if (count === 0) return { status: 0, stdout: "", stderr: "" };
+        if (count === 1)
+          return { status: 0, stdout: "❯ for shortcuts", stderr: "" };
+        return { status: 0, stdout: REAL_USAGE_OUTPUT, stderr: "" };
+      }
+      if (subcmd === "kill-session") {
+        const tIdx = args.indexOf("-t");
+        sessions.delete(args[tIdx + 1]);
+        killCount += 1;
+        return { status: 0, stdout: "", stderr: "" };
+      }
+      return { status: 1, stdout: "", stderr: "" };
+    };
+
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {
+        nowValue += 500;
+      },
+    });
+
+    const report = await collector.collect([profileA, profileB]);
+    expect(report.entries).toHaveLength(2);
+    expect(report.entries[0].status).toBe("timeout");
+    expect(report.entries[1].status).toBe("ok");
+    // 両方killされている
+    expect(killCount).toBe(2);
+    expect(sessions.size).toBe(0);
+  });
+
+  it("usage:progress イベントを各プロファイルで発火する", async () => {
+    const { tmuxExec } = createFakeTmux({
+      outputs: new Map([["dummy", ["❯ for shortcuts", REAL_USAGE_OUTPUT]]]),
+    });
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {
+        nowValue += 500;
+      },
+    });
+
+    const progressEvents: Array<{ name: string; completed: number }> = [];
+    collector.on("usage:progress", p => {
+      progressEvents.push({
+        name: p.currentProfileName,
+        completed: p.completed,
+      });
+    });
+
+    await collector.collect([profileA, profileB]);
+
+    expect(progressEvents).toEqual([
+      { name: "personal", completed: 0 },
+      { name: "work", completed: 1 },
+    ]);
+  });
+});

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -224,9 +224,16 @@ const CLAUDE_LAUNCH_COMMAND = resolveClaudePath() ?? "claude";
 
 const defaultDeps: UsageCollectorDeps = {
   tmuxExec: args => {
+    // tmux ハング時に collect() が無期限ブロックして usageInFlight ガードで
+    // 後続要求が永遠に詰まらないよう、各 spawnSync に 5秒 timeout を設定。
+    // タイムアウト時は r.signal が "SIGKILL" / r.error に ETIMEDOUT が入る。
+    // status は null になるが、capturePane 等の上位関数が status !== 0 の
+    // 扱いとして次回ポーリングへ進む。
     const r = spawnSync(TMUX_BINARY, args, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
+      timeout: 5_000,
+      killSignal: "SIGKILL",
     });
     return {
       status: r.status,

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -132,7 +132,10 @@ export function parseUsage(raw: string): UsageEntry["parsed"] | null {
   if (!session || !weeklyAll || !weeklySonnet) return null;
 
   const totalCostMatch = /Total cost:\s+(\$[\d.]+)/.exec(stripped);
-  const wallDurationMatch = /Total duration \(wall\):\s+(\S+)/.exec(stripped);
+  // 「1m 7s」「2h 3m」のような複数トークン値を切り詰めないよう行末まで取る
+  const wallDurationMatch = /Total duration \(wall\):\s+([^\n\r]+)/.exec(
+    stripped
+  );
 
   return {
     sessionPercent: session.percent,
@@ -142,7 +145,7 @@ export function parseUsage(raw: string): UsageEntry["parsed"] | null {
     weeklyAllResets: weeklyAll.resets,
     weeklySonnetResets: weeklySonnet.resets,
     totalCost: totalCostMatch ? totalCostMatch[1] : undefined,
-    wallDuration: wallDurationMatch ? wallDurationMatch[1] : undefined,
+    wallDuration: wallDurationMatch ? wallDurationMatch[1].trim() : undefined,
   };
 }
 
@@ -230,15 +233,23 @@ export class UsageCollector extends EventEmitter {
 
     for (let i = 0; i < profiles.length; i++) {
       const profile = profiles[i];
-      const progress: UsageProgress = {
+      // 開始時: 「i 件完了済み、これから profile.name を処理開始」
+      this.emit("usage:progress", {
         currentProfileName: profile.name,
         completed: i,
         total,
-      };
-      this.emit("usage:progress", progress);
+      });
 
       const entry = await this.collectOne(profile);
       entries.push(entry);
+
+      // 完了時: 「i+1 件完了」(typed event を信頼する consumer 用に正確な
+      // completed 件数も配信。最後のループ終了時に completed=total が届く)
+      this.emit("usage:progress", {
+        currentProfileName: profile.name,
+        completed: i + 1,
+        total,
+      });
     }
 
     return {

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -17,7 +17,7 @@
 
 import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -284,19 +284,19 @@ export class UsageCollector extends EventEmitter {
       configDir: profile.configDir,
     };
 
-    // claude を HOME で起動すると trust 自動承諾が「HOME 全体」に
-    // 永続化されてしまい、後続の通常 Claude セッションで HOME 配下の
-    // 任意のリポジトリの trust 確認がスキップされる副作用があるため、
-    // 毎回ユニークな一時ディレクトリを作って起動する。一時ディレクトリは
-    // finally で削除するので trust state は実質無害（存在しないパスへの
-    // trust エントリが該当 CLAUDE_CONFIG_DIR に残るが、参照されることはない）。
+    // claude を HOME で起動すると trust 自動承諾が HOME 全体に永続化される
+    // 副作用がある。一方、毎回ユニーク dir を作ると毎回 trust dialog が出る
+    // (数秒遅延 + プロファイルの trust store に死んだエントリが蓄積)。
     //
-    // mkdtempSync は try ブロック内で呼ぶ。/tmp 書き込み失敗等の例外で
-    // collect() ループ全体を中断させず、当該プロファイルだけ error にする。
+    // 折衷案: プロファイル毎の固定スクラッチ dir を使う。初回のみ trust
+    // dialog が出て自動承諾され、2回目以降は skip される。trust scope も
+    // この dir 限定なので HOME 全体への影響はない。
+    const sanitized = profile.id.replace(/[^A-Za-z0-9_-]/g, "_");
     let cwd: string | null = null;
 
     try {
-      cwd = mkdtempSync(path.join(os.tmpdir(), "ark-usage-"));
+      cwd = path.join(os.tmpdir(), `ark-usage-cwd-${sanitized}`);
+      mkdirSync(cwd, { recursive: true });
       // configDir が空文字 = デフォルトプロファイル指定。
       // CLAUDE_CONFIG_DIR を明示すると、たとえ ~/.claude を指していても claude が
       // 「カスタム設定」扱いし、テーマ未選択のオンボーディング画面が出てしまう
@@ -433,13 +433,9 @@ export class UsageCollector extends EventEmitter {
       } catch {
         // already gone
       }
-      if (cwd) {
-        try {
-          rmSync(cwd, { recursive: true, force: true });
-        } catch {
-          // tmpdir削除失敗は無視（次回起動時にOSが自動掃除する）
-        }
-      }
+      // cwd は次回再利用するため削除しない (trust dialog の繰り返しを避ける)
+      // OS の tmpdir 掃除に任せる
+      void cwd;
     }
   }
 

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -256,10 +256,15 @@ export class UsageCollector extends EventEmitter {
    *
    * ※ 以前は完了時にも emit していたが、UI が次のプロファイルを先取りして
    *   「2/2 personal」と誤表示する問題があったため廃止。
+   *
+   * `collectedAt` は loop 開始時 (capture が始まる時刻) に確定する。
+   * loop 終了後にすると深夜跨ぎ collect で先頭プロファイルの reset 日付
+   * 判定が render 時刻にズレる問題を避けるため。
    */
   async collect(profiles: Profile[]): Promise<UsageReport> {
     const entries: UsageEntry[] = [];
     const total = profiles.length;
+    const collectedAt = this.deps.now();
 
     for (let i = 0; i < profiles.length; i++) {
       const profile = profiles[i];
@@ -275,7 +280,7 @@ export class UsageCollector extends EventEmitter {
 
     return {
       entries,
-      collectedAt: this.deps.now(),
+      collectedAt,
     };
   }
 

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -27,6 +27,7 @@ import type {
   UsageReport,
 } from "../../shared/types.js";
 import { stripAnsi } from "./ansi.js";
+import { resolveTmuxPath } from "./system.js";
 
 /**
  * 起動完了検出のアンカー文字列（claude CLIのメインプロンプト）
@@ -202,9 +203,16 @@ export interface UsageCollectorDeps {
   sleep: (ms: number) => Promise<void>;
 }
 
+/**
+ * tmux 実行用の絶対パス。`resolveTmuxPath()` で起動時に解決し、なければ
+ * "tmux" にフォールバック (PATH依存)。pm2/systemd で PATH に tmux が無い
+ * 環境でも ENOENT にならないよう絶対パスを使う。
+ */
+const TMUX_BINARY = resolveTmuxPath() ?? "tmux";
+
 const defaultDeps: UsageCollectorDeps = {
   tmuxExec: args => {
-    const r = spawnSync("tmux", args, {
+    const r = spawnSync(TMUX_BINARY, args, {
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -64,11 +64,15 @@ const POLL_INTERVAL_MS = 200;
  */
 const READY_TIMEOUT_MS = 10_000;
 
-/** /usage結果待ちの最大時間 */
-const USAGE_RESULT_TIMEOUT_MS = 5_000;
+/**
+ * /usage結果待ちの最大時間。
+ * 実機で 5s 弱で完了することが多いが、API 遅延 / 大量出力時に 5s ぎりぎりで
+ * timeout する事象が観測されたため余裕を持たせる。
+ */
+const USAGE_RESULT_TIMEOUT_MS = 10_000;
 
 /** 1プロファイルあたりの全体タイムアウト（起動 + 送信 + 結果待ち） */
-const TOTAL_TIMEOUT_MS = 15_000;
+const TOTAL_TIMEOUT_MS = 20_000;
 
 /** /usage結果に必要な "% used" の出現回数（session, weekly all, weekly sonnet） */
 const REQUIRED_USAGE_MARKERS = 3;
@@ -297,11 +301,20 @@ export class UsageCollector extends EventEmitter {
     try {
       cwd = path.join(os.tmpdir(), `ark-usage-cwd-${sanitized}`);
       mkdirSync(cwd, { recursive: true });
-      // configDir が空文字 = デフォルトプロファイル指定。
-      // CLAUDE_CONFIG_DIR を明示すると、たとえ ~/.claude を指していても claude が
-      // 「カスタム設定」扱いし、テーマ未選択のオンボーディング画面が出てしまう
-      // (テーマ等の状態は設定ディレクトリ外に保存されているため)。デフォルト
-      // 動作を再現するには CLAUDE_CONFIG_DIR を渡さない方が確実。
+      // configDir が空文字 = デフォルトプロファイル指定。CLAUDE_CONFIG_DIR を
+      // 渡さないことで claude のデフォルト動作 (~/.claude を使用) に乗せる。
+      //
+      // - 明示的に ~/.claude を渡すと「カスタム設定」扱いでオンボーディング画面が
+      //   出てしまう (実機検証済み)。
+      // - 空文字 (`-e CLAUDE_CONFIG_DIR=`) を渡すと claude が壊れて
+      //   /usage が timeout する (実機検証済み)。
+      // - 残された手段は「渡さない」のみ。
+      //
+      // 既知の制約: tmux server もしくは Ark プロセスが CLAUDE_CONFIG_DIR を
+      // 環境変数として持っている場合、tmux new-session がそれを継承するため
+      // デフォルトプロファイルが意図しない config dir で動く可能性がある。
+      // 通常の deployment では Ark に CLAUDE_CONFIG_DIR を設定しないので
+      // 問題にならないが、テスト/開発環境で global に設定している場合は注意。
       const useDefault = profile.configDir === "";
       const envArgs: string[] = [
         "-e",

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -27,7 +27,7 @@ import type {
   UsageReport,
 } from "../../shared/types.js";
 import { stripAnsi } from "./ansi.js";
-import { resolveTmuxPath } from "./system.js";
+import { resolveClaudePath, resolveTmuxPath } from "./system.js";
 
 /**
  * 起動完了検出のアンカー文字列（claude CLIのメインプロンプト）
@@ -210,6 +210,14 @@ export interface UsageCollectorDeps {
  */
 const TMUX_BINARY = resolveTmuxPath() ?? "tmux";
 
+/**
+ * tmux shell 内に send-keys で渡す claude 起動コマンド。
+ * `resolveClaudePath()` が成功すれば絶対パスを送信し、PATH に claude が
+ * 無い環境でも shell が「command not found」にならないようにする。
+ * 失敗時は "claude" にフォールバック (PATH依存)。
+ */
+const CLAUDE_LAUNCH_COMMAND = resolveClaudePath() ?? "claude";
+
 const defaultDeps: UsageCollectorDeps = {
   tmuxExec: args => {
     const r = spawnSync(TMUX_BINARY, args, {
@@ -326,12 +334,14 @@ export class UsageCollector extends EventEmitter {
         };
       }
 
-      // シェル起動後に claude を送信
+      // シェル起動後に claude を送信。CLAUDE_LAUNCH_COMMAND は起動時に
+      // 解決した絶対パスを使うので、PATH に claude が無い pm2/systemd 環境
+      // でも shell が「command not found」にならない。
       const sendClaude = this.deps.tmuxExec([
         "send-keys",
         "-t",
         sessionName,
-        "claude",
+        CLAUDE_LAUNCH_COMMAND,
         "Enter",
       ]);
       if (sendClaude.status !== 0) {

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -1,0 +1,454 @@
+/**
+ * Usage Collector
+ *
+ * 全プロファイルの `claude /usage` 結果を順次取得する。
+ *
+ * tmux一時セッション (`ark-usage-*`) でclaude CLIを起動し、`/usage` コマンドを
+ * 送信、`tmux capture-pane` で出力をパースする。各プロファイルは直列実行する。
+ *
+ * 直列実行の理由:
+ *   同時に複数の claude CLIを別 CLAUDE_CONFIG_DIR で起動すると、
+ *   (a) Anthropic API側のレート制限を瞬間的に複数同時消費、
+ *   (b) `.credentials.json` への並行アクセス、
+ *   (c) tmuxサーバーへの同時アクセス競合、
+ *   (d) 各claudeが同時にトークンリフレッシュした場合の認証競合
+ *   を引き起こす可能性があるため、確実性を優先して直列実行する。
+ */
+
+import { spawnSync } from "node:child_process";
+import { EventEmitter } from "node:events";
+import type {
+  Profile,
+  UsageEntry,
+  UsageProgress,
+  UsageReport,
+} from "../../shared/types.js";
+import { stripAnsi } from "./ansi.js";
+
+/**
+ * 起動完了検出のアンカー文字列（claude CLIのメインプロンプト）
+ *
+ * `❯` 単独は trust dialog (`❯ 1. Yes, I trust this folder`) でも出現するため
+ * 必ず「ヘルプ表記が画面下部にある」状態 = `for shortcuts` で判定する。
+ */
+const READY_ANCHORS = ["for shortcuts"];
+
+/** オンボーディング画面検出のアンカー文字列（未認証 / 初回起動） */
+const ONBOARDING_ANCHORS = [
+  "Welcome to Claude Code",
+  "Let's get started",
+  "Choose the text style",
+];
+
+/**
+ * 「Trust this folder」ダイアログ検出のアンカー文字列。
+ * profile毎に trust 状態は独立しているため、新規プロファイルでは必ず出現する。
+ * 検出したら「1」+ Enter を送って自動承諾する。
+ */
+const TRUST_DIALOG_ANCHORS = ["trust this folder", "Quick safety check"];
+
+/** capture-paneの取得行数（/usage画面 + ヘッダ余裕分） */
+const CAPTURE_LINES = 300;
+
+/** ポーリング間隔（ミリ秒） */
+const POLL_INTERVAL_MS = 200;
+
+/**
+ * claude起動完了待ちの最大時間。
+ * trust dialog 自動承諾後の再描画も含めるため余裕を持たせる
+ * (素の起動: 4秒前後, trust 後再描画含む: ~8秒)
+ */
+const READY_TIMEOUT_MS = 10_000;
+
+/** /usage結果待ちの最大時間 */
+const USAGE_RESULT_TIMEOUT_MS = 5_000;
+
+/** 1プロファイルあたりの全体タイムアウト（起動 + 送信 + 結果待ち） */
+const TOTAL_TIMEOUT_MS = 15_000;
+
+/** /usage結果に必要な "% used" の出現回数（session, weekly all, weekly sonnet） */
+const REQUIRED_USAGE_MARKERS = 3;
+
+const sleep = (ms: number): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, ms));
+
+/**
+ * `tmux capture-pane` の生出力から /usage の数値情報をパースする。
+ * 認証済みプランの典型的な出力形式に対応。
+ */
+export function parseUsage(raw: string): UsageEntry["parsed"] | null {
+  const stripped = stripAnsi(raw);
+
+  // 各セクションを「アンカー → 次のアンカー or 末尾まで」で抽出
+  const sectionMatch = (anchor: string, nextAnchors: string[]): string => {
+    const startIdx = stripped.indexOf(anchor);
+    if (startIdx === -1) return "";
+    const sliceStart = startIdx + anchor.length;
+    let endIdx = stripped.length;
+    for (const next of nextAnchors) {
+      const idx = stripped.indexOf(next, sliceStart);
+      if (idx !== -1 && idx < endIdx) endIdx = idx;
+    }
+    return stripped.slice(sliceStart, endIdx);
+  };
+
+  const sessionSection = sectionMatch("Current session", [
+    "Current week (all models)",
+    "Current week (Sonnet only)",
+  ]);
+  const weeklyAllSection = sectionMatch("Current week (all models)", [
+    "Current week (Sonnet only)",
+  ]);
+  const weeklySonnetSection = sectionMatch("Current week (Sonnet only)", []);
+
+  /**
+   * セクションから percent / resets を抽出する。
+   * Resets行は optional (Team プランで Sonnet 使用率 0% の場合は表示されない)。
+   */
+  const extractSection = (
+    section: string,
+    requireResets: boolean
+  ): { percent: number; resets: string } | null => {
+    if (!section) return null;
+    const percentMatch = /(\d+)% used/.exec(section);
+    if (!percentMatch) return null;
+    const resetsMatch = /Resets\s+([^\n\r]+)/.exec(section);
+    if (requireResets && !resetsMatch) return null;
+    return {
+      percent: Number.parseInt(percentMatch[1], 10),
+      resets: resetsMatch ? resetsMatch[1].trim() : "",
+    };
+  };
+
+  // Session と weekly all は必須・Resets も必須
+  const session = extractSection(sessionSection, true);
+  const weeklyAll = extractSection(weeklyAllSection, true);
+  // Sonnet only は Resets が任意 (0% 時は表示されない Team プラン仕様)
+  const weeklySonnet = extractSection(weeklySonnetSection, false);
+
+  if (!session || !weeklyAll || !weeklySonnet) return null;
+
+  const totalCostMatch = /Total cost:\s+(\$[\d.]+)/.exec(stripped);
+  const wallDurationMatch = /Total duration \(wall\):\s+(\S+)/.exec(stripped);
+
+  return {
+    sessionPercent: session.percent,
+    weeklyAllPercent: weeklyAll.percent,
+    weeklySonnetPercent: weeklySonnet.percent,
+    sessionResets: session.resets,
+    weeklyAllResets: weeklyAll.resets,
+    weeklySonnetResets: weeklySonnet.resets,
+    totalCost: totalCostMatch ? totalCostMatch[1] : undefined,
+    wallDuration: wallDurationMatch ? wallDurationMatch[1] : undefined,
+  };
+}
+
+/** オンボーディング画面（未認証）であるかを判定する */
+export function isOnboardingScreen(raw: string): boolean {
+  const stripped = stripAnsi(raw);
+  return ONBOARDING_ANCHORS.some(anchor => stripped.includes(anchor));
+}
+
+/** claude CLIの起動完了（プロンプト表示）を判定する */
+export function isReadyScreen(raw: string): boolean {
+  const stripped = stripAnsi(raw);
+  return READY_ANCHORS.some(anchor => stripped.includes(anchor));
+}
+
+/**
+ * 「Trust this folder」ダイアログが表示されているかを判定する。
+ * 新規プロファイルでは必ず1回出るので、自動承諾する想定。
+ */
+export function isTrustDialog(raw: string): boolean {
+  const stripped = stripAnsi(raw);
+  return TRUST_DIALOG_ANCHORS.some(anchor => stripped.includes(anchor));
+}
+
+/**
+ * /usage 結果が画面に表示されているかを判定する。
+ *
+ * 描画途中の検出を避けるため、(a) `% used` が3つ揃い、(b) Sonnet only セクションの
+ * 前にある `Resets` 行が2つ以上揃っていること、を要求する。
+ *
+ * 注: Sonnet only セクションは Team プランで 0% 利用時に Resets 行が表示されない
+ * ため、3つ目の Resets は要求しない。代わりに Sonnet 区画の見出しが見えていれば
+ * 描画完了とみなす。
+ */
+export function hasUsageResult(raw: string): boolean {
+  const stripped = stripAnsi(raw);
+  const usedMatches = stripped.match(/% used/g);
+  const resetsMatches = stripped.match(/Resets\s+/g);
+  if ((usedMatches?.length ?? 0) < REQUIRED_USAGE_MARKERS) return false;
+  // Sonnet only 区画の見出しが描画されていることを確認
+  if (!stripped.includes("Current week (Sonnet only)")) return false;
+  // Session + weekly all の Resets は必ず存在する
+  return (resetsMatches?.length ?? 0) >= 2;
+}
+
+/** UsageCollectorの依存（テスト時に差し替え可能にする） */
+export interface UsageCollectorDeps {
+  tmuxExec: (args: string[]) => {
+    status: number | null;
+    stdout: string;
+    stderr: string;
+  };
+  now: () => number;
+  sleep: (ms: number) => Promise<void>;
+}
+
+const defaultDeps: UsageCollectorDeps = {
+  tmuxExec: args => {
+    const r = spawnSync("tmux", args, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return {
+      status: r.status,
+      stdout: r.stdout ?? "",
+      stderr: r.stderr ?? "",
+    };
+  },
+  now: () => Date.now(),
+  sleep,
+};
+
+export class UsageCollector extends EventEmitter {
+  private deps: UsageCollectorDeps;
+
+  constructor(deps?: Partial<UsageCollectorDeps>) {
+    super();
+    this.deps = { ...defaultDeps, ...deps };
+  }
+
+  /** 全プロファイルの /usage を順次取得する */
+  async collect(profiles: Profile[]): Promise<UsageReport> {
+    const entries: UsageEntry[] = [];
+    const total = profiles.length;
+
+    for (let i = 0; i < profiles.length; i++) {
+      const profile = profiles[i];
+      const progress: UsageProgress = {
+        currentProfileName: profile.name,
+        completed: i,
+        total,
+      };
+      this.emit("usage:progress", progress);
+
+      const entry = await this.collectOne(profile);
+      entries.push(entry);
+    }
+
+    return {
+      entries,
+      collectedAt: this.deps.now(),
+    };
+  }
+
+  /** 1プロファイル分の /usage を取得する */
+  async collectOne(profile: Profile): Promise<UsageEntry> {
+    const sessionName = `ark-usage-${profile.id}-${this.deps.now()}`;
+    const startedAt = this.deps.now();
+    const baseEntry: Omit<UsageEntry, "status"> = {
+      profileId: profile.id,
+      profileName: profile.name,
+      configDir: profile.configDir,
+    };
+
+    // claudeを HOME で起動する。プロファイルごとの「Trust this folder」
+    // 状態は CLAUDE_CONFIG_DIR 内に独立して保存されるため、毎回 trust dialog を
+    // 自動承諾する (waitForReady 内で実装)。HOME を選ぶ理由は: (a) 必ず存在し
+    // 安定、(b) 個別リポジトリの cwd に依存しないので副作用が無い。
+    const home = process.env.HOME || "/tmp";
+
+    try {
+      // configDir が空文字 = デフォルトプロファイル指定。
+      // CLAUDE_CONFIG_DIR を明示すると、たとえ ~/.claude を指していても claude が
+      // 「カスタム設定」扱いし、テーマ未選択のオンボーディング画面が出てしまう
+      // (テーマ等の状態は設定ディレクトリ外に保存されているため)。デフォルト
+      // 動作を再現するには CLAUDE_CONFIG_DIR を渡さない方が確実。
+      const useDefault = profile.configDir === "";
+      const envArgs: string[] = [
+        "-e",
+        "CLAUDECODE=",
+        "-e",
+        "CLAUDE_CODE_NO_FLICKER=1",
+      ];
+      if (!useDefault) {
+        envArgs.push("-e", `CLAUDE_CONFIG_DIR=${profile.configDir}`);
+      }
+
+      // 重要: claude を直接 new-session の引数として渡すと、CLAUDECODE 検出等で
+      // claude が即座に終了した場合 tmux がセッションを破棄してしまう
+      // (capture-pane で "can't find pane" エラー)。tmux-manager.ts と同じく、
+      // シェルを起動してから claude コマンドを send-keys で送る方式にする。
+      const newSession = this.deps.tmuxExec([
+        "new-session",
+        "-d",
+        "-s",
+        sessionName,
+        "-c",
+        home,
+        ...envArgs,
+      ]);
+      if (newSession.status !== 0) {
+        return {
+          ...baseEntry,
+          status: "error",
+          errorMessage: `tmux new-session failed (status: ${newSession.status}, stderr: ${newSession.stderr.trim()})`,
+        };
+      }
+
+      // シェル起動後に claude を送信
+      const sendClaude = this.deps.tmuxExec([
+        "send-keys",
+        "-t",
+        sessionName,
+        "claude",
+        "Enter",
+      ]);
+      if (sendClaude.status !== 0) {
+        return {
+          ...baseEntry,
+          status: "error",
+          errorMessage: `claude起動コマンド送信失敗 (stderr: ${sendClaude.stderr.trim()})`,
+        };
+      }
+
+      const readyResult = await this.waitForReady(
+        sessionName,
+        startedAt + READY_TIMEOUT_MS
+      );
+
+      if (readyResult === "onboarding") {
+        return {
+          ...baseEntry,
+          status: "unauthenticated",
+        };
+      }
+
+      if (readyResult === "timeout") {
+        return {
+          ...baseEntry,
+          status: "timeout",
+          errorMessage: "claude CLIの起動を検出できませんでした",
+        };
+      }
+
+      const sendResult = this.deps.tmuxExec([
+        "send-keys",
+        "-t",
+        sessionName,
+        "/usage",
+        "Enter",
+      ]);
+      if (sendResult.status !== 0) {
+        return {
+          ...baseEntry,
+          status: "error",
+          errorMessage: "/usage 送信に失敗しました",
+        };
+      }
+
+      const overallDeadline = Math.min(
+        startedAt + TOTAL_TIMEOUT_MS,
+        this.deps.now() + USAGE_RESULT_TIMEOUT_MS
+      );
+      const captured = await this.waitForUsageResult(
+        sessionName,
+        overallDeadline
+      );
+
+      if (!captured) {
+        return {
+          ...baseEntry,
+          status: "timeout",
+          errorMessage: "/usage 結果が時間内に表示されませんでした",
+        };
+      }
+
+      const parsed = parseUsage(captured);
+      if (!parsed) {
+        return {
+          ...baseEntry,
+          status: "error",
+          errorMessage: "/usage 出力のパースに失敗しました",
+          rawOutput:
+            process.env.NODE_ENV === "development" ? captured : undefined,
+        };
+      }
+
+      return {
+        ...baseEntry,
+        status: "ok",
+        parsed,
+      };
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : String(e);
+      return {
+        ...baseEntry,
+        status: "error",
+        errorMessage: message,
+      };
+    } finally {
+      try {
+        this.deps.tmuxExec(["kill-session", "-t", sessionName]);
+      } catch {
+        // already gone
+      }
+    }
+  }
+
+  /**
+   * claude CLIの起動完了を待つ。
+   * Trust dialog ("Quick safety check") が出た場合は自動承諾 (1 + Enter) する。
+   * @returns "ready" / "onboarding" / "timeout"
+   */
+  private async waitForReady(
+    sessionName: string,
+    deadline: number
+  ): Promise<"ready" | "onboarding" | "timeout"> {
+    let trustAccepted = false;
+    while (this.deps.now() < deadline) {
+      await this.deps.sleep(POLL_INTERVAL_MS);
+      const captured = this.capturePane(sessionName);
+      if (captured === null) continue;
+      if (isOnboardingScreen(captured)) return "onboarding";
+      if (isReadyScreen(captured)) return "ready";
+      // Trust dialog: 1 (= "Yes, I trust this folder") + Enter で自動承諾。
+      // 1度送ったら以降の繰り返しでは無視（連打しない）。プロファイル毎に
+      // CLAUDE_CONFIG_DIR が独立しているため、新規プロファイルでは必ず通る。
+      if (!trustAccepted && isTrustDialog(captured)) {
+        this.deps.tmuxExec(["send-keys", "-t", sessionName, "1", "Enter"]);
+        trustAccepted = true;
+      }
+    }
+    return "timeout";
+  }
+
+  /** /usage結果の表示を待つ */
+  private async waitForUsageResult(
+    sessionName: string,
+    deadline: number
+  ): Promise<string | null> {
+    while (this.deps.now() < deadline) {
+      await this.deps.sleep(POLL_INTERVAL_MS);
+      const captured = this.capturePane(sessionName);
+      if (captured === null) continue;
+      if (hasUsageResult(captured)) return captured;
+    }
+    return null;
+  }
+
+  private capturePane(sessionName: string): string | null {
+    const r = this.deps.tmuxExec([
+      "capture-pane",
+      "-t",
+      sessionName,
+      "-p",
+      "-S",
+      `-${CAPTURE_LINES}`,
+    ]);
+    if (r.status !== 0) return null;
+    return r.stdout;
+  }
+}

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -263,9 +263,13 @@ export class UsageCollector extends EventEmitter {
     // 毎回ユニークな一時ディレクトリを作って起動する。一時ディレクトリは
     // finally で削除するので trust state は実質無害（存在しないパスへの
     // trust エントリが該当 CLAUDE_CONFIG_DIR に残るが、参照されることはない）。
-    const cwd = mkdtempSync(path.join(os.tmpdir(), "ark-usage-"));
+    //
+    // mkdtempSync は try ブロック内で呼ぶ。/tmp 書き込み失敗等の例外で
+    // collect() ループ全体を中断させず、当該プロファイルだけ error にする。
+    let cwd: string | null = null;
 
     try {
+      cwd = mkdtempSync(path.join(os.tmpdir(), "ark-usage-"));
       // configDir が空文字 = デフォルトプロファイル指定。
       // CLAUDE_CONFIG_DIR を明示すると、たとえ ~/.claude を指していても claude が
       // 「カスタム設定」扱いし、テーマ未選択のオンボーディング画面が出てしまう
@@ -400,10 +404,12 @@ export class UsageCollector extends EventEmitter {
       } catch {
         // already gone
       }
-      try {
-        rmSync(cwd, { recursive: true, force: true });
-      } catch {
-        // tmpdir削除失敗は無視（次回起動時にOSが自動掃除する）
+      if (cwd) {
+        try {
+          rmSync(cwd, { recursive: true, force: true });
+        } catch {
+          // tmpdir削除失敗は無視（次回起動時にOSが自動掃除する）
+        }
       }
     }
   }

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -17,6 +17,9 @@
 
 import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import type {
   Profile,
   UsageEntry,
@@ -254,11 +257,13 @@ export class UsageCollector extends EventEmitter {
       configDir: profile.configDir,
     };
 
-    // claudeを HOME で起動する。プロファイルごとの「Trust this folder」
-    // 状態は CLAUDE_CONFIG_DIR 内に独立して保存されるため、毎回 trust dialog を
-    // 自動承諾する (waitForReady 内で実装)。HOME を選ぶ理由は: (a) 必ず存在し
-    // 安定、(b) 個別リポジトリの cwd に依存しないので副作用が無い。
-    const home = process.env.HOME || "/tmp";
+    // claude を HOME で起動すると trust 自動承諾が「HOME 全体」に
+    // 永続化されてしまい、後続の通常 Claude セッションで HOME 配下の
+    // 任意のリポジトリの trust 確認がスキップされる副作用があるため、
+    // 毎回ユニークな一時ディレクトリを作って起動する。一時ディレクトリは
+    // finally で削除するので trust state は実質無害（存在しないパスへの
+    // trust エントリが該当 CLAUDE_CONFIG_DIR に残るが、参照されることはない）。
+    const cwd = mkdtempSync(path.join(os.tmpdir(), "ark-usage-"));
 
     try {
       // configDir が空文字 = デフォルトプロファイル指定。
@@ -287,7 +292,7 @@ export class UsageCollector extends EventEmitter {
         "-s",
         sessionName,
         "-c",
-        home,
+        cwd,
         ...envArgs,
       ]);
       if (newSession.status !== 0) {
@@ -394,6 +399,11 @@ export class UsageCollector extends EventEmitter {
         this.deps.tmuxExec(["kill-session", "-t", sessionName]);
       } catch {
         // already gone
+      }
+      try {
+        rmSync(cwd, { recursive: true, force: true });
+      } catch {
+        // tmpdir削除失敗は無視（次回起動時にOSが自動掃除する）
       }
     }
   }

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -246,14 +246,23 @@ export class UsageCollector extends EventEmitter {
     this.deps = { ...defaultDeps, ...deps };
   }
 
-  /** 全プロファイルの /usage を順次取得する */
+  /**
+   * 全プロファイルの /usage を順次取得する。
+   *
+   * usage:progress は各プロファイル開始時のみ emit (BEFORE)。
+   * `completed` は「これまでに完了した件数 (= 0-based index of current)」。
+   * client は `completed + 1 / total currentProfileName` で「現在処理中の
+   * 順位」として表示する。最終的な完了通知は usage:complete に集約。
+   *
+   * ※ 以前は完了時にも emit していたが、UI が次のプロファイルを先取りして
+   *   「2/2 personal」と誤表示する問題があったため廃止。
+   */
   async collect(profiles: Profile[]): Promise<UsageReport> {
     const entries: UsageEntry[] = [];
     const total = profiles.length;
 
     for (let i = 0; i < profiles.length; i++) {
       const profile = profiles[i];
-      // 開始時: 「i 件完了済み、これから profile.name を処理開始」
       this.emit("usage:progress", {
         currentProfileName: profile.name,
         completed: i,
@@ -262,14 +271,6 @@ export class UsageCollector extends EventEmitter {
 
       const entry = await this.collectOne(profile);
       entries.push(entry);
-
-      // 完了時: 「i+1 件完了」(typed event を信頼する consumer 用に正確な
-      // completed 件数も配信。最後のループ終了時に completed=total が届く)
-      this.emit("usage:progress", {
-        currentProfileName: profile.name,
-        completed: i + 1,
-        total,
-      });
     }
 
     return {
@@ -350,11 +351,18 @@ export class UsageCollector extends EventEmitter {
       // シェル起動後に claude を送信。CLAUDE_LAUNCH_COMMAND は起動時に
       // 解決した絶対パスを使うので、PATH に claude が無い pm2/systemd 環境
       // でも shell が「command not found」にならない。
+      //
+      // デフォルトプロファイル時は `unset CLAUDE_CONFIG_DIR;` を前置して
+      // tmux/Ark から継承された CLAUDE_CONFIG_DIR を確実に解除する。
+      // (-e CLAUDE_CONFIG_DIR=「空文字」は claude が壊れて使えない実機検証済)
+      const launchCmd = useDefault
+        ? `unset CLAUDE_CONFIG_DIR; ${CLAUDE_LAUNCH_COMMAND}`
+        : CLAUDE_LAUNCH_COMMAND;
       const sendClaude = this.deps.tmuxExec([
         "send-keys",
         "-t",
         sessionName,
-        CLAUDE_LAUNCH_COMMAND,
+        launchCmd,
         "Enter",
       ]);
       if (sendClaude.status !== 0) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -242,6 +242,12 @@ export interface ServerToClientEvents {
 
   // Beacon events
   "beacon:message": (message: ChatMessage) => void;
+  /**
+   * Beacon履歴UIにのみ追加される外部メッセージ (Usage取得結果など)。
+   * `beacon:message` と異なり client 側の streaming state には影響しない。
+   * (LLM streaming 中に到着しても応答が切り捨てられないようにするため)
+   */
+  "beacon:external-message": (message: ChatMessage) => void;
   "beacon:stream": (data: BeaconStreamChunk) => void;
   "beacon:history": (data: { messages: ChatMessage[] }) => void;
   "beacon:error": (data: { error: string }) => void;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -246,6 +246,11 @@ export interface ServerToClientEvents {
   "beacon:history": (data: { messages: ChatMessage[] }) => void;
   "beacon:error": (data: { error: string }) => void;
 
+  // Usage取得
+  "usage:progress": (data: UsageProgress) => void;
+  "usage:complete": (report: UsageReport) => void;
+  "usage:error": (data: { message: string }) => void;
+
   // ファイルビューワー
   "file:content": (data: {
     filePath: string;
@@ -363,6 +368,50 @@ export interface ClientToServerEvents {
     profileId: string | null;
   }) => void;
   "session:restart-with-profile": (data: { sessionId: string }) => void;
+
+  // Usage取得 (Linux + multiProfileSupported 限定)
+  "usage:request": () => void;
+}
+
+/** Usage取得結果（プロファイル単位） */
+export interface UsageEntry {
+  profileId: string;
+  profileName: string;
+  configDir: string;
+  status: "ok" | "unauthenticated" | "timeout" | "error";
+  parsed?: {
+    sessionPercent: number;
+    weeklyAllPercent: number;
+    weeklySonnetPercent: number;
+    /** "8:20pm (Asia/Tokyo)" のような表示用文字列 */
+    sessionResets: string;
+    weeklyAllResets: string;
+    weeklySonnetResets: string;
+    /** "$0.0000" のような表示用文字列 */
+    totalCost?: string;
+    /** "7s" のような表示用文字列 */
+    wallDuration?: string;
+  };
+  /** デバッグ用（NODE_ENV=development 時のみ含める） */
+  rawOutput?: string;
+  errorMessage?: string;
+}
+
+/** Usage取得結果（全プロファイル分） */
+export interface UsageReport {
+  entries: UsageEntry[];
+  /** UNIXタイムスタンプ(ms) */
+  collectedAt: number;
+}
+
+/** Usage取得進捗 */
+export interface UsageProgress {
+  /** 現在処理中のプロファイル名 */
+  currentProfileName: string;
+  /** 完了済み件数 */
+  completed: number;
+  /** 全体件数 */
+  total: number;
 }
 
 /** Beaconチャットのメッセージ */


### PR DESCRIPTION
## Summary

Beaconパネルの「Usage」ボタンから登録済み全プロファイル + デフォルトアカウントの `/usage` 結果を順次取得し、Beaconチャットにバーチャートで比較表示する機能 (Linux + multiProfileSupported 限定)。

## 主な実装

### サーバ
- **`server/lib/usage-collector.ts` (新規)**: tmux一時セッションで claude を起動 → `/usage` 送信 → `tmux capture-pane` でパース。直列実行 (`.credentials.json` 競合・APIレート制限・トークンリフレッシュ競合を回避)
- **`server/lib/system.ts`**: `resolveTmuxPath()` / `resolveClaudePath()` を追加 (PATH非依存の絶対パス解決)
- **`server/lib/tmux-manager.ts`**: 全 tmux 呼び出しを `TMUX_BINARY_PATH` (resolveTmuxPath 解決値) に統一。orphan `ark-usage-*` セッションを起動時に kill
- **`server/lib/beacon-manager.ts`**: `postExternalMessage(content, expectedVersion?)` を追加 (LLMコンテキスト非注入の履歴投稿API)。`activeTurnCount` カウンタ + pending queue で multi-turn/multi-client での順序整合
- **`server/index.ts`**: `usage:request` ハンドラ、`formatUsageMarkdown` (バーチャート + JST 24時間表記の `M/D HH:MM` フォーマッタ)

### クライアント
- **`client/src/components/MobileChatView.tsx`**: Beaconクイックコマンドに「Usage」ボタン追加 (取得中は `1/3 デフォルト` 進捗表示 + Loaderスピナー)
- **`client/src/hooks/useSocket.ts`**: `requestUsage` / `usageRequesting` / `usageProgress` / `beacon:external-message` リスナー
- **`shared/types.ts`**: `UsageEntry` / `UsageReport` / `UsageProgress` 型 + イベント定義

## 表示例

\`\`\`
### デフォルト
\`\`\`
セ ██░░░░░░░░░░░░░░░░░░░░░░   8% 4/28 01:20
週 █████████░░░░░░░░░░░░░░░  37% 4/28 03:00
\`\`\`

### Knowbe1
\`\`\`
セ █████████████████████░░░  89% 4/28 20:40
週 ████░░░░░░░░░░░░░░░░░░░░  15% 5/4 13:00
\`\`\`
\`\`\`

## Test Plan

- [x] `pnpm vitest run` 全 84 テスト通過
- [x] `pnpm check` (TypeScript + Biome) クリア
- [x] `/codex review` 19 ラウンド実施、HIGH 0 件まで収束
- [x] 実機: 3 プロファイル全て取得成功 (デフォルト + Knowbe1 + Knowbe2)、tmux/tmpdir リーク無し
- [ ] mac / Windows: 機能非表示の確認 (UI 上 multiProfileSupported=false)
- [ ] Pro/Free/Team プランでの出力フォーマット確認 (Max + Team で確認済み)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * モバイルチャットビューに「使用状況」クイックコマンドを追加しました。このコマンドを実行すると、プロファイルごとの使用状況情報をリアルタイムで取得・表示できます。
  * マルチプロファイル対応時に、使用状況の取得進行状況をプログレスバーで表示するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->