### PR TITLE
fix: /usage レイアウト変更/rate limit で全プロファイル timeout する問題

### DIFF
--- a/server/lib/usage-collector.test.ts
+++ b/server/lib/usage-collector.test.ts
@@ -48,6 +48,61 @@ const ONBOARDING_OUTPUT = `Welcome to Claude Code
   Choose the text style that looks best with your terminal:
 `;
 
+/**
+ * Per-model 集計が API rate limit にぶつかった場合の旧UI出力。
+ * Sonnet only セクションごと「Per-model breakdown unavailable」に置き換わる。
+ * 実機 (Knowbe Team プラン・2026-04-29) で再現確認済み。
+ */
+const RATE_LIMITED_USAGE_OUTPUT = `    Status   Config   Usage   Stats
+
+   Session
+   Total cost:            $0.0000
+   Total duration (API):  0s
+   Total duration (wall): 4s
+   Total code changes:    0 lines added, 0 lines removed
+   Usage:                 0 input, 0 output, 0 cache read, 0 cache write
+
+   Current session
+                                                      0% used
+   Resets 6:10pm (Asia/Tokyo)
+
+   Current week (all models)
+   ███████████                                        22% used
+   Resets May 4, 1pm (Asia/Tokyo)
+
+   Per-model breakdown unavailable (rate limited — try again in a moment)
+
+   r to retry · Esc to cancel
+`;
+
+/**
+ * 新UI (claude 2.1.123 で確認) の `/usage` 画面初期表示。
+ * Session / Weekly all の直後に「What's contributing to your limits usage?」
+ * 説明セクションが入る。Sonnet only 見出しは画面下方にスクロールしないと
+ * 見えないため、capture-pane では取れない前提で完了判定する。
+ */
+const NEW_UI_USAGE_OUTPUT = `    Status   Config   Usage   Stats
+
+   Session
+   Total cost:            $0.0000
+   Total duration (API):  0s
+   Total duration (wall): 4s
+   Total code changes:    0 lines added, 0 lines removed
+   Usage:                 0 input, 0 output, 0 cache read, 0 cache write
+
+   Current session
+   ██████                                             12% used
+   Resets 5:40pm (Asia/Tokyo)
+
+   Current week (all models)
+   ██████                                             12% used
+   Resets May 5, 3am (Asia/Tokyo)
+
+   What's contributing to your limits usage?
+   Approximate, based on local sessions on this machine — does not include
+   other devices or claude.ai
+`;
+
 const ANSI_USAGE_OUTPUT = `\x1b[2J\x1b[H\x1b[1m   Current session\x1b[0m
    \x1b[36m██\x1b[0m                                                 4% used
    Resets 8:20pm (Asia/Tokyo)
@@ -101,6 +156,26 @@ describe("parseUsage", () => {
 
   it("オンボーディング画面では null を返す", () => {
     expect(parseUsage(ONBOARDING_OUTPUT)).toBeNull();
+  });
+
+  it("rate limit 時は Sonnet 関連を null にしつつパース成功", () => {
+    const parsed = parseUsage(RATE_LIMITED_USAGE_OUTPUT);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.sessionPercent).toBe(0);
+    expect(parsed?.weeklyAllPercent).toBe(22);
+    expect(parsed?.weeklySonnetPercent).toBeNull();
+    expect(parsed?.sessionResets).toBe("6:10pm (Asia/Tokyo)");
+    expect(parsed?.weeklyAllResets).toBe("May 4, 1pm (Asia/Tokyo)");
+    expect(parsed?.weeklySonnetResets).toBeNull();
+  });
+
+  it("新UI (Sonnet 区画なし) でも session + weekly all をパース成功", () => {
+    const parsed = parseUsage(NEW_UI_USAGE_OUTPUT);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.sessionPercent).toBe(12);
+    expect(parsed?.weeklyAllPercent).toBe(12);
+    expect(parsed?.weeklySonnetPercent).toBeNull();
+    expect(parsed?.weeklySonnetResets).toBeNull();
   });
 
   it("Team プラン (Sonnet 0% で Resets行欠落) も Sonnet resets を空文字でパース成功", () => {
@@ -207,7 +282,31 @@ Current week (Sonnet only)
     expect(hasUsageResult(teamPlanOutput)).toBe(true);
   });
 
-  it("Sonnet only 見出しがない描画途中の画面では false", () => {
+  it("rate limit 完了 ('Per-model breakdown unavailable' + % used 2つ + Resets 2つ) → true", () => {
+    expect(hasUsageResult(RATE_LIMITED_USAGE_OUTPUT)).toBe(true);
+  });
+
+  it("新UI ('What's contributing' アンカー + % used 2つ + Resets 2つ) → true", () => {
+    expect(hasUsageResult(NEW_UI_USAGE_OUTPUT)).toBe(true);
+  });
+
+  it("旧UI で Sonnet 見出しは描画されたが Sonnet 行が未描画 → false (mid-render race防止)", () => {
+    // 見出しが先に出て % used 行が遅れて描画されるレースケース。
+    // Sonnet 値を null で確定させないため 3個目の `% used` を待つ必要がある。
+    const sonnetHeaderOnly = `Current session
+4% used
+Resets 8:00pm
+
+Current week (all models)
+31% used
+Resets 3am
+
+Current week (Sonnet only)
+`;
+    expect(hasUsageResult(sonnetHeaderOnly)).toBe(false);
+  });
+
+  it("完了アンカーが無い描画途中の画面では false", () => {
     const midRender = `Current session
 4% used
 Resets 8:00pm

