### PR TITLE
feat(worktree): カスタム表示名と worktree個別プロファイル選択 UI

### DIFF
--- a/client/src/components/SessionCard.tsx
+++ b/client/src/components/SessionCard.tsx
@@ -1,5 +1,5 @@
-import { MessageSquare, Trash2 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { MessageSquare, Pencil, Trash2 } from "lucide-react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -43,6 +43,23 @@ interface SessionCardProps {
   /** セッション削除（停止 + メイン以外のWorktree削除） */
   onDelete: () => void;
   onStart?: () => void;
+  /**
+   * ステータスドットと worktree名 (branch) の間に挿入するバッジ等のスロット。
+   * worktree個別のプロファイル選択メニューを差し込むのに使う。
+   * 自身が `<button>` 等のインタラクティブ要素を含む場合があるため、
+   * SessionCard 外側のクリック領域は `<button>` ではなく role=button な div で実装する
+   * (HTML では button の入れ子が許されない)。
+   */
+  profileBadgeSlot?: ReactNode;
+  /**
+   * worktree のカスタム表示名 (未設定なら null、UI 側で branch にフォールバック)。
+   */
+  customDisplayName?: string | null;
+  /**
+   * 表示名を保存。null / 空文字でクリア (branch 名へのフォールバックに戻る)。
+   * 渡されたときだけ編集UI (鉛筆アイコン) が表示される。
+   */
+  onSetCustomDisplayName?: (displayName: string | null) => void;
 }
 
 export function SessionCard({
@@ -55,6 +72,9 @@ export function SessionCard({
   onClick,
   onDelete,
   onStart,
+  profileBadgeSlot,
+  customDisplayName,
+  onSetCustomDisplayName,
 }: SessionCardProps) {
   const branch =
     worktree?.branch ||
@@ -63,6 +83,11 @@ export function SessionCard({
           session.worktreePath.lastIndexOf("/") + 1
         )
       : "unknown");
+  const effectiveName = customDisplayName?.trim()
+    ? customDisplayName.trim()
+    : branch;
+  const isCustomName = !!customDisplayName?.trim();
+  const canRename = !!onSetCustomDisplayName;
 
   // プレビュー/アクティビティの変化を追跡してアイドル判定
   const prevTextRef = useRef(previewText);
@@ -70,6 +95,111 @@ export function SessionCard({
   const lastChangedRef = useRef(Date.now());
   const [isIdle, setIsIdle] = useState(false);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+
+  // インライン編集モード
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState("");
+  const editInputRef = useRef<HTMLInputElement | null>(null);
+
+  const startEditing = () => {
+    if (!canRename) return;
+    setEditValue(effectiveName);
+    setIsEditing(true);
+  };
+
+  const commitEditing = () => {
+    if (!canRename) {
+      setIsEditing(false);
+      return;
+    }
+    const trimmed = editValue.trim();
+    // 空文字 or branch と同一ならカスタム名をクリア (= branch にフォールバック)
+    if (trimmed.length === 0 || trimmed === branch) {
+      onSetCustomDisplayName?.(null);
+    } else if (trimmed !== effectiveName || !isCustomName) {
+      onSetCustomDisplayName?.(trimmed);
+    }
+    setIsEditing(false);
+  };
+
+  const cancelEditing = () => {
+    setIsEditing(false);
+    setEditValue("");
+  };
+
+  // 編集モード突入時に input にフォーカス + 全選択
+  useEffect(() => {
+    if (isEditing) {
+      const el = editInputRef.current;
+      if (el) {
+        el.focus();
+        el.select();
+      }
+    }
+  }, [isEditing]);
+
+  // worktree名スロットを描画。編集モードならテキスト入力、通常時は span + 鉛筆。
+  // 鉛筆は親 (role=button) のクリックを横取りしないように stopPropagation する。
+  const renderNameSlot = (textColorClass: string) => {
+    if (isEditing) {
+      return (
+        <input
+          ref={editInputRef}
+          type="text"
+          // size=1 で input の intrinsic min-width を 1ch まで縮められるようにする。
+          // 既定 size=20 だと長い既存名や狭いサイドバーで親 flex を押し広げてしまい、
+          // 結果としてコンテナ全体が水平スクロール状態になり左端が見切れる事象が起きた。
+          size={1}
+          value={editValue}
+          onChange={e => setEditValue(e.target.value)}
+          onClick={e => e.stopPropagation()}
+          onKeyDown={e => {
+            e.stopPropagation();
+            if (e.key === "Enter") {
+              e.preventDefault();
+              commitEditing();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              cancelEditing();
+            }
+          }}
+          onBlur={commitEditing}
+          className="text-sm font-mono bg-background/40 border border-input rounded px-1 py-0 min-w-0 w-0 flex-1 outline-none focus:border-primary"
+          maxLength={200}
+          aria-label="worktree表示名を編集"
+        />
+      );
+    }
+    return (
+      <>
+        <span
+          // flex item としては default で min-width: auto なので、長い名前を入れると
+          // 内容幅まで span が広がり親 flex を押し広げる → サイドバー全体に水平
+          // スクロールが発生して「左端が切れる」事象になる。min-w-0 で縮められる
+          // ようにし、truncate で末尾を ellipsis で打ち切る。
+          className={`text-sm font-mono truncate min-w-0 ${textColorClass}`}
+          title={isCustomName ? `branch: ${branch}` : undefined}
+        >
+          {effectiveName}
+        </span>
+        {canRename && (
+          <button
+            type="button"
+            onClick={e => {
+              e.stopPropagation();
+              startEditing();
+            }}
+            onKeyDown={e => e.stopPropagation()}
+            className="opacity-0 group-hover:opacity-100 focus:opacity-100 shrink-0 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-sidebar-accent transition-opacity"
+            aria-label="表示名を変更"
+            title="表示名を変更"
+          >
+            <Pencil className="w-3 h-3" />
+          </button>
+        )}
+      </>
+    );
+  };
 
   useEffect(() => {
     if (
@@ -91,28 +221,38 @@ export function SessionCard({
     return () => clearInterval(timer);
   }, []);
 
-  // セッション未起動の場合はシンプルなカードを表示
+  const handleStartClick = onStart ?? onClick;
+
+  // セッション未起動の場合はシンプルなカードを表示。
+  // profileBadgeSlot がインタラクティブ要素 (button 等) を含むため
+  // 外側は role=button な div として実装する (HTML の button 入れ子回避)。
   if (!session) {
     return (
-      <button
-        type="button"
-        className={`w-full text-left p-3 rounded-lg transition-colors group ${
+      <div
+        role="button"
+        tabIndex={0}
+        className={`w-full text-left p-3 rounded-lg transition-colors group cursor-pointer min-w-0 overflow-hidden ${
           isSelected
             ? "bg-primary/15 border border-primary/30"
             : "hover:bg-sidebar-accent/50"
         }`}
-        onClick={onStart ?? onClick}
+        onClick={handleStartClick}
+        onKeyDown={e => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            handleStartClick();
+          }
+        }}
       >
         <div className="flex items-center gap-2 min-w-0">
           <div className="w-2 h-2 rounded-full shrink-0 bg-muted-foreground/30" />
-          <span className="text-sm font-mono truncate text-sidebar-foreground/60">
-            {branch}
-          </span>
+          {profileBadgeSlot}
+          {renderNameSlot("text-sidebar-foreground/60")}
         </div>
         <p className="mt-1 text-xs text-muted-foreground truncate pl-4">
           セッション未起動
         </p>
-      </button>
+      </div>
     );
   }
 
@@ -130,21 +270,27 @@ export function SessionCard({
     <>
       <ContextMenu>
         <ContextMenuTrigger asChild>
-          <button
-            type="button"
-            className={`w-full text-left p-3 rounded-lg transition-colors group ${
+          <div
+            role="button"
+            tabIndex={0}
+            className={`w-full text-left p-3 rounded-lg transition-colors group cursor-pointer min-w-0 overflow-hidden ${
               isSelected
                 ? "bg-primary/15 border border-primary/30"
                 : "hover:bg-sidebar-accent/50"
             }`}
             onClick={onClick}
+            onKeyDown={e => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick();
+              }
+            }}
           >
             <div className="flex items-center gap-2 min-w-0">
               <div className={`w-2 h-2 rounded-full shrink-0 ${dotColor}`} />
-              <span className="text-sm font-mono truncate text-sidebar-foreground">
-                {branch}
-              </span>
-              {isSelected && (
+              {profileBadgeSlot}
+              {renderNameSlot("text-sidebar-foreground")}
+              {isSelected && !isEditing && (
                 <span className="ml-auto text-xs text-primary shrink-0">◀</span>
               )}
             </div>
@@ -155,13 +301,19 @@ export function SessionCard({
                 </p>
               </div>
             )}
-          </button>
+          </div>
         </ContextMenuTrigger>
         <ContextMenuContent className="w-48">
           <ContextMenuItem onSelect={onClick}>
             <MessageSquare className="w-4 h-4 mr-2" />
             セッションを開く
           </ContextMenuItem>
+          {canRename && (
+            <ContextMenuItem onSelect={() => startEditing()}>
+              <Pencil className="w-4 h-4 mr-2" />
+              表示名を変更
+            </ContextMenuItem>
+          )}
           <ContextMenuSeparator />
           <ContextMenuItem
             className="text-destructive focus:text-destructive"

--- a/client/src/components/SessionSidebar.tsx
+++ b/client/src/components/SessionSidebar.tsx
@@ -13,11 +13,13 @@
 
 import {
   AlertTriangle,
+  Check,
   FolderOpen,
   Globe,
   MoreVertical,
   Plus,
   RotateCw,
+  Settings,
   Terminal,
   X,
 } from "lucide-react";
@@ -38,22 +40,16 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
-  ContextMenuSub,
-  ContextMenuSubContent,
-  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Tooltip,
   TooltipContent,
@@ -94,8 +90,20 @@ interface SessionSidebarProps {
   /** プロファイル切替機能用 (Linux限定) */
   profiles?: Profile[];
   repoProfileLinks?: Map<string, string>;
+  /** worktreePath → profileId の個別override (worktree個別が優先) */
+  worktreeProfileLinks?: Map<string, string>;
   capabilities?: SystemCapabilities;
   onSetRepoProfile?: (repoPath: string, profileId: string | null) => void;
+  onSetWorktreeProfile?: (
+    worktreePath: string,
+    profileId: string | null
+  ) => void;
+  /** worktreePath → カスタム表示名 (未設定なら branch にフォールバック) */
+  worktreeDisplayNames?: Map<string, string>;
+  onSetWorktreeDisplayName?: (
+    worktreePath: string,
+    displayName: string | null
+  ) => void;
   onOpenProfileManager?: () => void;
   onRestartSession?: (sessionId: string) => void;
   /** リポジトリで新規Worktree作成を要求 */
@@ -129,8 +137,12 @@ export function SessionSidebar({
   isRemote = false,
   profiles,
   repoProfileLinks,
+  worktreeProfileLinks,
   capabilities,
   onSetRepoProfile,
+  onSetWorktreeProfile,
+  worktreeDisplayNames,
+  onSetWorktreeDisplayName,
   onOpenProfileManager,
   onRestartSession,
   onCreateWorktreeForRepo,
@@ -158,49 +170,203 @@ export function SessionSidebar({
     [profileList]
   );
 
-  // リポジトリ行に表示するプロファイルバッジを描画する
-  const renderRepoProfileBadge = (repoPath: string | undefined) => {
+  // リポジトリヘッダのプロファイルキャプション。
+  // ピル型バッジではなく "・ デフォルト: KB2" のような小さなテキストで表示し、
+  // worktree 側のピル型バッジと視覚的に区別する。
+  // クリックでプロファイル選択ドロップダウンを開ける (3点リーダーからは撤去済)。
+  const renderRepoProfileCaption = (repoPath: string | undefined) => {
     if (!multiProfileEnabled || !repoPath) return null;
-    const linkedId = repoProfileLinks?.get(repoPath);
-    if (linkedId) {
-      const profile = profileById.get(linkedId);
-      if (profile) {
-        const colorClass = colorFor(profile.id);
-        return (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                className={`shrink-0 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded border ${colorClass}`}
-              >
-                {badgeLabel(profile.name)}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="right">
-              <div className="text-xs">
-                <div className="font-medium">{profile.name}</div>
-                <div className="opacity-70">{profile.configDir}</div>
-              </div>
-            </TooltipContent>
-          </Tooltip>
-        );
-      }
+    const linkedId = repoProfileLinks?.get(repoPath) ?? null;
+    const profile = linkedId ? profileById.get(linkedId) : undefined;
+    const labelText = profile ? profile.name : "既定 (~/.claude)";
+    const canChange = !!onSetRepoProfile && !!onOpenProfileManager;
+
+    const caption = (
+      <span className="shrink-0 normal-case text-[11px] text-muted-foreground/80">
+        <span className="mr-1">・</span>
+        デフォルト: <span className="text-foreground/80">{labelText}</span>
+      </span>
+    );
+
+    if (!canChange) {
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>{caption}</TooltipTrigger>
+          <TooltipContent side="right">
+            {profile
+              ? `${profile.name} (${profile.configDir})`
+              : "紐付けなし (~/.claude を使用)"}
+          </TooltipContent>
+        </Tooltip>
+      );
     }
-    // 紐付けなし: 既定バッジ
+
     return (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="shrink-0 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded border bg-neutral-800 text-neutral-400 border-neutral-700">
-            既定
-          </span>
-        </TooltipTrigger>
-        <TooltipContent side="right">
-          紐付けなし (~/.claude を使用)
-        </TooltipContent>
-      </Tooltip>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="shrink-0 normal-case text-[11px] text-muted-foreground/80 hover:text-foreground transition-colors"
+            title={
+              profile
+                ? `リポジトリのデフォルトプロファイル: ${profile.name} (クリックで変更)`
+                : "リポジトリのデフォルトプロファイル: 既定 (~/.claude) (クリックで変更)"
+            }
+          >
+            <span className="mr-1">・</span>
+            デフォルト: <span className="text-foreground/80">{labelText}</span>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <RepoProfileMenu
+            variant="dropdown"
+            profiles={profileList}
+            currentProfileId={linkedId}
+            onSelect={profileId => onSetRepoProfile?.(repoPath, profileId)}
+            onOpenManager={() => onOpenProfileManager?.()}
+          />
+        </DropdownMenuContent>
+      </DropdownMenu>
     );
   };
 
-  // 古い設定 警告バッジ + 再起動ボタン
+  // SessionCard のステータスドット隣に差し込むプロファイル切替バッジ。
+  // worktree個別が未設定なら repoデフォルトを継承して同じ色で表示し、
+  // worktree個別が指定されている場合のみ末尾に `*` を表示する。
+  const renderProfileBadgeSlot = (
+    session: ManagedSession | null,
+    worktree: Worktree | undefined,
+    repoPath: string | undefined
+  ) => {
+    if (!multiProfileEnabled) return null;
+    if (!onSetWorktreeProfile || !onOpenProfileManager) return null;
+    const wtPath = worktree?.path ?? session?.worktreePath ?? null;
+    if (!wtPath) return null;
+
+    const wtLinkedId = worktreeProfileLinks?.get(wtPath) ?? null;
+    const effectiveRepoPath = repoPath ?? session?.repoPath ?? null;
+    const repoLinkedId = effectiveRepoPath
+      ? (repoProfileLinks?.get(effectiveRepoPath) ?? null)
+      : null;
+    const effectiveProfileId = wtLinkedId ?? repoLinkedId;
+    const effectiveProfile = effectiveProfileId
+      ? profileById.get(effectiveProfileId)
+      : undefined;
+
+    return (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            onClick={e => e.stopPropagation()}
+            onKeyDown={e => e.stopPropagation()}
+            className={`inline-flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded border transition-colors shrink-0 ${
+              effectiveProfile
+                ? colorFor(effectiveProfile.id)
+                : "bg-neutral-800 text-neutral-400 border-neutral-700 hover:bg-neutral-700"
+            }`}
+            title={
+              effectiveProfile
+                ? `プロファイル: ${effectiveProfile.name}${
+                    wtLinkedId ? "" : "（リポジトリのデフォルト）"
+                  }`
+                : "プロファイル: 既定 (~/.claude)"
+            }
+          >
+            {effectiveProfile ? badgeLabel(effectiveProfile.name) : "既定"}
+            {wtLinkedId && (
+              <span className="opacity-70" title="worktree個別設定">
+                *
+              </span>
+            )}
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-56">
+          <DropdownMenuLabel className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+            プロファイル
+          </DropdownMenuLabel>
+          {profileList.map(profile => {
+            const isCurrent = wtLinkedId === profile.id;
+            return (
+              <DropdownMenuItem
+                key={profile.id}
+                onSelect={() => onSetWorktreeProfile?.(wtPath, profile.id)}
+                className="flex items-center justify-between gap-2"
+              >
+                <span className="flex items-center gap-2 min-w-0">
+                  {isCurrent ? (
+                    <Check className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+                  ) : (
+                    <span className="w-3.5 h-3.5 shrink-0" aria-hidden />
+                  )}
+                  <span className="truncate">{profile.name}</span>
+                </span>
+                <span
+                  className={`shrink-0 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded border ${colorFor(profile.id)}`}
+                >
+                  {badgeLabel(profile.name)}
+                </span>
+              </DropdownMenuItem>
+            );
+          })}
+          <DropdownMenuSeparator />
+          {/*
+           * リポジトリにデフォルトが設定されている場合は「リポジトリの
+           * デフォルトに従う」を表示する。実 effective profile 名を
+           * 添えてバッジ表示と一致させる。worktree override が無い時の
+           * チェックはこの項目に付く。
+           * 設定されていない場合は従来通り「既定 (~/.claude)」とする。
+           */}
+          {repoLinkedId && profileById.has(repoLinkedId) ? (
+            <DropdownMenuItem
+              onSelect={() => onSetWorktreeProfile?.(wtPath, null)}
+              className="flex items-center justify-between gap-2"
+            >
+              <span className="flex items-center gap-2 min-w-0">
+                {wtLinkedId === null ? (
+                  <Check className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+                ) : (
+                  <span className="w-3.5 h-3.5 shrink-0" aria-hidden />
+                )}
+                <span className="truncate text-muted-foreground">
+                  リポジトリのデフォルトに従う
+                </span>
+              </span>
+              <span
+                className={`shrink-0 inline-flex items-center px-1.5 py-0.5 text-[10px] font-medium rounded border ${colorFor(repoLinkedId)}`}
+              >
+                {badgeLabel(profileById.get(repoLinkedId)?.name ?? "")}
+              </span>
+            </DropdownMenuItem>
+          ) : (
+            <DropdownMenuItem
+              onSelect={() => onSetWorktreeProfile?.(wtPath, null)}
+              className="flex items-center gap-2"
+            >
+              {wtLinkedId === null ? (
+                <Check className="w-3.5 h-3.5 text-emerald-400 shrink-0" />
+              ) : (
+                <span className="w-3.5 h-3.5 shrink-0" aria-hidden />
+              )}
+              <span className="truncate text-muted-foreground">
+                既定 (~/.claude)
+              </span>
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => onOpenProfileManager?.()}
+            className="flex items-center gap-2"
+          >
+            <Settings className="w-3.5 h-3.5" />
+            <span>プロファイル管理を開く...</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    );
+  };
+
+  // 古い設定 警告バッジ + 再起動ボタン (SessionCard の下に表示)
   const renderStaleProfileControls = (session: ManagedSession) => {
     if (!multiProfileEnabled || session.staleProfile !== true) return null;
     return (
@@ -213,7 +379,7 @@ export function SessionSidebar({
             </span>
           </TooltipTrigger>
           <TooltipContent side="right">
-            リポジトリのプロファイル紐付けが変更されました。このセッションは元の設定で動作中です
+            プロファイル紐付けが変更されました。このセッションは元の設定で動作中です
           </TooltipContent>
         </Tooltip>
         {onRestartSession && (
@@ -268,9 +434,15 @@ export function SessionSidebar({
         </div>
       </div>
 
-      {/* セッション一覧 */}
-      <ScrollArea className="flex-1">
-        <div className="p-2">
+      {/* セッション一覧。
+          Radix ScrollArea を使うと Viewport の中に display: table の
+          無 class ラッパーが挟まり、子要素 (input 等) が想定外に広がると
+          ラッパーが content-size で膨らんで Viewport が水平スクロール状態に
+          なる (`overflow-x: hidden` は Viewport に効いても scrollLeft が
+          焼き付き、確定後に左端を戻せない)。Radix 経由を諦めて素直な div の
+          縦スクロール + `overflow-x: hidden` で完全に水平拡張を抑止する。 */}
+      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+        <div className="p-2 overflow-x-hidden">
           {sessions.size === 0 && worktrees.length === 0 ? (
             <div className="p-8 text-center text-muted-foreground text-sm">
               <Terminal className="w-8 h-8 mx-auto mb-3 opacity-50" />
@@ -281,16 +453,10 @@ export function SessionSidebar({
             Array.from(groupedItems.entries()).map(([repoPath, group]) => {
               const { repoName, disambiguator, items } = group;
               const canRemove = !!onRemoveRepo;
-              const currentLinkId = repoProfileLinks?.get(repoPath) ?? null;
-              const showProfileSubmenu =
-                multiProfileEnabled &&
-                !!onSetRepoProfile &&
-                !!onOpenProfileManager;
               const canCreateWorktree = !!onCreateWorktreeForRepo;
-              // Worktree作成 / プロファイル変更 / サイドバーから除外
-              // のいずれかが可能なら repoヘッダに ContextMenu を付ける
-              const showRepoContextMenu =
-                canCreateWorktree || showProfileSubmenu || canRemove;
+              // 三点リーダー / 右クリックメニューは「Worktreeを作成」「サイドバーから除外」のみ。
+              // プロファイル変更はリポジトリヘッダのバッジクリックに集約済み。
+              const showRepoContextMenu = canCreateWorktree || canRemove;
 
               const repoHeader = (
                 <div className="sticky left-0 flex items-center gap-1.5 px-2 py-1.5">
@@ -309,40 +475,15 @@ export function SessionSidebar({
                       </DropdownMenuTrigger>
                       <DropdownMenuContent align="start" className="w-56">
                         {canCreateWorktree && (
-                          <>
-                            <DropdownMenuItem
-                              onSelect={() =>
-                                onCreateWorktreeForRepo?.(repoPath)
-                              }
-                            >
-                              <Plus className="w-3.5 h-3.5 mr-2" />
-                              新規Worktreeを作成
-                            </DropdownMenuItem>
-                            {(showProfileSubmenu || canRemove) && (
-                              <DropdownMenuSeparator />
-                            )}
-                          </>
+                          <DropdownMenuItem
+                            onSelect={() => onCreateWorktreeForRepo?.(repoPath)}
+                          >
+                            <Plus className="w-3.5 h-3.5 mr-2" />
+                            新規Worktreeを作成
+                          </DropdownMenuItem>
                         )}
-                        {showProfileSubmenu && (
-                          <>
-                            <DropdownMenuSub>
-                              <DropdownMenuSubTrigger>
-                                プロファイルを変更
-                              </DropdownMenuSubTrigger>
-                              <DropdownMenuSubContent className="w-56">
-                                <RepoProfileMenu
-                                  variant="dropdown"
-                                  profiles={profileList}
-                                  currentProfileId={currentLinkId}
-                                  onSelect={profileId =>
-                                    onSetRepoProfile?.(repoPath, profileId)
-                                  }
-                                  onOpenManager={() => onOpenProfileManager?.()}
-                                />
-                              </DropdownMenuSubContent>
-                            </DropdownMenuSub>
-                            {canRemove && <DropdownMenuSeparator />}
-                          </>
+                        {canCreateWorktree && canRemove && (
+                          <DropdownMenuSeparator />
                         )}
                         {canRemove && (
                           <DropdownMenuItem
@@ -388,7 +529,7 @@ export function SessionSidebar({
                       )}
                     </span>
                   )}
-                  {renderRepoProfileBadge(repoPath)}
+                  {renderRepoProfileCaption(repoPath)}
                 </div>
               );
 
@@ -402,37 +543,15 @@ export function SessionSidebar({
                       </ContextMenuTrigger>
                       <ContextMenuContent className="w-56">
                         {canCreateWorktree && (
-                          <>
-                            <ContextMenuItem
-                              onSelect={() =>
-                                onCreateWorktreeForRepo?.(repoPath)
-                              }
-                            >
-                              <Plus className="w-3.5 h-3.5 mr-2" />
-                              新規Worktreeを作成
-                            </ContextMenuItem>
-                            <ContextMenuSeparator />
-                          </>
+                          <ContextMenuItem
+                            onSelect={() => onCreateWorktreeForRepo?.(repoPath)}
+                          >
+                            <Plus className="w-3.5 h-3.5 mr-2" />
+                            新規Worktreeを作成
+                          </ContextMenuItem>
                         )}
-                        {showProfileSubmenu && (
-                          <>
-                            <ContextMenuSub>
-                              <ContextMenuSubTrigger>
-                                プロファイルを変更
-                              </ContextMenuSubTrigger>
-                              <ContextMenuSubContent className="w-56">
-                                <RepoProfileMenu
-                                  profiles={profileList}
-                                  currentProfileId={currentLinkId}
-                                  onSelect={profileId =>
-                                    onSetRepoProfile?.(repoPath, profileId)
-                                  }
-                                  onOpenManager={() => onOpenProfileManager?.()}
-                                />
-                              </ContextMenuSubContent>
-                            </ContextMenuSub>
-                            {canRemove && <ContextMenuSeparator />}
-                          </>
+                        {canCreateWorktree && canRemove && (
+                          <ContextMenuSeparator />
                         )}
                         {canRemove && (
                           <ContextMenuItem
@@ -475,6 +594,29 @@ export function SessionSidebar({
                             onDeleteSession(session.id, wt ?? undefined)
                           }
                           onStart={() => (wt ? onStartSession(wt) : undefined)}
+                          profileBadgeSlot={renderProfileBadgeSlot(
+                            session,
+                            wt ?? undefined,
+                            repoPath
+                          )}
+                          customDisplayName={(() => {
+                            const wtPath =
+                              wt?.path ?? session?.worktreePath ?? null;
+                            return wtPath
+                              ? (worktreeDisplayNames?.get(wtPath) ?? null)
+                              : null;
+                          })()}
+                          onSetCustomDisplayName={
+                            onSetWorktreeDisplayName
+                              ? (name: string | null) => {
+                                  const wtPath =
+                                    wt?.path ?? session?.worktreePath ?? null;
+                                  if (wtPath) {
+                                    onSetWorktreeDisplayName(wtPath, name);
+                                  }
+                                }
+                              : undefined
+                          }
                         />
                         {session && renderStaleProfileControls(session)}
                       </div>
@@ -485,7 +627,7 @@ export function SessionSidebar({
             })
           )}
         </div>
-      </ScrollArea>
+      </div>
 
       <AlertDialog
         open={removeTargetRepoPath !== null}

--- a/client/src/hooks/useSocket.ts
+++ b/client/src/hooks/useSocket.ts
@@ -167,8 +167,10 @@ interface UseSocketReturn {
 
   // プロファイル切替 (Linux限定)
   profiles: Profile[];
-  /** repoPath → profileId のマップ */
+  /** repoPath → profileId のマップ (リポジトリのデフォルト) */
   repoProfileLinks: Map<string, string>;
+  /** worktreePath → profileId のマップ (個別override、worktree個別が優先) */
+  worktreeProfileLinks: Map<string, string>;
   capabilities: SystemCapabilities;
   loadProfiles: () => void;
   createProfile: (name: string, configDir: string) => void;
@@ -178,6 +180,13 @@ interface UseSocketReturn {
   ) => void;
   deleteProfile: (id: string) => void;
   setRepoProfile: (repoPath: string, profileId: string | null) => void;
+  setWorktreeProfile: (worktreePath: string, profileId: string | null) => void;
+  /** worktreePath → カスタム表示名 のマップ。未設定の worktree は branch にフォールバック */
+  worktreeDisplayNames: Map<string, string>;
+  setWorktreeDisplayName: (
+    worktreePath: string,
+    displayName: string | null
+  ) => void;
   restartSessionWithProfile: (sessionId: string) => void;
 
   // メッセージショートカット
@@ -317,6 +326,13 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   const [repoProfileLinks, setRepoProfileLinks] = useState<Map<string, string>>(
     new Map()
   );
+  const [worktreeProfileLinks, setWorktreeProfileLinks] = useState<
+    Map<string, string>
+  >(new Map());
+  // worktreePath → カスタム表示名。プロファイル機能とは独立 (capabilities 不要)。
+  const [worktreeDisplayNames, setWorktreeDisplayNames] = useState<
+    Map<string, string>
+  >(new Map());
   const [capabilities, setCapabilities] = useState<SystemCapabilities>({
     multiProfileSupported: false,
   });
@@ -819,6 +835,46 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       setRepoProfileLinks(next);
     });
 
+    socket.on("worktree:profile-changed", ({ worktreePath, profileId }) => {
+      setWorktreeProfileLinks(prev => {
+        const next = new Map(prev);
+        if (profileId) {
+          next.set(worktreePath, profileId);
+        } else {
+          next.delete(worktreePath);
+        }
+        return next;
+      });
+    });
+
+    socket.on("worktree:profile-links", links => {
+      const next = new Map<string, string>();
+      for (const link of links) next.set(link.worktreePath, link.profileId);
+      setWorktreeProfileLinks(next);
+    });
+
+    // worktree カスタム表示名 ----------------------------------
+    socket.on("worktree:display-names", names => {
+      const next = new Map<string, string>();
+      for (const n of names) next.set(n.worktreePath, n.displayName);
+      setWorktreeDisplayNames(next);
+    });
+
+    socket.on(
+      "worktree:display-name-changed",
+      ({ worktreePath, displayName }) => {
+        setWorktreeDisplayNames(prev => {
+          const next = new Map(prev);
+          if (displayName) {
+            next.set(worktreePath, displayName);
+          } else {
+            next.delete(worktreePath);
+          }
+          return next;
+        });
+      }
+    );
+
     // メッセージショートカット ----------------------------------
     socket.on("shortcut:list", list => {
       setMessageShortcuts(list);
@@ -1292,6 +1348,26 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     []
   );
 
+  const setWorktreeProfile = useCallback(
+    (worktreePath: string, profileId: string | null) => {
+      socketRef.current?.emit("worktree:set-profile", {
+        worktreePath,
+        profileId,
+      });
+    },
+    []
+  );
+
+  const setWorktreeDisplayName = useCallback(
+    (worktreePath: string, displayName: string | null) => {
+      socketRef.current?.emit("worktree:set-display-name", {
+        worktreePath,
+        displayName,
+      });
+    },
+    []
+  );
+
   const restartSessionWithProfile = useCallback((sessionId: string) => {
     socketRef.current?.emit("session:restart-with-profile", { sessionId });
   }, []);
@@ -1481,12 +1557,16 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     // プロファイル切替 (Linux限定)
     profiles,
     repoProfileLinks,
+    worktreeProfileLinks,
     capabilities,
     loadProfiles,
     createProfile,
     updateProfile,
     deleteProfile,
     setRepoProfile,
+    setWorktreeProfile,
+    worktreeDisplayNames,
+    setWorktreeDisplayName,
     restartSessionWithProfile,
     // メッセージショートカット
     messageShortcuts,

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -116,12 +116,16 @@ export default function Dashboard() {
     navigateBrowser,
     profiles,
     repoProfileLinks,
+    worktreeProfileLinks,
     capabilities,
     loadProfiles,
     createProfile,
     updateProfile,
     deleteProfile,
     setRepoProfile,
+    setWorktreeProfile,
+    worktreeDisplayNames,
+    setWorktreeDisplayName,
     restartSessionWithProfile,
     mcpCatalog,
     mcpConnections,
@@ -641,8 +645,12 @@ export default function Dashboard() {
               isRemote={isRemote}
               profiles={profiles}
               repoProfileLinks={repoProfileLinks}
+              worktreeProfileLinks={worktreeProfileLinks}
               capabilities={capabilities}
               onSetRepoProfile={setRepoProfile}
+              onSetWorktreeProfile={setWorktreeProfile}
+              worktreeDisplayNames={worktreeDisplayNames}
+              onSetWorktreeDisplayName={setWorktreeDisplayName}
               onOpenProfileManager={() => setShowProfileManager(true)}
               onRestartSession={handleRestartSession}
               onCreateWorktreeForRepo={handleCreateWorktreeForRepo}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1213,6 +1213,17 @@ async function startServer() {
       socket.emit("shortcut:error", { message: getErrorMessage(e) });
     }
 
+    // worktree表示名（カスタム名）の一覧を初期同期。
+    // プロファイル機能と独立した汎用機能のため capabilities に依存しない。
+    try {
+      socket.emit("worktree:display-names", db.listWorktreeDisplayNames());
+    } catch (e) {
+      console.error(
+        "[Socket] failed to emit worktree:display-names:",
+        getErrorMessage(e)
+      );
+    }
+
     // ===== Session Orchestrator Event Handlers =====
     // sessionOrchestrator のイベントをそのまま Socket.IO クライアントへ転送する
     // 注意: session:list送信やttyd自動復元より前に登録する必要がある
@@ -2158,6 +2169,24 @@ async function startServer() {
     };
 
     /**
+     * link.worktreePath が session.worktreePath と論理的に一致するか判定する。
+     * 新規保存は canonical 形式に揃えているが、symlink 経由で異なる文字列に
+     * なっているケースを realpath fallback で救済。
+     */
+    const worktreePathMatchesSession = (
+      linkPath: string,
+      sessionWorktreePath: string | undefined
+    ): boolean => {
+      if (!sessionWorktreePath) return false;
+      if (sessionWorktreePath === linkPath) return true;
+      try {
+        return fs.realpathSync(linkPath) === sessionWorktreePath;
+      } catch {
+        return false;
+      }
+    };
+
+    /**
      * configDir のバリデーション。
      * @returns 正規化済み configDir、または null（エラーは socket に emit 済み）
      */
@@ -2212,8 +2241,9 @@ async function startServer() {
       }
       try {
         socket.emit("profile:list", db.listProfiles());
-        // リポジトリ紐付けも同梱送信（リロード時の初期同期用）
+        // リポジトリ / worktree 紐付けも同梱送信（リロード時の初期同期用）
         socket.emit("repo:profile-links", db.listRepoProfileLinks());
+        socket.emit("worktree:profile-links", db.listWorktreeProfileLinks());
       } catch (e) {
         socket.emit("profile:error", { message: getErrorMessage(e) });
       }
@@ -2286,12 +2316,18 @@ async function startServer() {
           .listRepoProfileLinks()
           .filter(link => link.profileId === id)
           .map(link => link.repoPath);
+        const affectedWorktreePaths = db
+          .listWorktreeProfileLinks()
+          .filter(link => link.profileId === id)
+          .map(link => link.worktreePath);
         for (const sess of sessionOrchestrator.getAllSessions()) {
-          if (
-            affectedRepoPaths.some(p =>
-              repoPathMatchesSession(p, sess.repoPath)
-            )
-          ) {
+          const repoMatches = affectedRepoPaths.some(p =>
+            repoPathMatchesSession(p, sess.repoPath)
+          );
+          const wtMatches = affectedWorktreePaths.some(p =>
+            worktreePathMatchesSession(p, sess.worktreePath)
+          );
+          if (repoMatches || wtMatches) {
             io.emit("session:updated", sess);
           }
         }
@@ -2311,6 +2347,10 @@ async function startServer() {
           .listRepoProfileLinks()
           .filter(link => link.profileId === id)
           .map(link => link.repoPath);
+        const affectedWorktreePaths = db
+          .listWorktreeProfileLinks()
+          .filter(link => link.profileId === id)
+          .map(link => link.worktreePath);
 
         db.deleteProfile(id);
         io.emit("profile:deleted", { id });
@@ -2323,13 +2363,24 @@ async function startServer() {
             repoPath,
             profileId: null,
           });
-          // そのリポジトリで稼働中のセッションを列挙して staleProfile 再計算
-          // (link 側 = 受信値 / 旧 symlink、session 側 = canonical の可能性が
-          //  あるため realpath fallback で判定する)
-          for (const sess of sessionOrchestrator.getAllSessions()) {
-            if (repoPathMatchesSession(repoPath, sess.repoPath)) {
-              io.emit("session:updated", sess);
-            }
+        }
+        for (const worktreePath of affectedWorktreePaths) {
+          io.emit("worktree:profile-changed", {
+            worktreePath,
+            profileId: null,
+          });
+        }
+        // 稼働中セッションを再emit。worktree個別 / repoデフォルト どちらか
+        // 一方でも該当すれば staleProfile が変化し得るため両方を見る。
+        for (const sess of sessionOrchestrator.getAllSessions()) {
+          const repoMatches = affectedRepoPaths.some(p =>
+            repoPathMatchesSession(p, sess.repoPath)
+          );
+          const wtMatches = affectedWorktreePaths.some(p =>
+            worktreePathMatchesSession(p, sess.worktreePath)
+          );
+          if (repoMatches || wtMatches) {
+            io.emit("session:updated", sess);
           }
         }
       } catch (e) {
@@ -2542,6 +2593,9 @@ async function startServer() {
 
         // 該当 repoPath 配下の稼働中セッションを再emit
         // (session.repoPath は canonical なので canonicalRepoPath で直接比較可能)
+        // worktree個別の紐付けがあるセッションは resolveProfileForWorktree が
+        // worktree側を優先するため、staleProfile が変化しないことを期待する
+        // (toManagedSession 内で再評価されるので別途分岐は不要)
         for (const session of sessionOrchestrator.getAllSessions()) {
           if (session.repoPath === canonicalRepoPath) {
             io.emit("session:updated", session);
@@ -2551,6 +2605,174 @@ async function startServer() {
         socket.emit("profile:error", { message: getErrorMessage(e) });
       }
     });
+
+    socket.on("worktree:set-profile", async ({ worktreePath, profileId }) => {
+      if (!capabilities.multiProfileSupported) {
+        emitUnsupported();
+        return;
+      }
+      if (typeof worktreePath !== "string" || worktreePath.length === 0) {
+        socket.emit("profile:error", {
+          message: "worktreePath は必須です",
+          code: "invalid_worktree",
+        });
+        return;
+      }
+      // ManagedSession.worktreePath は tmux 起動時の引数を保存しているため、
+      // 必ずしも canonical ではない。そこで保存も lookup も canonical に揃える。
+      let canonicalWorktreePath: string;
+      try {
+        canonicalWorktreePath = fs.realpathSync(worktreePath);
+      } catch {
+        socket.emit("profile:error", {
+          message: "worktreeパスが解決できません",
+          code: "invalid_worktree",
+        });
+        return;
+      }
+      try {
+        if (!(await isGitRepository(canonicalWorktreePath))) {
+          socket.emit("profile:error", {
+            message: "worktreeパスがgit working treeではありません",
+            code: "invalid_worktree",
+          });
+          return;
+        }
+
+        // 境界検証: worktree が属する repoPath を導出し、allowedRepos に
+        // 含まれているか確認。任意 path への書き込みを防ぐ。
+        if (allowedRepos.length > 0) {
+          let derivedRepoPath: string | undefined;
+          try {
+            const { stdout } = await execAsync(
+              `git -C "${canonicalWorktreePath}" rev-parse --path-format=absolute --git-common-dir`
+            );
+            const gitCommonDir = stdout.trim();
+            derivedRepoPath =
+              gitCommonDir.replace(/\/\.git\/?$/, "") || undefined;
+          } catch {
+            // 導出失敗 → 許可リストありなら拒否
+          }
+          const allowedMatch = (() => {
+            if (!derivedRepoPath) return false;
+            if (allowedRepos.includes(derivedRepoPath)) return true;
+            try {
+              const real = fs.realpathSync(derivedRepoPath);
+              return allowedRepos.includes(real);
+            } catch {
+              return false;
+            }
+          })();
+          if (!allowedMatch) {
+            socket.emit("profile:error", {
+              message: "リポジトリが許可リストに含まれていません",
+              code: "repo_not_allowed",
+            });
+            return;
+          }
+        }
+
+        if (profileId === null) {
+          db.removeWorktreeProfileLink(canonicalWorktreePath);
+        } else {
+          db.setWorktreeProfileLink(canonicalWorktreePath, profileId);
+        }
+        io.emit("worktree:profile-changed", {
+          worktreePath: canonicalWorktreePath,
+          profileId,
+        });
+
+        // 該当worktreeの稼働中セッションを再emit (staleProfile再評価)
+        for (const session of sessionOrchestrator.getAllSessions()) {
+          if (
+            worktreePathMatchesSession(
+              canonicalWorktreePath,
+              session.worktreePath
+            )
+          ) {
+            io.emit("session:updated", session);
+          }
+        }
+      } catch (e) {
+        socket.emit("profile:error", { message: getErrorMessage(e) });
+      }
+    });
+
+    socket.on(
+      "worktree:set-display-name",
+      async ({ worktreePath, displayName }) => {
+        if (typeof worktreePath !== "string" || worktreePath.length === 0) {
+          // エラー専用 channel が無いので silent reject (UI 側は不変表示のまま)
+          return;
+        }
+        // canonical 化して保存と broadcast の key を統一する
+        let canonicalWorktreePath: string;
+        try {
+          canonicalWorktreePath = fs.realpathSync(worktreePath);
+        } catch {
+          return;
+        }
+        // git working tree であることを確認 (任意 path への書き込みを防ぐ)
+        try {
+          if (!(await isGitRepository(canonicalWorktreePath))) return;
+        } catch {
+          return;
+        }
+
+        // 境界検証: allowedRepos が指定されていれば、worktree の親 repo が
+        // 含まれているかチェック。worktree:set-profile と同じ防御。
+        if (allowedRepos.length > 0) {
+          let derivedRepoPath: string | undefined;
+          try {
+            const { stdout } = await execAsync(
+              `git -C "${canonicalWorktreePath}" rev-parse --path-format=absolute --git-common-dir`
+            );
+            const gitCommonDir = stdout.trim();
+            derivedRepoPath =
+              gitCommonDir.replace(/\/\.git\/?$/, "") || undefined;
+          } catch {
+            // 導出失敗 → 許可リストありなら拒否
+          }
+          const allowedMatch = (() => {
+            if (!derivedRepoPath) return false;
+            if (allowedRepos.includes(derivedRepoPath)) return true;
+            try {
+              const real = fs.realpathSync(derivedRepoPath);
+              return allowedRepos.includes(real);
+            } catch {
+              return false;
+            }
+          })();
+          if (!allowedMatch) return;
+        }
+
+        // 入力正規化: trim 後に空 / null なら削除、それ以外は upsert
+        const trimmed =
+          typeof displayName === "string" ? displayName.trim() : "";
+        const MAX_LEN = 200;
+        try {
+          if (trimmed.length === 0) {
+            db.removeWorktreeDisplayName(canonicalWorktreePath);
+            io.emit("worktree:display-name-changed", {
+              worktreePath: canonicalWorktreePath,
+              displayName: null,
+            });
+          } else {
+            const value = trimmed.slice(0, MAX_LEN);
+            db.setWorktreeDisplayName(canonicalWorktreePath, value);
+            io.emit("worktree:display-name-changed", {
+              worktreePath: canonicalWorktreePath,
+              displayName: value,
+            });
+          }
+        } catch (e) {
+          console.error(
+            "[Socket] worktree:set-display-name failed:",
+            getErrorMessage(e)
+          );
+        }
+      }
+    );
 
     socket.on("session:restart-with-profile", async ({ sessionId }) => {
       if (!capabilities.multiProfileSupported) {

--- a/server/lib/database.ts
+++ b/server/lib/database.ts
@@ -25,6 +25,7 @@ import {
   type RepoProfileLink,
   type Session,
   type SessionStatus,
+  type WorktreeDisplayName,
   type WorktreeProfileLink,
 } from "../../shared/types.js";
 
@@ -296,6 +297,11 @@ export class SessionDatabase {
         profile_id TEXT NOT NULL,
         updated_at INTEGER NOT NULL,
         FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
+      );
+      CREATE TABLE IF NOT EXISTS worktree_display_names (
+        worktree_path TEXT PRIMARY KEY,
+        display_name TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
       );
     `);
 
@@ -1037,6 +1043,77 @@ export class SessionDatabase {
   removeWorktreeProfileLink(worktreePath: string): void {
     const stmt = this.db.prepare(
       "DELETE FROM worktree_profile_links WHERE worktree_path = ?"
+    );
+    stmt.run(worktreePath);
+  }
+
+  // ============================================================
+  // Worktree カスタム表示名CRUD操作
+  // 未設定時は UI 側で branch 名にフォールバックする
+  // ============================================================
+
+  /**
+   * すべてのworktree表示名を取得（クライアントの初期同期用）
+   */
+  listWorktreeDisplayNames(): WorktreeDisplayName[] {
+    const stmt = this.db.prepare(
+      "SELECT * FROM worktree_display_names ORDER BY updated_at DESC"
+    );
+    const rows = stmt.all() as Array<{
+      worktree_path: string;
+      display_name: string;
+      updated_at: number;
+    }>;
+    return rows.map(row => ({
+      worktreePath: row.worktree_path,
+      displayName: row.display_name,
+      updatedAt: row.updated_at,
+    }));
+  }
+
+  /**
+   * worktreeパスから表示名を取得
+   */
+  getWorktreeDisplayName(worktreePath: string): WorktreeDisplayName | null {
+    const stmt = this.db.prepare(
+      "SELECT * FROM worktree_display_names WHERE worktree_path = ?"
+    );
+    const row = stmt.get(worktreePath) as
+      | {
+          worktree_path: string;
+          display_name: string;
+          updated_at: number;
+        }
+      | undefined;
+    if (!row) return null;
+    return {
+      worktreePath: row.worktree_path,
+      displayName: row.display_name,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  /**
+   * worktreeにカスタム表示名を設定（UPSERT）
+   */
+  setWorktreeDisplayName(worktreePath: string, displayName: string): void {
+    const now = Date.now();
+    const stmt = this.db.prepare(`
+      INSERT INTO worktree_display_names (worktree_path, display_name, updated_at)
+      VALUES (?, ?, ?)
+      ON CONFLICT(worktree_path) DO UPDATE SET
+        display_name = excluded.display_name,
+        updated_at = excluded.updated_at
+    `);
+    stmt.run(worktreePath, displayName, now);
+  }
+
+  /**
+   * worktreeの表示名を解除（branch名にフォールバック）
+   */
+  removeWorktreeDisplayName(worktreePath: string): void {
+    const stmt = this.db.prepare(
+      "DELETE FROM worktree_display_names WHERE worktree_path = ?"
     );
     stmt.run(worktreePath);
   }

--- a/server/lib/session-orchestrator.test.ts
+++ b/server/lib/session-orchestrator.test.ts
@@ -55,6 +55,7 @@ vi.mock("./ttyd-manager.js", async () => {
 vi.mock("./database.js", () => {
   const db = {
     getRepoProfileLink: vi.fn(),
+    getWorktreeProfileLink: vi.fn(),
     getProfile: vi.fn(),
     getSessionByWorktreePath: vi.fn(),
     upsertSession: vi.fn(),
@@ -120,6 +121,7 @@ describe("SessionOrchestrator - プロファイル切替", () => {
 
     // db: link / profile / sessionは未設定
     mockedDb.getRepoProfileLink.mockReturnValue(null);
+    mockedDb.getWorktreeProfileLink.mockReturnValue(null);
     mockedDb.getProfile.mockReturnValue(null);
     mockedDb.getSessionByWorktreePath.mockReturnValue(null);
 

--- a/server/lib/session-orchestrator.ts
+++ b/server/lib/session-orchestrator.ts
@@ -169,14 +169,16 @@ export class SessionOrchestrator extends EventEmitter {
       db.updateSessionRepoPath(dbSession.id, derivedRepoPath);
     }
 
-    // 起動時に確定したプロファイルと、現在のリポジトリ紐付け+プロファイル状態
-    // を比較して staleProfile を判定する。
+    // 起動時に確定したプロファイルと、現在の (worktree個別 or repoデフォルト)
+    // 紐付けの解決結果を比較して staleProfile を判定する。
     // - profileId 切替 (null↔id、id↔別id) → stale
     // - 同一profileIdでも configDir が変わった場合も stale
     //   (tmux env は起動時に固定されるため再起動しないと反映されない)
     const current = this.sessionProfiles.get(tmuxSession.id) ?? null;
-    const link = repoPath ? db.getRepoProfileLink(repoPath) : null;
-    const desiredProfile = link ? db.getProfile(link.profileId) : null;
+    const { snapshot: desiredProfile } = this.resolveProfileForWorktree(
+      tmuxSession.worktreePath,
+      repoPath
+    );
     const staleProfile = !this.profileSnapshotsEqual(current, desiredProfile);
 
     return {
@@ -259,42 +261,70 @@ export class SessionOrchestrator extends EventEmitter {
   /**
    * 紐付けプロファイルから env / プロファイルスナップショットを解決する。
    *
-   * - 紐付け無し → null env / null snapshot
-   * - 紐付けあるが profile が無い（削除済等）→ null env / null snapshot
-   * - 紐付けあり → env={CLAUDE_CONFIG_DIR}, snapshot={id, configDir}
+   * 解決順序:
+   * 1. worktree_profile_links[worktreePath] (worktree個別の紐付けが優先)
+   * 2. repo_profile_links[repoPath] (リポジトリのデフォルト)
+   * 3. どちらも無ければ null env / null snapshot
    *
+   * 紐付けはあるが profile が無い (削除済等) 場合も null 扱い。
    * configDir/.credentials.json の存在チェックは行わない。claude CLI が
    * 必要なら自動で /login を促す。
    *
    * lookup 戦略:
-   * - まず受信した repoPath で getRepoProfileLink を試す
+   * - まず受信した path で lookup を試す
    * - 見つからなければ fs.realpathSync で正規化したパスで再試行
    *   (クライアントは symlink path で送ってくる場合と、git rev-parse 経由
    *    で正規化した path で送ってくる場合の両方があり、保存と lookup の key
    *    が食い違う可能性があるため)
    */
-  private resolveProfileForRepo(repoPath: string | undefined): {
+  private resolveProfileForWorktree(
+    worktreePath: string | undefined,
+    repoPath: string | undefined
+  ): {
     env: Record<string, string> | undefined;
     snapshot: { id: string; configDir: string } | null;
   } {
-    if (!repoPath) {
-      return { env: undefined, snapshot: null };
-    }
-    let link = db.getRepoProfileLink(repoPath);
-    if (!link) {
-      try {
-        const real = fs.realpathSync(repoPath);
-        if (real !== repoPath) {
-          link = db.getRepoProfileLink(real);
+    // 1. worktree個別の紐付け
+    let profileId: string | null = null;
+    if (worktreePath) {
+      let wtLink = db.getWorktreeProfileLink(worktreePath);
+      if (!wtLink) {
+        try {
+          const real = fs.realpathSync(worktreePath);
+          if (real !== worktreePath) {
+            wtLink = db.getWorktreeProfileLink(real);
+          }
+        } catch {
+          // realpath 解決失敗 → 受信値のままで紐付けなし扱い
         }
-      } catch {
-        // realpath 解決失敗 → 受信値のままで紐付けなし扱い
+      }
+      if (wtLink) {
+        profileId = wtLink.profileId;
       }
     }
-    if (!link) {
+
+    // 2. リポジトリのデフォルト紐付け
+    if (!profileId && repoPath) {
+      let repoLink = db.getRepoProfileLink(repoPath);
+      if (!repoLink) {
+        try {
+          const real = fs.realpathSync(repoPath);
+          if (real !== repoPath) {
+            repoLink = db.getRepoProfileLink(real);
+          }
+        } catch {
+          // realpath 解決失敗 → 受信値のままで紐付けなし扱い
+        }
+      }
+      if (repoLink) {
+        profileId = repoLink.profileId;
+      }
+    }
+
+    if (!profileId) {
       return { env: undefined, snapshot: null };
     }
-    const profile = db.getProfile(link.profileId);
+    const profile = db.getProfile(profileId);
     if (!profile) {
       return { env: undefined, snapshot: null };
     }
@@ -345,7 +375,11 @@ export class SessionOrchestrator extends EventEmitter {
     }
 
     // 新規作成パス: 紐付けプロファイルから env / スナップショットを解決
-    const { env, snapshot } = this.resolveProfileForRepo(resolvedRepoPath);
+    // (worktree個別 → repoデフォルト の順で解決)
+    const { env, snapshot } = this.resolveProfileForWorktree(
+      worktreePath,
+      resolvedRepoPath
+    );
 
     // 新規tmuxセッションを作成（envがあれば注入）
     const tmuxSession = await tmuxManager.createSession(
@@ -423,8 +457,11 @@ export class SessionOrchestrator extends EventEmitter {
       dbSession?.repoPath ||
       (worktreePath ? this.deriveRepoPath(worktreePath) : undefined);
 
-    // 1. 新プロファイルを解決
-    const { env, snapshot } = this.resolveProfileForRepo(repoPath);
+    // 1. 新プロファイルを解決 (worktree個別 → repoデフォルト の順)
+    const { env, snapshot } = this.resolveProfileForWorktree(
+      worktreePath,
+      repoPath
+    );
 
     // 2. 新tmuxセッションを別IDで作成 (失敗時は旧セッション無傷)
     const newTmux = await tmuxManager.createSession(
@@ -505,8 +542,9 @@ export class SessionOrchestrator extends EventEmitter {
   /**
    * 指定セッションの staleProfile を再評価する。
    *
-   * `repo:set-profile` 等で紐付けが変わった際に、稼働中セッションの
-   * staleProfile を再計算してクライアントへ反映するためのヘルパー。
+   * `repo:set-profile` / `worktree:set-profile` 等で紐付けが変わった際に、
+   * 稼働中セッションの staleProfile を再計算してクライアントへ反映するための
+   * ヘルパー。
    *
    * @returns 現在 staleProfile かどうか（セッション不存在時は false）
    */
@@ -516,8 +554,10 @@ export class SessionOrchestrator extends EventEmitter {
     const repoPath = tmuxSession.worktreePath
       ? this.deriveRepoPath(tmuxSession.worktreePath)
       : undefined;
-    const link = repoPath ? db.getRepoProfileLink(repoPath) : null;
-    const desired = link ? db.getProfile(link.profileId) : null;
+    const { snapshot: desired } = this.resolveProfileForWorktree(
+      tmuxSession.worktreePath,
+      repoPath
+    );
     const current = this.sessionProfiles.get(sessionId) ?? null;
     return !this.profileSnapshotsEqual(current, desired);
   }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -238,6 +238,16 @@ export interface WorktreeProfileLink {
 }
 
 /**
+ * worktreeのカスタム表示名
+ * 未設定時はクライアント側で branch 名にフォールバックする。
+ */
+export interface WorktreeDisplayName {
+  worktreePath: string;
+  displayName: string;
+  updatedAt: number;
+}
+
+/**
  * 実行環境の機能フラグ
  * クライアントは初期化時に受け取り、UI表示の可否を判断する
  */
@@ -460,6 +470,11 @@ export interface ServerToClientEvents {
     worktreePath: string;
     profileId: string | null;
   }) => void;
+  "worktree:display-names": (names: WorktreeDisplayName[]) => void;
+  "worktree:display-name-changed": (data: {
+    worktreePath: string;
+    displayName: string | null;
+  }) => void;
 
   // メッセージショートカット
   "shortcut:list": (shortcuts: MessageShortcut[]) => void;
@@ -588,6 +603,11 @@ export interface ClientToServerEvents {
   "worktree:set-profile": (data: {
     worktreePath: string;
     profileId: string | null;
+  }) => void;
+  "worktree:set-display-name": (data: {
+    worktreePath: string;
+    /** null / 空文字でクリア（branch名にフォールバック） */
+    displayName: string | null;
   }) => void;
   "session:restart-with-profile": (data: { sessionId: string }) => void;
 


### PR DESCRIPTION
## Summary

#176 で入った Beacon・worktree個別プロファイル紐付けの基盤の上に、UI側 (Sidebar / Card) のバッジ表示・編集を載せる。同時に worktree カスタム表示名機能も追加する。

## 主な変更

### バックエンド
- `shared/types.ts`: `WorktreeDisplayName` 型 + Socket.IO event 型 (`worktree:display-names` / `worktree:display-name-changed` / `worktree:set-display-name`) を追加
- `server/lib/database.ts`: `worktree_display_names` テーブル + CRUD (list/get/set/remove) を追加
- `server/lib/session-orchestrator.ts`: profile 解決を repo 単位から **worktree個別 → repoデフォルト** の順に変更 (`worktree:set-profile` に追従)。`isSessionStaleProfile` も同じ解決ロジックを使う
- `server/index.ts`: `worktree:set-display-name` / `worktree:set-profile` の socket ハンドラを追加。`worktree:display-names` / `worktree:profile-links` を接続時に初期同期

### クライアント
- `client/src/hooks/useSocket.ts`: worktree display name / profile link の state を受信し、`setWorktreeDisplayName` / `setWorktreeProfile` emit を追加
- `client/src/pages/Dashboard.tsx`: SessionSidebar へ display name / profile link state を伝搬
- `client/src/components/SessionCard.tsx`: profile バッジ slot を追加
- `client/src/components/SessionSidebar.tsx`: worktree 右クリックメニューに「表示名を変更」「プロファイル」項目を追加。バッジ表示も統合

## Test plan

- [ ] worktree 右クリックメニューから表示名を変更 → ブランチ名の代わりにカスタム名が表示される
- [ ] 表示名をクリア (空文字 / null) → ブランチ名にフォールバック
- [ ] worktree 右クリックから個別プロファイルを設定 → SessionSidebar / SessionCard のバッジがそのプロファイル名になる
- [ ] worktree 個別プロファイル未設定の場合は repo のデフォルトが反映される
- [ ] 稼働中セッションのプロファイルを切り替えると staleProfile バッジが表示される