### PR TITLE
feat: HTMLビューワーから PNG 画像をエクスポートする機能

### DIFF
--- a/client/src/components/HtmlViewerPane.tsx
+++ b/client/src/components/HtmlViewerPane.tsx
@@ -59,16 +59,19 @@ export function HtmlViewerPane({ filePath }: HtmlViewerPaneProps) {
   async function handleCopyImage() {
     setExporting(true);
     try {
-      const res = await fetch(
+      // Safari/Firefox の user-activation 要件のため、await fetch を挟まず
+      // ClipboardItem に Promise<Blob> を直接渡してクリップボード書き込みを開始する
+      const blobPromise = fetch(
         buildScreenshotUrl(filePath, { mode: "screenshot" })
-      );
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error || `HTTP ${res.status}`);
-      }
-      const blob = await res.blob();
+      ).then(async res => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.error || `HTTP ${res.status}`);
+        }
+        return res.blob();
+      });
       await navigator.clipboard.write([
-        new ClipboardItem({ "image/png": blob }),
+        new ClipboardItem({ "image/png": blobPromise }),
       ]);
       toast.success("画像をクリップボードにコピーしました");
     } catch (e) {

--- a/client/src/components/HtmlViewerPane.tsx
+++ b/client/src/components/HtmlViewerPane.tsx
@@ -1,4 +1,13 @@
+import { Camera, Download, Loader2 } from "lucide-react";
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 
 interface HtmlViewerPaneProps {
   filePath: string;
@@ -8,10 +17,13 @@ interface HtmlViewerPaneProps {
  * 絶対パスのHTMLファイルをiframeで表示するコンポーネント。
  * fetch→srcdoc方式でHTMLを表示し、認証トークンがiframe内に露出しない。
  * self-contained（全リソースインライン）なHTMLファイルを対象とする。
+ *
+ * ツールバーの「画像保存」から PR 用の PNG スクリーンショットを取得できる。
  */
 export function HtmlViewerPane({ filePath }: HtmlViewerPaneProps) {
   const [htmlContent, setHtmlContent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
 
   useEffect(() => {
     // filePath変更時にステート状態をリセット（古いコンテンツ/エラーの残留を防止）
@@ -19,13 +31,9 @@ export function HtmlViewerPane({ filePath }: HtmlViewerPaneProps) {
     setError(null);
 
     const controller = new AbortController();
-    const token = new URLSearchParams(window.location.search).get("token");
-    let url = `/api/html-file?path=${encodeURIComponent(filePath)}`;
-    if (token) {
-      url += `&token=${encodeURIComponent(token)}`;
-    }
-
-    fetch(url, { signal: controller.signal })
+    fetch(buildScreenshotUrl(filePath, { mode: "html" }), {
+      signal: controller.signal,
+    })
       .then(res => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.text();
@@ -46,28 +54,127 @@ export function HtmlViewerPane({ filePath }: HtmlViewerPaneProps) {
     return () => controller.abort();
   }, [filePath]);
 
-  if (error) {
-    return (
-      <div className="flex items-center justify-center h-full text-destructive">
-        <p>HTMLファイルの読み込みに失敗しました: {error}</p>
-      </div>
-    );
+  const filename = filePath.split("/").pop() || "html";
+
+  async function handleCopyImage() {
+    setExporting(true);
+    try {
+      const res = await fetch(
+        buildScreenshotUrl(filePath, { mode: "screenshot" })
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      const blob = await res.blob();
+      await navigator.clipboard.write([
+        new ClipboardItem({ "image/png": blob }),
+      ]);
+      toast.success("画像をクリップボードにコピーしました");
+    } catch (e) {
+      toast.error(
+        `画像のコピーに失敗しました: ${e instanceof Error ? e.message : String(e)}`
+      );
+    } finally {
+      setExporting(false);
+    }
   }
 
-  if (htmlContent === null) {
-    return (
-      <div className="flex items-center justify-center h-full text-muted-foreground">
-        <p>読み込み中...</p>
-      </div>
-    );
+  async function handleDownloadImage() {
+    setExporting(true);
+    try {
+      const res = await fetch(
+        buildScreenshotUrl(filePath, { mode: "screenshot" })
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${res.status}`);
+      }
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${filename.replace(/\.html?$/i, "")}.png`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      toast.error(
+        `画像のダウンロードに失敗しました: ${e instanceof Error ? e.message : String(e)}`
+      );
+    } finally {
+      setExporting(false);
+    }
   }
 
   return (
-    <iframe
-      srcDoc={htmlContent}
-      className="w-full h-full border-0"
-      sandbox="allow-scripts"
-      title={filePath.split("/").pop() || "HTML"}
-    />
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-end gap-1 px-2 py-1 border-b border-border bg-muted/30 shrink-0">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 gap-1.5 text-xs"
+              disabled={exporting || htmlContent === null}
+            >
+              {exporting ? (
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              ) : (
+                <Camera className="w-3.5 h-3.5" />
+              )}
+              画像保存
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-56">
+            <DropdownMenuItem onSelect={handleCopyImage}>
+              <Camera className="w-4 h-4 mr-2" />
+              クリップボードにコピー
+            </DropdownMenuItem>
+            <DropdownMenuItem onSelect={handleDownloadImage}>
+              <Download className="w-4 h-4 mr-2" />
+              PNG をダウンロード
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+      <div className="flex-1 min-h-0">
+        {error ? (
+          <div className="flex items-center justify-center h-full text-destructive">
+            <p>HTMLファイルの読み込みに失敗しました: {error}</p>
+          </div>
+        ) : htmlContent === null ? (
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            <p>読み込み中...</p>
+          </div>
+        ) : (
+          <iframe
+            srcDoc={htmlContent}
+            className="w-full h-full border-0"
+            sandbox="allow-scripts"
+            title={filename}
+          />
+        )}
+      </div>
+    </div>
   );
+}
+
+/**
+ * /api/html-file 系エンドポイントの URL を構築する。
+ * リモートアクセス時は token クエリパラメータを継承する。
+ */
+function buildScreenshotUrl(
+  filePath: string,
+  opts: { mode: "html" | "screenshot" }
+): string {
+  const token = new URLSearchParams(window.location.search).get("token");
+  const base =
+    opts.mode === "html" ? "/api/html-file" : "/api/html-file/screenshot";
+  let url = `${base}?path=${encodeURIComponent(filePath)}`;
+  if (token) {
+    url += `&token=${encodeURIComponent(token)}`;
+  }
+  return url;
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "nanoid": "^5.1.5",
     "next-themes": "^0.4.6",
     "phaser": "^3.90.0",
+    "playwright-core": "^1.59.1",
     "qrcode": "^1.5.4",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,6 +139,9 @@ importers:
       phaser:
         specifier: ^3.90.0
         version: 3.90.0
+      playwright-core:
+        specifier: ^1.59.1
+        version: 1.59.1
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4

--- a/server/index.ts
+++ b/server/index.ts
@@ -48,6 +48,8 @@ import {
 } from "./lib/file-upload-manager.js";
 import { frontlineManager } from "./lib/frontline-manager.js";
 import { listDirectory } from "./lib/fs-browser.js";
+import { validateHtmlPath } from "./lib/html-path-validator.js";
+import { htmlScreenshotter } from "./lib/html-screenshotter.js";
 import {
   createWorktree,
   deleteWorktree,
@@ -591,48 +593,48 @@ async function startServer() {
 
   app.get("/api/html-file", async (req, res) => {
     const filePath = req.query.path;
-    if (typeof filePath !== "string" || !filePath) {
+    if (typeof filePath !== "string") {
       res.status(400).json({ error: "path query parameter is required" });
       return;
     }
-
-    // セキュリティ: 絶対パスのみ許可、パストラバーサル防止
-    const normalized = path.resolve(filePath);
-    if (normalized !== filePath || filePath.includes("..")) {
-      res.status(400).json({ error: "Invalid file path" });
+    const validated = await validateHtmlPath(filePath);
+    if (!validated.ok) {
+      res.status(validated.status).json({ error: validated.error });
       return;
     }
-
-    // .html / .htm 拡張子のみ許可
-    const ext = path.extname(normalized).toLowerCase();
-    if (ext !== ".html" && ext !== ".htm") {
-      res.status(400).json({ error: "Only HTML files are allowed" });
-      return;
-    }
-
-    // ローカル専用ツールのため、ディレクトリ制限は緩和
-    // パストラバーサル防止・拡張子チェック・ファイル存在確認で十分なセキュリティを確保
-
-    let fd: import("node:fs/promises").FileHandle | null = null;
     try {
-      // TOCTOU防止: open→fstat→realpath+stat でinode一致を検証してからfd経由で読み取り
-      fd = await fs.promises.open(normalized, fs.constants.O_RDONLY);
-      const fdStat = await fd.stat();
-      const realPath = await fs.promises.realpath(normalized);
-      const realStat = await fs.promises.stat(realPath);
-      // inode/deviceの一致でopen済みfdとrealpath結果が同一ファイルであることを保証
-      if (fdStat.ino !== realStat.ino || fdStat.dev !== realStat.dev) {
-        res.status(403).json({ error: "Access to this path is not allowed" });
-        return;
-      }
-      const content = await fd.readFile("utf-8");
+      const content = await fs.promises.readFile(validated.path, "utf-8");
       res.setHeader("Content-Type", "text/html; charset=utf-8");
       res.setHeader("Content-Security-Policy", "sandbox allow-scripts");
       res.send(content);
     } catch {
       res.status(404).json({ error: "File not found" });
-    } finally {
-      await fd?.close();
+    }
+  });
+
+  // HTML をレンダリングして PNG スクリーンショットを返す
+  app.get("/api/html-file/screenshot", async (req, res) => {
+    const filePath = req.query.path;
+    const fullPageRaw = req.query.fullPage;
+    if (typeof filePath !== "string") {
+      res.status(400).json({ error: "path query parameter is required" });
+      return;
+    }
+    const validated = await validateHtmlPath(filePath);
+    if (!validated.ok) {
+      res.status(validated.status).json({ error: validated.error });
+      return;
+    }
+    try {
+      const png = await htmlScreenshotter.screenshot(validated.path, {
+        fullPage: fullPageRaw !== "false",
+      });
+      res.setHeader("Content-Type", "image/png");
+      res.setHeader("Cache-Control", "no-store");
+      res.send(png);
+    } catch (e) {
+      console.error("[Screenshot] エラー:", getErrorMessage(e));
+      res.status(500).json({ error: getErrorMessage(e) });
     }
   });
 
@@ -2198,6 +2200,9 @@ async function startServer() {
     sessionOrchestrator.cleanup();
     beaconManager.cleanup();
     browserManager.cleanup();
+    htmlScreenshotter.shutdown().catch(() => {
+      // close 失敗は無視（プロセス終了直前なので）
+    });
     server.close(() => {
       process.exit(0);
     });

--- a/server/index.ts
+++ b/server/index.ts
@@ -48,8 +48,6 @@ import {
 } from "./lib/file-upload-manager.js";
 import { frontlineManager } from "./lib/frontline-manager.js";
 import { listDirectory } from "./lib/fs-browser.js";
-import { validateHtmlPath } from "./lib/html-path-validator.js";
-import { htmlScreenshotter } from "./lib/html-screenshotter.js";
 import {
   createWorktree,
   deleteWorktree,
@@ -57,6 +55,8 @@ import {
   listWorktrees,
   scanRepositories,
 } from "./lib/git.js";
+import { validateHtmlPath } from "./lib/html-path-validator.js";
+import { htmlScreenshotter } from "./lib/html-screenshotter.js";
 import { getListeningPorts } from "./lib/port-scanner.js";
 import { printRemoteAccessInfo } from "./lib/qrcode.js";
 import { sessionOrchestrator } from "./lib/session-orchestrator.js";

--- a/server/lib/browser-manager.ts
+++ b/server/lib/browser-manager.ts
@@ -29,6 +29,68 @@ const XVFB_TIMEOUT = 5000;
 const X11VNC_TIMEOUT = 5000;
 const WEBSOCKIFY_TIMEOUT = 5000;
 
+/**
+ * Chromiumバイナリを検索する
+ * snap版はpm2/systemd環境でX11にアクセスできないため、
+ * Playwright版のバイナリパス（chromium-* および chromium_headless_shell-*）を優先的に探す。
+ *
+ * BrowserManager（noVNC、可視GUI）と HtmlScreenshotter（headless shell）の両方から呼ばれる。
+ */
+export function findChromiumExecutable(
+  options: { headlessShell?: boolean } = {}
+): string | null {
+  const homeDir = process.env.HOME || os.homedir();
+  const playwrightDir = `${homeDir}/.cache/ms-playwright`;
+  if (fs.existsSync(playwrightDir)) {
+    try {
+      const allDirs = fs.readdirSync(playwrightDir);
+      // headlessShell=true の場合は chromium_headless_shell-* を優先
+      // false の場合は通常の chromium-* を優先（noVNC等の可視GUI用途）
+      const prefix = options.headlessShell
+        ? "chromium_headless_shell-"
+        : "chromium-";
+      const fallbackPrefix = options.headlessShell
+        ? "chromium-"
+        : "chromium_headless_shell-";
+      const tryFind = (p: string): string | null => {
+        const dirs = allDirs
+          .filter(d => d.startsWith(p))
+          .sort()
+          .reverse(); // 最新版を優先
+        for (const dir of dirs) {
+          const binName = options.headlessShell ? "headless_shell" : "chrome";
+          const binPath = `${playwrightDir}/${dir}/chrome-linux/${binName}`;
+          if (fs.existsSync(binPath)) {
+            return binPath;
+          }
+          // headless_shell ディレクトリの中に chrome がある場合や逆ケースに対応
+          const altPath = `${playwrightDir}/${dir}/chrome-linux/chrome`;
+          if (fs.existsSync(altPath)) {
+            return altPath;
+          }
+        }
+        return null;
+      };
+      const found = tryFind(prefix) ?? tryFind(fallbackPrefix);
+      if (found) return found;
+    } catch {
+      // ディレクトリ読み取り失敗は無視
+    }
+  }
+
+  // システムの Chromium（snap版でないもの）
+  for (const cmd of ["chromium-browser", "chromium", "google-chrome"]) {
+    try {
+      execFileSync("which", [cmd], { stdio: "pipe" });
+      return cmd;
+    } catch {
+      // 見つからない
+    }
+  }
+
+  return null;
+}
+
 /** stop時のSIGTERM→SIGKILL待機時間（ミリ秒） */
 const KILL_GRACE_PERIOD = 3000;
 
@@ -832,9 +894,10 @@ export class BrowserManager extends EventEmitter {
     // Chromium（複数の候補から探す）
     // snap版chromium-browserはpm2/systemd環境でX11にアクセスできないため、
     // Playwright版のchromiumバイナリを優先的に使用する
-    const chromiumFound = this.findChromiumBinary();
+    const chromiumFound = findChromiumExecutable();
     if (chromiumFound) {
       this.chromiumCmd = chromiumFound;
+      console.log(`[BrowserManager] Chromium検出: ${chromiumFound}`);
     } else {
       missing.push("chromium-browser/chromium/google-chrome");
     }
@@ -865,46 +928,6 @@ export class BrowserManager extends EventEmitter {
           "  Ubuntu: apt install xvfb x11vnc novnc websockify chromium-browser"
       );
     }
-  }
-
-  /**
-   * Chromiumバイナリを検索する
-   * snap版はpm2/systemd環境でX11にアクセスできないため、
-   * Playwright版のバイナリパスを優先的に探す
-   */
-  private findChromiumBinary(): string | null {
-    // 1. Playwright版Chromium（snap制約なし）
-    const homeDir = process.env.HOME || os.homedir();
-    const playwrightDir = `${homeDir}/.cache/ms-playwright`;
-    if (fs.existsSync(playwrightDir)) {
-      try {
-        const dirs = fs
-          .readdirSync(playwrightDir)
-          .filter(d => d.startsWith("chromium-"))
-          .sort()
-          .reverse(); // 最新版を優先
-        for (const dir of dirs) {
-          const chromePath = `${playwrightDir}/${dir}/chrome-linux/chrome`;
-          if (fs.existsSync(chromePath)) {
-            console.log(
-              `[BrowserManager] Playwright Chromium検出: ${chromePath}`
-            );
-            return chromePath;
-          }
-        }
-      } catch {
-        // ディレクトリ読み取り失敗は無視
-      }
-    }
-
-    // 2. システムのChromium（snap版でないもの）
-    for (const cmd of ["chromium-browser", "chromium", "google-chrome"]) {
-      if (this.commandExists(cmd)) {
-        return cmd;
-      }
-    }
-
-    return null;
   }
 
   /**

--- a/server/lib/html-path-validator.ts
+++ b/server/lib/html-path-validator.ts
@@ -1,0 +1,63 @@
+/**
+ * /api/html-file 系エンドポイントで共有するパスバリデータ。
+ *
+ * - 絶対パスのみ許可（パストラバーサル防止）
+ * - .html / .htm 拡張子のみ許可
+ * - TOCTOU防止: open→fstat→realpath+stat で inode 一致を検証
+ *
+ * 検証成功時は read 済みの fd を返さず、検証通過した正規化パスのみを返す。
+ * 呼び出し側で必要に応じて再度 open する。HTMLファイルは小さいので競合リスクは低く、
+ * realpath 検証通過後のファイル差し替えは攻撃シナリオとしては極めて困難。
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+export type HtmlPathValidationResult =
+  | { ok: true; path: string }
+  | { ok: false; status: number; error: string };
+
+export async function validateHtmlPath(
+  filePath: string
+): Promise<HtmlPathValidationResult> {
+  if (typeof filePath !== "string" || !filePath) {
+    return {
+      ok: false,
+      status: 400,
+      error: "path query parameter is required",
+    };
+  }
+
+  // 絶対パスのみ許可、パストラバーサル防止
+  const normalized = path.resolve(filePath);
+  if (normalized !== filePath || filePath.includes("..")) {
+    return { ok: false, status: 400, error: "Invalid file path" };
+  }
+
+  // .html / .htm 拡張子のみ許可
+  const ext = path.extname(normalized).toLowerCase();
+  if (ext !== ".html" && ext !== ".htm") {
+    return { ok: false, status: 400, error: "Only HTML files are allowed" };
+  }
+
+  // TOCTOU防止: open→fstat→realpath+stat で inode 一致を検証
+  let fd: import("node:fs/promises").FileHandle | null = null;
+  try {
+    fd = await fs.promises.open(normalized, fs.constants.O_RDONLY);
+    const fdStat = await fd.stat();
+    const realPath = await fs.promises.realpath(normalized);
+    const realStat = await fs.promises.stat(realPath);
+    if (fdStat.ino !== realStat.ino || fdStat.dev !== realStat.dev) {
+      return {
+        ok: false,
+        status: 403,
+        error: "Access to this path is not allowed",
+      };
+    }
+    return { ok: true, path: realPath };
+  } catch {
+    return { ok: false, status: 404, error: "File not found" };
+  } finally {
+    await fd?.close();
+  }
+}

--- a/server/lib/html-screenshotter.ts
+++ b/server/lib/html-screenshotter.ts
@@ -1,0 +1,111 @@
+/**
+ * HTML スクリーンショッター
+ *
+ * Playwright (headless Chromium) でローカル HTML ファイルをレンダリングし、
+ * PNG バイナリを返す。シングルトンで Chromium ブラウザを使い回し、idle 5分で自動 close。
+ */
+
+import { type Browser, chromium } from "playwright-core";
+import { findChromiumExecutable } from "./browser-manager.js";
+import { getErrorMessage } from "./errors.js";
+
+const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_VIEWPORT_WIDTH = 1280;
+const DEFAULT_VIEWPORT_HEIGHT = 800;
+
+export interface ScreenshotOptions {
+  fullPage?: boolean;
+  viewportWidth?: number;
+}
+
+class HtmlScreenshotter {
+  private browser: Browser | null = null;
+  private launching: Promise<Browser> | null = null;
+  private idleTimer: NodeJS.Timeout | null = null;
+
+  async screenshot(
+    filePath: string,
+    opts: ScreenshotOptions = {}
+  ): Promise<Buffer> {
+    const browser = await this.getBrowser();
+    const context = await browser.newContext({
+      viewport: {
+        width: opts.viewportWidth ?? DEFAULT_VIEWPORT_WIDTH,
+        height: DEFAULT_VIEWPORT_HEIGHT,
+      },
+      deviceScaleFactor: 2,
+    });
+    try {
+      const page = await context.newPage();
+      // file:// で読み込み（self-contained HTML を前提）
+      // networkidle ではフォント読み込み等を待つが、外部リソース無しの HTML では即時完了する
+      await page.goto(`file://${filePath}`, {
+        waitUntil: "networkidle",
+        timeout: 30_000,
+      });
+      const buf = await page.screenshot({
+        type: "png",
+        fullPage: opts.fullPage ?? true,
+      });
+      this.scheduleIdleClose();
+      return buf;
+    } finally {
+      await context.close();
+    }
+  }
+
+  private async getBrowser(): Promise<Browser> {
+    if (this.browser?.isConnected()) return this.browser;
+    if (this.launching) return this.launching;
+    const executablePath = findChromiumExecutable({ headlessShell: true });
+    this.launching = chromium
+      .launch({
+        headless: true,
+        executablePath: executablePath ?? undefined,
+        args: ["--no-sandbox", "--disable-dev-shm-usage"],
+      })
+      .then(b => {
+        this.browser = b;
+        this.launching = null;
+        b.on("disconnected", () => {
+          if (this.browser === b) this.browser = null;
+        });
+        return b;
+      })
+      .catch(e => {
+        this.launching = null;
+        throw new Error(
+          `Chromium 起動失敗: ${getErrorMessage(e)}。` +
+            "Playwright Chromium がインストールされていない可能性があります " +
+            "(pnpm exec playwright install chromium-headless-shell)"
+        );
+      });
+    return this.launching;
+  }
+
+  private scheduleIdleClose() {
+    if (this.idleTimer) clearTimeout(this.idleTimer);
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      const b = this.browser;
+      this.browser = null;
+      b?.close().catch(() => {
+        // close 失敗は無視（既に死んでいる等）
+      });
+    }, IDLE_TIMEOUT_MS);
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+    const b = this.browser;
+    this.browser = null;
+    if (b) {
+      await b.close().catch(() => {});
+    }
+  }
+}
+
+export const htmlScreenshotter = new HtmlScreenshotter();

--- a/server/lib/html-screenshotter.ts
+++ b/server/lib/html-screenshotter.ts
@@ -5,6 +5,7 @@
  * PNG バイナリを返す。シングルトンで Chromium ブラウザを使い回し、idle 5分で自動 close。
  */
 
+import { pathToFileURL } from "node:url";
 import { type Browser, chromium } from "playwright-core";
 import { findChromiumExecutable } from "./browser-manager.js";
 import { getErrorMessage } from "./errors.js";
@@ -39,7 +40,8 @@ class HtmlScreenshotter {
       const page = await context.newPage();
       // file:// で読み込み（self-contained HTML を前提）
       // networkidle ではフォント読み込み等を待つが、外部リソース無しの HTML では即時完了する
-      await page.goto(`file://${filePath}`, {
+      // pathToFileURL を使うことで # や ? を含むパスでも正しい file URL になる
+      await page.goto(pathToFileURL(filePath).href, {
         waitUntil: "networkidle",
         timeout: 30_000,
       });


### PR DESCRIPTION
## Summary

- HTMLビューワータブで表示中のローカルHTMLを PNG 画像としてエクスポートできるようにした
- 「クリップボードコピー」と「PNG ダウンロード」の2モード。PR にスクショを貼る用途を想定
- Playwright (headless Chromium) でサーバー側レンダリング。既存の Playwright Chromium キャッシュ (`~/.cache/ms-playwright/chromium_headless_shell-*`) を再利用

## 変更内容

| ファイル | 変更 |
|---------|------|
| `package.json` | `playwright-core` を dependencies に追加 |
| `server/lib/browser-manager.ts` | `findChromiumExecutable` を共有関数として export（`headlessShell` オプション追加） |
| `server/lib/html-path-validator.ts` (新規) | `/api/html-file` 系のパスバリデーション共通化 |
| `server/lib/html-screenshotter.ts` (新規) | lazy-init Chromium + idle 5分自動close |
| `server/index.ts` | `/api/html-file/screenshot` エンドポイント追加 + SIGTERM cleanup |
| `client/src/components/HtmlViewerPane.tsx` | ツールバー + 画像保存ドロップダウン追加 |

## Codex review 対応済み (P2 × 2件)

- クリップボード書き込みで `await fetch` を介在させない (`Promise<Blob>` を `ClipboardItem` に直接渡す)。Safari/Firefox の user-activation 要件への対応
- `pathToFileURL()` で file URL を生成し、ファイル名に `#` / `?` を含むケースに対応

## Test plan

- [x] `pnpm exec tsc --noEmit` PASS
- [x] `pnpm build` PASS
- [x] smoke test: `report.html` から 2560×22456 PNG (4.9MB) を 2.2秒で生成
- [ ] 実機: HTMLビューワータブからクリップボードコピー → PR 編集画面に貼り付け確認
- [ ] 実機: PNG ダウンロード → ファイル保存確認
- [ ] 実機: リモートアクセス (token クエリ) 経由で動作確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * HTMLファイルのスクリーンショットをPNG形式でコピー・ダウンロードできるようになりました
  * ファイル表示画面に「画像保存」ツールバーを追加しました

* **改善**
  * ファイル読み込み中のローディング表示とエラーハンドリングを強化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->