--- a/server/lib/usage-collector.ts
+++ b/server/lib/usage-collector.ts
@@ -74,8 +74,29 @@ const USAGE_RESULT_TIMEOUT_MS = 10_000;
 /** 1プロファイルあたりの全体タイムアウト（起動 + 送信 + 結果待ち） */
 const TOTAL_TIMEOUT_MS = 20_000;
 
-/** /usage結果に必要な "% used" の出現回数（session, weekly all, weekly sonnet） */
-const REQUIRED_USAGE_MARKERS = 3;
+/**
+ * 完了判定に必要な必須セクション数 (session + weekly all)。
+ * `% used` と `Resets` が最低この数だけ揃っていれば数値表示は可能。
+ */
+const REQUIRED_USAGE_MARKERS = 2;
+
+/** 旧UI 完了アンカー: Sonnet only セクションの見出し */
+const OLD_UI_SONNET_ANCHOR = "Current week (Sonnet only)";
+
+/**
+ * Sonnet 区画が「Per-model breakdown unavailable」or 新UI で観測できない
+ * パターンの完了アンカー。これらが見えた時点で session + weekly all より
+ * 後ろの要素が描画済みなので、上2セクションの数値は確定している。
+ *
+ * - `Per-model breakdown unavailable` : Sonnet 区画が rate limit で欠落した版
+ * - `What's contributing to your limits usage?` : 新UI (claude 2.1.123 で確認)。
+ *   Session / Weekly all の直後に表示される breakdown 説明セクション。
+ *   Sonnet 区画が画面下方にスクロールアウトしているケースもこれで完了判定する。
+ */
+const SONNET_OPTIONAL_ANCHORS = [
+  "Per-model breakdown unavailable",
+  "What's contributing to your limits usage?",
+];
 
 const sleep = (ms: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, ms));
