### PR TITLE
feat: Bridge ダッシュボード + リポジトリ別セッショングリッドビュー

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,12 +4,14 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/NotFound";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { ThemeProvider } from "./contexts/ThemeContext";
+import Bridge from "./pages/Bridge";
 import Dashboard from "./pages/Dashboard";
 
 function Router() {
   return (
     <Switch>
       <Route path="/" component={Dashboard} />
+      <Route path="/bridge" component={Bridge} />
       <Route path="/404" component={NotFound} />
       <Route component={NotFound} />
     </Switch>

--- a/client/src/components/RepoGridView.tsx
+++ b/client/src/components/RepoGridView.tsx
@@ -1,0 +1,249 @@
+/**
+ * RepoGridView — リポジトリ選択時のセッショングリッド表示
+ *
+ * 主 Dashboard でリポジトリヘッダをクリックすると、その repo 配下の全セッションを
+ * グリッドで一覧する。各セルは:
+ *   - 大きな状態バッジ (TOOL / THINK / AWAITING / IDLE / ERR / STOP) - 一瞥で状態が分かる
+ *   - ターミナル末尾プレビュー (静的スナップショット、1.5秒間隔で更新)
+ *   - セッション名 + 経過時間
+ *
+ * セルクリックで selectedSessionId を切替えて従来の TerminalPane に潜る。
+ *
+ * 軽量化のため ttyd iframe は使わず、サーバ側で tmux capture-pane した
+ * プレーンテキストを流し込む (= 操作不可、見るだけ)。
+ */
+
+import { Activity, AlertTriangle, Brain, Loader2, Pause } from "lucide-react";
+import type {
+  BridgeSessionStatus,
+  ManagedSession,
+  SessionGridSnapshot,
+} from "../../../shared/types";
+
+interface RepoGridViewProps {
+  /** 表示対象のリポジトリ絶対パス (ヘッダ表示用) */
+  repoPath: string;
+  /** 表示対象のセッション一覧 (このリポジトリのもの) */
+  sessions: ManagedSession[];
+  /** Worktree マップ (worktreeId → branch名) */
+  worktreeBranchById: Map<string, string>;
+  /** サーバから配信中のスナップショット (Dashboard が常時購読しているもの) */
+  snapshots: Map<string, SessionGridSnapshot>;
+  /** セルクリックでフルターミナル表示に切替 */
+  onSelectSession: (sessionId: string) => void;
+}
+
+export function RepoGridView({
+  repoPath,
+  sessions,
+  worktreeBranchById,
+  snapshots,
+  onSelectSession,
+}: RepoGridViewProps) {
+  const repoName = repoPath.split("/").filter(Boolean).pop() ?? repoPath;
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      <div className="px-4 py-3 border-b border-border bg-background/40 flex items-baseline gap-2 shrink-0">
+        <h2 className="text-base font-semibold">{repoName}</h2>
+        <span className="text-xs text-muted-foreground truncate">
+          {repoPath}
+        </span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {sessions.length} sessions
+        </span>
+      </div>
+      <div className="flex-1 overflow-auto p-4">
+        {sessions.length === 0 ? (
+          <div className="h-full flex items-center justify-center text-muted-foreground text-sm">
+            このリポジトリにはまだセッションがありません
+          </div>
+        ) : (
+          <div className="grid gap-4 grid-cols-1 md:grid-cols-2 2xl:grid-cols-3">
+            {sessions.map(session => (
+              <SessionCell
+                key={session.id}
+                session={session}
+                branch={worktreeBranchById.get(session.worktreeId)}
+                snapshot={snapshots.get(session.id)}
+                onClick={() => onSelectSession(session.id)}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// セル
+// ─────────────────────────────────────────────────────────────────
+
+function SessionCell({
+  session,
+  branch,
+  snapshot,
+  onClick,
+}: {
+  session: ManagedSession;
+  branch: string | undefined;
+  snapshot: SessionGridSnapshot | undefined;
+  onClick: () => void;
+}) {
+  const status: BridgeSessionStatus = snapshot?.status ?? "IDLE";
+  const elapsed = snapshot
+    ? formatElapsed(snapshot.elapsedMs)
+    : formatElapsed(Date.now() - new Date(session.createdAt).getTime());
+  const name = snapshot?.name ?? deriveName(session.worktreePath);
+  const previewText = snapshot?.previewText ?? "";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-left bg-card border border-border rounded-lg overflow-hidden hover:border-primary/60 hover:bg-accent/30 transition-colors flex flex-col h-72"
+    >
+      {/* ヘッダー行: 名前 / branch / 経過時間 */}
+      <div className="px-3 py-2 border-b border-border flex items-center justify-between gap-2 shrink-0">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium truncate">{name}</div>
+          {branch ? (
+            <div className="text-[10px] text-muted-foreground truncate font-mono">
+              {branch}
+            </div>
+          ) : null}
+        </div>
+        <div className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+          {elapsed}
+        </div>
+      </div>
+
+      {/* 大きな状態バッジ */}
+      <div className="px-3 py-2 border-b border-border shrink-0">
+        <StatusBadge status={status} />
+      </div>
+
+      {/* ターミナルプレビュー */}
+      <div className="flex-1 min-h-0 overflow-hidden bg-black/40 text-foreground/80">
+        {previewText ? (
+          <pre className="text-[10px] leading-tight font-mono p-2 whitespace-pre overflow-hidden h-full">
+            {previewText}
+          </pre>
+        ) : (
+          <div className="h-full flex items-center justify-center text-[10px] text-muted-foreground">
+            (no output)
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 状態バッジ
+// ─────────────────────────────────────────────────────────────────
+
+const STATUS_CONFIG: Record<
+  BridgeSessionStatus,
+  {
+    label: string;
+    sublabel: string;
+    bgClass: string;
+    fgClass: string;
+    Icon: React.ComponentType<{ className?: string }>;
+    spin?: boolean;
+  }
+> = {
+  // サイドバー左ドットの配色に合わせる:
+  //   緑 (bg-green-500) = 動作中 → TOOL / THINK
+  //   赤 (bg-red-500)   = 入力待ち → IDLE / ERR
+  // AWAITING は新概念なのでサイドバーに対応色がない。橙で強調 + 点滅。
+  TOOL: {
+    label: "実行中",
+    sublabel: "tool calls running",
+    bgClass: "bg-green-500/15 border-green-500/40",
+    fgClass: "text-green-300",
+    Icon: Loader2,
+    spin: true,
+  },
+  THINK: {
+    label: "思考中",
+    sublabel: "pondering",
+    bgClass: "bg-green-500/15 border-green-500/40",
+    fgClass: "text-green-300",
+    Icon: Brain,
+  },
+  AWAITING: {
+    label: "判断要",
+    sublabel: "awaiting decision",
+    // 最も目立たせる: オレンジ太枠 (サイドバーに対応色なし)
+    bgClass: "bg-orange-500/25 border-orange-500/70 border-2",
+    fgClass: "text-orange-200",
+    Icon: AlertTriangle,
+  },
+  IDLE: {
+    label: "入力待ち",
+    sublabel: "waiting for input",
+    bgClass: "bg-red-500/15 border-red-500/40",
+    fgClass: "text-red-300",
+    Icon: Activity,
+  },
+  READY: {
+    label: "待機",
+    sublabel: "ready (empty)",
+    // /clear 直後など、何もしていない状態。サイドバーの青ドットに対応するが
+    // グレー寄りに抑えて「特にアクション不要」を示す。
+    bgClass: "bg-neutral-500/15 border-neutral-500/40",
+    fgClass: "text-neutral-400",
+    Icon: Activity,
+  },
+  ERR: {
+    label: "エラー",
+    sublabel: "error detected",
+    bgClass: "bg-red-500/25 border-red-500/60",
+    fgClass: "text-red-200",
+    Icon: AlertTriangle,
+  },
+  STOP: {
+    label: "停止",
+    sublabel: "session stopped",
+    bgClass: "bg-neutral-500/15 border-neutral-500/40",
+    fgClass: "text-neutral-300",
+    Icon: Pause,
+  },
+};
+
+function StatusBadge({ status }: { status: BridgeSessionStatus }) {
+  const cfg = STATUS_CONFIG[status];
+  const Icon = cfg.Icon;
+  return (
+    <div
+      className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-md border ${cfg.bgClass} ${cfg.fgClass}`}
+    >
+      <Icon className={`w-4 h-4 ${cfg.spin ? "animate-spin" : ""}`} />
+      <div className="leading-tight">
+        <div className="text-sm font-semibold">{cfg.label}</div>
+        <div className="text-[10px] opacity-70">{cfg.sublabel}</div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 補助
+// ─────────────────────────────────────────────────────────────────
+
+function deriveName(worktreePath: string): string {
+  return worktreePath.split("/").filter(Boolean).pop() ?? worktreePath;
+}
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}

--- a/client/src/components/RepoGridView.tsx
+++ b/client/src/components/RepoGridView.tsx
@@ -14,6 +14,7 @@
  */
 
 import { Activity, AlertTriangle, Brain, Loader2, Pause } from "lucide-react";
+import { useEffect } from "react";
 import type {
   BridgeSessionStatus,
   ManagedSession,
@@ -27,8 +28,11 @@ interface RepoGridViewProps {
   sessions: ManagedSession[];
   /** Worktree マップ (worktreeId → branch名) */
   worktreeBranchById: Map<string, string>;
-  /** サーバから配信中のスナップショット (Dashboard が常時購読しているもの) */
+  /** サーバから配信中のスナップショット (mount 中だけ購読) */
   snapshots: Map<string, SessionGridSnapshot>;
+  /** マウント時に購読、アンマウント時に解除 */
+  onSubscribe: () => void;
+  onUnsubscribe: () => void;
   /** セルクリックでフルターミナル表示に切替 */
   onSelectSession: (sessionId: string) => void;
 }
@@ -38,8 +42,17 @@ export function RepoGridView({
   sessions,
   worktreeBranchById,
   snapshots,
+  onSubscribe,
+  onUnsubscribe,
   onSelectSession,
 }: RepoGridViewProps) {
+  // RepoGridView 表示中だけ session:grid:snapshot を購読する
+  // (常時購読すると pane polling が二重化するため)
+  useEffect(() => {
+    onSubscribe();
+    return () => onUnsubscribe();
+  }, [onSubscribe, onUnsubscribe]);
+
   const repoName = repoPath.split("/").filter(Boolean).pop() ?? repoPath;
 
   return (

--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -17,7 +17,11 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
-import type { ManagedSession, Worktree } from "../../../shared/types";
+import type {
+  BridgeSessionStatus,
+  ManagedSession,
+  Worktree,
+} from "../../../shared/types";
 
 /** プレビュー無変化でアイドル判定するまでの秒数 */
 const IDLE_THRESHOLD_MS = 10_000;
@@ -29,6 +33,12 @@ interface SessionCardProps {
   isSelected: boolean;
   previewText: string;
   activityText: string;
+  /**
+   * Bridge collector が判定した最新のセッション状態 (グリッドビューと同じソース)。
+   * 渡されればこれを優先してドット色を決定し、サイドバーとグリッドで表示が一致する。
+   * 未取得 (snapshot 未着信) の場合は activityText/previewText 由来のフォールバックを使う。
+   */
+  gridStatus?: BridgeSessionStatus;
   onClick: () => void;
   /** セッション削除（停止 + メイン以外のWorktree削除） */
   onDelete: () => void;
@@ -41,6 +51,7 @@ export function SessionCard({
   isSelected,
   previewText,
   activityText,
+  gridStatus,
   onClick,
   onDelete,
   onStart,
@@ -105,27 +116,11 @@ export function SessionCard({
     );
   }
 
-  // ✢✻はアニメーション記号、◼◻はタスク表示記号、"* verb…"は処理中表示
-  const hasActivitySymbol =
-    /[✢✻◼◻]/.test(activityText) ||
-    /[◼◻]/.test(previewText) ||
-    /\S+…/.test(activityText);
-  // タスク記号・処理中表示はidle判定を無視する
-  const hasTaskSymbol =
-    /[◼◻]/.test(activityText) ||
-    /[◼◻]/.test(previewText) ||
-    /\S+…/.test(activityText);
-
-  // 緑: 動作中（✢✻+変化あり or タスク進行中）、青: 起動直後/clear後、赤: それ以外
-  const hasVisibleContent =
-    previewText.trim().length > 0 || activityText.trim().length > 0;
-
-  const dotColor =
-    hasActivitySymbol && (!isIdle || hasTaskSymbol)
-      ? "bg-green-500"
-      : !hasVisibleContent
-        ? "bg-blue-500"
-        : "bg-red-500";
+  // ドット色はグリッドビューと統一するため BridgeSessionStatus を優先する。
+  // gridStatus が未着信のときだけ既存ヒューリスティック (✢✻ / ◼◻ / …) にフォールバック。
+  const dotColor = gridStatus
+    ? statusToDotColor(gridStatus)
+    : fallbackDotColor(previewText, activityText, isIdle);
 
   // アイドル時はactivityText（✻ Baked for ...）、アクティブ時はコンテンツ行
   const idle = session.status === "idle" || isIdle;
@@ -205,4 +200,55 @@ export function SessionCard({
       </AlertDialog>
     </>
   );
+}
+
+/**
+ * Bridge の状態判定 → サイドバードット色のマップ。
+ * グリッドビュー側 (RepoGridView の STATUS_CONFIG) と色を揃える。
+ *
+ *   TOOL/THINK = 緑     (動作中)
+ *   AWAITING   = 橙     (判断要)
+ *   IDLE/ERR   = 赤     (アクション必要)
+ *   READY/STOP = グレー (アイドル相当)
+ */
+function statusToDotColor(status: BridgeSessionStatus): string {
+  switch (status) {
+    case "TOOL":
+    case "THINK":
+      return "bg-green-500";
+    case "AWAITING":
+      return "bg-orange-500";
+    case "IDLE":
+    case "ERR":
+      return "bg-red-500";
+    case "READY":
+    case "STOP":
+      return "bg-neutral-500";
+  }
+}
+
+/**
+ * gridStatus が未着信の間だけ使う旧ロジックのフォールバック。
+ *   - 緑: 活動記号 (✢✻◼◻ / `…`) あり、かつ idle でない or タスク記号
+ *   - 青: 出力なし (起動直後/clear 後)
+ *   - 赤: それ以外
+ */
+function fallbackDotColor(
+  previewText: string,
+  activityText: string,
+  isIdle: boolean
+): string {
+  const hasActivitySymbol =
+    /[✢✻◼◻]/.test(activityText) ||
+    /[◼◻]/.test(previewText) ||
+    /\S+…/.test(activityText);
+  const hasTaskSymbol =
+    /[◼◻]/.test(activityText) ||
+    /[◼◻]/.test(previewText) ||
+    /\S+…/.test(activityText);
+  const hasVisibleContent =
+    previewText.trim().length > 0 || activityText.trim().length > 0;
+  if (hasActivitySymbol && (!isIdle || hasTaskSymbol)) return "bg-green-500";
+  if (!hasVisibleContent) return "bg-neutral-500";
+  return "bg-red-500";
 }

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -62,6 +62,7 @@ import {
 import { useGroupedWorktreeItems } from "@/hooks/useGroupedWorktreeItems";
 import { getBaseName } from "@/utils/pathUtils";
 import type {
+  BridgeSessionStatus,
   ManagedSession,
   Profile,
   SystemCapabilities,
@@ -99,6 +100,16 @@ interface SessionSidebarProps {
   onRestartSession?: (sessionId: string) => void;
   /** リポジトリで新規Worktree作成を要求 */
   onCreateWorktreeForRepo?: (repoPath: string) => void;
+  /** リポジトリヘッダクリック時: メイン領域をセッショングリッドビューに切替える */
+  onSelectRepoGrid?: (repoPath: string) => void;
+  /** 現在グリッド表示中のリポジトリパス（ヘッダのハイライト判定用） */
+  gridRepoPath?: string | null;
+  /**
+   * 各セッションの BridgeSessionStatus スナップショット (sessionId → status)。
+   * SessionCard のドット色を統一するために渡す。
+   * 未設定 (Map empty) の場合は SessionCard 側のフォールバック判定が使われる。
+   */
+  gridStatuses?: Map<string, BridgeSessionStatus>;
 }
 
 export function SessionSidebar({
@@ -123,6 +134,9 @@ export function SessionSidebar({
   onOpenProfileManager,
   onRestartSession,
   onCreateWorktreeForRepo,
+  onSelectRepoGrid,
+  gridRepoPath,
+  gridStatuses,
 }: SessionSidebarProps) {
   const { groupedItems } = useGroupedWorktreeItems(
     worktrees,
@@ -343,17 +357,37 @@ export function SessionSidebar({
                   ) : (
                     <FolderOpen className="w-3 h-3 text-muted-foreground shrink-0" />
                   )}
-                  <span
-                    className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate"
-                    title={repoPath}
-                  >
-                    {repoName}
-                    {disambiguator && (
-                      <span className="ml-1 text-muted-foreground/70 normal-case">
-                        ({disambiguator})
-                      </span>
-                    )}
-                  </span>
+                  {onSelectRepoGrid ? (
+                    <button
+                      type="button"
+                      onClick={() => onSelectRepoGrid(repoPath)}
+                      className={`text-xs font-medium uppercase tracking-wider truncate text-left hover:text-foreground transition-colors ${
+                        gridRepoPath === repoPath
+                          ? "text-foreground"
+                          : "text-muted-foreground"
+                      }`}
+                      title={`${repoPath} (クリックでセッション一覧)`}
+                    >
+                      {repoName}
+                      {disambiguator && (
+                        <span className="ml-1 text-muted-foreground/70 normal-case">
+                          ({disambiguator})
+                        </span>
+                      )}
+                    </button>
+                  ) : (
+                    <span
+                      className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate"
+                      title={repoPath}
+                    >
+                      {repoName}
+                      {disambiguator && (
+                        <span className="ml-1 text-muted-foreground/70 normal-case">
+                          ({disambiguator})
+                        </span>
+                      )}
+                    </span>
+                  )}
                   {renderRepoProfileBadge(repoPath)}
                 </div>
               );
@@ -431,6 +465,9 @@ export function SessionSidebar({
                             session
                               ? sessionActivityTexts.get(session.id) || ""
                               : ""
+                          }
+                          gridStatus={
+                            session ? gridStatuses?.get(session.id) : undefined
                           }
                           onClick={() => session && onSelectSession(session.id)}
                           onDelete={() =>

--- a/client/src/components/bridge/BridgeDashboard.tsx
+++ b/client/src/components/bridge/BridgeDashboard.tsx
@@ -1,0 +1,514 @@
+/**
+ * Bridge Dashboard — 1280x720 1bit Mac OS 風モニタリングUI
+ *
+ * モック (docs/superpowers の HTML) をそのまま React コンポーネント化したもの。
+ * すべてのセクションで `bridge-` prefix の CSS を使う。
+ */
+
+import { useMemo } from "react";
+import type {
+  BridgeSession,
+  BridgeSessionStatus,
+  BridgeSnapshot,
+  HostMetrics,
+} from "../../../../shared/types";
+import "./bridge.css";
+
+interface BridgeDashboardProps {
+  /** Socket.IO から受信した最新スナップショット (未着なら null) */
+  snapshot: BridgeSnapshot | null;
+  /** 現在時刻 (秒精度の表示用) */
+  now: Date;
+}
+
+export function BridgeDashboard({ snapshot, now }: BridgeDashboardProps) {
+  return (
+    <div className="bridge-root">
+      <div className="bridge-stage">
+        <MenuBar now={now} />
+
+        <SessionsGridWindow sessions={snapshot?.sessions ?? []} />
+
+        <SystemMonitorWindow metrics={snapshot?.metrics ?? null} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// メニューバー
+// ─────────────────────────────────────────────────────────────────
+
+function MenuBar({ now }: { now: Date }) {
+  const day = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"][now.getDay()];
+  const hh = String(now.getHours()).padStart(2, "0");
+  const mm = String(now.getMinutes()).padStart(2, "0");
+  return (
+    <div className="bridge-menubar">
+      <span className="apple"></span>
+      <span>
+        <b>Ark Bridge</b>
+      </span>
+      <span>File</span>
+      <span>Edit</span>
+      <span>View</span>
+      <span>Sessions</span>
+      <span>Special</span>
+      <span className="clock">
+        {day} {hh}:{mm}
+      </span>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Sessions Grid (Bridge メイン: 全セッションを 1bit セルで並べる)
+// ─────────────────────────────────────────────────────────────────
+
+function SessionsGridWindow({ sessions }: { sessions: BridgeSession[] }) {
+  const count = sessions.length;
+  return (
+    <Window
+      className="bridge-w-grid"
+      title={count > 0 ? `Sessions — ${count}` : "Sessions"}
+    >
+      {count === 0 ? (
+        <EmptyHint text="no active sessions" />
+      ) : (
+        <div className="bridge-grid-body" data-count={String(count)}>
+          {sessions.map(s => (
+            <SessionCell key={s.id} session={s} />
+          ))}
+        </div>
+      )}
+    </Window>
+  );
+}
+
+function SessionCell({ session }: { session: BridgeSession }) {
+  return (
+    <div className="bridge-cell">
+      <div className="bridge-cell-titlebar">
+        <span className="bridge-cell-title" title={session.name}>
+          {session.name}
+        </span>
+      </div>
+      <div className="bridge-cell-head">
+        <span className={`bridge-cell-status${statusClass(session.status)}`}>
+          {formatStatusBadge(session.status)}
+        </span>
+        <span className="bridge-cell-elapsed">
+          {formatElapsed(session.elapsedMs)}
+        </span>
+      </div>
+      <div className="bridge-cell-body">
+        {session.previewText ? (
+          session.previewText
+        ) : (
+          <span className="bridge-cell-empty">— no output —</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function formatStatusBadge(status: BridgeSessionStatus): string {
+  if (status === "ERR") return "!! ERR";
+  if (status === "AWAITING") return "!! WAIT";
+  return status;
+}
+
+/**
+ * セルの status バッジに付ける CSS クラスを返す。
+ * 1bit デザインを破って状態ごとに色付け (CSS 側 .s-<status> で配色)。
+ */
+function statusClass(status: BridgeSessionStatus): string {
+  return ` s-${status.toLowerCase()}`;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// System Monitor (CPU / Cores / Memory / Storage) — 4カラム
+// ─────────────────────────────────────────────────────────────────
+
+function SystemMonitorWindow({ metrics }: { metrics: HostMetrics | null }) {
+  return (
+    <Window
+      className="bridge-w-monitor"
+      title={`System Monitor — ${metrics ? `${metrics.cores.length} cores` : "loading"}`}
+    >
+      <div className="bridge-monitor-body">
+        <CpuSection metrics={metrics} />
+        <CoresSection metrics={metrics} />
+        <MemorySection metrics={metrics} />
+        <StorageSection metrics={metrics} />
+      </div>
+    </Window>
+  );
+}
+
+function StorageSection({ metrics }: { metrics: HostMetrics | null }) {
+  const volumes = metrics?.volumes ?? [];
+  // 容量大きい順に host-metrics 側でソート済み。先頭を主ボリュームとして大きく表示する。
+  const primary = volumes[0];
+  const others = volumes.slice(1);
+  const percent = primary ? Math.round(primary.usedPercent) : 0;
+  return (
+    <div className="bridge-mon-section">
+      <div className="bridge-mon-title">
+        <span>Storage</span>
+        <span className="sub">
+          {primary ? primary.name : `${volumes.length} volumes`}
+        </span>
+      </div>
+      {!primary ? (
+        <EmptyHint text="no volumes" />
+      ) : (
+        <>
+          <div className="bridge-storage-pie-wrap">
+            <div
+              className="bridge-storage-pie"
+              style={{
+                background: `conic-gradient(#000 0 ${primary.usedPercent}%, #fff ${primary.usedPercent}% 100%)`,
+              }}
+            />
+          </div>
+          <div className="bridge-gauge-readout">{percent} %</div>
+          <div className="bridge-gauge-label">
+            {formatGB(primary.usedGB)} / {formatGB(primary.totalGB)}
+          </div>
+          {others.length > 0 ? (
+            <div className="bridge-storage-others">+ {others.length} more</div>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+function CpuSection({ metrics }: { metrics: HostMetrics | null }) {
+  const percent = metrics?.cpuPercent ?? 0;
+  const loadAvg = metrics?.loadAvg ?? [0, 0, 0];
+  // 0%→-90deg、100%→+90deg
+  const angle = -90 + (clamp(percent, 0, 100) / 100) * 180;
+  return (
+    <div className="bridge-mon-section">
+      <div className="bridge-mon-title">
+        <span>CPU</span>
+        <span className="sub">
+          {metrics ? `${metrics.cores.length} cores` : "—"}
+        </span>
+      </div>
+      <div className="bridge-gauge">
+        <svg viewBox="0 0 200 110" preserveAspectRatio="xMidYMid meet">
+          <title>CPU usage gauge</title>
+          {/* outer arc */}
+          <path
+            d="M 10 100 A 90 90 0 0 1 190 100"
+            fill="none"
+            stroke="#000"
+            strokeWidth="1.5"
+          />
+          {/* tick marks */}
+          <g stroke="#000" strokeWidth="1">
+            <line x1="10" y1="100" x2="18" y2="100" />
+            <line x1="22" y1="63" x2="29" y2="68" />
+            <line x1="51" y1="32" x2="56" y2="39" />
+            <line x1="100" y1="14" x2="100" y2="22" />
+            <line x1="149" y1="32" x2="144" y2="39" />
+            <line x1="178" y1="63" x2="171" y2="68" />
+            <line x1="190" y1="100" x2="182" y2="100" />
+          </g>
+          <g stroke="#000" strokeWidth="0.5">
+            <line x1="14" y1="80" x2="20" y2="82" />
+            <line x1="34" y1="48" x2="40" y2="52" />
+            <line x1="73" y1="20" x2="76" y2="27" />
+            <line x1="127" y1="20" x2="124" y2="27" />
+            <line x1="166" y1="48" x2="160" y2="52" />
+            <line x1="186" y1="80" x2="180" y2="82" />
+          </g>
+          <g
+            fontFamily="Chicago, Charcoal, sans-serif"
+            fontSize="9"
+            textAnchor="middle"
+          >
+            <text x="10" y="112">
+              0
+            </text>
+            <text x="100" y="9">
+              50
+            </text>
+            <text x="190" y="112">
+              100
+            </text>
+          </g>
+          {/* needle */}
+          <g transform={`rotate(${angle} 100 100)`}>
+            <line
+              x1="100"
+              y1="100"
+              x2="100"
+              y2="22"
+              stroke="#000"
+              strokeWidth="2"
+            />
+            <polygon points="96,30 100,18 104,30" fill="#000" />
+          </g>
+          <circle
+            cx="100"
+            cy="100"
+            r="5"
+            fill="#fff"
+            stroke="#000"
+            strokeWidth="1.5"
+          />
+          <circle cx="100" cy="100" r="1.5" fill="#000" />
+        </svg>
+      </div>
+      <div className="bridge-gauge-readout">{Math.round(percent)} %</div>
+      <div className="bridge-gauge-label">
+        load avg {loadAvg[0].toFixed(2)} · {loadAvg[1].toFixed(2)} ·{" "}
+        {loadAvg[2].toFixed(2)}
+      </div>
+    </div>
+  );
+}
+
+function CoresSection({ metrics }: { metrics: HostMetrics | null }) {
+  const cores = metrics?.cores ?? [];
+  // 表示は最大12コアまで
+  const displayed = cores.slice(0, 12);
+  // 履歴は最大36サンプル前提で 0-100 → 0-100% の高さに
+  const history = metrics?.cpuHistory ?? [];
+  return (
+    <div className="bridge-mon-section">
+      <div className="bridge-mon-title">
+        <span>Cores</span>
+        <span className="sub">{cores.length} total</span>
+      </div>
+      <div className="bridge-core-grid">
+        {displayed.length === 0
+          ? Array.from({ length: 4 }).map((_, i) => (
+              <CoreRow key={`p-${i}`} label={`P${i}`} percent={0} />
+            ))
+          : displayed.map((p, i) => (
+              <CoreRow
+                key={`c-${i}`}
+                label={i < 8 ? `P${i}` : `E${i - 8}`}
+                percent={p}
+                dense={i >= 8}
+              />
+            ))}
+      </div>
+      <div className="bridge-strip">
+        {(history.length > 0
+          ? history
+          : Array.from({ length: 36 }).fill(0)
+        ).map((h, i) => (
+          <div
+            key={`s-${i}`}
+            className="s"
+            style={{ height: `${clamp(h as number, 0, 100)}%` }}
+          />
+        ))}
+      </div>
+      <div className="bridge-strip-axis">
+        <span>−60s</span>
+        <span>now</span>
+      </div>
+    </div>
+  );
+}
+
+function CoreRow({
+  label,
+  percent,
+  dense,
+}: {
+  label: string;
+  percent: number;
+  dense?: boolean;
+}) {
+  const p = clamp(percent, 0, 100);
+  return (
+    <div className="bridge-core-row">
+      <span className="lbl">{label}</span>
+      <div className="bridge-core-bar">
+        <div className={dense ? "dense" : ""} style={{ width: `${p}%` }} />
+      </div>
+      <span className="v">{Math.round(p)}%</span>
+    </div>
+  );
+}
+
+function MemorySection({ metrics }: { metrics: HostMetrics | null }) {
+  const mem = metrics?.memory;
+  const segments = useMemo(() => {
+    if (!mem || mem.totalGB <= 0) {
+      return [
+        { kind: "solid" as const, percent: 0, label: "Wired", value: 0 },
+        { kind: "dense" as const, percent: 0, label: "App", value: 0 },
+        { kind: "sparse" as const, percent: 0, label: "Cached", value: 0 },
+        { kind: "blank" as const, percent: 0, label: "Free", value: 0 },
+      ];
+    }
+    const total = mem.totalGB;
+    const wiredPct = (mem.wiredGB / total) * 100;
+    const appPct = (mem.appGB / total) * 100;
+    const cachedPct = (mem.cachedGB / total) * 100;
+    const compressPct = (mem.compressGB / total) * 100;
+    const freePct = (mem.freeGB / total) * 100;
+    return [
+      {
+        kind: "solid" as const,
+        percent: wiredPct,
+        label: "Wired",
+        value: mem.wiredGB,
+      },
+      {
+        kind: "dense" as const,
+        percent: appPct,
+        label: "App",
+        value: mem.appGB,
+      },
+      {
+        kind: "sparse" as const,
+        percent: cachedPct,
+        label: "Cached",
+        value: mem.cachedGB,
+      },
+      {
+        kind: "sparse" as const,
+        percent: compressPct,
+        label: "Compress",
+        value: mem.compressGB,
+      },
+      {
+        kind: "blank" as const,
+        percent: freePct,
+        label: "Free",
+        value: mem.freeGB,
+      },
+    ];
+  }, [mem]);
+
+  const memHistory = metrics?.memHistory ?? [];
+
+  return (
+    <div className="bridge-mon-section">
+      <div className="bridge-mon-title">
+        <span>Memory</span>
+        <span className="sub">
+          {mem
+            ? `${mem.usedGB.toFixed(1)} / ${mem.totalGB.toFixed(0)} GB`
+            : "—"}
+        </span>
+      </div>
+      <div className="bridge-mem-segments">
+        {segments.map((s, i) => (
+          <div
+            key={`seg-${i}`}
+            className={`bridge-mem-seg${s.kind === "blank" ? "" : ` ${s.kind}`}`}
+            style={{ width: `${clamp(s.percent, 0, 100)}%` }}
+          />
+        ))}
+      </div>
+      <div className="bridge-mem-legend">
+        {segments.map((s, i) => (
+          <div key={`lg-${i}`} className="bridge-mem-legend-row">
+            <span
+              className={`bridge-legend-swatch${
+                s.kind === "blank" ? "" : ` ${s.kind}`
+              }`}
+            />
+            <span>{s.label}</span>
+            <span className="v">{s.value.toFixed(1)}</span>
+          </div>
+        ))}
+        <div className="bridge-mem-legend-row">
+          <span />
+          <span>Swap</span>
+          <span className="v">{mem ? `${mem.swapGB.toFixed(1)} GB` : "—"}</span>
+        </div>
+      </div>
+      <div className="bridge-strip" style={{ marginTop: "auto" }}>
+        {(memHistory.length > 0
+          ? memHistory
+          : Array.from({ length: 18 }).fill(0)
+        ).map((h, i) => (
+          <div
+            key={`m-${i}`}
+            className="s"
+            style={{ height: `${clamp(h as number, 0, 100)}%` }}
+          />
+        ))}
+      </div>
+      <div className="bridge-strip-axis">
+        <span>−10m</span>
+        <span>now</span>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 共通
+// ─────────────────────────────────────────────────────────────────
+
+function Window({
+  className,
+  title,
+  children,
+}: {
+  className: string;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`bridge-window ${className}`}>
+      <div className="bridge-titlebar">
+        <span className="bridge-close-box" />
+        <span className="bridge-title-text">{title}</span>
+        <span className="bridge-zoom-box" />
+      </div>
+      <div className="bridge-window-body">{children}</div>
+    </div>
+  );
+}
+
+function EmptyHint({ text }: { text: string }) {
+  return (
+    <div
+      style={{
+        padding: "10px 12px",
+        fontSize: 11,
+        fontStyle: "italic",
+        opacity: 0.7,
+      }}
+    >
+      {text}
+    </div>
+  );
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+function formatElapsed(ms: number): string {
+  const totalSeconds = Math.max(0, Math.floor(ms / 1000));
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  if (h > 0) return `${h}:${pad(m)}:${pad(s)}`;
+  return `${pad(m)}:${pad(s)}`;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function formatGB(gb: number): string {
+  if (gb >= 1024) return `${(gb / 1024).toFixed(2)} TB`;
+  if (gb >= 100) return `${gb.toFixed(0)} GB`;
+  return `${gb.toFixed(1)} GB`;
+}

--- a/client/src/components/bridge/bridge.css
+++ b/client/src/components/bridge/bridge.css
@@ -168,28 +168,31 @@
 .bridge-grid-body {
   padding: 6px;
   height: 100%;
-  overflow: hidden;
+  /* 7+ セッション時に下行が切れないよう縦スクロールを許可 */
+  overflow-y: auto;
+  overflow-x: hidden;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: 1fr;
+  /* セルは最低 180px 確保。それを下回るほど詰まったら 2行に積む */
+  grid-auto-rows: minmax(180px, 1fr);
   gap: 6px;
 }
 
-/* 4セッション以下なら 2 列、それ以上は 3 列にして詰めすぎを防ぐ */
+/* 4セッション以下なら 2 列以下にして詰めすぎを防ぐ */
 .bridge-grid-body[data-count="1"] {
   grid-template-columns: 1fr;
-  grid-template-rows: 1fr;
+  grid-auto-rows: 1fr;
 }
 .bridge-grid-body[data-count="2"] {
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr;
+  grid-auto-rows: 1fr;
 }
 .bridge-grid-body[data-count="3"],
 .bridge-grid-body[data-count="4"] {
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 1fr;
+  grid-auto-rows: 1fr;
 }
-/* 5以上は 3列固定 (デフォルト) */
+/* 5以上は 3列固定 (デフォルト)、行数は内容に合わせて伸びる */
 
 .bridge-cell {
   background: var(--wt);

--- a/client/src/components/bridge/bridge.css
+++ b/client/src/components/bridge/bridge.css
@@ -1,0 +1,598 @@
+/*
+ * Ark Bridge — Classic Mac OS (System 1-6) style 1bit dashboard
+ * 1280x720 固定。1bit デザイン (黒/白のみ + ディザリング) を厳守。
+ *
+ * すべてのクラスは .bridge-root スコープ下に閉じ込めている。
+ * Tailwind/index.css との競合を避けるため変数も :where(.bridge-root) で定義する。
+ */
+
+.bridge-root {
+  --bk: #000000;
+  --wt: #ffffff;
+}
+
+/* リセット相当（既存 index.css の box-sizing と被らないように上書き） */
+.bridge-root,
+.bridge-root *,
+.bridge-root *::before,
+.bridge-root *::after {
+  box-sizing: border-box;
+}
+
+/* ステージ全体（外枠コンテナ） */
+.bridge-stage {
+  width: 1280px;
+  height: 720px;
+  position: relative;
+  background: var(--wt);
+  color: var(--bk);
+  font-family:
+    "ChicagoFLF", "Chicago", "Charcoal", "Geneva", "Helvetica", sans-serif;
+  font-size: 12px;
+  line-height: 1.2;
+  -webkit-font-smoothing: none;
+  font-smooth: never;
+  overflow: hidden;
+
+  /* デスクトップ: 50% ディザリング */
+  background-image:
+    linear-gradient(
+      45deg,
+      var(--bk) 25%,
+      transparent 25%,
+      transparent 75%,
+      var(--bk) 75%
+    ),
+    linear-gradient(
+      45deg,
+      var(--bk) 25%,
+      transparent 25%,
+      transparent 75%,
+      var(--bk) 75%
+    );
+  background-size: 2px 2px;
+  background-position:
+    0 0,
+    1px 1px;
+  background-color: var(--wt);
+}
+
+/* メニューバー */
+.bridge-menubar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 20px;
+  background: var(--wt);
+  border-bottom: 1px solid var(--bk);
+  display: flex;
+  align-items: center;
+  padding: 0 10px;
+  gap: 18px;
+  font-size: 12px;
+  z-index: 10;
+}
+
+.bridge-menubar .apple {
+  font-size: 14px;
+  line-height: 1;
+}
+
+.bridge-menubar .clock {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ウィンドウ */
+.bridge-window {
+  position: absolute;
+  background: var(--wt);
+  border: 1px solid var(--bk);
+  box-shadow: 1px 1px 0 var(--bk);
+}
+
+.bridge-titlebar {
+  height: 18px;
+  border-bottom: 1px solid var(--bk);
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
+  position: relative;
+  background-image: repeating-linear-gradient(
+    0deg,
+    var(--bk) 0,
+    var(--bk) 1px,
+    var(--wt) 1px,
+    var(--wt) 2px
+  );
+}
+
+.bridge-close-box,
+.bridge-zoom-box {
+  width: 11px;
+  height: 11px;
+  border: 1px solid var(--bk);
+  background: var(--wt);
+  flex-shrink: 0;
+}
+
+.bridge-zoom-box {
+  margin-left: auto;
+  position: relative;
+}
+
+.bridge-zoom-box::after {
+  content: "";
+  position: absolute;
+  inset: 1px;
+  border: 1px solid var(--bk);
+}
+
+.bridge-title-text {
+  background: var(--wt);
+  padding: 0 8px;
+  font-size: 12px;
+  line-height: 1;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 50%;
+  margin-top: -6px;
+  white-space: nowrap;
+}
+
+.bridge-window-body {
+  background: var(--wt);
+  overflow: hidden;
+  height: calc(100% - 19px);
+  position: relative;
+}
+
+/* レイアウト座標 */
+.bridge-w-grid {
+  top: 30px;
+  left: 12px;
+  width: 1256px;
+  height: 410px;
+}
+
+.bridge-w-monitor {
+  top: 452px;
+  left: 12px;
+  width: 1256px;
+  height: 256px;
+}
+
+/* SESSIONS GRID — Bridge メインの全セッション一覧 */
+.bridge-grid-body {
+  padding: 6px;
+  height: 100%;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: 1fr;
+  gap: 6px;
+}
+
+/* 4セッション以下なら 2 列、それ以上は 3 列にして詰めすぎを防ぐ */
+.bridge-grid-body[data-count="1"] {
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr;
+}
+.bridge-grid-body[data-count="2"] {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr;
+}
+.bridge-grid-body[data-count="3"],
+.bridge-grid-body[data-count="4"] {
+  grid-template-columns: 1fr 1fr;
+  grid-template-rows: 1fr 1fr;
+}
+/* 5以上は 3列固定 (デフォルト) */
+
+.bridge-cell {
+  background: var(--wt);
+  border: 1px solid var(--bk);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  /* セルもMac OSウィンドウ風のドロップシャドウ */
+  box-shadow: 1px 1px 0 var(--bk);
+}
+
+.bridge-cell-titlebar {
+  height: 18px;
+  border-bottom: 1px solid var(--bk);
+  display: flex;
+  align-items: center;
+  padding: 0 6px;
+  position: relative;
+  background-image: repeating-linear-gradient(
+    0deg,
+    var(--bk) 0,
+    var(--bk) 1px,
+    var(--wt) 1px,
+    var(--wt) 2px
+  );
+  flex-shrink: 0;
+}
+
+.bridge-cell-title {
+  background: var(--wt);
+  padding: 0 6px;
+  font-size: 11px;
+  line-height: 1;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  top: 50%;
+  margin-top: -5px;
+  white-space: nowrap;
+  max-width: 80%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* セルヘッダ (status badge + 経過時間) */
+.bridge-cell-head {
+  border-bottom: 1px solid var(--bk);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 4px 8px;
+  flex-shrink: 0;
+  font-size: 11px;
+}
+
+/*
+ * セルの状態バッジ。視認性を優先して 1bit を破って色を入れる
+ * (フレーム/タイトルバー/プレビューは 1bit のまま維持)。
+ *
+ * 全バッジ共通: 太字 + tracking + 黒文字輪郭線 (1bit ベースに馴染ませる)
+ */
+.bridge-cell-status {
+  font-weight: bold;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+  padding: 2px 8px;
+  border: 1px solid var(--bk);
+  background: var(--wt);
+  color: var(--bk);
+}
+
+.bridge-cell-status.s-tool,
+.bridge-cell-status.s-think {
+  background: #1a7f37; /* green */
+  color: var(--wt);
+}
+
+.bridge-cell-status.s-awaiting {
+  background: #fb8500; /* vivid orange */
+  color: var(--wt);
+  border: 2px solid var(--bk);
+  padding: 1px 7px;
+  animation: bridge-status-blink 1s steps(2) infinite;
+}
+
+.bridge-cell-status.s-idle {
+  background: #d73a49; /* vivid red */
+  color: var(--wt);
+}
+
+.bridge-cell-status.s-err {
+  background: #991b1b; /* darker red */
+  color: var(--wt);
+  border: 2px solid var(--bk);
+  padding: 1px 7px;
+}
+
+.bridge-cell-status.s-ready,
+.bridge-cell-status.s-stop {
+  background: #737373; /* neutral gray */
+  color: var(--wt);
+}
+
+@keyframes bridge-status-blink {
+  50% {
+    background: var(--wt);
+    color: var(--bk);
+  }
+}
+
+.bridge-cell-elapsed {
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+/* プレビュー本体 */
+.bridge-cell-body {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  padding: 4px 8px;
+  font-family: "Monaco", "Courier New", monospace;
+  font-size: 10px;
+  line-height: 1.35;
+  white-space: pre;
+}
+
+.bridge-cell-empty {
+  color: var(--bk);
+  opacity: 0.4;
+  font-style: italic;
+  font-family: inherit;
+  white-space: normal;
+}
+
+/* SYSTEM MONITOR (4 sections: CPU / Cores / Memory / Storage) */
+.bridge-monitor-body {
+  height: 100%;
+  display: grid;
+  grid-template-columns: 320px 1fr 290px 320px;
+  gap: 0;
+}
+
+.bridge-mon-section {
+  border-right: 1px solid var(--bk);
+  padding: 10px 14px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.bridge-mon-section:last-child {
+  border-right: none;
+}
+
+.bridge-mon-title {
+  font-size: 11px;
+  margin-bottom: 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--bk);
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.bridge-mon-title .sub {
+  font-size: 10px;
+}
+
+/* CPU gauge */
+.bridge-gauge {
+  width: 200px;
+  height: 110px;
+  margin: 4px auto 6px;
+  position: relative;
+}
+
+.bridge-gauge svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.bridge-gauge-readout {
+  text-align: center;
+  font-size: 22px;
+  line-height: 1;
+  margin-top: -8px;
+}
+
+.bridge-gauge-label {
+  text-align: center;
+  font-size: 10px;
+  margin-top: 2px;
+}
+
+/* Cores */
+.bridge-core-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px 10px;
+  margin-top: 8px;
+  font-size: 10px;
+}
+
+.bridge-core-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bridge-core-row .lbl {
+  width: 32px;
+}
+
+.bridge-core-row .v {
+  width: 28px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.bridge-core-bar {
+  flex: 1;
+  height: 7px;
+  border: 1px solid var(--bk);
+  background: var(--wt);
+  position: relative;
+}
+
+.bridge-core-bar > div {
+  position: absolute;
+  inset: 0;
+  background: var(--bk);
+}
+
+.bridge-core-bar > div.dense {
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--bk) 0,
+    var(--bk) 1px,
+    var(--wt) 1px,
+    var(--wt) 2px
+  );
+  background-color: var(--wt);
+}
+
+/* Memory */
+.bridge-mem-segments {
+  display: flex;
+  height: 22px;
+  border: 1px solid var(--bk);
+  margin: 4px 0 8px;
+}
+
+.bridge-mem-seg {
+  border-right: 1px solid var(--bk);
+  position: relative;
+  overflow: hidden;
+}
+
+.bridge-mem-seg:last-child {
+  border-right: none;
+}
+
+.bridge-mem-seg.solid {
+  background: var(--bk);
+}
+
+.bridge-mem-seg.dense {
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--bk) 0,
+    var(--bk) 1px,
+    var(--wt) 1px,
+    var(--wt) 2px
+  );
+}
+
+.bridge-mem-seg.sparse {
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--bk) 0,
+    var(--bk) 1px,
+    var(--wt) 1px,
+    var(--wt) 4px
+  );
+}
+
+.bridge-mem-legend {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2px 10px;
+  font-size: 10px;
+}
+
+.bridge-mem-legend-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bridge-legend-swatch {
+  width: 10px;
+  height: 10px;
+  border: 1px solid var(--bk);
+  flex-shrink: 0;
+}
+
+.bridge-legend-swatch.solid {
+  background: var(--bk);
+}
+
+.bridge-legend-swatch.dense {
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--bk) 0,
+    var(--bk) 1px,
+    var(--wt) 1px,
+    var(--wt) 2px
+  );
+}
+
+.bridge-legend-swatch.sparse {
+  background-image: repeating-linear-gradient(
+    45deg,
+    var(--bk) 0,
+    var(--bk) 1px,
+    var(--wt) 1px,
+    var(--wt) 4px
+  );
+}
+
+.bridge-mem-legend-row .v {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Stripchart (CPU/Memory 履歴) */
+.bridge-strip {
+  flex: 1;
+  margin-top: 8px;
+  border: 1px solid var(--bk);
+  padding: 2px;
+  display: flex;
+  align-items: flex-end;
+  gap: 0;
+  min-height: 50px;
+}
+
+.bridge-strip .s {
+  flex: 1;
+  background: var(--bk);
+  margin-right: 1px;
+}
+
+.bridge-strip .s:last-child {
+  margin-right: 0;
+}
+
+.bridge-strip-axis {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9px;
+  margin-top: 2px;
+}
+
+/* Storage (System Monitor 4カラム目, CPU の gauge と同等のサイズ感で中央配置) */
+.bridge-storage-pie-wrap {
+  margin: 4px auto 16px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.bridge-storage-pie {
+  width: 140px;
+  height: 140px;
+  border: 1px solid var(--bk);
+  border-radius: 50%;
+  position: relative;
+}
+
+/* パイ中央の白丸 (ドーナツ風) - 数値は表示せず外部読み取り側に集約 */
+.bridge-storage-pie::after {
+  content: "";
+  position: absolute;
+  inset: 36px;
+  background: var(--wt);
+  border: 1px solid var(--bk);
+  border-radius: 50%;
+}
+
+/*
+ * CPU の .bridge-gauge-readout は半円ゲージ前提で margin-top: -8px が入っている。
+ * Storage は円形パイなので詰まって見えるため、隣接時は余白をリセットする。
+ */
+.bridge-storage-pie-wrap + .bridge-gauge-readout {
+  margin-top: 0;
+}
+
+.bridge-storage-others {
+  text-align: center;
+  font-size: 9px;
+  margin-top: 4px;
+  opacity: 0.6;
+}

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -19,6 +19,7 @@ import type {
   Profile,
   RepoInfo,
   ServerToClientEvents,
+  SessionGridSnapshot,
   SpecialKey,
   SystemCapabilities,
   UsageProgress,
@@ -126,6 +127,14 @@ interface UseSocketReturn {
   // Session previews
   sessionPreviews: Map<string, string>;
   sessionActivityTexts: Map<string, string>;
+
+  // Repo Grid View (主 Dashboard 用、購読中のみ更新される)
+  /** sessionId → 最新スナップショット。購読していなければ空 */
+  gridSnapshots: Map<string, SessionGridSnapshot>;
+  /** RepoGridView マウント時に呼ぶ。購読中は 1.5秒ごとに gridSnapshots が更新される */
+  subscribeGrid: () => void;
+  /** RepoGridView アンマウント時に呼ぶ */
+  unsubscribeGrid: () => void;
 
   // Beacon
   beaconMessages: ChatMessage[];
@@ -238,6 +247,11 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   );
   const [sessionActivityTexts, setSessionActivityTexts] = useState<
     Map<string, string>
+  >(new Map());
+
+  // Repo Grid View 用 (主 Dashboard が購読中のみ更新)
+  const [gridSnapshots, setGridSnapshots] = useState<
+    Map<string, SessionGridSnapshot>
   >(new Map());
 
   // Browser session state
@@ -630,6 +644,19 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       });
     });
 
+    // Repo Grid View
+    socket.on("session:grid:snapshot", snapshots => {
+      setGridSnapshots(prev => {
+        const next = new Map(prev);
+        // 配信は「現在の全セッション」なので、購読中のスナップショットで全置換する
+        next.clear();
+        for (const s of snapshots) {
+          next.set(s.sessionId, s);
+        }
+        return next;
+      });
+    });
+
     // Browser session events (noVNC)
     socket.on("browser:started", (session: BrowserSession) => {
       setBrowserSessions(prev => {
@@ -744,6 +771,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       socket.off("beacon:history");
       socket.off("beacon:error");
       socket.off("session:previews");
+      socket.off("session:grid:snapshot");
       socket.off("browser:started");
       socket.off("browser:stopped");
       socket.off("browser:error");
@@ -1084,6 +1112,16 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     setUsageError(null);
   }, []);
 
+  // Repo Grid View 購読
+  const subscribeGrid = useCallback(() => {
+    socketRef.current?.emit("session:grid:subscribe");
+  }, []);
+
+  const unsubscribeGrid = useCallback(() => {
+    socketRef.current?.emit("session:grid:unsubscribe");
+    setGridSnapshots(new Map());
+  }, []);
+
   return {
     socket: socketRef.current,
     isConnected,
@@ -1130,6 +1168,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     // Session previews
     sessionPreviews,
     sessionActivityTexts,
+    gridSnapshots,
+    subscribeGrid,
+    unsubscribeGrid,
     // Beacon
     beaconMessages,
     beaconStreaming,

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -340,6 +340,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         pendingRepoPathRef.current = repoPathRef.current;
         socket.emit("repo:select", repoPathRef.current);
       }
+
+      // grid 購読中だった場合は再購読する。
+      // サーバ側は disconnect 時に interval を破棄するので、再接続後は再 emit が必須。
+      if (gridSubscribedRef.current) {
+        socket.emit("session:grid:subscribe");
+      }
     });
 
     socket.on("disconnect", () => {
@@ -1113,11 +1119,17 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   }, []);
 
   // Repo Grid View 購読
+  // 再接続対応: サーバ側は disconnect 時に interval を破棄するので、
+  // クライアント側で「現在購読中か」を ref に持ち、connect 時に都度 re-emit する。
+  const gridSubscribedRef = useRef(false);
+
   const subscribeGrid = useCallback(() => {
+    gridSubscribedRef.current = true;
     socketRef.current?.emit("session:grid:subscribe");
   }, []);
 
   const unsubscribeGrid = useCallback(() => {
+    gridSubscribedRef.current = false;
     socketRef.current?.emit("session:grid:unsubscribe");
     setGridSnapshots(new Map());
   }, []);

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -11,6 +11,7 @@ import { io, type Socket } from "socket.io-client";
 import { toast } from "sonner";
 import type {
   BeaconStreamChunk,
+  BridgeSessionStatus,
   BrowserSession,
   ChatMessage,
   ClientToServerEvents,
@@ -136,6 +137,12 @@ interface UseSocketReturn {
   /** RepoGridView アンマウント時に呼ぶ */
   unsubscribeGrid: () => void;
 
+  /**
+   * sessionId → BridgeSessionStatus。session:previews ペイロードから派生。
+   * RepoGridView 購読の有無に関わらず常に最新化されるので、サイドバードット色等で利用する。
+   */
+  sessionStatuses: Map<string, BridgeSessionStatus>;
+
   // Beacon
   beaconMessages: ChatMessage[];
   beaconStreaming: boolean;
@@ -252,6 +259,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   // Repo Grid View 用 (主 Dashboard が購読中のみ更新)
   const [gridSnapshots, setGridSnapshots] = useState<
     Map<string, SessionGridSnapshot>
+  >(new Map());
+
+  // BridgeSessionStatus を session:previews から取り出して保持。
+  // サイドバードット色用。RepoGridView 購読の有無に関わらず常時更新される。
+  const [sessionStatuses, setSessionStatuses] = useState<
+    Map<string, BridgeSessionStatus>
   >(new Map());
 
   // Browser session state
@@ -645,6 +658,15 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         const next = new Map(prev);
         for (const p of previews) {
           next.set(p.sessionId, p.activityText);
+        }
+        return next;
+      });
+      // BridgeSessionStatus は Bridge collector の判定結果。サイドバードット色を
+      // RepoGridView と揃えるために sessionStatuses Map に保持する。
+      setSessionStatuses(prev => {
+        const next = new Map(prev);
+        for (const p of previews) {
+          next.set(p.sessionId, p.bridgeStatus);
         }
         return next;
       });
@@ -1183,6 +1205,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     gridSnapshots,
     subscribeGrid,
     unsubscribeGrid,
+    sessionStatuses,
     // Beacon
     beaconMessages,
     beaconStreaming,

--- a/client/src/pages/Bridge.tsx
+++ b/client/src/pages/Bridge.tsx
@@ -40,9 +40,10 @@ export default function Bridge() {
   // Socket.IO 接続 (1回だけ確立)
   useEffect(() => {
     const token = getTokenFromUrl();
+    // transports は default (polling + websocket) のまま。
+    // WebSocket upgrade をブロックするリバースプロキシ等でも繋がるよう polling fallback を残す。
     const socket: TypedSocket = io({
       auth: token ? { token } : undefined,
-      transports: ["websocket"],
     });
     socketRef.current = socket;
 

--- a/client/src/pages/Bridge.tsx
+++ b/client/src/pages/Bridge.tsx
@@ -1,0 +1,79 @@
+/**
+ * Bridge ページ — Ark のメインダッシュボード
+ *
+ * 1280x720 固定レイアウトの 1bit Mac OS 風モニタリング画面。
+ * 5インチサブディスプレイ常駐を主目的とするが、ブラウザタブでも閲覧できる。
+ *
+ * 上半分: 全セッションのグリッド (状態 + ターミナル末尾プレビュー)
+ * 下半分: System Monitor (CPU / Cores / Memory / Storage)
+ *
+ * フォーカス概念やライブストリームは持たない (静的スナップショット型)。
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { io, type Socket } from "socket.io-client";
+import type {
+  BridgeSnapshot,
+  ClientToServerEvents,
+  ServerToClientEvents,
+} from "../../../shared/types";
+import { BridgeDashboard } from "../components/bridge/BridgeDashboard";
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+function getTokenFromUrl(): string | null {
+  const params = new URLSearchParams(window.location.search);
+  return params.get("token");
+}
+
+export default function Bridge() {
+  const socketRef = useRef<TypedSocket | null>(null);
+  const [snapshot, setSnapshot] = useState<BridgeSnapshot | null>(null);
+  const [now, setNow] = useState(new Date());
+
+  // 時計表示を 30秒ごとに更新（メニューバー用）
+  useEffect(() => {
+    const t = setInterval(() => setNow(new Date()), 30_000);
+    return () => clearInterval(t);
+  }, []);
+
+  // Socket.IO 接続 (1回だけ確立)
+  useEffect(() => {
+    const token = getTokenFromUrl();
+    const socket: TypedSocket = io({
+      auth: token ? { token } : undefined,
+      transports: ["websocket"],
+    });
+    socketRef.current = socket;
+
+    socket.on("connect", () => {
+      socket.emit("bridge:subscribe", { focusSessionId: null });
+    });
+
+    socket.on("bridge:snapshot", snap => {
+      setSnapshot(snap);
+    });
+
+    return () => {
+      socket.emit("bridge:unsubscribe");
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, []);
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        inset: 0,
+        background: "#000",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        overflow: "auto",
+      }}
+    >
+      <BridgeDashboard snapshot={snapshot} now={now} />
+    </div>
+  );
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { AlertCircle, Copy, Loader2, Terminal } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { BrowserPane } from "@/components/BrowserPane";
 import { CreateWorktreeDialog } from "@/components/CreateWorktreeDialog";
@@ -40,11 +40,7 @@ import {
   findRepoForSession,
   isSessionBelongsToRepo,
 } from "@/utils/sessionUtils";
-import type {
-  BridgeSessionStatus,
-  ManagedSession,
-  Worktree,
-} from "../../../shared/types";
+import type { ManagedSession, Worktree } from "../../../shared/types";
 
 export default function Dashboard() {
   const {
@@ -101,6 +97,7 @@ export default function Dashboard() {
     gridSnapshots,
     subscribeGrid,
     unsubscribeGrid,
+    sessionStatuses,
     readFile,
     fileContent,
     browserSessions,
@@ -158,16 +155,6 @@ export default function Dashboard() {
     setGridRepoPath(null);
     setSelectedSessionId(sessionId);
   }, []);
-
-  // gridSnapshots (sessionId → SessionGridSnapshot) からサイドバードット用の
-  // (sessionId → BridgeSessionStatus) Map を導出。SessionCard のドット色判定に渡す。
-  const gridStatusesMap = useMemo(() => {
-    const m = new Map<string, BridgeSessionStatus>();
-    gridSnapshots.forEach((snap, id) => {
-      m.set(id, snap.status);
-    });
-    return m;
-  }, [gridSnapshots]);
 
   /** ブラウザを選択（未起動なら起動） */
   const handleSelectBrowser = useCallback(() => {
@@ -237,16 +224,11 @@ export default function Dashboard() {
     }
   }, [selectedSessionId, setSetting]);
 
-  // セッショングリッドのスナップショット購読を常時 ON にする。
-  // RepoGridView 表示時だけでなく、サイドバーの状態ドット (緑/橙/赤/グレー) も
-  // BridgeSessionStatus を使うため、Dashboard マウント中は常に購読する。
-  useEffect(() => {
-    if (isSettingsLoading) return;
-    subscribeGrid();
-    return () => {
-      unsubscribeGrid();
-    };
-  }, [isSettingsLoading, subscribeGrid, unsubscribeGrid]);
+  // 注: 以前はここで subscribeGrid を常時 ON にしていたが、サーバ側で
+  // collectGridSnapshots() が 1.5秒ごとに走り session:previews と pane polling が
+  // 二重化していた。サイドバードット色は session:previews が運ぶ
+  // bridgeStatus (sessionStatuses) を使うので、grid 購読は RepoGridView 内で
+  // mount/unmount に紐付ける形に戻している。
 
   // リロード時にブラウザ選択状態を維持:
   // selectedSessionIdが"browser"のまま復元された場合、
@@ -591,7 +573,7 @@ export default function Dashboard() {
               onCreateWorktreeForRepo={handleCreateWorktreeForRepo}
               onSelectRepoGrid={handleSelectRepoGrid}
               gridRepoPath={gridRepoPath}
-              gridStatuses={gridStatusesMap}
+              gridStatuses={sessionStatuses}
             />
           }
           main={
@@ -623,6 +605,8 @@ export default function Dashboard() {
                       new Map(worktrees.map(w => [w.id, w.branch]))
                     }
                     snapshots={gridSnapshots}
+                    onSubscribe={subscribeGrid}
+                    onUnsubscribe={unsubscribeGrid}
                     onSelectSession={handleSelectSessionFromGrid}
                   />
                 ) : null}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { AlertCircle, Copy, Loader2, Terminal } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { BrowserPane } from "@/components/BrowserPane";
 import { CreateWorktreeDialog } from "@/components/CreateWorktreeDialog";
@@ -8,6 +8,7 @@ import { FrontLineModal } from "@/components/frontline/FrontLineModal";
 import { MobileChatView } from "@/components/MobileChatView";
 import { MobileLayout } from "@/components/MobileLayout";
 import { ProfileManagerDialog } from "@/components/ProfileManagerDialog";
+import { RepoGridView } from "@/components/RepoGridView";
 import { RepoSelectDialog } from "@/components/RepoSelectDialog";
 import { SessionSidebar } from "@/components/SessionSidebar";
 import { SidebarMainLayout } from "@/components/SidebarMainLayout";
@@ -36,7 +37,11 @@ import { useSocket } from "@/hooks/useSocket";
 import { useViewerTabs } from "@/hooks/useViewerTabs";
 import { getBaseName } from "@/utils/pathUtils";
 import { findRepoForSession } from "@/utils/sessionUtils";
-import type { ManagedSession, Worktree } from "../../../shared/types";
+import type {
+  BridgeSessionStatus,
+  ManagedSession,
+  Worktree,
+} from "../../../shared/types";
 
 export default function Dashboard() {
   const {
@@ -90,6 +95,9 @@ export default function Dashboard() {
     beaconClear,
     sessionPreviews,
     sessionActivityTexts,
+    gridSnapshots,
+    subscribeGrid,
+    unsubscribeGrid,
     readFile,
     fileContent,
     browserSessions,
@@ -130,6 +138,33 @@ export default function Dashboard() {
   // ブラウザビューを一度でも開いたかどうかのフラグ
   // 一度開いたら常に描画してdisplay:hiddenで切り替え、BrowserPaneの再マウント（VNC再接続）を防ぐ
   const [hasBrowserOpened, setHasBrowserOpened] = useState(false);
+
+  // リポジトリ別セッショングリッドビュー (B案: スナップショット型)
+  // null 以外のとき main 領域は RepoGridView に切り替わる。
+  // selectedSessionId とは独立。セルクリックで selectedSessionId に切替えてターミナル表示に潜る
+  const [gridRepoPath, setGridRepoPath] = useState<string | null>(null);
+
+  /** リポジトリヘッダクリック時: グリッドビューを開く */
+  const handleSelectRepoGrid = useCallback((repoPath: string) => {
+    setGridRepoPath(repoPath);
+    setSelectedSessionId(null);
+  }, []);
+
+  /** グリッドのセルクリック時: ターミナル表示に切替 */
+  const handleSelectSessionFromGrid = useCallback((sessionId: string) => {
+    setGridRepoPath(null);
+    setSelectedSessionId(sessionId);
+  }, []);
+
+  // gridSnapshots (sessionId → SessionGridSnapshot) からサイドバードット用の
+  // (sessionId → BridgeSessionStatus) Map を導出。SessionCard のドット色判定に渡す。
+  const gridStatusesMap = useMemo(() => {
+    const m = new Map<string, BridgeSessionStatus>();
+    gridSnapshots.forEach((snap, id) => {
+      m.set(id, snap.status);
+    });
+    return m;
+  }, [gridSnapshots]);
 
   /** ブラウザを選択（未起動なら起動） */
   const handleSelectBrowser = useCallback(() => {
@@ -198,6 +233,17 @@ export default function Dashboard() {
       setSetting("selectedSessionId", selectedSessionId);
     }
   }, [selectedSessionId, setSetting]);
+
+  // セッショングリッドのスナップショット購読を常時 ON にする。
+  // RepoGridView 表示時だけでなく、サイドバーの状態ドット (緑/橙/赤/グレー) も
+  // BridgeSessionStatus を使うため、Dashboard マウント中は常に購読する。
+  useEffect(() => {
+    if (isSettingsLoading) return;
+    subscribeGrid();
+    return () => {
+      unsubscribeGrid();
+    };
+  }, [isSettingsLoading, subscribeGrid, unsubscribeGrid]);
 
   // リロード時にブラウザ選択状態を維持:
   // selectedSessionIdが"browser"のまま復元された場合、
@@ -334,7 +380,8 @@ export default function Dashboard() {
       }
     }
 
-    if (!selectedSessionId && sessions.size > 0) {
+    // グリッドビュー表示中は自動選択を抑制 (ユーザーがセルクリックで明示的に選ぶ)
+    if (!selectedSessionId && sessions.size > 0 && !gridRepoPath) {
       const first = Array.from(sessions.values())[0];
       setSelectedSessionId(first.id);
     }
@@ -342,7 +389,7 @@ export default function Dashboard() {
       const remaining = Array.from(sessions.values());
       setSelectedSessionId(remaining.length > 0 ? remaining[0].id : null);
     }
-  }, [sessions, selectedSessionId]);
+  }, [sessions, selectedSessionId, gridRepoPath]);
 
   useEffect(() => {
     if (deletedWorktreeId) {
@@ -539,6 +586,9 @@ export default function Dashboard() {
               onOpenProfileManager={() => setShowProfileManager(true)}
               onRestartSession={handleRestartSession}
               onCreateWorktreeForRepo={handleCreateWorktreeForRepo}
+              onSelectRepoGrid={handleSelectRepoGrid}
+              gridRepoPath={gridRepoPath}
+              gridStatuses={gridStatusesMap}
             />
           }
           main={
@@ -550,6 +600,21 @@ export default function Dashboard() {
                 </div>
               )}
               <div className="flex-1 overflow-hidden relative">
+                {/* リポジトリグリッドビュー: gridRepoPath が設定されているとき
+                    全 TerminalPane と独立して表示する (ttyd iframe は非マウント) */}
+                {gridRepoPath && !selectedSessionId ? (
+                  <RepoGridView
+                    repoPath={gridRepoPath}
+                    sessions={Array.from(sessions.values()).filter(
+                      s => (s.repoPath ?? "") === gridRepoPath
+                    )}
+                    worktreeBranchById={
+                      new Map(worktrees.map(w => [w.id, w.branch]))
+                    }
+                    snapshots={gridSnapshots}
+                    onSelectSession={handleSelectSessionFromGrid}
+                  />
+                ) : null}
                 {/* ブラウザビュー: 一度開いたら常に描画してdisplay:hiddenで切り替え。
                     BrowserPaneの再マウント（VNC再接続）を防ぐ */}
                 {hasBrowserOpened && (

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -36,7 +36,10 @@ import { useSettings } from "@/hooks/useSettings";
 import { useSocket } from "@/hooks/useSocket";
 import { useViewerTabs } from "@/hooks/useViewerTabs";
 import { getBaseName } from "@/utils/pathUtils";
-import { findRepoForSession } from "@/utils/sessionUtils";
+import {
+  findRepoForSession,
+  isSessionBelongsToRepo,
+} from "@/utils/sessionUtils";
 import type {
   BridgeSessionStatus,
   ManagedSession,
@@ -605,9 +608,17 @@ export default function Dashboard() {
                 {gridRepoPath && !selectedSessionId ? (
                   <RepoGridView
                     repoPath={gridRepoPath}
-                    sessions={Array.from(sessions.values()).filter(
-                      s => (s.repoPath ?? "") === gridRepoPath
-                    )}
+                    sessions={Array.from(sessions.values()).filter(s => {
+                      // useGroupedWorktreeItems と同じフォールバック判定:
+                      //  1. session.repoPath が gridRepoPath に一致
+                      //  2. worktreePath が gridRepoPath で始まる (worktree)
+                      //  3. isSessionBelongsToRepo で姉妹worktreeを判定
+                      if (s.repoPath === gridRepoPath) return true;
+                      if (s.worktreePath.startsWith(`${gridRepoPath}/`))
+                        return true;
+                      if (s.worktreePath === gridRepoPath) return true;
+                      return isSessionBelongsToRepo(s, gridRepoPath);
+                    })}
                     worktreeBranchById={
                       new Map(worktrees.map(w => [w.id, w.branch]))
                     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -29,6 +29,12 @@ import type {
 } from "../shared/types.js";
 import { authManager } from "./lib/auth.js";
 import { beaconManager } from "./lib/beacon-manager.js";
+import {
+  buildTunnelEntries,
+  collectBridgeSessions,
+  collectGridSnapshots,
+  collectStreamLines,
+} from "./lib/bridge-collector.js";
 import { browserManager } from "./lib/browser-manager.js";
 import {
   CDP_PORT,
@@ -55,6 +61,7 @@ import {
   listWorktrees,
   scanRepositories,
 } from "./lib/git.js";
+import { hostMetrics } from "./lib/host-metrics.js";
 import { validateHtmlPath } from "./lib/html-path-validator.js";
 import { htmlScreenshotter } from "./lib/html-screenshotter.js";
 import { getListeningPorts } from "./lib/port-scanner.js";
@@ -2069,10 +2076,120 @@ async function startServer() {
       console.error("[Preview] Initial error:", getErrorMessage(err));
     }
 
+    // ===== Bridge Dashboard =====
+    // Bridge ダッシュボード（5インチ常駐表示）専用のサブスクリプション。
+    // クライアントが /bridge を開いたら subscribe し、毎秒スナップショットを送る。
+    let bridgeSnapshotInterval: NodeJS.Timeout | null = null;
+    let bridgeStreamInterval: NodeJS.Timeout | null = null;
+    let bridgeFocusSessionId: string | null = null;
+
+    const stopBridge = () => {
+      if (bridgeSnapshotInterval) {
+        clearInterval(bridgeSnapshotInterval);
+        bridgeSnapshotInterval = null;
+      }
+      if (bridgeStreamInterval) {
+        clearInterval(bridgeStreamInterval);
+        bridgeStreamInterval = null;
+      }
+      bridgeFocusSessionId = null;
+    };
+
+    socket.on("bridge:subscribe", async data => {
+      stopBridge();
+      bridgeFocusSessionId = data?.focusSessionId ?? null;
+
+      // 初回スナップショットは即送る（履歴が空なので CPU 0% になるのは許容）
+      try {
+        const metrics = await hostMetrics.sample();
+        const sessions = collectBridgeSessions();
+        const tunnels = buildTunnelEntries({ primaryUrl: tunnelUrl });
+        socket.emit("bridge:snapshot", {
+          metrics,
+          sessions,
+          tunnels,
+          collectedAt: Date.now(),
+        });
+      } catch (err) {
+        console.error(
+          "[Bridge] 初回スナップショット失敗:",
+          getErrorMessage(err)
+        );
+      }
+
+      // 1秒間隔のスナップショット
+      bridgeSnapshotInterval = setInterval(async () => {
+        try {
+          const metrics = await hostMetrics.sample();
+          const sessions = collectBridgeSessions();
+          const tunnels = buildTunnelEntries({ primaryUrl: tunnelUrl });
+          socket.emit("bridge:snapshot", {
+            metrics,
+            sessions,
+            tunnels,
+            collectedAt: Date.now(),
+          });
+        } catch (err) {
+          console.error("[Bridge] スナップショット失敗:", getErrorMessage(err));
+        }
+      }, 1000);
+
+      // フォーカス中セッションのライブストリームは 1.5秒間隔で送る
+      bridgeStreamInterval = setInterval(() => {
+        if (!bridgeFocusSessionId) return;
+        try {
+          const lines = collectStreamLines(bridgeFocusSessionId, 24);
+          socket.emit("bridge:stream", {
+            sessionId: bridgeFocusSessionId,
+            lines,
+          });
+        } catch (err) {
+          console.error("[Bridge] ストリーム取得失敗:", getErrorMessage(err));
+        }
+      }, 1500);
+    });
+
+    socket.on("bridge:unsubscribe", () => {
+      stopBridge();
+    });
+
+    // ===== Repo Grid View =====
+    // 主 Dashboard でリポジトリ選択時に表示するセッショングリッド用の購読。
+    // Bridge と独立して購読/解除できる。
+    let gridInterval: NodeJS.Timeout | null = null;
+
+    const stopGrid = () => {
+      if (gridInterval) {
+        clearInterval(gridInterval);
+        gridInterval = null;
+      }
+    };
+
+    const emitGridSnapshot = () => {
+      try {
+        socket.emit("session:grid:snapshot", collectGridSnapshots());
+      } catch (err) {
+        console.error("[Grid] スナップショット失敗:", getErrorMessage(err));
+      }
+    };
+
+    socket.on("session:grid:subscribe", () => {
+      stopGrid();
+      // 初回は即送る
+      emitGridSnapshot();
+      gridInterval = setInterval(emitGridSnapshot, 1500);
+    });
+
+    socket.on("session:grid:unsubscribe", () => {
+      stopGrid();
+    });
+
     // Cleanup on disconnect
     socket.on("disconnect", () => {
       console.log(`Client disconnected: ${socket.id}`);
       clearInterval(previewInterval);
+      stopBridge();
+      stopGrid();
 
       forwardHandlers.forEach((handler, event) => {
         sessionOrchestrator.off(event, handler);

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,8 +20,10 @@ import { fileURLToPath } from "node:url";
 import httpProxy from "http-proxy";
 import { Server, type Socket } from "socket.io";
 import type {
+  BridgeSnapshot,
   ClientToServerEvents,
   ServerToClientEvents,
+  SessionGridSnapshot,
   SystemCapabilities,
   UsageEntry,
   UsageProgress,
@@ -979,18 +981,26 @@ async function startServer() {
   const BRIDGE_ROOM = "bridge:subscribers";
   const GRID_ROOM = "grid:subscribers";
 
+  // 直近のブロードキャスト結果。新規 subscribe 時に即時応答として送る
+  // (subscribe ハンドラ内で hostMetrics.sample() を再実行すると、内部の prev*
+  // 状態が乱れて次回 broadcast の差分計算が崩れるためキャッシュ参照に絞る)
+  let lastBridgeSnapshot: BridgeSnapshot | null = null;
+  let lastGridSnapshots: SessionGridSnapshot[] | null = null;
+
   const broadcastBridgeSnapshot = async () => {
     if (io.sockets.adapter.rooms.get(BRIDGE_ROOM)?.size === undefined) return;
     try {
       const metrics = await hostMetrics.sample();
       const sessions = collectBridgeSessions();
       const tunnels = buildTunnelEntries({ primaryUrl: tunnelUrl });
-      io.to(BRIDGE_ROOM).emit("bridge:snapshot", {
+      const snapshot = {
         metrics,
         sessions,
         tunnels,
         collectedAt: Date.now(),
-      });
+      };
+      lastBridgeSnapshot = snapshot;
+      io.to(BRIDGE_ROOM).emit("bridge:snapshot", snapshot);
     } catch (err) {
       console.error("[Bridge] スナップショット失敗:", getErrorMessage(err));
     }
@@ -999,7 +1009,9 @@ async function startServer() {
   const broadcastGridSnapshot = () => {
     if (io.sockets.adapter.rooms.get(GRID_ROOM)?.size === undefined) return;
     try {
-      io.to(GRID_ROOM).emit("session:grid:snapshot", collectGridSnapshots());
+      const snapshots = collectGridSnapshots();
+      lastGridSnapshots = snapshots;
+      io.to(GRID_ROOM).emit("session:grid:snapshot", snapshots);
     } catch (err) {
       console.error("[Grid] スナップショット失敗:", getErrorMessage(err));
     }
@@ -2120,26 +2132,13 @@ async function startServer() {
     // ===== Bridge Dashboard =====
     // 購読は Socket.IO room (BRIDGE_ROOM) で管理。
     // 実際のサンプリング/送信はサーバ共有の broadcastBridgeSnapshot が行う。
-    socket.on("bridge:subscribe", async () => {
+    // 初回応答はキャッシュ参照のみ (sample() を呼ぶと共有 prev* 状態が乱れる)。
+    socket.on("bridge:subscribe", () => {
       socket.join(BRIDGE_ROOM);
-      // 初回スナップショットだけは購読開始の即時応答として個別送信する
-      // (履歴が空なので CPU 0% になるのは許容)
-      try {
-        const metrics = await hostMetrics.sample();
-        const sessions = collectBridgeSessions();
-        const tunnels = buildTunnelEntries({ primaryUrl: tunnelUrl });
-        socket.emit("bridge:snapshot", {
-          metrics,
-          sessions,
-          tunnels,
-          collectedAt: Date.now(),
-        });
-      } catch (err) {
-        console.error(
-          "[Bridge] 初回スナップショット失敗:",
-          getErrorMessage(err)
-        );
+      if (lastBridgeSnapshot) {
+        socket.emit("bridge:snapshot", lastBridgeSnapshot);
       }
+      // キャッシュ未着の場合 (起動直後) は次回 broadcastBridgeSnapshot で受け取る
     });
 
     socket.on("bridge:unsubscribe", () => {
@@ -2150,11 +2149,8 @@ async function startServer() {
     // 同じく room (GRID_ROOM) で購読管理。Bridge と独立して購読/解除できる。
     socket.on("session:grid:subscribe", () => {
       socket.join(GRID_ROOM);
-      // 初回は即送る
-      try {
-        socket.emit("session:grid:snapshot", collectGridSnapshots());
-      } catch (err) {
-        console.error("[Grid] 初回スナップショット失敗:", getErrorMessage(err));
+      if (lastGridSnapshots) {
+        socket.emit("session:grid:snapshot", lastGridSnapshots);
       }
     });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,7 +33,6 @@ import {
   buildTunnelEntries,
   collectBridgeSessions,
   collectGridSnapshots,
-  collectStreamLines,
 } from "./lib/bridge-collector.js";
 import { browserManager } from "./lib/browser-manager.js";
 import {
@@ -971,6 +970,48 @@ async function startServer() {
 
   // 複数クライアント同時接続時の重複復元を防ぐ（セッションID → 復元中のPromise）
   const pendingAutoRestores = new Map<string, Promise<void>>();
+
+  // ===== Bridge / Grid 共有サンプリング =====
+  // hostMetrics.sample() / capturePane は前回値との差分や時間あたりレートを内部状態で
+  // 持つ。クライアントごとに setInterval を回すと、複数クライアントで差分計算の基準が
+  // 乱れて不正な値になる。サーバ全体で 1本のループに統一して、購読中のクライアント
+  // (Socket.IO room) にブロードキャストする。
+  const BRIDGE_ROOM = "bridge:subscribers";
+  const GRID_ROOM = "grid:subscribers";
+
+  const broadcastBridgeSnapshot = async () => {
+    if (io.sockets.adapter.rooms.get(BRIDGE_ROOM)?.size === undefined) return;
+    try {
+      const metrics = await hostMetrics.sample();
+      const sessions = collectBridgeSessions();
+      const tunnels = buildTunnelEntries({ primaryUrl: tunnelUrl });
+      io.to(BRIDGE_ROOM).emit("bridge:snapshot", {
+        metrics,
+        sessions,
+        tunnels,
+        collectedAt: Date.now(),
+      });
+    } catch (err) {
+      console.error("[Bridge] スナップショット失敗:", getErrorMessage(err));
+    }
+  };
+
+  const broadcastGridSnapshot = () => {
+    if (io.sockets.adapter.rooms.get(GRID_ROOM)?.size === undefined) return;
+    try {
+      io.to(GRID_ROOM).emit("session:grid:snapshot", collectGridSnapshots());
+    } catch (err) {
+      console.error("[Grid] スナップショット失敗:", getErrorMessage(err));
+    }
+  };
+
+  // 購読クライアントがいるときだけ実行する (idle 時は no-op)
+  const bridgeBroadcastInterval = setInterval(() => {
+    void broadcastBridgeSnapshot();
+  }, 1000);
+  const gridBroadcastInterval = setInterval(() => {
+    broadcastGridSnapshot();
+  }, 1500);
 
   io.on("connection", socket => {
     console.log(`Client connected: ${socket.id}`);
@@ -2077,29 +2118,12 @@ async function startServer() {
     }
 
     // ===== Bridge Dashboard =====
-    // Bridge ダッシュボード（5インチ常駐表示）専用のサブスクリプション。
-    // クライアントが /bridge を開いたら subscribe し、毎秒スナップショットを送る。
-    let bridgeSnapshotInterval: NodeJS.Timeout | null = null;
-    let bridgeStreamInterval: NodeJS.Timeout | null = null;
-    let bridgeFocusSessionId: string | null = null;
-
-    const stopBridge = () => {
-      if (bridgeSnapshotInterval) {
-        clearInterval(bridgeSnapshotInterval);
-        bridgeSnapshotInterval = null;
-      }
-      if (bridgeStreamInterval) {
-        clearInterval(bridgeStreamInterval);
-        bridgeStreamInterval = null;
-      }
-      bridgeFocusSessionId = null;
-    };
-
-    socket.on("bridge:subscribe", async data => {
-      stopBridge();
-      bridgeFocusSessionId = data?.focusSessionId ?? null;
-
-      // 初回スナップショットは即送る（履歴が空なので CPU 0% になるのは許容）
+    // 購読は Socket.IO room (BRIDGE_ROOM) で管理。
+    // 実際のサンプリング/送信はサーバ共有の broadcastBridgeSnapshot が行う。
+    socket.on("bridge:subscribe", async () => {
+      socket.join(BRIDGE_ROOM);
+      // 初回スナップショットだけは購読開始の即時応答として個別送信する
+      // (履歴が空なので CPU 0% になるのは許容)
       try {
         const metrics = await hostMetrics.sample();
         const sessions = collectBridgeSessions();
@@ -2116,80 +2140,34 @@ async function startServer() {
           getErrorMessage(err)
         );
       }
-
-      // 1秒間隔のスナップショット
-      bridgeSnapshotInterval = setInterval(async () => {
-        try {
-          const metrics = await hostMetrics.sample();
-          const sessions = collectBridgeSessions();
-          const tunnels = buildTunnelEntries({ primaryUrl: tunnelUrl });
-          socket.emit("bridge:snapshot", {
-            metrics,
-            sessions,
-            tunnels,
-            collectedAt: Date.now(),
-          });
-        } catch (err) {
-          console.error("[Bridge] スナップショット失敗:", getErrorMessage(err));
-        }
-      }, 1000);
-
-      // フォーカス中セッションのライブストリームは 1.5秒間隔で送る
-      bridgeStreamInterval = setInterval(() => {
-        if (!bridgeFocusSessionId) return;
-        try {
-          const lines = collectStreamLines(bridgeFocusSessionId, 24);
-          socket.emit("bridge:stream", {
-            sessionId: bridgeFocusSessionId,
-            lines,
-          });
-        } catch (err) {
-          console.error("[Bridge] ストリーム取得失敗:", getErrorMessage(err));
-        }
-      }, 1500);
     });
 
     socket.on("bridge:unsubscribe", () => {
-      stopBridge();
+      socket.leave(BRIDGE_ROOM);
     });
 
     // ===== Repo Grid View =====
-    // 主 Dashboard でリポジトリ選択時に表示するセッショングリッド用の購読。
-    // Bridge と独立して購読/解除できる。
-    let gridInterval: NodeJS.Timeout | null = null;
-
-    const stopGrid = () => {
-      if (gridInterval) {
-        clearInterval(gridInterval);
-        gridInterval = null;
-      }
-    };
-
-    const emitGridSnapshot = () => {
+    // 同じく room (GRID_ROOM) で購読管理。Bridge と独立して購読/解除できる。
+    socket.on("session:grid:subscribe", () => {
+      socket.join(GRID_ROOM);
+      // 初回は即送る
       try {
         socket.emit("session:grid:snapshot", collectGridSnapshots());
       } catch (err) {
-        console.error("[Grid] スナップショット失敗:", getErrorMessage(err));
+        console.error("[Grid] 初回スナップショット失敗:", getErrorMessage(err));
       }
-    };
-
-    socket.on("session:grid:subscribe", () => {
-      stopGrid();
-      // 初回は即送る
-      emitGridSnapshot();
-      gridInterval = setInterval(emitGridSnapshot, 1500);
     });
 
     socket.on("session:grid:unsubscribe", () => {
-      stopGrid();
+      socket.leave(GRID_ROOM);
     });
 
     // Cleanup on disconnect
     socket.on("disconnect", () => {
       console.log(`Client disconnected: ${socket.id}`);
       clearInterval(previewInterval);
-      stopBridge();
-      stopGrid();
+      // socket.leave は disconnect 時に Socket.IO が自動で行うので room の明示的な
+      // クリーンアップは不要
 
       forwardHandlers.forEach((handler, event) => {
         sessionOrchestrator.off(event, handler);
@@ -2314,6 +2292,8 @@ async function startServer() {
   const shutdown = () => {
     console.log("Shutting down...");
     clearInterval(fileUploadCleanupInterval);
+    clearInterval(bridgeBroadcastInterval);
+    clearInterval(gridBroadcastInterval);
     sessionOrchestrator.cleanup();
     beaconManager.cleanup();
     browserManager.cleanup();

--- a/server/lib/bridge-collector.ts
+++ b/server/lib/bridge-collector.ts
@@ -1,0 +1,480 @@
+/**
+ * Bridge Data Collector
+ *
+ * tmux capture-pane の最新出力からセッションの状態 (TOOL/THINK/AWAITING/IDLE/ERR) と
+ * 「現在やっていること」の1行サマリ、ライブストリーム用の構造化行を抽出する。
+ *
+ * Bridge ダッシュボード専用の解析ロジック。既存 SessionOrchestrator の
+ * getAllPreviews と似ているが、Bridge 用に「最後の数行」をストリームとして
+ * 並べる必要があるためここに別実装する。
+ */
+
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import type {
+  BridgeSession,
+  BridgeSessionStatus,
+  BridgeStreamLine,
+  BridgeTunnelEntry,
+  SessionGridSnapshot,
+} from "../../shared/types.js";
+import { stripAnsi } from "./ansi.js";
+import { db } from "./database.js";
+import { sessionOrchestrator } from "./session-orchestrator.js";
+import { tmuxManager } from "./tmux-manager.js";
+
+/** capture-pane を独自フォーマットでパースした結果 */
+interface PaneAnalysis {
+  status: BridgeSessionStatus;
+  currentTask: string;
+  streamLines: BridgeStreamLine[];
+}
+
+/**
+ * Bridge 用にセッション一覧を組み立てる。
+ *
+ * 主UI（Dashboard）の表示と一貫させるため、2段の同期を行う:
+ *
+ *   1. `sessionOrchestrator.getAllSessions()` で worktree 削除済みセッションを自動クリーンアップ
+ *   2. settings DB の `repoList` キー（主UIサイドバーの表示対象リポジトリ）でフィルタ
+ *
+ * `repoList` が未設定（≒ 主UI未訪問）の場合は全件返す。
+ * `tmuxManager.getAllSessions()` を直接使うと孤立セッション + 非表示リポジトリのセッションも混ざる。
+ */
+export function collectBridgeSessions(): BridgeSession[] {
+  const managedSessions = sessionOrchestrator.getAllSessions();
+  const allowedRepos = readUserRepoList();
+  const filtered =
+    allowedRepos === null
+      ? managedSessions
+      : managedSessions.filter(ms => {
+          // repoPath が無い古いセッションは worktreePath を repoList の prefix と
+          // 突き合わせる（useGroupedWorktreeItems と同じロジック）
+          if (ms.repoPath) return allowedRepos.has(ms.repoPath);
+          return Array.from(allowedRepos).some(r =>
+            ms.worktreePath.startsWith(r)
+          );
+        });
+  const result: BridgeSession[] = [];
+  for (const ms of filtered) {
+    // 可視範囲のみ取得 (scrollback を含めると /clear 後でも過去ログが残り、
+    // READY 判定や preview 表示が壊れる)
+    const raw = tmuxManager.capturePaneVisible(ms.id);
+    const analysis = raw ? analyzePane(raw) : EMPTY_ANALYSIS;
+    const paneId = lookupPaneId(ms.tmuxSessionName);
+    const previewText = raw ? extractPreviewText(raw, 12) : "";
+    let status: BridgeSessionStatus;
+    if (ms.status === "stopped") {
+      status = "STOP";
+    } else if (analysis.status === "IDLE" && previewText.trim().length === 0) {
+      // /clear 直後・起動直後など、画面に意味あるテキストがない場合は READY (グレー)
+      status = "READY";
+    } else {
+      status = analysis.status;
+    }
+    result.push({
+      id: ms.id,
+      name: deriveDisplayName(ms.worktreePath, ms.repoPath),
+      status,
+      paneId,
+      tokens: estimateTokens(raw),
+      elapsedMs: Date.now() - new Date(ms.createdAt).getTime(),
+      currentTask: analysis.currentTask,
+      previewText,
+    });
+  }
+  // 状態優先で並び替え (要対応 → 動作中 → 入力待ち → 空 → 停止)
+  result.sort((a, b) => {
+    const order: Record<BridgeSessionStatus, number> = {
+      ERR: 0,
+      AWAITING: 1,
+      TOOL: 2,
+      THINK: 3,
+      IDLE: 4,
+      READY: 5,
+      STOP: 6,
+    };
+    return order[a.status] - order[b.status];
+  });
+  return result;
+}
+
+/**
+ * フォーカス中セッションのライブストリームを取得する。
+ * 直近 N 行を構造化して返す。
+ */
+export function collectStreamLines(
+  sessionId: string,
+  maxLines = 20
+): BridgeStreamLine[] {
+  const raw = tmuxManager.capturePane(sessionId, 400);
+  if (!raw) return [];
+  const analysis = analyzePane(raw);
+  return analysis.streamLines.slice(-maxLines);
+}
+
+/**
+ * 主 Dashboard の RepoGridView 用に、各セッションの状態 + 末尾プレビューを返す。
+ *
+ * collectBridgeSessions と同じく:
+ *   - sessionOrchestrator 経由で孤立セッションをクリーンアップ
+ *   - settings DB の repoList でフィルタ
+ *
+ * Bridge と異なる点:
+ *   - プレビューは ANSI 除去済みの「プレーンテキスト」(改行込み)
+ *   - 1メッセージで全セッション分を返す（フォーカス概念なし）
+ */
+export function collectGridSnapshots(maxLines = 12): SessionGridSnapshot[] {
+  const managedSessions = sessionOrchestrator.getAllSessions();
+  const allowedRepos = readUserRepoList();
+  const filtered =
+    allowedRepos === null
+      ? managedSessions
+      : managedSessions.filter(ms => {
+          if (ms.repoPath) return allowedRepos.has(ms.repoPath);
+          return Array.from(allowedRepos).some(r =>
+            ms.worktreePath.startsWith(r)
+          );
+        });
+
+  const now = Date.now();
+  const result: SessionGridSnapshot[] = [];
+  for (const ms of filtered) {
+    // 可視範囲のみ取得 (collectBridgeSessions と統一)
+    const raw = tmuxManager.capturePaneVisible(ms.id);
+    const analysis = raw ? analyzePane(raw) : EMPTY_ANALYSIS;
+    const previewText = raw ? extractPreviewText(raw, maxLines) : "";
+    // collectBridgeSessions と同じ READY 判定を適用
+    let status: BridgeSessionStatus;
+    if (ms.status === "stopped") {
+      status = "STOP";
+    } else if (analysis.status === "IDLE" && previewText.trim().length === 0) {
+      status = "READY";
+    } else {
+      status = analysis.status;
+    }
+    result.push({
+      sessionId: ms.id,
+      repoPath: ms.repoPath ?? ms.worktreePath,
+      name: deriveDisplayName(ms.worktreePath, ms.repoPath),
+      status,
+      previewText,
+      currentTask: analysis.currentTask,
+      elapsedMs: now - new Date(ms.createdAt).getTime(),
+      capturedAt: now,
+    });
+  }
+  return result;
+}
+
+/**
+ * capture-pane の文字列から末尾 maxLines 行を抽出してプレーン文字列に整形する。
+ * UI装飾行 (アニメーション、ステータスバー、起動ヘッダー等) は除外し、
+ * クリーンな「ターミナル中身プレビュー」として返す。
+ */
+function extractPreviewText(raw: string, maxLines: number): string {
+  const cleaned = stripAnsi(raw)
+    .split("\n")
+    .map(l => l.replace(/\s+$/, ""));
+  // 末尾から非UI行を maxLines 集める
+  const collected: string[] = [];
+  for (let i = cleaned.length - 1; i >= 0 && collected.length < maxLines; i--) {
+    const t = cleaned[i].trim();
+    if (!t) continue;
+    if (isUiLine(t)) continue;
+    collected.push(cleaned[i]);
+  }
+  return collected.reverse().join("\n");
+}
+
+/**
+ * Tunnel エントリを Cloudflare に問い合わせず、サーバ内の状態のみで構築する簡易版。
+ * 真の cloudflared 統合は server/index.ts 側で activeTunnel から組み立てる。
+ */
+export function buildTunnelEntries(input: {
+  /** 現在 active な Quick / Named tunnel の URL（無ければ null） */
+  primaryUrl: string | null;
+}): BridgeTunnelEntry[] {
+  const entries: BridgeTunnelEntry[] = [];
+  if (input.primaryUrl) {
+    entries.push({
+      name: "Gangway",
+      host: extractHost(input.primaryUrl),
+      status: "on",
+      stat: "active",
+    });
+  } else {
+    entries.push({
+      name: "Gangway",
+      host: "—",
+      status: "off",
+      stat: "down",
+    });
+  }
+  return entries;
+}
+
+// ─────────────────────────────────────────────────────────────────
+// 内部
+// ─────────────────────────────────────────────────────────────────
+
+const EMPTY_ANALYSIS: PaneAnalysis = {
+  status: "IDLE",
+  currentTask: "",
+  streamLines: [],
+};
+
+/**
+ * settings DB の `repoList` キーを読む。
+ *
+ * - 値が配列でない / 空 / 未設定 → null（フィルタしない＝全件表示）
+ * - 配列なら Set<string> として返す
+ *
+ * 主UI（Dashboard）が `setSetting("repoList", paths)` で書き込んでいる値を、
+ * Bridge は読み取り専用で参照する。
+ */
+function readUserRepoList(): Set<string> | null {
+  try {
+    const raw = db.getSetting("repoList");
+    if (!Array.isArray(raw) || raw.length === 0) return null;
+    const list = raw.filter((p): p is string => typeof p === "string");
+    if (list.length === 0) return null;
+    return new Set(list);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 表示名を作る。
+ *
+ * 優先順位:
+ *   1. worktreePath が repoPath と異なる（= worktree branch）→ worktree basename
+ *   2. それ以外（メインブランチ or repoPath 不明）→ repo basename
+ *
+ * 例:
+ *   worktreePath=/.../promarche-feat-x, repoPath=/.../promarche → "promarche-feat-x"
+ *   worktreePath=/.../tally,            repoPath=/.../tally    → "tally"
+ */
+function deriveDisplayName(
+  worktreePath: string,
+  repoPath?: string | null
+): string {
+  if (repoPath && worktreePath !== repoPath) {
+    return path.basename(worktreePath) || worktreePath;
+  }
+  return path.basename(repoPath || worktreePath) || worktreePath;
+}
+
+/** tmux list-panes で先頭ペインの %ID を取得（取れなければ null） */
+function lookupPaneId(tmuxSessionName: string): string | null {
+  try {
+    const r = spawnSync(
+      "tmux",
+      ["list-panes", "-t", tmuxSessionName, "-F", "%#{pane_index}"],
+      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+    );
+    if (r.status !== 0) return null;
+    const first = (r.stdout ?? "").split("\n").find(Boolean);
+    return first ? first.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * tmux capture-pane の文字列を解析し、
+ *   1. 状態 (TOOL/THINK/AWAITING/IDLE/ERR)
+ *   2. 現在タスク（最終非UI行）
+ *   3. ライブストリーム表示用に分類した行配列
+ * を返す。
+ *
+ * Claude Code v2 (2.x) の出力形式に対応:
+ *   - ⏺ <Tool>(...)        ツール呼び出し
+ *   - ⎿ <result> / Error:  ツール結果 / エラー
+ *   - ✻ Wibbling… (...esc) 思考中 (gerund)
+ *   - ✻ Sautéed for 12s    完了 (過去形 + 経過時間)
+ *   - ❯                    プロンプト
+ *   - 1. Yes / 2. No       判断要メニュー
+ */
+function analyzePane(raw: string): PaneAnalysis {
+  const lines = stripAnsi(raw)
+    .split("\n")
+    .map(l => l.replace(/\s+$/, ""));
+
+  // ストリーム分類 (空行は除く)
+  const streamLines: BridgeStreamLine[] = [];
+  for (const line of lines) {
+    const t = line.trim();
+    if (!t) continue;
+    streamLines.push(classifyLine(t));
+  }
+
+  // 状態判定: 優先度順に判定する (高 → 低)
+  // ERR > AWAITING > TOOL > THINK > IDLE
+  const tail = lines.slice(-50);
+  const status = detectStatus(tail);
+
+  // 現在タスク: 末尾から非UI行を探す
+  let currentTask = "";
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const t = lines[i].trim();
+    if (!t) continue;
+    if (isUiLine(t)) continue;
+    if (/^❯/.test(t)) continue;
+    currentTask = t.length > 80 ? `${t.slice(0, 78)}…` : t;
+    break;
+  }
+
+  return { status, currentTask, streamLines };
+}
+
+/**
+ * 末尾 N 行から現在状態を判定する。
+ * 各検知器は独立に評価し、優先度順に返す。
+ */
+function detectStatus(tail: string[]): BridgeSessionStatus {
+  // 1. ERR — Claude セッション自体が壊れているケースのみ
+  // 注意: 単純な "panic!"/"fatal:"/"Error:" 部分一致だと、Claude が編集中の
+  // ソースコードに含まれる文字列まで拾って誤検知する (このコード自体がトリガー
+  // になった)。ここでは:
+  //   - 直近 10 行に限定
+  //   - 行頭の panicked at / Segmentation fault / 行頭 ⎿ Error: のみ
+  // をシグナルにする。1回失敗しただけのツール結果は ERR にしない。
+  const recent = tail.slice(-10);
+  const hasError = recent.some(l =>
+    /^\s*(panicked at|Segmentation fault|Aborted)\b/.test(l)
+  );
+  if (hasError) return "ERR";
+
+  // 2. AWAITING — ユーザー判断待ち
+  // 数字付きメニュー (1. ... / 2. ...) が連続2行以上、または
+  // y/n プロンプト、許可確認文言
+  if (detectAwaiting(tail)) return "AWAITING";
+
+  // 3. アクティブ判定
+  // Claude Code はアクティブな進行中の行に必ず `…` + ` (経過時間 · ...)` を付ける:
+  //   "✻ Wibbling… (4s · 23 tokens · esc to interrupt)"
+  //   "✶ Jitterbugging… (14m 32s · ↓ 42.8k tokens)"
+  //   "✢ 動作確認を実行中… (11m 9s · ↓ 26.7k tokens · almost done thinking)"
+  // 先頭アイコンは ✻ ✽ ✢ ✶ ✵ * ● 等いろいろ変わるので「アイコン無依存」で判定する。
+  // 完了形 "✻ Sautéed for 12s" や、純粋な省略 "Reading 1 file…" は対象外
+  // (前者は … を持たない、後者は … の後にカッコ付き時間が来ない)。
+  const isActive = tail.some(l => /…\s*\(\d+\w*/.test(l));
+  if (isActive) {
+    // ツール実行中 vs 純粋な思考中 を区別:
+    //   最後の ⏺ ToolName( が、最後の ⎿ 結果より新しければ TOOL
+    //   そうでなければ THINK
+    let lastToolIdx = -1;
+    let lastResultIdx = -1;
+    for (let i = 0; i < tail.length; i++) {
+      const l = tail[i];
+      if (/^\s*⏺\s+[A-Z][a-zA-Z_]*\(/.test(l)) lastToolIdx = i;
+      if (/^\s*⎿/.test(l)) lastResultIdx = i;
+    }
+    return lastToolIdx > lastResultIdx ? "TOOL" : "THINK";
+  }
+
+  // 4. それ以外は IDLE (DONE は廃止し IDLE に統合)
+  return "IDLE";
+}
+
+/**
+ * ユーザー判断待ち (AWAITING) の検出。
+ *
+ * 注意: 単純に "連続する `<digit>.` 行" でメニュー判定すると、Claude が
+ * チャット中で生成した番号付きタスクリスト (例: テスト観点 1〜6) も拾って
+ * 誤検知する。Claude Code の本物の確認 UI に固有のフレーズだけを見る。
+ *
+ * 真陽性を狙うフレーズ (実装時点の Claude Code v2 の許諾 UI 由来):
+ *   - "Do you want to ...?" (Edit/Bash の許諾)
+ *   - "Tool use approval required"
+ *   - "(y/n)" / "[Y/n]" / "[y/N]"
+ *   - "Allow Claude to" / "Deny" のような選択肢ヘッダ
+ */
+function detectAwaiting(tail: string[]): boolean {
+  // 直近 15 行に絞って探す (古い発話に含まれる質問文での誤発火を避ける)
+  const window = tail.slice(-15);
+  return window.some(l =>
+    /\(y\/n\)|\[y\/N\]|\[Y\/n\]|Do you want to|Tool use approval|approval required/i.test(
+      l
+    )
+  );
+}
+
+function classifyLine(t: string): BridgeStreamLine {
+  // プロンプト行 (❯ U+276F)
+  if (/^\s*❯/.test(t)) return { kind: "prompt", text: t };
+  // ツール呼び出し: ⏺ ToolName(...)
+  if (/^\s*⏺\s+[A-Z][a-zA-Z_]*\(/.test(t)) return { kind: "tool", text: t };
+  // ツール結果のエラー
+  if (/^\s*⎿\s+(Error|Failed|Killed):/.test(t))
+    return { kind: "error", text: t };
+  // ツール結果 (一般)
+  if (/^\s*⎿/.test(t)) return { kind: "result", text: t };
+  // 思考中インジケータ (… の後にカッコ付き経過時間)
+  if (/…\s*\(\d+\w*/.test(t)) return { kind: "think", text: t };
+  // 既存マークも残す (古い出力の後方互換)
+  if (/^\s*✓/.test(t)) return { kind: "ok", text: t };
+  // ✗ で始まるエラーマーク (panic!/Error: の部分一致は誤検知が多いので除外)
+  if (/^\s*✗/.test(t)) return { kind: "error", text: t };
+  return { kind: "text", text: t };
+}
+
+/**
+ * Claude Code UI 装飾行の判定。
+ * session-orchestrator.ts の getAllPreviews と同等の判定だが、Bridge では
+ * 部分的にしか使わないので簡易版を持つ。
+ */
+function isUiLine(line: string): boolean {
+  if (/[✢✻▘▝▛▜▐▌█]/.test(line)) return true;
+  if (line.includes("Sautéed for")) return true;
+  if (line.includes("Baked for")) return true;
+  if (line.includes("⏵")) return true;
+  if (line.includes("bypass permissions")) return true;
+  if (line.includes("shift+tab to cycle")) return true;
+  if (line.includes("almost done thinking")) return true;
+  if (/^[A-Za-z0-9]\.\s/.test(line) && line.length < 60) return true;
+  // プロンプト行 (❯ で始まる行は中身があってもユーザー入力エリアなので UI 扱い)
+  if (/^❯/.test(line)) return true;
+  // 他シェルの空プロンプト
+  if (/^[>$%#]\s*$/.test(line)) return true;
+  if (/^[─━═▔▁]{3,}$/.test(line)) return true;
+  // Welcome バナーの枠線 (╭─── Claude Code v2.x ───╮ / ╰───╯)
+  if (/^[╭╮╯╰][─═]/.test(line)) return true;
+  if (/^[│║]/.test(line)) return true;
+  if (/^Claude Code\s/.test(line)) return true;
+  if (/context\)/.test(line) && /Opus|Sonnet|Haiku/.test(line)) return true;
+  if (/^[~/][\w.\-/]+$/.test(line)) return true;
+  if (/^\/[a-z][\w-]*$/.test(line)) return true;
+  if (line.includes("(no content)")) return true;
+  if (/^[└├│]/.test(line)) return true;
+  return false;
+}
+
+/**
+ * トークン数の概算。capture-pane の本文文字数を雑に 1/4 してトークン換算する。
+ * 真のトークンカウントは jsonl 読み込みが必要だが、Bridge では「桁感」が
+ * 出れば十分なので簡易見積もりに留める。
+ */
+function estimateTokens(raw: string | null): number {
+  if (!raw) return 0;
+  const stripped = stripAnsi(raw).replace(/\s+/g, " ");
+  return Math.round(stripped.length / 4);
+}
+
+function extractHost(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.host;
+  } catch {
+    return url;
+  }
+}
+
+// re-export 用（server/index.ts から呼びやすくするため）
+export const bridgeCollector = {
+  collectSessions: collectBridgeSessions,
+  collectStreamLines,
+  buildTunnelEntries,
+};

--- a/server/lib/bridge-collector.ts
+++ b/server/lib/bridge-collector.ts
@@ -255,10 +255,12 @@ function isWorktreeOfRepo(worktreePath: string, repoPath: string): boolean {
 function readUserRepoList(): Set<string> | null {
   try {
     const raw = db.getSetting("repoList");
-    if (!Array.isArray(raw) || raw.length === 0) return null;
-    const list = raw.filter((p): p is string => typeof p === "string");
-    if (list.length === 0) return null;
-    return new Set(list);
+    // 未設定/型不正 → null (= フィルタなし、全件表示)
+    if (!Array.isArray(raw)) return null;
+    // 空配列はユーザーが「全 repo を非表示にした」状態を表すため、
+    // 空 Set を返してすべてのセッションを除外する。
+    // (useGroupedWorktreeItems の repoListEmpty 分岐と同じ意味づけ)
+    return new Set(raw.filter((p): p is string => typeof p === "string"));
   } catch {
     return null;
   }

--- a/server/lib/bridge-collector.ts
+++ b/server/lib/bridge-collector.ts
@@ -100,6 +100,31 @@ export function collectBridgeSessions(): BridgeSession[] {
 }
 
 /**
+ * 既に取得済みの capture-pane 出力から BridgeSessionStatus + 末尾プレビューを解析する。
+ *
+ * session-orchestrator から呼んで session:previews ペイロードに status を載せ、
+ * Bridge と主 Dashboard の重複ポーリングを避けるためのヘルパー。
+ *
+ * raw は capturePaneVisible() の戻り値を渡すこと。scrollback 込みだと READY 判定が壊れる。
+ */
+export function analyzeBridgeStatus(
+  raw: string,
+  sessionStopped: boolean
+): { status: BridgeSessionStatus; previewText: string } {
+  const analysis = analyzePane(raw);
+  const previewText = extractPreviewText(raw, 12);
+  let status: BridgeSessionStatus;
+  if (sessionStopped) {
+    status = "STOP";
+  } else if (analysis.status === "IDLE" && previewText.trim().length === 0) {
+    status = "READY";
+  } else {
+    status = analysis.status;
+  }
+  return { status, previewText };
+}
+
+/**
  * フォーカス中セッションのライブストリームを取得する。
  * 直近 N 行を構造化して返す。
  */

--- a/server/lib/bridge-collector.ts
+++ b/server/lib/bridge-collector.ts
@@ -434,7 +434,10 @@ function isUiLine(line: string): boolean {
   if (line.includes("bypass permissions")) return true;
   if (line.includes("shift+tab to cycle")) return true;
   if (line.includes("almost done thinking")) return true;
-  if (/^[A-Za-z0-9]\.\s/.test(line) && line.length < 60) return true;
+  // 番号付きリストの行除外は撤廃。Claude が生成した短い箇条書き
+  // (例: "1. ファイルを読む") まで preview から消えてしまい、
+  // READY を誤判定していた。AWAITING (許諾メニュー) は detectAwaiting() で
+  // 別途検出されるためここで preview から外す必要はない。
   // プロンプト行 (❯ で始まる行は中身があってもユーザー入力エリアなので UI 扱い)
   if (/^❯/.test(line)) return true;
   // 他シェルの空プロンプト

--- a/server/lib/bridge-collector.ts
+++ b/server/lib/bridge-collector.ts
@@ -48,11 +48,11 @@ export function collectBridgeSessions(): BridgeSession[] {
     allowedRepos === null
       ? managedSessions
       : managedSessions.filter(ms => {
-          // repoPath が無い古いセッションは worktreePath を repoList の prefix と
-          // 突き合わせる（useGroupedWorktreeItems と同じロジック）
           if (ms.repoPath) return allowedRepos.has(ms.repoPath);
+          // legacy session (repoPath 未設定): repo 境界を意識した判定でフィルタ。
+          // 単純な startsWith だと "app" が "app-old" などの兄弟 repo にも誤マッチする
           return Array.from(allowedRepos).some(r =>
-            ms.worktreePath.startsWith(r)
+            isWorktreeOfRepo(ms.worktreePath, r)
           );
         });
   const result: BridgeSession[] = [];
@@ -133,7 +133,7 @@ export function collectGridSnapshots(maxLines = 12): SessionGridSnapshot[] {
       : managedSessions.filter(ms => {
           if (ms.repoPath) return allowedRepos.has(ms.repoPath);
           return Array.from(allowedRepos).some(r =>
-            ms.worktreePath.startsWith(r)
+            isWorktreeOfRepo(ms.worktreePath, r)
           );
         });
 
@@ -233,6 +233,25 @@ const EMPTY_ANALYSIS: PaneAnalysis = {
  * 主UI（Dashboard）が `setSetting("repoList", paths)` で書き込んでいる値を、
  * Bridge は読み取り専用で参照する。
  */
+/**
+ * worktreePath が repoPath の worktree (本体 or 兄弟ディレクトリ) かを判定する。
+ *
+ * 単純な `worktreePath.startsWith(repoPath)` だと "app" と "app-old" が誤マッチする。
+ * クライアント側 sessionUtils.ts の isSessionBelongsToRepo と同等のロジック:
+ *   1. 完全一致 (本体)
+ *   2. 親ディレクトリが一致 + worktree名が "<repo名>-..." で始まる (兄弟 worktree)
+ */
+function isWorktreeOfRepo(worktreePath: string, repoPath: string): boolean {
+  if (worktreePath === repoPath) return true;
+  const repoParent = path.dirname(repoPath);
+  const repoName = path.basename(repoPath);
+  const worktreeParent = path.dirname(worktreePath);
+  const worktreeName = path.basename(worktreePath);
+  return (
+    worktreeParent === repoParent && worktreeName.startsWith(`${repoName}-`)
+  );
+}
+
 function readUserRepoList(): Set<string> | null {
   try {
     const raw = db.getSetting("repoList");

--- a/server/lib/host-metrics.ts
+++ b/server/lib/host-metrics.ts
@@ -34,8 +34,9 @@ interface NetSnapshot {
   ms: number;
 }
 
-const HISTORY_CPU_SAMPLES = 36; // 60秒分(=1.6秒間隔×36 ≒ 60s)：UI上は単純に直近60秒として扱う
-const HISTORY_MEM_SAMPLES = 18; // 10分分(33s間隔×18≒10m)：CPUより低頻度で間引き
+// sample() は 1秒間隔で呼ばれる前提。UI 軸ラベル ("−60s" / "−10m") と整合させる。
+const HISTORY_CPU_SAMPLES = 60; // 1秒×60 = 60秒
+const HISTORY_MEM_SAMPLES = 18; // 33秒間隔×18 ≒ 10分 (memSampleCount で33tick毎に1回push)
 
 export class HostMetricsCollector {
   private prevCpu: CpuSnapshot | null = null;

--- a/server/lib/host-metrics.ts
+++ b/server/lib/host-metrics.ts
@@ -10,10 +10,13 @@
  * 差分で算出する。履歴は内部リングバッファで保持する。
  */
 
-import { execSync } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promises as fs, readFileSync, statSync } from "node:fs";
 import os from "node:os";
+import { promisify } from "node:util";
 import type { HostMetrics } from "../../shared/types.js";
+
+const execFileAsync = promisify(execFile);
 
 /** /proc/stat の cpu 行を集計したスナップショット */
 interface CpuSnapshot {
@@ -55,7 +58,7 @@ export class HostMetricsCollector {
     this.prevCpu = cpu;
 
     const memory = await readMemory();
-    const volumes = readVolumes();
+    const volumes = await readVolumes();
     const disk = await readDiskBytesPerSec(this.prevDisk);
     if (disk.snapshot) this.prevDisk = disk.snapshot;
     const net = await readNetBytesPerSec(this.prevNet);
@@ -193,20 +196,31 @@ async function readMemory(): Promise<HostMetrics["memory"]> {
     const text = await readFileAsyncSafe("/proc/meminfo");
     if (text) {
       const m = parseMeminfo(text);
-      const totalGB = kbToGB(m.MemTotal);
-      const freeGB = kbToGB(m.MemAvailable ?? m.MemFree);
-      const cachedGB = kbToGB((m.Cached ?? 0) + (m.Buffers ?? 0));
-      const wiredGB = kbToGB((m.Slab ?? 0) + (m.KernelStack ?? 0));
-      // App ≒ Active - Cached - Wired を概算（負値は0クランプ）
-      const appGB = Math.max(
-        0,
-        kbToGB(m.Active ?? m.MemTotal - (m.MemFree ?? 0) - (m.Cached ?? 0)) -
-          cachedGB -
-          wiredGB
-      );
+      // Wired / App / Cached / Free の4セグメントが MemTotal にきっちり積み上がるよう、
+      // 引き算ベースで導出する。
+      //   Free   = MemFree                               (純粋に未使用)
+      //   Cached = Buffers + Cached                      (再利用可能なファイルキャッシュ)
+      //   Wired  = Slab + KernelStack                    (カーネルの非ページ可能領域)
+      //   App    = MemTotal − Free − Cached − Wired      (残り = ユーザプロセス匿名メモリ)
+      const memTotalKB = m.MemTotal ?? 0;
+      const memFreeKB = m.MemFree ?? 0;
+      const cachedKB = (m.Cached ?? 0) + (m.Buffers ?? 0);
+      const wiredKB = (m.Slab ?? 0) + (m.KernelStack ?? 0);
+      const appKB = Math.max(0, memTotalKB - memFreeKB - cachedKB - wiredKB);
+
+      const totalGB = kbToGB(memTotalKB);
+      const freeGB = kbToGB(memFreeKB);
+      const cachedGB = kbToGB(cachedKB);
+      const wiredGB = kbToGB(wiredKB);
+      const appGB = kbToGB(appKB);
+
+      // usedGB はサマリ表示用 (reclaimable cache を含む実質使用感)。
+      // MemAvailable があればそれ基準、無ければ Total - MemFree。
+      const availableGB = kbToGB(m.MemAvailable ?? memFreeKB);
+      const usedGB = Math.max(0, totalGB - availableGB);
+
       const swapTotal = kbToGB(m.SwapTotal ?? 0);
       const swapFree = kbToGB(m.SwapFree ?? 0);
-      const usedGB = Math.max(0, totalGB - freeGB);
       return {
         totalGB,
         usedGB,
@@ -246,13 +260,14 @@ function parseMeminfo(text: string): Record<string, number> {
   return out;
 }
 
-function readVolumes(): HostMetrics["volumes"] {
+async function readVolumes(): Promise<HostMetrics["volumes"]> {
   // df は Linux/macOS で共通。-P で POSIX フォーマット、-k で KB 単位。
   // 対象は / と $HOME とユーザのデータディレクトリ程度に絞る
+  // 非同期 (execFile) を使って Node の event loop を毎秒ブロックしないようにする。
+  // df がスタックしたマウントで応答しない場合に備え 2秒で timeout する。
   try {
-    const out = execSync("df -Pk", {
+    const { stdout: out } = await execFileAsync("df", ["-Pk"], {
       encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
       timeout: 2000,
     });
     const lines = out.split("\n").slice(1).filter(Boolean);

--- a/server/lib/host-metrics.ts
+++ b/server/lib/host-metrics.ts
@@ -316,10 +316,7 @@ async function readDiskBytesPerSec(
     const parts = raw.trim().split(/\s+/);
     if (parts.length < 14) continue;
     const name = parts[2];
-    // ループバック / RAM / パーティション (sda1 等数字尾) は除外
-    if (name.startsWith("loop")) continue;
-    if (name.startsWith("ram")) continue;
-    if (/\d+$/.test(name)) continue;
+    if (!isWholeDiskDevice(name)) continue;
     const readSectors = Number(parts[5]);
     const writeSectors = Number(parts[9]);
     if (Number.isFinite(readSectors)) sectors += readSectors;
@@ -333,6 +330,31 @@ async function readDiskBytesPerSec(
   const bytes = (sectors - prev.sectors) * 512;
   const ioMBs = Math.max(0, bytes / 1024 / 1024 / dt);
   return { ioMBs, snapshot: { sectors, ms: now } };
+}
+
+/**
+ * /proc/diskstats のデバイス名から、集計対象とすべき「ホールデバイス」かを判定する。
+ *
+ * 単純に「末尾が数字 → パーティション」とすると、`nvme0n1` や `mmcblk0`
+ * などのデバイス本体を誤って除外してしまう (これらの数字は識別子の一部)。
+ *
+ * 含める: sda / sdb / hda / vda / xvda / nvme0n1 / mmcblk0 / md0 / dm-0
+ * 除外:   sda1 / nvme0n1p1 / mmcblk0p1 / loop* / ram*
+ */
+function isWholeDiskDevice(name: string): boolean {
+  if (name.startsWith("loop")) return false;
+  if (name.startsWith("ram")) return false;
+  // SCSI/SATA/IDE/Xen/VirtIO: sda, hdb, vdc, xvda 等。"sda1" 等のパーティションは除外
+  if (/^(s|h|v|xv)d[a-z]+$/.test(name)) return true;
+  // NVMe: "nvme<ctrl>n<ns>"。partition は "...p<n>"
+  if (/^nvme\d+n\d+$/.test(name)) return true;
+  // eMMC/SD: "mmcblk<n>"。partition は "...p<n>"
+  if (/^mmcblk\d+$/.test(name)) return true;
+  // RAID
+  if (/^md\d+$/.test(name)) return true;
+  // Device mapper (LVM 等)
+  if (/^dm-\d+$/.test(name)) return true;
+  return false;
 }
 
 async function readNetBytesPerSec(

--- a/server/lib/host-metrics.ts
+++ b/server/lib/host-metrics.ts
@@ -1,0 +1,434 @@
+/**
+ * Host Metrics Collector
+ *
+ * Bridge ダッシュボード用にホストの CPU / Memory / Disk / Network を取得する。
+ *
+ * 依存ゼロで動かすため Node 標準 (os, fs, child_process) のみを使用。
+ * Linux は /proc を直接読み、macOS は os モジュール + sysctl で代替する。
+ *
+ * 1秒間隔で sample() を呼び出すことを想定し、CPU 使用率は前回スナップショットからの
+ * 差分で算出する。履歴は内部リングバッファで保持する。
+ */
+
+import { execSync } from "node:child_process";
+import { promises as fs, readFileSync, statSync } from "node:fs";
+import os from "node:os";
+import type { HostMetrics } from "../../shared/types.js";
+
+/** /proc/stat の cpu 行を集計したスナップショット */
+interface CpuSnapshot {
+  /** 全コア (cpu) と各論理コア (cpu0, cpu1, ...) の (user+nice+sys+irq+softirq, total) */
+  cpus: Array<{ active: number; total: number }>;
+}
+
+/** /proc/diskstats の集計値 (sectors read+written) */
+interface DiskSnapshot {
+  sectors: number;
+  ms: number; // 計測時刻 ms
+}
+
+/** /proc/net/dev の集計値 */
+interface NetSnapshot {
+  rxBytes: number;
+  txBytes: number;
+  ms: number;
+}
+
+const HISTORY_CPU_SAMPLES = 36; // 60秒分(=1.6秒間隔×36 ≒ 60s)：UI上は単純に直近60秒として扱う
+const HISTORY_MEM_SAMPLES = 18; // 10分分(33s間隔×18≒10m)：CPUより低頻度で間引き
+
+export class HostMetricsCollector {
+  private prevCpu: CpuSnapshot | null = null;
+  private prevDisk: DiskSnapshot | null = null;
+  private prevNet: NetSnapshot | null = null;
+
+  private cpuHistory: number[] = [];
+  private memHistory: number[] = [];
+  private memSampleCount = 0;
+
+  /** 現在のスナップショットを返す。差分計算のため初回呼び出しは CPU 使用率が 0% になる。 */
+  async sample(): Promise<HostMetrics> {
+    const cpu = readCpuSnapshot();
+    const cpuPercent = this.diffCpuPercent(cpu, "all");
+    const cores = this.diffCoresPercent(cpu);
+    this.prevCpu = cpu;
+
+    const memory = await readMemory();
+    const volumes = readVolumes();
+    const disk = await readDiskBytesPerSec(this.prevDisk);
+    if (disk.snapshot) this.prevDisk = disk.snapshot;
+    const net = await readNetBytesPerSec(this.prevNet);
+    if (net.snapshot) this.prevNet = net.snapshot;
+
+    // 履歴更新
+    this.cpuHistory.push(cpuPercent);
+    if (this.cpuHistory.length > HISTORY_CPU_SAMPLES) this.cpuHistory.shift();
+
+    // メモリ履歴は 10分窓を狙って ~33秒に1度だけ追加（1秒ポーリング前提で 33step に1回）
+    this.memSampleCount += 1;
+    const memPercent =
+      memory.totalGB > 0 ? (memory.usedGB / memory.totalGB) * 100 : 0;
+    if (this.memSampleCount >= 33) {
+      this.memSampleCount = 0;
+      this.memHistory.push(memPercent);
+      if (this.memHistory.length > HISTORY_MEM_SAMPLES) this.memHistory.shift();
+    }
+
+    return {
+      cpuPercent,
+      loadAvg: os.loadavg() as [number, number, number],
+      memory,
+      cores,
+      volumes,
+      network: { txMBs: net.txMBs, rxMBs: net.rxMBs },
+      diskIOMBs: disk.ioMBs,
+      tempC: readTemperatureC(),
+      gpuPercent: null, // GPU は環境依存度が高いため一旦未対応
+      cpuHistory: [...this.cpuHistory],
+      memHistory: [...this.memHistory],
+    };
+  }
+
+  private diffCpuPercent(current: CpuSnapshot, _target: "all"): number {
+    if (!this.prevCpu || this.prevCpu.cpus.length === 0) return 0;
+    const prev = this.prevCpu.cpus[0];
+    const cur = current.cpus[0];
+    if (!prev || !cur) return 0;
+    const dActive = cur.active - prev.active;
+    const dTotal = cur.total - prev.total;
+    if (dTotal <= 0) return 0;
+    return clamp((dActive / dTotal) * 100, 0, 100);
+  }
+
+  private diffCoresPercent(current: CpuSnapshot): number[] {
+    if (!this.prevCpu) {
+      // 初回は 0% を物理コア数分返す
+      return current.cpus.slice(1).map(() => 0);
+    }
+    const result: number[] = [];
+    for (let i = 1; i < current.cpus.length; i++) {
+      const prev = this.prevCpu.cpus[i];
+      const cur = current.cpus[i];
+      if (!prev || !cur) {
+        result.push(0);
+        continue;
+      }
+      const dActive = cur.active - prev.active;
+      const dTotal = cur.total - prev.total;
+      result.push(dTotal <= 0 ? 0 : clamp((dActive / dTotal) * 100, 0, 100));
+    }
+    return result;
+  }
+}
+
+/**
+ * CPU スナップショットを取得する。
+ * Linux: /proc/stat
+ * 他: os.cpus() の times を集計（差分計算は同様に動く）
+ */
+function readCpuSnapshot(): CpuSnapshot {
+  if (process.platform === "linux") {
+    try {
+      const text = readFileSyncSafe("/proc/stat");
+      if (text) {
+        const lines = text.split("\n").filter(line => line.startsWith("cpu"));
+        return { cpus: lines.map(parseProcStatLine) };
+      }
+    } catch {
+      // fallthrough
+    }
+  }
+
+  const cpus = os.cpus();
+  const all = aggregateCpus(cpus);
+  return {
+    cpus: [
+      all,
+      ...cpus.map(c => ({
+        active: c.times.user + c.times.nice + c.times.sys + c.times.irq,
+        total:
+          c.times.user +
+          c.times.nice +
+          c.times.sys +
+          c.times.idle +
+          c.times.irq,
+      })),
+    ],
+  };
+}
+
+function parseProcStatLine(line: string): { active: number; total: number } {
+  // "cpu  user nice system idle iowait irq softirq steal guest guest_nice"
+  const parts = line.trim().split(/\s+/).slice(1).map(Number);
+  const [
+    user = 0,
+    nice = 0,
+    system = 0,
+    idle = 0,
+    iowait = 0,
+    irq = 0,
+    softirq = 0,
+    steal = 0,
+  ] = parts;
+  const active = user + nice + system + irq + softirq + steal;
+  const total = active + idle + iowait;
+  return { active, total };
+}
+
+function aggregateCpus(cpus: os.CpuInfo[]): { active: number; total: number } {
+  let active = 0;
+  let total = 0;
+  for (const c of cpus) {
+    const a = c.times.user + c.times.nice + c.times.sys + c.times.irq;
+    const t = a + c.times.idle;
+    active += a;
+    total += t;
+  }
+  return { active, total };
+}
+
+async function readMemory(): Promise<HostMetrics["memory"]> {
+  if (process.platform === "linux") {
+    const text = await readFileAsyncSafe("/proc/meminfo");
+    if (text) {
+      const m = parseMeminfo(text);
+      const totalGB = kbToGB(m.MemTotal);
+      const freeGB = kbToGB(m.MemAvailable ?? m.MemFree);
+      const cachedGB = kbToGB((m.Cached ?? 0) + (m.Buffers ?? 0));
+      const wiredGB = kbToGB((m.Slab ?? 0) + (m.KernelStack ?? 0));
+      // App ≒ Active - Cached - Wired を概算（負値は0クランプ）
+      const appGB = Math.max(
+        0,
+        kbToGB(m.Active ?? m.MemTotal - (m.MemFree ?? 0) - (m.Cached ?? 0)) -
+          cachedGB -
+          wiredGB
+      );
+      const swapTotal = kbToGB(m.SwapTotal ?? 0);
+      const swapFree = kbToGB(m.SwapFree ?? 0);
+      const usedGB = Math.max(0, totalGB - freeGB);
+      return {
+        totalGB,
+        usedGB,
+        wiredGB,
+        appGB,
+        cachedGB,
+        compressGB: 0,
+        freeGB,
+        swapGB: Math.max(0, swapTotal - swapFree),
+      };
+    }
+  }
+  // Fallback (macOS など): os.totalmem / freemem のみで簡易表示
+  const totalGB = bytesToGB(os.totalmem());
+  const freeGB = bytesToGB(os.freemem());
+  const usedGB = Math.max(0, totalGB - freeGB);
+  return {
+    totalGB,
+    usedGB,
+    wiredGB: 0,
+    appGB: usedGB,
+    cachedGB: 0,
+    compressGB: 0,
+    freeGB,
+    swapGB: 0,
+  };
+}
+
+function parseMeminfo(text: string): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line) continue;
+    const m = line.match(/^([A-Za-z()_]+):\s+(\d+)\s*kB$/);
+    if (m) out[m[1]] = Number(m[2]);
+  }
+  return out;
+}
+
+function readVolumes(): HostMetrics["volumes"] {
+  // df は Linux/macOS で共通。-P で POSIX フォーマット、-k で KB 単位。
+  // 対象は / と $HOME とユーザのデータディレクトリ程度に絞る
+  try {
+    const out = execSync("df -Pk", {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: 2000,
+    });
+    const lines = out.split("\n").slice(1).filter(Boolean);
+    const seenMounts = new Set<string>();
+    const volumes: HostMetrics["volumes"] = [];
+    for (const line of lines) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 6) continue;
+      const totalKB = Number(parts[1]);
+      const usedKB = Number(parts[2]);
+      const mount = parts.slice(5).join(" ");
+      // 仮想FSや小容量のマウントは除外
+      if (totalKB < 1024 * 1024) continue; // < 1GB は無視
+      if (
+        mount.startsWith("/snap") ||
+        mount.startsWith("/boot") ||
+        mount.startsWith("/var/lib/docker") ||
+        mount === "/dev" ||
+        mount.startsWith("/dev/") || // /dev/shm 等の tmpfs を除外
+        mount.startsWith("/run") ||
+        mount.startsWith("/sys") ||
+        mount.startsWith("/proc")
+      ) {
+        continue;
+      }
+      if (seenMounts.has(mount)) continue;
+      seenMounts.add(mount);
+      const totalGB = totalKB / 1024 / 1024;
+      const usedGB = usedKB / 1024 / 1024;
+      const usedPercent = totalKB > 0 ? (usedKB / totalKB) * 100 : 0;
+      volumes.push({
+        name: deriveVolumeName(mount),
+        mount,
+        usedPercent: clamp(usedPercent, 0, 100),
+        totalGB,
+        usedGB,
+      });
+    }
+    // 上位3件のみ（容量大きい順）
+    volumes.sort((a, b) => b.totalGB - a.totalGB);
+    return volumes.slice(0, 3);
+  } catch {
+    return [];
+  }
+}
+
+function deriveVolumeName(mount: string): string {
+  if (mount === "/") return "Root";
+  if (mount === os.homedir()) return "Home";
+  const base = mount.split("/").filter(Boolean).pop();
+  return base ? base : mount;
+}
+
+async function readDiskBytesPerSec(
+  prev: DiskSnapshot | null
+): Promise<{ ioMBs: number; snapshot: DiskSnapshot | null }> {
+  if (process.platform !== "linux") return { ioMBs: 0, snapshot: null };
+  const text = await readFileAsyncSafe("/proc/diskstats");
+  if (!text) return { ioMBs: 0, snapshot: null };
+  let sectors = 0;
+  for (const raw of text.split("\n")) {
+    const parts = raw.trim().split(/\s+/);
+    if (parts.length < 14) continue;
+    const name = parts[2];
+    // ループバック / RAM / パーティション (sda1 等数字尾) は除外
+    if (name.startsWith("loop")) continue;
+    if (name.startsWith("ram")) continue;
+    if (/\d+$/.test(name)) continue;
+    const readSectors = Number(parts[5]);
+    const writeSectors = Number(parts[9]);
+    if (Number.isFinite(readSectors)) sectors += readSectors;
+    if (Number.isFinite(writeSectors)) sectors += writeSectors;
+  }
+  const now = Date.now();
+  if (!prev) return { ioMBs: 0, snapshot: { sectors, ms: now } };
+  const dt = (now - prev.ms) / 1000;
+  if (dt <= 0) return { ioMBs: 0, snapshot: { sectors, ms: now } };
+  // 1 sector = 512 bytes
+  const bytes = (sectors - prev.sectors) * 512;
+  const ioMBs = Math.max(0, bytes / 1024 / 1024 / dt);
+  return { ioMBs, snapshot: { sectors, ms: now } };
+}
+
+async function readNetBytesPerSec(
+  prev: NetSnapshot | null
+): Promise<{ txMBs: number; rxMBs: number; snapshot: NetSnapshot | null }> {
+  if (process.platform !== "linux")
+    return { txMBs: 0, rxMBs: 0, snapshot: null };
+  const text = await readFileAsyncSafe("/proc/net/dev");
+  if (!text) return { txMBs: 0, rxMBs: 0, snapshot: null };
+  let rx = 0;
+  let tx = 0;
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    const m = line.match(
+      /^([^:\s]+):\s+(\d+)\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+\d+\s+(\d+)/
+    );
+    if (!m) continue;
+    const iface = m[1];
+    if (iface === "lo") continue;
+    if (iface.startsWith("docker") || iface.startsWith("br-")) continue;
+    rx += Number(m[2]);
+    tx += Number(m[3]);
+  }
+  const now = Date.now();
+  if (!prev)
+    return {
+      txMBs: 0,
+      rxMBs: 0,
+      snapshot: { rxBytes: rx, txBytes: tx, ms: now },
+    };
+  const dt = (now - prev.ms) / 1000;
+  if (dt <= 0)
+    return {
+      txMBs: 0,
+      rxMBs: 0,
+      snapshot: { rxBytes: rx, txBytes: tx, ms: now },
+    };
+  const rxMBs = Math.max(0, (rx - prev.rxBytes) / 1024 / 1024 / dt);
+  const txMBs = Math.max(0, (tx - prev.txBytes) / 1024 / 1024 / dt);
+  return { rxMBs, txMBs, snapshot: { rxBytes: rx, txBytes: tx, ms: now } };
+}
+
+function readTemperatureC(): number | null {
+  if (process.platform !== "linux") return null;
+  // hwmon/thermal_zone から最初の有効値を拾う
+  try {
+    const candidates = [
+      "/sys/class/thermal/thermal_zone0/temp",
+      "/sys/class/thermal/thermal_zone1/temp",
+    ];
+    for (const p of candidates) {
+      try {
+        const stat = statSync(p);
+        if (!stat.isFile()) continue;
+        const text = readFileSyncSafe(p);
+        if (!text) continue;
+        const v = Number(text.trim());
+        if (Number.isFinite(v) && v > 0) {
+          return v / 1000;
+        }
+      } catch {
+        // ignore
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return null;
+}
+
+function readFileSyncSafe(p: string): string | null {
+  try {
+    return readFileSync(p, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+async function readFileAsyncSafe(p: string): Promise<string | null> {
+  try {
+    return await fs.readFile(p, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+function kbToGB(kb: number): number {
+  return kb / 1024 / 1024;
+}
+
+function bytesToGB(b: number): number {
+  return b / 1024 / 1024 / 1024;
+}
+
+function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export const hostMetrics = new HostMetricsCollector();

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -9,11 +9,13 @@ import { execFileSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import type {
+  BridgeSessionStatus,
   ManagedSession,
   SessionStatus,
   SpecialKey,
 } from "../../shared/types.js";
 import { stripAnsi } from "./ansi.js";
+import { analyzeBridgeStatus } from "./bridge-collector.js";
 import { db } from "./database.js";
 import { type TmuxSession, tmuxManager } from "./tmux-manager.js";
 import { ttydManager } from "./ttyd-manager.js";
@@ -674,6 +676,7 @@ export class SessionOrchestrator extends EventEmitter {
     text: string;
     activityText: string;
     status: SessionStatus;
+    bridgeStatus: BridgeSessionStatus;
     timestamp: number;
   }> {
     const allSessions = tmuxManager.getAllSessions();
@@ -682,12 +685,22 @@ export class SessionOrchestrator extends EventEmitter {
       text: string;
       activityText: string;
       status: SessionStatus;
+      bridgeStatus: BridgeSessionStatus;
       timestamp: number;
     }> = [];
 
     for (const session of allSessions) {
-      const raw = tmuxManager.capturePane(session.id, 200);
+      // 可視範囲のみ取得 (scrollback 込みだと /clear 後にも過去ログが残り、
+      // BridgeSessionStatus の READY 判定や preview 表示が壊れる)
+      const raw = tmuxManager.capturePaneVisible(session.id);
       if (raw === null) continue;
+      // Bridge dashboard / サイドバードット / RepoGridView で共通利用する状態判定。
+      // 既存の text/activityText/status (legacy SessionStatus) と同じ raw から
+      // 派生させて、tmux capture を1回で済ませる
+      const { status: bridgeStatus } = analyzeBridgeStatus(
+        raw,
+        session.status === "stopped"
+      );
       const allLines = stripAnsi(raw)
         .split("\n")
         .map(line => line.trim())
@@ -757,6 +770,7 @@ export class SessionOrchestrator extends EventEmitter {
         text,
         activityText: activityLine,
         status,
+        bridgeStatus,
         timestamp: Date.now(),
       });
     }

--- a/server/lib/tmux-manager.ts
+++ b/server/lib/tmux-manager.ts
@@ -445,6 +445,28 @@ export class TmuxManager extends EventEmitter {
   }
 
   /**
+   * tmux capture-pane で「現在画面に表示されている範囲のみ」を取得する。
+   *
+   * `capturePane` は -S -N で scrollback を含むが、こちらは引数なしで visible 範囲のみ。
+   * 用途: /clear 後に「現状の見え方」を取りたい場合、scrollback を含まないことが必要。
+   */
+  capturePaneVisible(sessionId: string): string | null {
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+    try {
+      const result = spawnSync(
+        TMUX_BINARY_PATH,
+        ["capture-pane", "-t", session.tmuxSessionName, "-p"],
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+      );
+      if (result.status !== 0) return null;
+      return (result.stdout ?? "").trimEnd();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * IDでセッションを取得
    */
   getSession(sessionId: string): TmuxSession | undefined {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -311,6 +311,16 @@ export interface ServerToClientEvents {
     repoPath: string;
     profileId: string | null;
   }) => void;
+
+  // Bridge ダッシュボード
+  "bridge:snapshot": (snapshot: BridgeSnapshot) => void;
+  "bridge:stream": (data: {
+    sessionId: string;
+    lines: BridgeStreamLine[];
+  }) => void;
+
+  // 主 Dashboard の Repo グリッドビュー
+  "session:grid:snapshot": (snapshots: SessionGridSnapshot[]) => void;
 }
 
 export interface ClientToServerEvents {
@@ -399,6 +409,23 @@ export interface ClientToServerEvents {
 
   // Usage取得 (Linux + multiProfileSupported 限定)
   "usage:request": () => void;
+
+  // Bridge ダッシュボード
+  /**
+   * Bridgeダッシュボードを購読する。
+   * サーバ側で定期ポーリングを開始し、bridge:snapshot を emit する。
+   * トラッキング対象セッションを指定するとそのライブストリームも配信される。
+   */
+  "bridge:subscribe": (data: { focusSessionId?: string | null }) => void;
+  "bridge:unsubscribe": () => void;
+
+  // 主 Dashboard の Repo グリッドビュー
+  /**
+   * セッショングリッド購読。サーバ側で 1.5秒間隔で session:grid:snapshot を emit する。
+   * 主 Dashboard の RepoGridView がマウントされている間だけ購読する想定。
+   */
+  "session:grid:subscribe": () => void;
+  "session:grid:unsubscribe": () => void;
 }
 
 /** Usage取得結果（プロファイル単位） */
@@ -515,4 +542,160 @@ export interface FrontlineRecordSaved {
 export interface FrontlineError {
   action: "get_stats" | "get_records" | "save_record";
   message: string;
+}
+
+// ============================================================
+// Bridge ダッシュボード（5インチサブディスプレイ常駐）
+// ============================================================
+
+/**
+ * Bridge 上で表示するセッションの状態。
+ * Claude Code v2 のターミナル出力 (⏺/⎿/✻/❯ + Sautéed/Wibbling 等) を解析して判定する。
+ *
+ * 優先度 (高→低): ERR > AWAITING > TOOL > THINK > IDLE > READY
+ */
+export type BridgeSessionStatus =
+  | "TOOL" // ツール実行中 (⏺ Tool(...) 直近、⎿ 結果未到着)
+  | "THINK" // 思考中 (✻ Wibbling… / esc to interrupt)
+  | "AWAITING" // ユーザー判断待ち (1./2. メニュー or y/n プロンプト)
+  | "IDLE" // 入力待ち (出力あり、アクション要)
+  | "READY" // 空 / クリア直後 (画面に意味あるテキストなし)
+  | "ERR" // エラー検出
+  | "STOP"; // tmux セッション停止
+
+/** Bridge ダッシュボードに渡すセッション情報 */
+export interface BridgeSession {
+  /** ManagedSession.id と一致 */
+  id: string;
+  /** worktree のディレクトリ名（短縮表示用） */
+  name: string;
+  /** ステータスバッジ用 */
+  status: BridgeSessionStatus;
+  /** tmux pane インデックス表示用（"%3" など。取得不可なら null） */
+  paneId: string | null;
+  /** トークン数概算（"2.1k" 等の表示文字列を含む数値） */
+  tokens: number;
+  /** 経過時間 ms */
+  elapsedMs: number;
+  /** 現在タスクの1行サマリ（capture-pane の最終非UI行） */
+  currentTask: string;
+  /**
+   * capture-pane 末尾のプレーンテキスト（改行込み、UI装飾行は除外済み）。
+   * Bridge のセッショングリッドでターミナル中身プレビュー表示用。
+   */
+  previewText: string;
+}
+
+/** Bridge ライブストリームの1行 */
+export interface BridgeStreamLine {
+  /** プロンプト / ツールコール / 思考 / 出力 などの分類 */
+  kind: "prompt" | "tool" | "think" | "ok" | "error" | "result" | "text";
+  /** 表示テキスト（ANSI 除去済み） */
+  text: string;
+}
+
+/** ホストシステムのリソースメトリクス（毎秒スナップショット） */
+export interface HostMetrics {
+  /** 0-100 全体CPU使用率 */
+  cpuPercent: number;
+  /** load average [1m, 5m, 15m] */
+  loadAvg: [number, number, number];
+  /** 物理メモリ */
+  memory: {
+    /** 全体 GB */
+    totalGB: number;
+    /** 使用中 GB */
+    usedGB: number;
+    /** Wired 相当 GB（Linux の場合 Slab + KernelStack 概算） */
+    wiredGB: number;
+    /** App / Active GB */
+    appGB: number;
+    /** Cached GB */
+    cachedGB: number;
+    /** 圧縮 GB（取得不可なら 0） */
+    compressGB: number;
+    /** 空き GB */
+    freeGB: number;
+    /** swap GB */
+    swapGB: number;
+  };
+  /** コアごと使用率 0-100。配列長 = 物理コア数 */
+  cores: number[];
+  /** ストレージボリューム */
+  volumes: Array<{
+    name: string;
+    mount: string;
+    /** 使用率 0-100 */
+    usedPercent: number;
+    /** 全体 GB */
+    totalGB: number;
+    /** 使用 GB */
+    usedGB: number;
+  }>;
+  /** Network 集計（MB/s） */
+  network: {
+    txMBs: number;
+    rxMBs: number;
+  };
+  /** Disk I/O 集計 (MB/s) */
+  diskIOMBs: number;
+  /** VM温度 °C（取れなければ null） */
+  tempC: number | null;
+  /** GPU使用率 0-100（取れなければ null） */
+  gpuPercent: number | null;
+  /** 直近60秒の総CPU使用率履歴（古い→新しい） */
+  cpuHistory: number[];
+  /** 直近10分のメモリ使用率履歴 0-100 */
+  memHistory: number[];
+}
+
+/** Cloudflare Tunnel エントリ（Bridge 表示用） */
+export interface BridgeTunnelEntry {
+  /** 表示名（例: Gangway） */
+  name: string;
+  /** ホスト名 / URL */
+  host: string;
+  /** ステータス LED */
+  status: "on" | "warn" | "off";
+  /** 統計テキスト（"18ms · 142/h" 等） */
+  stat: string;
+}
+
+/** Bridge ダッシュボードへの全データを1メッセージにまとめたスナップショット */
+export interface BridgeSnapshot {
+  metrics: HostMetrics;
+  sessions: BridgeSession[];
+  tunnels: BridgeTunnelEntry[];
+  /** UNIX ms */
+  collectedAt: number;
+}
+
+// ============================================================
+// 主 Dashboard の Repo グリッドビュー
+// ============================================================
+
+/**
+ * 主 Dashboard でリポジトリ選択時に表示する「セッションのグリッド」用スナップショット。
+ *
+ * 各セッションの状態と末尾プレビュー (プレーンテキスト) を返す。
+ * Bridge の BridgeSession と似ているが、こちらはターミナル中身のプレビュー行を
+ * 含む点が異なる (Bridge は構造化された BridgeStreamLine をフォーカスセッションのみ別経路で送る)。
+ */
+export interface SessionGridSnapshot {
+  /** ManagedSession.id */
+  sessionId: string;
+  /** リポジトリの絶対パス。フィルタとグルーピングに使う */
+  repoPath: string;
+  /** worktree のディレクトリ名 (短縮表示) */
+  name: string;
+  /** ステータスバッジ用 */
+  status: BridgeSessionStatus;
+  /** capture-pane 末尾のプレーンテキスト (改行込み、UI装飾行は除外済み) */
+  previewText: string;
+  /** 直近1行サマリ (UIヘッダーなど用、currentTask と同じ) */
+  currentTask: string;
+  /** 経過時間 ms */
+  elapsedMs: number;
+  /** 取得時刻 UNIX ms */
+  capturedAt: number;
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -213,6 +213,11 @@ export interface ServerToClientEvents {
       text: string;
       activityText: string;
       status: SessionStatus;
+      /**
+       * Bridge collector が判定した詳細ステータス。
+       * サイドバードット色 (SessionCard) や RepoGridView と表示を統一するための情報。
+       */
+      bridgeStatus: BridgeSessionStatus;
       timestamp: number;
     }>
   ) => void;


### PR DESCRIPTION
## Summary
- 1280×720 固定の **Bridge ダッシュボード** (`/bridge`) を新設。1bit Mac OS 風の常駐モニタリング画面で、上半分が全セッションのグリッド (状態 + tmux 末尾プレビュー)、下半分が System Monitor (CPU/Cores/Memory/Storage)
- 主 Dashboard で **リポジトリヘッダクリック → 配下セッションのグリッド表示**。各セルに状態バッジ + プレビュー、クリックで従来 TerminalPane に切替
- セッション状態判定を Claude Code v2 の出力形式 (⏺/⎿/✻/❯ + Sautéed/Wibbling 等) に対応した **`BridgeSessionStatus`** (`TOOL`/`THINK`/`AWAITING`/`IDLE`/`READY`/`ERR`/`STOP`) に刷新。`/clear` 直後を `READY` (グレー) で `IDLE` と区別
- サイドバードット色も `BridgeSessionStatus` 駆動に。グリッドビューと色を統一

## 主な実装
- **`server/lib/host-metrics.ts`** (新規): Linux `/proc` 直読みで CPU/メモリ/コア別/ディスク/ネット/温度を毎秒スナップショット。メモリは Wired/App/Cached/Free が `MemTotal` に 100% で積み上がるよう引き算ベースで導出
- **`server/lib/bridge-collector.ts`** (新規): tmux `capturePaneVisible` (scrollback 除外) を解析して状態と末尾プレビューを返す。`analyzeBridgeStatus()` を `session-orchestrator.getAllPreviews()` から共有して、`session:previews` 1本で Bridge と主 Dashboard 両方の必要情報を運ぶ
- **`server/index.ts`**: Socket.IO room (`BRIDGE_ROOM`/`GRID_ROOM`) で購読管理。サーバ全体で1本のサンプリング loop からブロードキャスト (per-socket interval を排除)。`hostMetrics` の差分計算が複数クライアント開放で乱れる問題を解消
- **`client/src/pages/Bridge.tsx`** (新規): 1280×720 固定ページ。`bridge:subscribe` で 1秒スナップショットを受信
- **`client/src/components/RepoGridView.tsx`** (新規): 主 Dashboard 用グリッド。マウント時のみ `session:grid:subscribe` を発行 (常時購読しない)
- **`client/src/components/SessionCard.tsx`**: ドット色を `gridStatus` 優先 + 旧ヒューリスティックフォールバック

## 状態判定の主なポイント
- アクティブ判定: `…\s*\(\d+\w*` (`Wibbling… (4s ·` 等) — 全アイコン (`✻ ✽ ✢ ✶ * ●`) と全言語に対応
- AWAITING: `Do you want to` / `(y/n)` / `Tool use approval` のみで誤検知抑制 (連続 `1./2.` メニューは Claude 応答の番号付きリストと衝突するため不採用)
- ERR: 直近 10 行の `panicked at` / `Segmentation fault` / `Aborted` のみ。ツール結果のエラーや編集中ソースコードに含まれる `panic!` 文字列で誤発火しない
- READY: previewText が空 → グレー (`/clear` 直後を IDLE と区別)
- セッション一覧は settings DB の `repoList` でフィルタ。境界判定は `isWorktreeOfRepo` で `app` と `app-old` を区別

## Test plan
- [ ] `pnpm check` (tsc + biome) パス
- [ ] `pnpm build` パス
- [ ] `https://ccm.ignission.tech/bridge` を開いて 1bit ダッシュボードが表示
- [ ] 主 Dashboard で大文字リポジトリ名をクリック → グリッドビュー表示、セル → ターミナル切替
- [ ] `/clear` 後のセッションが Bridge セルでグレー (`READY`) かつサイドバードットもグレー
- [ ] セッション状態が動的に切替 (Claude が動作中 → 緑、待機 → 赤、空 → グレー)
- [ ] メモリセグメント合計が 100% に揃う
- [ ] NVMe / VirtIO ホスト両方で disk I/O が 0 でない
- [ ] Socket.IO 切断 → 再接続でグリッド購読が再発行される