### PR TITLE
fix: SystemStatusBar クリックで Bridge を別タブで開く

### DIFF
--- a/client/src/components/bridge/SystemStatusBar.tsx
+++ b/client/src/components/bridge/SystemStatusBar.tsx
@@ -20,7 +20,13 @@ export function SystemStatusBar({ metrics }: SystemStatusBarProps) {
   const cpuHistory = metrics?.cpuHistory ?? [];
 
   return (
-    <div className="flex items-center gap-5 px-3 py-2 border-t border-white/10 bg-black/60 text-sm font-mono text-gray-200 select-none">
+    <a
+      href="/bridge"
+      target="_blank"
+      rel="noopener noreferrer"
+      title="Bridge を別タブで開く"
+      className="flex items-center gap-5 px-3 py-2 border-t border-white/10 bg-black/60 text-sm font-mono text-gray-200 select-none hover:bg-black/80 hover:text-white transition-colors cursor-pointer"
+    >
       <span className="flex items-center gap-2 flex-1 min-w-0">
         <span className="text-gray-500 shrink-0">CPU</span>
         <Sparkline values={cpuHistory} />
@@ -30,7 +36,7 @@ export function SystemStatusBar({ metrics }: SystemStatusBarProps) {
       </span>
       <Metric label="MEM" percent={mem} />
       <Metric label="DISK" percent={disk} />
-    </div>
+    </a>
   );
 }
 

--- a/client/src/components/bridge/SystemStatusBar.tsx
+++ b/client/src/components/bridge/SystemStatusBar.tsx
@@ -19,9 +19,13 @@ export function SystemStatusBar({ metrics }: SystemStatusBarProps) {
     : null;
   const cpuHistory = metrics?.cpuHistory ?? [];
 
+  // Quick Tunnel 等のトークン認証下でも新タブで Bridge にアクセスできるよう
+  // 現在の URL の token クエリを引き継ぐ
+  const bridgeHref = buildBridgeHref();
+
   return (
     <a
-      href="/bridge"
+      href={bridgeHref}
       target="_blank"
       rel="noopener noreferrer"
       title="Bridge を別タブで開く"
@@ -49,6 +53,12 @@ function Metric({ label, percent }: { label: string; percent: number | null }) {
       </span>
     </span>
   );
+}
+
+function buildBridgeHref(): string {
+  if (typeof window === "undefined") return "/bridge";
+  const token = new URLSearchParams(window.location.search).get("token");
+  return token ? `/bridge?token=${encodeURIComponent(token)}` : "/bridge";
 }
 
 function Sparkline({ values }: { values: number[] }) {


### PR DESCRIPTION
## 概要

サイドバー左下の `SystemStatusBar`（CPU/MEM/DISK 表示行）をクリックすると `/bridge` が別タブで開くようにした。

## 変更内容

- `SystemStatusBar` を `<div>` から `<a href="/bridge" target="_blank" rel="noopener noreferrer">` に変更
- ホバー時に背景・テキストが少し明るくなるトランジションを追加
- Quick Tunnel 等のトークン認証下でも動作するよう、現在 URL の `token` クエリを引き継いで href を構築（`buildBridgeHref()`）

## テスト手順

- [ ] ローカルでサイドバー左下のシステム状態行をクリック → 新しいタブで `/bridge` が開く
- [ ] ⌘+クリック / ミドルクリックでも新タブで開く
- [ ] Quick Tunnel 経由（`pnpm dev:quick`）で開いた状態でクリック → 新タブの Bridge も認証通過し `bridge:snapshot` を受信できる