### PR TITLE
feat: PCサイドバー下端にシステムステータスバーを表示

### DIFF
--- a/client/src/components/SidebarMainLayout.tsx
+++ b/client/src/components/SidebarMainLayout.tsx
@@ -13,6 +13,8 @@ import {
   useRef,
   useState,
 } from "react";
+import type { HostMetrics } from "../../../shared/types";
+import { SystemStatusBar } from "./bridge/SystemStatusBar";
 
 const SIDEBAR_MIN_WIDTH = 180;
 const SIDEBAR_MAX_WIDTH = 450;
@@ -32,6 +34,7 @@ interface SidebarMainLayoutProps {
   initialSidebarWidth?: number;
   onSidebarWidthChange?: (width: number) => void;
   onOpenFrontLine?: () => void;
+  hostMetrics?: HostMetrics | null;
   beaconVisible?: boolean;
   onBeaconVisibleChange?: (visible: boolean) => void;
   initialBeaconWidth?: number;
@@ -57,6 +60,7 @@ export function SidebarMainLayout({
   initialSidebarWidth = SIDEBAR_DEFAULT_WIDTH,
   onSidebarWidthChange,
   onOpenFrontLine,
+  hostMetrics = null,
   beaconVisible = true,
   onBeaconVisibleChange,
   initialBeaconWidth = BEACON_DEFAULT_WIDTH,
@@ -235,6 +239,7 @@ export function SidebarMainLayout({
             🎯 FrontLine
           </button>
         )}
+        <SystemStatusBar metrics={hostMetrics} />
         {/* biome-ignore lint/a11y/noStaticElementInteractions: リサイズハンドルはマウス操作専用 */}
         <div
           className={`absolute top-0 -right-1 w-3 h-full cursor-col-resize hover:bg-primary/50 transition-colors ${

--- a/client/src/components/bridge/BridgeDashboard.tsx
+++ b/client/src/components/bridge/BridgeDashboard.tsx
@@ -13,6 +13,7 @@ import type {
   HostMetrics,
 } from "../../../../shared/types";
 import "./bridge.css";
+import { clamp, formatGB } from "./utils";
 
 interface BridgeDashboardProps {
   /** Socket.IO から受信した最新スナップショット (未着なら null) */
@@ -490,10 +491,6 @@ function EmptyHint({ text }: { text: string }) {
   );
 }
 
-function clamp(v: number, lo: number, hi: number): number {
-  return Math.max(lo, Math.min(hi, v));
-}
-
 function formatElapsed(ms: number): string {
   const totalSeconds = Math.max(0, Math.floor(ms / 1000));
   const h = Math.floor(totalSeconds / 3600);
@@ -505,10 +502,4 @@ function formatElapsed(ms: number): string {
 
 function pad(n: number): string {
   return String(n).padStart(2, "0");
-}
-
-function formatGB(gb: number): string {
-  if (gb >= 1024) return `${(gb / 1024).toFixed(2)} TB`;
-  if (gb >= 100) return `${gb.toFixed(0)} GB`;
-  return `${gb.toFixed(1)} GB`;
 }

--- a/client/src/components/bridge/SystemStatusBar.tsx
+++ b/client/src/components/bridge/SystemStatusBar.tsx
@@ -1,0 +1,81 @@
+import type { HostMetrics } from "../../../../shared/types";
+import { clamp } from "./utils";
+
+interface SystemStatusBarProps {
+  metrics: HostMetrics | null;
+}
+
+const SPARK_H = 14;
+const SPARK_SAMPLES = 30;
+
+export function SystemStatusBar({ metrics }: SystemStatusBarProps) {
+  const cpu = metrics ? Math.round(metrics.cpuPercent) : null;
+  const memTotal = metrics?.memory.totalGB ?? 0;
+  const memUsed = metrics?.memory.usedGB ?? 0;
+  const mem =
+    metrics && memTotal > 0 ? Math.round((memUsed / memTotal) * 100) : null;
+  const disk = metrics?.volumes[0]
+    ? Math.round(metrics.volumes[0].usedPercent)
+    : null;
+  const cpuHistory = metrics?.cpuHistory ?? [];
+
+  return (
+    <div className="flex items-center gap-5 px-3 py-2 border-t border-white/10 bg-black/60 text-sm font-mono text-gray-200 select-none">
+      <span className="flex items-center gap-2 flex-1 min-w-0">
+        <span className="text-gray-500 shrink-0">CPU</span>
+        <Sparkline values={cpuHistory} />
+        <span className="text-gray-100 tabular-nums shrink-0">
+          {cpu !== null ? `${cpu}%` : "--"}
+        </span>
+      </span>
+      <Metric label="MEM" percent={mem} />
+      <Metric label="DISK" percent={disk} />
+    </div>
+  );
+}
+
+function Metric({ label, percent }: { label: string; percent: number | null }) {
+  return (
+    <span className="flex items-center gap-1.5 shrink-0">
+      <span className="text-gray-500">{label}</span>
+      <span className="text-gray-100 tabular-nums">
+        {percent !== null ? `${percent}%` : "--"}
+      </span>
+    </span>
+  );
+}
+
+function Sparkline({ values }: { values: number[] }) {
+  const samples =
+    values.length >= SPARK_SAMPLES ? values.slice(-SPARK_SAMPLES) : values;
+  // viewBox の幅は固定 100 にして、preserveAspectRatio="none" で親幅に伸縮させる
+  const points =
+    samples.length > 1
+      ? samples
+          .map((v, i) => {
+            const x = (i / (samples.length - 1)) * 100;
+            const y = SPARK_H - (clamp(v, 0, 100) / 100) * SPARK_H;
+            return `${x.toFixed(1)},${y.toFixed(1)}`;
+          })
+          .join(" ")
+      : "";
+  return (
+    <svg
+      viewBox={`0 0 100 ${SPARK_H}`}
+      preserveAspectRatio="none"
+      className="flex-1 min-w-0 h-4 text-gray-400"
+      aria-hidden="true"
+    >
+      {points ? (
+        <polyline
+          points={points}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      ) : null}
+    </svg>
+  );
+}

--- a/client/src/components/bridge/utils.ts
+++ b/client/src/components/bridge/utils.ts
@@ -1,0 +1,9 @@
+export function clamp(v: number, lo: number, hi: number): number {
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export function formatGB(gb: number): string {
+  if (gb >= 1024) return `${(gb / 1024).toFixed(2)} TB`;
+  if (gb >= 100) return `${gb.toFixed(0)} GB`;
+  return `${gb.toFixed(1)} GB`;
+}

--- a/client/src/hooks/useBridgeSnapshot.ts
+++ b/client/src/hooks/useBridgeSnapshot.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import type { Socket } from "socket.io-client";
+import type {
+  BridgeSnapshot,
+  ClientToServerEvents,
+  ServerToClientEvents,
+} from "../../../shared/types";
+
+type ArkSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+/**
+ * `bridge:snapshot` を購読して最新の BridgeSnapshot を返すフック。
+ *
+ * `enabled=true` のときのみ購読し、`false` または unmount で `bridge:unsubscribe` を送る。
+ *
+ * 同一ソケットでの並行呼び出しは想定していない。cleanup は無条件に
+ * `bridge:unsubscribe` を送るので、別箇所がまだ購読中だと巻き添えで購読解除される。
+ * 複数消費者が必要になったら refcount などで対応すること。
+ */
+export function useBridgeSnapshot(
+  socket: ArkSocket | null,
+  enabled: boolean
+): BridgeSnapshot | null {
+  const [snapshot, setSnapshot] = useState<BridgeSnapshot | null>(null);
+
+  useEffect(() => {
+    if (!socket || !enabled) return;
+
+    const subscribe = () =>
+      socket.emit("bridge:subscribe", { focusSessionId: null });
+
+    const onSnapshot = (snap: BridgeSnapshot) => setSnapshot(snap);
+
+    if (socket.connected) subscribe();
+    socket.on("connect", subscribe);
+    socket.on("bridge:snapshot", onSnapshot);
+
+    return () => {
+      socket.off("connect", subscribe);
+      socket.off("bridge:snapshot", onSnapshot);
+      if (socket.connected) socket.emit("bridge:unsubscribe");
+    };
+  }, [socket, enabled]);
+
+  return snapshot;
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -31,6 +31,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useBridgeSnapshot } from "@/hooks/useBridgeSnapshot";
 import { useIsMobile } from "@/hooks/useMobile";
 import { useSettings } from "@/hooks/useSettings";
 import { useSocket } from "@/hooks/useSocket";
@@ -124,6 +125,9 @@ export default function Dashboard() {
   });
 
   const isMobile = useIsMobile();
+
+  // PCサイドバー下部のシステムステータスバー用に bridge:snapshot を購読
+  const bridgeSnapshot = useBridgeSnapshot(socket, !isMobile);
 
   const isRemote =
     typeof window !== "undefined" &&
@@ -693,6 +697,7 @@ export default function Dashboard() {
           initialSidebarWidth={getSetting<number>("ark-sidebar-width", 250)}
           onSidebarWidthChange={w => setSetting("ark-sidebar-width", w)}
           onOpenFrontLine={() => setShowFrontLine(true)}
+          hostMetrics={bridgeSnapshot?.metrics ?? null}
           beaconVisible={getSetting<boolean>("ark-beacon-visible", true)}
           onBeaconVisibleChange={v => setSetting("ark-beacon-visible", v)}
           initialBeaconWidth={getSetting<number>("ark-beacon-width", 350)}


### PR DESCRIPTION
## Summary

- bridge の `bridge:snapshot` を Dashboard で購読し、`SidebarMainLayout` 経由で `SystemStatusBar` に渡す
- PC サイドバーの 🎯 FrontLine ボタン直下に CPU(sparkline + %) / MEM% / DISK% を常時表示
- モバイル時は購読しない（`!isMobile` で gate）

## 変更点

- 新規 `client/src/components/bridge/SystemStatusBar.tsx` — sparkline + テキストのコンパクトな表示
- 新規 `client/src/components/bridge/utils.ts` — `clamp` / `formatGB` 共通化（BridgeDashboard と共有）
- 新規 `client/src/hooks/useBridgeSnapshot.ts` — `enabled` で購読/解除制御。**単一消費者前提**（複数消費者が必要になったら refcount 化）
- `BridgeDashboard.tsx` — `clamp` / `formatGB` を utils から import
- `Dashboard.tsx` / `SidebarMainLayout.tsx` — 配線

## 動作確認

- [x] PC で FrontLine ボタン下にステータスバー表示
- [x] sparkline が CPU 履歴で更新される
- [x] type check / biome / build 通過
- [ ] 別ウィンドウで `/bridge` ページを同時に開いた場合の動作確認（別ソケットなので影響なしのはず）