### PR TITLE
fix: ターミナル内ローカルファイルリンクのHTMLパス対応とタブ遷移修正

### DIFF
--- a/client/src/hooks/useTerminalLinkInjection.ts
+++ b/client/src/hooks/useTerminalLinkInjection.ts
@@ -2,18 +2,24 @@ import { type RefObject, useEffect } from "react";
 
 /**
  * 端末出力由来のファイルパスを `ark:open-file` で送信して良いかを判定する。
- * サーバ側 `resolveSafePath` (server/lib/file-manager.ts) のポリシーに合わせ、
- * クライアント側でも defense in depth として弾く。
+ * サーバ側 2 系統のポリシーと整合させる (defense in depth):
  *
- * - `..` を含むパス (パストラバーサル) は拒否
- * - 絶対パスは `/tmp/` または `/private/tmp/` 配下のみ許可
- *   (macOS では realpath が `/tmp/...` を `/private/tmp/...` に解決するため両方対応)
+ * - 非HTML 絶対パス: `socket.on("file:read")` → `resolveSafePath` が
+ *   `/tmp/` (macOS は realpath で `/private/tmp/`) 配下のみ許可
+ * - HTML 絶対パス: `/api/html-file` → `validateHtmlPath` は worktree 制限なし
+ *   (絶対パス + `..` なし + `.html/.htm` のみチェック)。クライアントも
+ *   useViewerTabs.ts で HTML 絶対パスは iframe 描画にルーティングする
  * - 相対パスは許可 (サーバ側で worktree 配下に解決される)
+ * - `..` を含むパス (パストラバーサル) は常に拒否
  */
 function isAllowedFilePath(filePath: string): boolean {
   if (filePath.includes("..")) return false;
   if (filePath.startsWith("/")) {
-    return filePath.startsWith("/tmp/") || filePath.startsWith("/private/tmp/");
+    if (filePath.startsWith("/tmp/") || filePath.startsWith("/private/tmp/")) {
+      return true;
+    }
+    // HTML 絶対パスは /api/html-file 経由で iframe 表示するため許可
+    return /\.html?$/i.test(filePath);
   }
   return true;
 }

--- a/client/src/hooks/useViewerTabs.ts
+++ b/client/src/hooks/useViewerTabs.ts
@@ -67,7 +67,14 @@ export function useViewerTabs(
 
   const openFileTab = useCallback(
     (sessionId: string, filePath: string, targetLine?: number | null) => {
-      let newActiveIndex: number | null = null;
+      // 注意: 以前は setSessionTabs の updater 内で closure 変数 newActiveIndex を
+      // 代入し、updater 外で setSessionActiveTab を呼んでいた。React の useState
+      // updater は eager bailout 最適化が効くときだけ同期実行され、保留 update が
+      // ある等の条件で render phase まで遅延されると closure 変数が null のまま
+      // 条件分岐に落ちて active tab が切り替わらない (= タブは追加されるが遷移しない)
+      // 回帰が発生する。両方の setState を同じ updater 内に閉じ込めることで
+      // closure timing 依存を排除する。strict mode の二重実行でも同じ idx を
+      // 書き込むだけで idempotent。
       const isHtml = /\.html?$/i.test(filePath) && filePath.startsWith("/");
       setSessionTabs(prev => {
         const tabs = [
@@ -75,13 +82,16 @@ export function useViewerTabs(
             { type: "terminal" as const, id: "terminal" },
           ]),
         ];
+        const setActive = (idx: number) => {
+          setSessionActiveTab(p => ({ ...p, [sessionId]: idx }));
+        };
         // HTMLタブ: filePathで既存タブを検索
         if (isHtml) {
           const existing = tabs.findIndex(
             t => t.type === "html" && t.filePath === filePath
           );
           if (existing >= 0) {
-            newActiveIndex = existing;
+            setActive(existing);
             return { ...prev, [sessionId]: tabs };
           }
           tabs.push({
@@ -89,7 +99,7 @@ export function useViewerTabs(
             id: `html-${Date.now()}`,
             filePath,
           });
-          newActiveIndex = tabs.length - 1;
+          setActive(tabs.length - 1);
           return { ...prev, [sessionId]: tabs };
         }
         // ファイルタブ: 既存のロジック
@@ -101,7 +111,7 @@ export function useViewerTabs(
           if (tab.type === "file") {
             tabs[existing] = { ...tab, targetLine };
           }
-          newActiveIndex = existing;
+          setActive(existing);
           return { ...prev, [sessionId]: tabs };
         }
         tabs.push({
@@ -113,13 +123,9 @@ export function useViewerTabs(
           size: 0,
           targetLine,
         });
-        newActiveIndex = tabs.length - 1;
+        setActive(tabs.length - 1);
         return { ...prev, [sessionId]: tabs };
       });
-      if (newActiveIndex !== null) {
-        const idx = newActiveIndex;
-        setSessionActiveTab(p => ({ ...p, [sessionId]: idx }));
-      }
     },
     []
   );


### PR DESCRIPTION
## 修正内容

### HTML 絶対パスのリンク検出が抜けていた
`isAllowedFilePath` が絶対パスを `/tmp/` 配下のみに制限していたため、
`/home/user/.../foo.html` のような worktree 外の HTML パスがリンクとして
検出されず、クリックすらできなかった。サーバー側 `/api/html-file` は
`validateHtmlPath` で worktree 制限なしに HTML を配信するため、
クライアント側のホワイトリストとの不整合だった。

絶対パスでも `.html`/`.htm` 拡張子なら許可するよう緩和。
非HTML 絶対パスは引き続き `/tmp/` 配下のみ。

### HTML タブが追加されてもアクティブ遷移しない
`useViewerTabs.openFileTab` で `setSessionTabs` の updater 内で closure 変数
`newActiveIndex` を代入し updater 外で参照していた。React の useState
updater は eager bailout 最適化が効くときだけ同期実行され、保留 update が
ある等の条件で render phase まで遅延されると closure 変数が初期値のまま
条件分岐に落ち、`setSessionActiveTab` が呼ばれない。

両方の `setState` を同じ updater 内に閉じ込めることで closure timing 依存を
排除。strict mode の二重実行でも同じ idx を書き込むだけで idempotent。

## 動作確認
- `/home/admin/dev/.../foo.html` のリンクがターミナル上でクリック可能
- クリック後に HTML ビューワータブが追加され、そのタブに遷移
- `file:///` プレフィックス付きでも同様に動作

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

- ターミナルリンク機能でHTMLファイルへのアクセスが正常に動作するようになりました
- ファイルビューアーのタブ切り替え時における同期タイミングの問題を修正し、タブ操作の信頼性が向上しました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ignission/claude-code-ark/pull/175)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->