### PR TITLE
fix: リロード時のセッション選択保持とモバイルファイル添付の Portal 競合修正

### DIFF
--- a/client/src/components/MobileSessionView.tsx
+++ b/client/src/components/MobileSessionView.tsx
@@ -109,6 +109,10 @@ export function MobileSessionView({
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  // ファイル選択input は DropdownMenuContent (Radix Portal) の外に配置する。
+  // 内部に置くとメニューを閉じた瞬間に Portal が unmount され、
+  // OS のファイル選択画面から戻った時に input が DOM に存在せず onChange が発火しない。
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // トンネル経由のアクセス時はURLのトークンをiframeにも付与
   const urlToken =
@@ -351,21 +355,9 @@ export function MobileSessionView({
                 </DropdownMenuItem>
               )}
               {onUploadFile && (
-                <DropdownMenuItem asChild>
-                  <label className="cursor-pointer flex items-center w-full">
-                    <input
-                      type="file"
-                      multiple
-                      className="hidden"
-                      onChange={async e => {
-                        const files = Array.from(e.target.files ?? []);
-                        await handleFilesSelected(files);
-                        e.target.value = "";
-                      }}
-                    />
-                    <FileIcon className="mr-2 h-4 w-4" />
-                    ファイルを添付
-                  </label>
+                <DropdownMenuItem onClick={() => fileInputRef.current?.click()}>
+                  <FileIcon className="mr-2 h-4 w-4" />
+                  ファイルを添付
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem onClick={handleReloadIframe}>
@@ -618,6 +610,23 @@ export function MobileSessionView({
           </Button>
         </div>
       </form>
+
+      {/* 添付ファイル選択用の隠しinput
+          DropdownMenuContent の外に置くことで、メニューが閉じても DOM に残り続け、
+          OS のファイル選択画面から戻った時に onChange が確実に発火する。 */}
+      {onUploadFile && (
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={async e => {
+            const files = Array.from(e.target.files ?? []);
+            await handleFilesSelected(files);
+            e.target.value = "";
+          }}
+        />
+      )}
 
       {/* 削除確認ダイアログ */}
       <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -501,13 +501,9 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     };
 
     socket.on("session:list", (sessions: ManagedSession[]) => {
-      setSessions(prev => {
-        const next = new Map(prev);
-        for (const session of sessions) {
-          next.set(session.id, session);
-        }
-        return next;
-      });
+      // session:list はサーバ側の権威ある全件スナップショット。
+      // 再接続時に死んだセッションが残らないよう、マージではなく置き換える。
+      setSessions(new Map(sessions.map(s => [s.id, s])));
       setSessionsLoaded(true);
     });
 

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -80,6 +80,7 @@ interface UseSocketReturn {
 
   // Sessions
   sessions: Map<string, ManagedSession>;
+  sessionsLoaded: boolean;
   startSession: (worktreeId: string, worktreePath: string) => void;
   stopSession: (sessionId: string) => void;
   sendMessage: (sessionId: string, message: string) => void;
@@ -226,6 +227,10 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   const [sessions, setSessions] = useState<Map<string, ManagedSession>>(
     new Map()
   );
+  // session:list を一度でも受信したか。
+  // 空配列でも true になるため、リロード直後の savedId 復元処理で
+  // 「サーバ側にセッションが存在しない」ことを判定できる。
+  const [sessionsLoaded, setSessionsLoaded] = useState(false);
 
   // Tunnel state
   const [tunnelActive, setTunnelActive] = useState(false);
@@ -503,6 +508,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         }
         return next;
       });
+      setSessionsLoaded(true);
     });
 
     socket.on("session:created", session => {
@@ -1176,6 +1182,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     deletedWorktreeId,
     clearDeletedWorktreeId,
     sessions,
+    sessionsLoaded,
     startSession,
     stopSession,
     sendMessage,

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -71,6 +71,7 @@ export default function Dashboard() {
     createWorktree,
     deleteWorktree,
     sessions,
+    sessionsLoaded,
     startSession,
     stopSession,
     sendMessage,
@@ -295,16 +296,6 @@ export default function Dashboard() {
   // restartingWorktreePathRef に保存し、新セッションへ追従できるようにする。
   const lastSelectedSessionRef = useRef<ManagedSession | null>(null);
 
-  // session:list を一度でも受信したか (sessions が初めて非空になった時点で true)。
-  // リロード直後は設定復元 → selectedSessionId=savedId と同時に sessions={} の
-  // 状態で auto-select effect が走るため、!sessions.has(savedId) のフォールバック
-  // が即座に発火して savedId が消失する。session:list 受信前は dangling 判定を
-  // 行わないことで、savedId を保持したまま sessions の到着を待つ。
-  const sessionsLoadedOnceRef = useRef(false);
-  useEffect(() => {
-    if (sessions.size > 0) sessionsLoadedOnceRef.current = true;
-  }, [sessions]);
-
   // selectedSessionId に対応する ManagedSession を毎回スナップショット
   useEffect(() => {
     if (selectedSessionId && selectedSessionId !== "browser") {
@@ -384,16 +375,18 @@ export default function Dashboard() {
       const first = Array.from(sessions.values())[0];
       setSelectedSessionId(first.id);
     }
-    // session:list を未受信のうちは dangling 判定をスキップ (savedId 復元保護)
+    // session:list を未受信のうちは dangling 判定をスキップ (savedId 復元保護)。
+    // sessionsLoaded は空配列の session:list でも true になるため、
+    // 「全セッション停止後にリロード」のケースでも savedId を null にリセットできる。
     if (
-      sessionsLoadedOnceRef.current &&
+      sessionsLoaded &&
       selectedSessionId &&
       !sessions.has(selectedSessionId)
     ) {
       const remaining = Array.from(sessions.values());
       setSelectedSessionId(remaining.length > 0 ? remaining[0].id : null);
     }
-  }, [sessions, selectedSessionId, gridRepoPath]);
+  }, [sessions, sessionsLoaded, selectedSessionId, gridRepoPath]);
 
   useEffect(() => {
     if (deletedWorktreeId) {

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -295,6 +295,16 @@ export default function Dashboard() {
   // restartingWorktreePathRef に保存し、新セッションへ追従できるようにする。
   const lastSelectedSessionRef = useRef<ManagedSession | null>(null);
 
+  // session:list を一度でも受信したか (sessions が初めて非空になった時点で true)。
+  // リロード直後は設定復元 → selectedSessionId=savedId と同時に sessions={} の
+  // 状態で auto-select effect が走るため、!sessions.has(savedId) のフォールバック
+  // が即座に発火して savedId が消失する。session:list 受信前は dangling 判定を
+  // 行わないことで、savedId を保持したまま sessions の到着を待つ。
+  const sessionsLoadedOnceRef = useRef(false);
+  useEffect(() => {
+    if (sessions.size > 0) sessionsLoadedOnceRef.current = true;
+  }, [sessions]);
+
   // selectedSessionId に対応する ManagedSession を毎回スナップショット
   useEffect(() => {
     if (selectedSessionId && selectedSessionId !== "browser") {
@@ -374,7 +384,12 @@ export default function Dashboard() {
       const first = Array.from(sessions.values())[0];
       setSelectedSessionId(first.id);
     }
-    if (selectedSessionId && !sessions.has(selectedSessionId)) {
+    // session:list を未受信のうちは dangling 判定をスキップ (savedId 復元保護)
+    if (
+      sessionsLoadedOnceRef.current &&
+      selectedSessionId &&
+      !sessions.has(selectedSessionId)
+    ) {
       const remaining = Array.from(sessions.values());
       setSelectedSessionId(remaining.length > 0 ? remaining[0].id : null);
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -1067,11 +1067,12 @@ async function startServer() {
       sessionOrchestrator.on(event, handler);
     }
 
-    // 既存セッション一覧を送信（リロード時のペイン復元用）
+    // 既存セッション一覧を送信（リロード時のペイン復元用）。
+    // クライアント側で「session:list 受信完了」を正確に判定できるよう、
+    // 0件でも必ず emit する。0件で emit しないと、savedId 復元時の
+    // dangling cleanup が動かず stale な selectedSessionId が残り続ける。
     const existingSessions = sessionOrchestrator.getAllSessions();
-    if (existingSessions.length > 0) {
-      socket.emit("session:list", existingSessions);
-    }
+    socket.emit("session:list", existingSessions);
 
     // ttydが未起動のセッションを自動復元（非同期）
     // 複数クライアント同時接続でも同一セッションの復元は1回だけ実行される


### PR DESCRIPTION
## Summary

- **リロード時に選択中セッションが失われ別セッションがアクティブになる問題を修正**
  - `useSocket` は設定読込後に socket 接続を開始するため、`session:list` 受信前に savedId 復元 → auto-select effect の dangling fallback が `sessions={}` で発火 → savedId が消失していた
  - `sessionsLoaded` フラグを `useSocket` に追加し、`session:list` イベント受信を直接トラッキング (空配列でも true)
  - サーバ側を「既存セッション0件でも `session:list` を必ず emit」に変更し、フラグが永久に false になるケースを排除
  - `session:list` 受信時の Map をマージから置換に変更し、再接続時に死んだセッションが残らないように
- **モバイルのファイル添付メニューでピッカーが開かない問題を修正**
  - 隠しinputが DropdownMenuContent (Radix Portal) 内にあり、メニューを閉じた瞬間に Portal が unmount されて OS のファイル選択画面から戻った時に `onChange` が発火しなかった
  - inputを Portal の外へ移動し、`fileInputRef.current?.click()` で起動

## Test plan

- [ ] PCビュー: セッションを選択 → ブラウザリロード → 同じセッションが選択されていること
- [ ] PCビュー: 全セッションを停止 → リロード → 選択状態がクリアされ、新規セッションを起動するとそれが選ばれること
- [ ] PCビュー: 別タブからセッションを停止 → 元タブで dangling 判定が動き他セッションへフォールバックすること
- [ ] モバイルビュー: ヘッダメニューから「ファイルを添付」→ ピッカーが開く → 画像選択 → セッションに添付されること