### PR TITLE
fix: ttyd の同時接続数を -m 5 に制限 (高CPU事象の保護策、真因は #173)

### DIFF
--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -13,11 +13,11 @@ export const TTYD_PORT_END = 7780;
  *      `-m` で接続数に上限を設けて累積を頭打ちにする。
  * 想定: PC + iPhone + 別タブ + リモートトンネル越し = 最大4接続を想定し、
  *      余裕分を1足して5。1ユーザが複数接続を消費しうるため "client" ではなく
- *      "connection" の語を採用。
+ *      "connection" の語を採用し、識別子にも "PER_INSTANCE" を含めて単位を明示。
  * 注: これは症状の天井化であり stale 接続自体は残る。idle 接続のクリーンアップ
- *     や接続上限到達時の退避策はフォローアップ Issue で対応する。
+ *     と上限到達時の退避策（health monitor）は #173 で対応予定。
  */
-export const TTYD_MAX_CONNECTIONS = 5;
+export const TTYD_MAX_CONNECTIONS_PER_INSTANCE = 5;
 
 /**
  * VNCポート範囲の開始ポート（x11vnc用）

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -5,6 +5,18 @@ export const TTYD_PORT_START = 7680;
 export const TTYD_PORT_END = 7780;
 
 /**
+ * 1ttydインスタンス（=1tmuxセッション）あたりの最大同時接続数
+ *
+ * Why: ttyd 1.7.4 には idle timeout オプションが無く、stale な WebSocket
+ *      接続（タブclose・ネットワーク断・スリープ復帰で綺麗に閉じない接続）
+ *      が累積すると ttyd が epoll_wait を空回りして %sys CPU を浴び続ける。
+ *      `-m` で接続数に上限を設けて累積を頭打ちにする。
+ * 想定: PC + iPhone + 別タブ + リモートトンネル越し = 最大4接続を想定し、
+ *      余裕分を1足して5。
+ */
+export const TTYD_MAX_CLIENTS = 5;
+
+/**
  * VNCポート範囲の開始ポート（x11vnc用）
  *
  * 注: x11vncには `-rfbport <port>` で明示的にポートを指定して起動しているため、

--- a/server/lib/constants.ts
+++ b/server/lib/constants.ts
@@ -12,9 +12,12 @@ export const TTYD_PORT_END = 7780;
  *      が累積すると ttyd が epoll_wait を空回りして %sys CPU を浴び続ける。
  *      `-m` で接続数に上限を設けて累積を頭打ちにする。
  * 想定: PC + iPhone + 別タブ + リモートトンネル越し = 最大4接続を想定し、
- *      余裕分を1足して5。
+ *      余裕分を1足して5。1ユーザが複数接続を消費しうるため "client" ではなく
+ *      "connection" の語を採用。
+ * 注: これは症状の天井化であり stale 接続自体は残る。idle 接続のクリーンアップ
+ *     や接続上限到達時の退避策はフォローアップ Issue で対応する。
  */
-export const TTYD_MAX_CLIENTS = 5;
+export const TTYD_MAX_CONNECTIONS = 5;
 
 /**
  * VNCポート範囲の開始ポート（x11vnc用）

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -9,7 +9,7 @@ import { type ChildProcess, execSync, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import net from "node:net";
 import {
-  TTYD_MAX_CLIENTS,
+  TTYD_MAX_CONNECTIONS,
   TTYD_PORT_END,
   TTYD_PORT_START,
 } from "./constants.js";
@@ -149,6 +149,13 @@ export class TtydManager extends EventEmitter {
     sessionId: string,
     tmuxSessionName: string
   ): Promise<TtydInstance> {
+    // 上限値の妥当性検証（将来 0 や負値が混入しても fail-fast させる）
+    if (!Number.isInteger(TTYD_MAX_CONNECTIONS) || TTYD_MAX_CONNECTIONS < 1) {
+      throw new Error(
+        `TTYD_MAX_CONNECTIONS must be an integer >= 1, got ${TTYD_MAX_CONNECTIONS}`
+      );
+    }
+
     const port = await this.findAvailablePort();
     const basePath = `/ttyd/${sessionId}`;
 
@@ -166,7 +173,7 @@ export class TtydManager extends EventEmitter {
         "-p",
         port.toString(),
         "-m",
-        TTYD_MAX_CLIENTS.toString(),
+        TTYD_MAX_CONNECTIONS.toString(),
         "-i",
         // ループバックインターフェース名はOSによって異なる
         // macOS: lo0, Linux: lo
@@ -232,7 +239,7 @@ export class TtydManager extends EventEmitter {
     this.emit("instance:started", instance);
 
     console.log(
-      `[TtydManager] Started ttyd for ${tmuxSessionName} on port ${port}`
+      `[TtydManager] Started ttyd for ${tmuxSessionName} on port ${port} (max connections: ${TTYD_MAX_CONNECTIONS})`
     );
 
     // プロセス終了時の処理

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -32,6 +32,12 @@ export class TtydManager extends EventEmitter {
 
   constructor(startPort = TTYD_PORT_START, maxPort = TTYD_PORT_END) {
     super();
+    // モジュール初期化時に上限値の不変条件を一度だけ検証する
+    if (!Number.isInteger(TTYD_MAX_CONNECTIONS) || TTYD_MAX_CONNECTIONS < 1) {
+      throw new Error(
+        `TTYD_MAX_CONNECTIONS must be an integer >= 1, got ${TTYD_MAX_CONNECTIONS}`
+      );
+    }
     this.MIN_PORT = startPort;
     this.nextPort = startPort;
     this.MAX_PORT = maxPort;
@@ -149,13 +155,6 @@ export class TtydManager extends EventEmitter {
     sessionId: string,
     tmuxSessionName: string
   ): Promise<TtydInstance> {
-    // 上限値の妥当性検証（将来 0 や負値が混入しても fail-fast させる）
-    if (!Number.isInteger(TTYD_MAX_CONNECTIONS) || TTYD_MAX_CONNECTIONS < 1) {
-      throw new Error(
-        `TTYD_MAX_CONNECTIONS must be an integer >= 1, got ${TTYD_MAX_CONNECTIONS}`
-      );
-    }
-
     const port = await this.findAvailablePort();
     const basePath = `/ttyd/${sessionId}`;
 

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -8,7 +8,11 @@
 import { type ChildProcess, execSync, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import net from "node:net";
-import { TTYD_PORT_END, TTYD_PORT_START } from "./constants.js";
+import {
+  TTYD_MAX_CLIENTS,
+  TTYD_PORT_END,
+  TTYD_PORT_START,
+} from "./constants.js";
 
 export interface TtydInstance {
   sessionId: string;
@@ -151,6 +155,7 @@ export class TtydManager extends EventEmitter {
     // ttydオプション:
     // -W: クライアント入力を許可
     // -p: ポート番号
+    // -m: 同時接続数の上限（stale接続の累積によるCPU浴びを防ぐ。constants.ts参照）
     // --base-path: WebSocket接続のベースパス（プロキシ経由用）
     // -t: ターミナルオプション（テーマ設定）
     // -i: バインドインターフェース（lo0でローカルのみ）
@@ -160,6 +165,8 @@ export class TtydManager extends EventEmitter {
         "-W", // Writable
         "-p",
         port.toString(),
+        "-m",
+        TTYD_MAX_CLIENTS.toString(),
         "-i",
         // ループバックインターフェース名はOSによって異なる
         // macOS: lo0, Linux: lo

--- a/server/lib/ttyd-manager.ts
+++ b/server/lib/ttyd-manager.ts
@@ -9,7 +9,7 @@ import { type ChildProcess, execSync, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import net from "node:net";
 import {
-  TTYD_MAX_CONNECTIONS,
+  TTYD_MAX_CONNECTIONS_PER_INSTANCE,
   TTYD_PORT_END,
   TTYD_PORT_START,
 } from "./constants.js";
@@ -32,10 +32,14 @@ export class TtydManager extends EventEmitter {
 
   constructor(startPort = TTYD_PORT_START, maxPort = TTYD_PORT_END) {
     super();
-    // モジュール初期化時に上限値の不変条件を一度だけ検証する
-    if (!Number.isInteger(TTYD_MAX_CONNECTIONS) || TTYD_MAX_CONNECTIONS < 1) {
+    // TtydManager のコンストラクタ実行時に上限値の不変条件を一度だけ検証する
+    // (TtydManager はシングルトン export なので実質的に起動時 1 回)
+    if (
+      !Number.isInteger(TTYD_MAX_CONNECTIONS_PER_INSTANCE) ||
+      TTYD_MAX_CONNECTIONS_PER_INSTANCE < 1
+    ) {
       throw new Error(
-        `TTYD_MAX_CONNECTIONS must be an integer >= 1, got ${TTYD_MAX_CONNECTIONS}`
+        `TTYD_MAX_CONNECTIONS_PER_INSTANCE must be an integer >= 1, got ${TTYD_MAX_CONNECTIONS_PER_INSTANCE}`
       );
     }
     this.MIN_PORT = startPort;
@@ -172,7 +176,7 @@ export class TtydManager extends EventEmitter {
         "-p",
         port.toString(),
         "-m",
-        TTYD_MAX_CONNECTIONS.toString(),
+        TTYD_MAX_CONNECTIONS_PER_INSTANCE.toString(),
         "-i",
         // ループバックインターフェース名はOSによって異なる
         // macOS: lo0, Linux: lo
@@ -238,7 +242,7 @@ export class TtydManager extends EventEmitter {
     this.emit("instance:started", instance);
 
     console.log(
-      `[TtydManager] Started ttyd for ${tmuxSessionName} on port ${port} (max connections: ${TTYD_MAX_CONNECTIONS})`
+      `[TtydManager] Started ttyd for ${tmuxSessionName} on port ${port} (max connections: ${TTYD_MAX_CONNECTIONS_PER_INSTANCE})`
     );
 
     // プロセス終了時の処理


### PR DESCRIPTION
## Summary

長時間稼働で ttyd プロセスが %sys 74% / load >5 まで CPU を浴びる事象が本番で観測された。
**ただし真因はまだ特定できていない**。当初は「stale 接続が `-m` 無制限のもと累積している」
と仮説を立てたが、観測時に 5 端末以上の同時接続が発生していた裏取りができておらず、
"累積による天井超え" という仮説は実態と合わない可能性が高い。

本 PR は **真因特定までの低コストな保護策** として ttyd の `-m 5` (1 ttyd インスタンス
あたり同時接続 5) を導入する。

- 副作用は小さい (PC + iPhone + 別タブ + ngrok 想定でも上限 5 で足りる)
- 万一 stale 累積が起きた場合の天井としては機能する
- 真因が別 (ttyd/libwebsockets/tmux 相互作用 等) であってもこの設定が悪化要因にはならない

## 変更内容

- `server/lib/constants.ts`: `TTYD_MAX_CONNECTIONS_PER_INSTANCE = 5` を追加
- `server/lib/ttyd-manager.ts`: spawn 引数に `-m 5` 追加 / コンストラクタで 1 以上 assert / 起動ログに上限を明記

値 `5` の根拠: PC + iPhone + 別タブ + リモートトンネル越しで最大 4 接続を想定し、+1 マージン。

## 真因候補 (#173 で追跡)

各 ttyd インスタンスが**少数の接続でも** 7-8% CPU を浴びていた事実から、以下の可能性がある:

- ttyd 1.7.4 自身のループバグ (既知 issue を要確認)
- libwebsockets 内部のタイマー/ハートビート
- tmux 出力ストリームとの相互作用 (改行多量バッファ等)
- ports スキャン (`server/lib/port-scanner.ts`) が ttyd ポートに ss を打って何かを誘発
- 何らかのカーネル側 syscall ループ (Rl 状態)

再発時に `ss -tnp` / `strace -c -p <pid>` / `top -H -p <pid>` でデータを取り、
真因を特定する。

## 観測値 (本番反映前 → 反映後)

| | before | after |
|---|---|---|
| load average | 5.17 / 5.42 / 4.93 | 1.76 / 2.16 / 3.31 |
| %sys | 74% | 7.1% |
| %idle | 0.12% | 75% |

注: 本番反映後の数値は `pkill -f ttyd` (ttyd プロセス全消し) → `pm2 restart` の効果が
含まれており、**`-m 5` 単独の効果は分離できていない**。長期稼働で再発するかは継続観測。

## Test plan

- [x] \`pnpm check\` (\`tsc --noEmit\`) 通過
- [x] \`pnpm vitest run server/lib/session-orchestrator.test.ts server/lib/tmux-manager.test.ts\` 通過
- [x] 本番 (pm2) 反映、ttyd 全インスタンスが \`-m 5\` 付きで起動、ログに \`max connections: 5\` 出力
- [x] tmux セッション + Claude Code 会話履歴が再起動越しに保全されることを確認
- [ ] 長期稼働で再発するか観測 (再発時は #173 で真因特定)