@@ -131,10 +152,11 @@ export function parseUsage(raw: string): UsageEntry["parsed"] | null {
   // Session と weekly all は必須・Resets も必須
   const session = extractSection(sessionSection, true);
   const weeklyAll = extractSection(weeklyAllSection, true);
-  // Sonnet only は Resets が任意 (0% 時は表示されない Team プラン仕様)
+  // Sonnet only は Resets が任意 (0% 時は表示されない Team プラン仕様)。
+  // さらに API rate limit 時は Sonnet セクション自体が欠落するため null 許容。
   const weeklySonnet = extractSection(weeklySonnetSection, false);
 
-  if (!session || !weeklyAll || !weeklySonnet) return null;
+  if (!session || !weeklyAll) return null;
 
   const totalCostMatch = /Total cost:\s+(\$[\d.]+)/.exec(stripped);
   // 「1m 7s」「2h 3m」のような複数トークン値を切り詰めないよう行末まで取る
@@ -145,10 +167,10 @@ export function parseUsage(raw: string): UsageEntry["parsed"] | null {
   return {
     sessionPercent: session.percent,
     weeklyAllPercent: weeklyAll.percent,
-    weeklySonnetPercent: weeklySonnet.percent,
+    weeklySonnetPercent: weeklySonnet ? weeklySonnet.percent : null,
     sessionResets: session.resets,
     weeklyAllResets: weeklyAll.resets,
-    weeklySonnetResets: weeklySonnet.resets,
+    weeklySonnetResets: weeklySonnet ? weeklySonnet.resets : null,
     totalCost: totalCostMatch ? totalCostMatch[1] : undefined,
     wallDuration: wallDurationMatch ? wallDurationMatch[1].trim() : undefined,
   };
@@ -178,22 +200,36 @@ export function isTrustDialog(raw: string): boolean {
 /**
  * /usage 結果が画面に表示されているかを判定する。
  *
- * 描画途中の検出を避けるため、(a) `% used` が3つ揃い、(b) Sonnet only セクションの
- * 前にある `Resets` 行が2つ以上揃っていること、を要求する。
+ * パターン1 (旧UI 全描画完了):
+ *   `Current week (Sonnet only)` 見出しがあり、かつ `% used` が3個以上ある。
+ *   旧UIでは見出しが先に描画され、Sonnet 行は遅れて描画されるため、見出し
+ *   単独だと Sonnet 値が空のまま脱出するレースがある。3個目の `% used` を
+ *   必須にして Sonnet 行が確定するまで待つ。
  *
- * 注: Sonnet only セクションは Team プランで 0% 利用時に Resets 行が表示されない
- * ため、3つ目の Resets は要求しない。代わりに Sonnet 区画の見出しが見えていれば
- * 描画完了とみなす。
+ * パターン2 (Sonnet 区画が見えない確定状態):
+ *   `Per-model breakdown unavailable` (rate limit) または `What's contributing
+ *   to your limits usage?` (新UI) が描画されている。これらは session + weekly
+ *   all セクションの後に出る要素なので、`% used` 2個 + Resets 2個で完了。
+ *
+ * いずれにせよ session + weekly all の数値が確定している必要があるため、
+ * `% used` ≥ 2 と `Resets` ≥ 2 を共通の必須条件とする。
  */
 export function hasUsageResult(raw: string): boolean {
   const stripped = stripAnsi(raw);
   const usedMatches = stripped.match(/% used/g);
   const resetsMatches = stripped.match(/Resets\s+/g);
-  if ((usedMatches?.length ?? 0) < REQUIRED_USAGE_MARKERS) return false;
-  // Sonnet only 区画の見出しが描画されていることを確認
-  if (!stripped.includes("Current week (Sonnet only)")) return false;
-  // Session + weekly all の Resets は必ず存在する
-  return (resetsMatches?.length ?? 0) >= 2;
+  const usedCount = usedMatches?.length ?? 0;
+  const resetsCount = resetsMatches?.length ?? 0;
+  if (usedCount < REQUIRED_USAGE_MARKERS) return false;
+  if (resetsCount < 2) return false;
+
+  // 旧UI: Sonnet 行が描画されるまで待つ (% used 3個以上)
+  if (stripped.includes(OLD_UI_SONNET_ANCHOR)) {
+    return usedCount >= 3;
+  }
+
+  // 新UI / rate limit: Sonnet 区画が無いことが確定する終端アンカーが必要
+  return SONNET_OPTIONAL_ANCHORS.some(anchor => stripped.includes(anchor));
 }
 
 /** UsageCollectorの依存（テスト時に差し替え可能にする） */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -410,11 +410,17 @@ export interface UsageEntry {
   parsed?: {
     sessionPercent: number;
     weeklyAllPercent: number;
-    weeklySonnetPercent: number;
+    /**
+     * Per-model 集計が取得できなかった場合 null。
+     * - API rate limit (画面に「Per-model breakdown unavailable」表示)
+     * - claude 2.1.123 以降の新UIで Sonnet 区画がスクロール下方に押し出される
+     */
+    weeklySonnetPercent: number | null;
     /** "8:20pm (Asia/Tokyo)" のような表示用文字列 */
     sessionResets: string;
     weeklyAllResets: string;
-    weeklySonnetResets: string;
+    /** Sonnet 取得不可時は null。 */
+    weeklySonnetResets: string | null;
     /** "$0.0000" のような表示用文字列 */
     totalCost?: string;
     /** "7s" のような表示用文字列 */


### PR DESCRIPTION
## Summary

- claude 2.1.123 の新UIで `/usage` の Sonnet only セクションが画面下方へスクロールアウトするレイアウトに変わり、旧来の完了判定 (Sonnet only 見出し + `% used` 3個必須) が永遠に満たされず全プロファイルが timeout していた問題を修正。
- 加えて per-model 集計が API rate limit にぶつかった場合の「Per-model breakdown unavailable」表示にも対応。
- 完了判定を旧UI / 新UI・rate limit の2系統に分岐し、Sonnet 区画は欠落許容 (`weeklySonnetPercent: number | null`)。

## 原因

実機 `tmux capture-pane` で観測した3パターン:

| プロファイル | 画面パターン | `% used` 数 | 旧判定 | 新判定 |
|---|---|---|---|---|
| A | 新UI: 末尾に `What's contributing to your limits usage?` | 2 | ❌ timeout | ✅ ok |
| B | rate limit: `Per-model breakdown unavailable` | 2 | ❌ timeout | ✅ ok (sonnet=null) |
| C | 旧UI: `Current week (Sonnet only)` あり | 3 | ✅ ok | ✅ ok (従来通り) |

`server/index.ts` の表示処理 `formatUsageEntryLines` は元々 Sonnet を表示していない (セ/週 2行のみ) ため、UI 変更なし。

## 完了判定ロジック

```
% used >= 2 AND Resets >= 2 が前提
├─ "Current week (Sonnet only)" あり → さらに % used >= 3 必須 (旧UI 互換 + mid-render race 防止)
└─ "What's contributing..." or "Per-model breakdown unavailable" あり → 完了 (Sonnet 区画は最初から無い)
```

旧UI で Sonnet 見出しを relax の終端アンカーにしてしまうと、見出し → Sonnet 行 の描画間にレースが発生し Sonnet 値を null 確定させる問題があったため (codex review P1 指摘)、見出し検出時のみ従来の3個ルールを維持。

## Test plan
- [x] `pnpm vitest run server/lib/usage-collector.test.ts` (31 passed)
- [x] `pnpm vitest run` (89 passed)
- [x] `pnpm tsc --noEmit` (clean)
- [x] 実機: pm2 再起動後 socket.io で `usage:request` を投げて 3/3 ok 確認 (新UI / rate limit / 旧UI 全パターン網羅)
- [x] codex review (再レビューで P1 解消・regression なしと確認)