### PR TITLE
fix: Beacon応答中にキャンセルできるよう停止ボタンを追加

### DIFF
--- a/client/src/components/MobileChatView.tsx
+++ b/client/src/components/MobileChatView.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
   Radar,
   Send,
+  Square,
   Terminal,
   Trash2,
 } from "lucide-react";
@@ -44,6 +45,8 @@ interface MobileChatViewProps {
   streamingText: string;
   /** メッセージ送信コールバック */
   onSendMessage: (message: string) => void;
+  /** 応答キャンセルコールバック（ストリーミング中の query を中断） */
+  onCancel?: () => void;
   /** 戻るボタンコールバック */
   onBack?: () => void;
   /** チャットクリアコールバック */
@@ -91,14 +94,7 @@ type MarkdownSegment =
 
 // --- クイックコマンド定義 ---
 
-const QUICK_COMMANDS: QuickCommand[] = [
-  { label: "進捗確認", message: "進捗確認" },
-  { label: "判断", message: "判断" },
-  { label: "タスク着手", message: "タスク着手" },
-  { label: "PR URL", message: "PR URL" },
-  { kind: "usage", label: "Usage" },
-  { kind: "mcp", label: "MCP" },
-];
+const QUICK_COMMANDS: QuickCommand[] = [{ kind: "usage", label: "Usage" }];
 
 // --- 簡易マークダウンパーサー ---
 
@@ -443,6 +439,7 @@ export function MobileChatView({
   isStreaming,
   streamingText,
   onSendMessage,
+  onCancel,
   onBack,
   onClear,
   onRequestUsage,
@@ -698,18 +695,32 @@ export function MobileChatView({
               className="w-full h-11 bg-input border border-border/50 rounded-xl px-4 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all disabled:opacity-50"
             />
           </div>
-          <Button
-            type="submit"
-            size="icon"
-            className="h-11 w-11 shrink-0 rounded-xl shadow-sm shadow-primary/20"
-            disabled={isInputDisabled || !inputValue.trim()}
-          >
-            {isStreaming ? (
-              <Loader2 className="w-5 h-5 animate-spin" />
-            ) : (
-              <Send className="w-5 h-5" />
-            )}
-          </Button>
+          {isStreaming && onCancel ? (
+            <Button
+              type="button"
+              size="icon"
+              variant="destructive"
+              aria-label="応答をキャンセル"
+              className="h-11 w-11 shrink-0 rounded-xl shadow-sm shadow-destructive/20"
+              onClick={onCancel}
+            >
+              <Square className="w-4 h-4 fill-current" />
+            </Button>
+          ) : (
+            <Button
+              type="submit"
+              size="icon"
+              aria-label="メッセージ送信"
+              className="h-11 w-11 shrink-0 rounded-xl shadow-sm shadow-primary/20"
+              disabled={isInputDisabled || !inputValue.trim()}
+            >
+              {isStreaming ? (
+                <Loader2 className="w-5 h-5 animate-spin" />
+              ) : (
+                <Send className="w-5 h-5" />
+              )}
+            </Button>
+          )}
         </div>
       </form>
     </div>

--- a/client/src/components/MobileChatView.tsx
+++ b/client/src/components/MobileChatView.tsx
@@ -45,8 +45,17 @@ interface MobileChatViewProps {
   streamingText: string;
   /** メッセージ送信コールバック */
   onSendMessage: (message: string) => void;
-  /** 応答キャンセルコールバック（ストリーミング中の query を中断） */
-  onCancel?: () => void;
+  /**
+   * 応答停止コールバック（abort + セッションリセット）。
+   * required: 「isStreaming のときに止める手段が無い」状態を型レベルで防ぐ。
+   */
+  onStopAndReset: () => void;
+  /**
+   * Socket.IO 接続状態。停止ボタンの活殺判定に使う。
+   * 切断中は emit がサーバに届かないので、ボタンを disabled にしてユーザーに
+   * 「今は止められない」を視覚的に伝える (Assertive Programming: 失敗を黙らせない)。
+   */
+  isConnected: boolean;
   /** 戻るボタンコールバック */
   onBack?: () => void;
   /** チャットクリアコールバック */
@@ -439,7 +448,8 @@ export function MobileChatView({
   isStreaming,
   streamingText,
   onSendMessage,
-  onCancel,
+  onStopAndReset,
+  isConnected,
   onBack,
   onClear,
   onRequestUsage,
@@ -695,14 +705,22 @@ export function MobileChatView({
               className="w-full h-11 bg-input border border-border/50 rounded-xl px-4 text-sm text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:border-primary/50 focus:ring-1 focus:ring-primary/20 transition-all disabled:opacity-50"
             />
           </div>
-          {isStreaming && onCancel ? (
+          {isStreaming ? (
             <Button
               type="button"
               size="icon"
               variant="destructive"
-              aria-label="応答をキャンセル"
+              aria-label={
+                isConnected
+                  ? "応答を停止 (セッションリセット)"
+                  : "サーバ未接続のため停止できません"
+              }
+              title={
+                isConnected ? undefined : "サーバ未接続のため停止できません"
+              }
               className="h-11 w-11 shrink-0 rounded-xl shadow-sm shadow-destructive/20"
-              onClick={onCancel}
+              onClick={onStopAndReset}
+              disabled={!isConnected}
             >
               <Square className="w-4 h-4 fill-current" />
             </Button>
@@ -714,11 +732,7 @@ export function MobileChatView({
               className="h-11 w-11 shrink-0 rounded-xl shadow-sm shadow-primary/20"
               disabled={isInputDisabled || !inputValue.trim()}
             >
-              {isStreaming ? (
-                <Loader2 className="w-5 h-5 animate-spin" />
-              ) : (
-                <Send className="w-5 h-5" />
-              )}
+              <Send className="w-5 h-5" />
             </Button>
           )}
         </div>

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -98,6 +98,7 @@ interface MobileLayoutProps {
   beaconStreamText: string;
   onBeaconSend: (message: string) => void;
   onBeaconClear?: () => void;
+  onBeaconCancel?: () => void;
   // Usage取得（Linux + multiProfileSupported のみ）
   onRequestUsage?: () => void;
   usageRequesting?: boolean;
@@ -147,6 +148,7 @@ export function MobileLayout({
   beaconStreamText,
   onBeaconSend,
   onBeaconClear,
+  onBeaconCancel,
   onRequestUsage,
   usageRequesting,
   usageProgress,
@@ -380,6 +382,7 @@ export function MobileLayout({
           isStreaming={beaconStreaming}
           streamingText={beaconStreamText}
           onSendMessage={onBeaconSend}
+          onCancel={onBeaconCancel}
           onClear={onBeaconClear}
           onRequestUsage={onRequestUsage}
           usageRequesting={usageRequesting}

--- a/client/src/components/MobileLayout.tsx
+++ b/client/src/components/MobileLayout.tsx
@@ -98,7 +98,10 @@ interface MobileLayoutProps {
   beaconStreamText: string;
   onBeaconSend: (message: string) => void;
   onBeaconClear?: () => void;
-  onBeaconCancel?: () => void;
+  /** 応答停止 + セッションリセット。required: 型で「停止不能」を防ぐ */
+  onBeaconStopAndReset: () => void;
+  /** Socket.IO 接続状態。停止ボタンを切断時に disabled にするために使う */
+  isSocketConnected: boolean;
   // Usage取得（Linux + multiProfileSupported のみ）
   onRequestUsage?: () => void;
   usageRequesting?: boolean;
@@ -148,7 +151,8 @@ export function MobileLayout({
   beaconStreamText,
   onBeaconSend,
   onBeaconClear,
-  onBeaconCancel,
+  onBeaconStopAndReset,
+  isSocketConnected,
   onRequestUsage,
   usageRequesting,
   usageProgress,
@@ -382,7 +386,8 @@ export function MobileLayout({
           isStreaming={beaconStreaming}
           streamingText={beaconStreamText}
           onSendMessage={onBeaconSend}
-          onCancel={onBeaconCancel}
+          onStopAndReset={onBeaconStopAndReset}
+          isConnected={isSocketConnected}
           onClear={onBeaconClear}
           onRequestUsage={onRequestUsage}
           usageRequesting={usageRequesting}

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -156,7 +156,7 @@ interface UseSocketReturn {
   beaconLoadHistory: () => void;
   beaconClose: () => void;
   beaconClear: () => void;
-  beaconCancel: () => void;
+  beaconStopAndReset: () => void;
 
   // Browser sessions
   browserSessions: Map<string, BrowserSession>;
@@ -1209,15 +1209,17 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     setBeaconStreamText("");
   }, []);
 
-  // Beacon応答キャンセル（進行中の query を abort する）
-  // 履歴は残し streaming state のみ即座に解除する。サーバー側は closeSession 経由で
-  // beacon:stream(done) を返すが、UI を即時に応答可能にするためローカルでも先回りで解除。
-  const beaconCancel = useCallback(() => {
+  // Beacon応答停止 + セッションリセット (進行中の query を abort する)
+  // 楽観的なローカル state クリアは行わない。サーバ側の closeSession() の
+  // catch/finally で必ず beacon:stream(done) と beacon:error が emit されるため
+  // それを受信して streaming state が解除される。先回りクリアは race を生む
+  // (停止直前まで in-flight だった chunk が遅れて届くと、空の streamText に
+  // chunk が積もり「止めたのに新しい応答が始まる」ように見える)。
+  // 切断時はそもそも UI 側でボタンを disabled にする想定 (isConnected を expose 済)。
+  const beaconStopAndReset = useCallback(() => {
     const socket = socketRef.current;
     if (!socket?.connected) return;
-    socket.emit("beacon:cancel");
-    setBeaconStreaming(false);
-    setBeaconStreamText("");
+    socket.emit("beacon:stop-and-reset");
   }, []);
 
   // Copy buffer action
@@ -1469,7 +1471,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     beaconLoadHistory,
     beaconClose,
     beaconClear,
-    beaconCancel,
+    beaconStopAndReset,
     // Browser sessions
     browserSessions,
     browserError,

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -156,6 +156,7 @@ interface UseSocketReturn {
   beaconLoadHistory: () => void;
   beaconClose: () => void;
   beaconClear: () => void;
+  beaconCancel: () => void;
 
   // Browser sessions
   browserSessions: Map<string, BrowserSession>;
@@ -1208,6 +1209,17 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     setBeaconStreamText("");
   }, []);
 
+  // Beacon応答キャンセル（進行中の query を abort する）
+  // 履歴は残し streaming state のみ即座に解除する。サーバー側は closeSession 経由で
+  // beacon:stream(done) を返すが、UI を即時に応答可能にするためローカルでも先回りで解除。
+  const beaconCancel = useCallback(() => {
+    const socket = socketRef.current;
+    if (!socket?.connected) return;
+    socket.emit("beacon:cancel");
+    setBeaconStreaming(false);
+    setBeaconStreamText("");
+  }, []);
+
   // Copy buffer action
   const copyBuffer = useCallback(
     (sessionId: string): Promise<string | null> => {
@@ -1457,6 +1469,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     beaconLoadHistory,
     beaconClose,
     beaconClear,
+    beaconCancel,
     // Browser sessions
     browserSessions,
     browserError,

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -102,7 +102,7 @@ export default function Dashboard() {
     beaconSend,
     beaconLoadHistory,
     beaconClear,
-    beaconCancel,
+    beaconStopAndReset,
     sessionPreviews,
     sessionActivityTexts,
     gridSnapshots,
@@ -599,7 +599,8 @@ export default function Dashboard() {
           beaconStreamText={beaconStreamText}
           onBeaconSend={beaconSend}
           onBeaconClear={beaconClear}
-          onBeaconCancel={beaconCancel}
+          onBeaconStopAndReset={beaconStopAndReset}
+          isSocketConnected={isConnected}
           onRequestUsage={requestUsage}
           usageRequesting={usageRequesting}
           usageProgress={usageProgress}
@@ -761,7 +762,8 @@ export default function Dashboard() {
               isStreaming={beaconStreaming}
               streamingText={beaconStreamText}
               onSendMessage={beaconSend}
-              onCancel={beaconCancel}
+              onStopAndReset={beaconStopAndReset}
+              isConnected={isConnected}
               onClear={beaconClear}
               onRequestUsage={requestUsage}
               usageRequesting={usageRequesting}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -102,6 +102,7 @@ export default function Dashboard() {
     beaconSend,
     beaconLoadHistory,
     beaconClear,
+    beaconCancel,
     sessionPreviews,
     sessionActivityTexts,
     gridSnapshots,
@@ -598,6 +599,7 @@ export default function Dashboard() {
           beaconStreamText={beaconStreamText}
           onBeaconSend={beaconSend}
           onBeaconClear={beaconClear}
+          onBeaconCancel={beaconCancel}
           onRequestUsage={requestUsage}
           usageRequesting={usageRequesting}
           usageProgress={usageProgress}
@@ -759,6 +761,7 @@ export default function Dashboard() {
               isStreaming={beaconStreaming}
               streamingText={beaconStreamText}
               onSendMessage={beaconSend}
+              onCancel={beaconCancel}
               onClear={beaconClear}
               onRequestUsage={requestUsage}
               usageRequesting={usageRequesting}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1757,6 +1757,13 @@ async function startServer() {
       beaconManager.closeSession();
     });
 
+    // Beacon応答キャンセル（進行中の query を abort する）
+    // closeSession は session を null にするため次の sendMessage は新規 session で開始される。
+    // 履歴 (DB / messages) は残るので、UI 上のチャット表示は維持される。
+    socket.on("beacon:cancel", () => {
+      beaconManager.closeSession();
+    });
+
     // Beacon履歴クリア（LLMコンテキスト・DB履歴もリセット）
     // 履歴は全接続クライアントで共有されるため、broadcastで他タブ・他端末も同期する
     socket.on("beacon:clear", () => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -1757,10 +1757,24 @@ async function startServer() {
       beaconManager.closeSession();
     });
 
-    // Beacon応答キャンセル（進行中の query を abort する）
-    // closeSession は session を null にするため次の sendMessage は新規 session で開始される。
-    // 履歴 (DB / messages) は残るので、UI 上のチャット表示は維持される。
-    socket.on("beacon:cancel", () => {
+    // Beacon応答停止 + セッションリセット (UI の停止ボタン)
+    //
+    // 名前で意図を明示: 単なる「キャンセル」ではなく、abort + session 破棄を伴う。
+    // SDK の AbortController が単発 (一度 abort すると同じ query を再開不可) のため
+    // 次の sendMessage は新規 session で起動し、LLM の multi-turn 中間状態は失われる。
+    // チャット履歴 (DB / messages) は残るので UI 上の見た目は連続するが、
+    // モデル側の文脈は仕切り直しになる。「応答が止まらない」よりは ましという判断。
+    //
+    // ガード: 進行中の session が無いときの誤送信は no-op にする。idle 状態で
+    // closeSession を呼んでもメソッド側の `if (!this.session) return;` で安全だが、
+    // ここで明示的に弾くことで「destructive 操作は条件成立時のみ受理」を契約として
+    // 表明する (Assertive Programming)。
+    //
+    // セキュリティ: payload なしで停止できるが、これは既存 beacon:close /
+    // beacon:clear と同じ trust model (Beacon は接続クライアント間で共有資源)。
+    // Cloudflare Tunnel + token 認証の後ろにある前提で、追加の所有者制御は持たない。
+    socket.on("beacon:stop-and-reset", () => {
+      if (!beaconManager.hasSession()) return;
       beaconManager.closeSession();
     });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -533,6 +533,7 @@ export interface ClientToServerEvents {
   "beacon:history": () => void;
   "beacon:close": () => void;
   "beacon:clear": () => void;
+  "beacon:cancel": () => void;
 
   // ファイルビューワー
   "file:read": (data: { sessionId: string; filePath: string }) => void;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -533,7 +533,13 @@ export interface ClientToServerEvents {
   "beacon:history": () => void;
   "beacon:close": () => void;
   "beacon:clear": () => void;
-  "beacon:cancel": () => void;
+  /**
+   * 進行中の query を abort し、内部 session を破棄する。
+   * 命名で「単に止めるだけではなくセッションリセットも伴う」ことを明示。
+   * (SDK の AbortController は単発のため abort 後は session 再構築が必須。
+   * その結果 LLM の multi-turn コンテキストは失われる。)
+   */
+  "beacon:stop-and-reset": () => void;
 
   // ファイルビューワー
   "file:read": (data: { sessionId: string; filePath: string }) => void;


### PR DESCRIPTION
## Summary

- Beacon ストリーミング中に進行中の query を中断する手段がなかった (送信ボタンが Loader2 spinner で disabled)
- 停止ボタン (Square / 赤) に切り替え、押下で `beacon:stop-and-reset` を発火 → サーバ側で `beaconManager.closeSession()` を呼んで abort
- 切断時はボタンを disabled にして「止められない」を視覚的に伝える

## 主な変更

- `shared/types.ts`: `beacon:stop-and-reset` イベントを追加 (命名で副作用を明示)
- `server/index.ts`: ハンドラ + idle 時の no-op ガード (`hasSession()` チェック)
- `useSocket.ts`: `beaconStopAndReset` callback。サーバの `beacon:stream(done)` を信頼して楽観 UI 更新は撤廃
- `MobileChatView.tsx`: 停止ボタン UI、`onStopAndReset` / `isConnected` を required prop で受ける
- `MobileLayout.tsx` / `Dashboard.tsx`: prop 配線 + isConnected 注入

## トレードオフ (Codex P5 review で挙がった指摘の扱い)

- **LLM コンテキストの喪失**: SDK の `AbortController` は単発のため、abort 後は session 再構築が必要 → multi-turn 中間状態は失われる。チャット履歴 (DB) は残るので UI 上は連続。「応答が止まらない」よりはマシという判断
- **fire-and-forget (ack なし)**: 既存 `beacon:close` / `beacon:clear` と同じ設計に揃えた
- **共有資源の DoS 面**: Beacon は意図的に全クライアントで共有される設計。Cloudflare Tunnel + token 認証の trust boundary に依拠

## Test plan

- [ ] モバイル: Beacon に質問を送る → 応答中に停止ボタン (赤の Square) が出る → 押すと止まる
- [ ] 停止後、新しいメッセージを送れる (新セッションで継続)
- [ ] サーバ切断時は停止ボタンが disabled、tooltip に理由表示
- [ ] PC (sidebar): 同様に停止ボタンが機能

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Beaconの実行中のレスポンスを停止・リセットできる新しいストップボタンを追加しました。
  * ストップボタンはストリーミング中に表示され、従来のローダーアニメーションに置き換わります。
  * 接続状態に応じてストップボタンの有効/無効が制御されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->