### PR TITLE
fix(deploy): pm2 interpreter を絶対パス解決して旧 Node 混入を防ぐ

### DIFF
--- a/packages/server/ecosystem.config.cjs
+++ b/packages/server/ecosystem.config.cjs
@@ -4,10 +4,24 @@ const path = require("node:path");
 // data/sessions.db や logs/ は従来通りリポジトリルート基準で保持する。
 const projectRoot = path.resolve(__dirname, "..", "..");
 
-// interpreter は PM2_INTERPRETER 環境変数があればその絶対パスを使う。
-// scripts/deploy.sh が `mise which node` で解決して export する。
-// 古い /usr/bin/node v18 が PATH 先頭に来た場合の --env-file 起動失敗を防ぐ。
-const interpreter = process.env.PM2_INTERPRETER || "node";
+// interpreter は PM2_INTERPRETER 環境変数があればその値を使う。
+// 本番デプロイでは scripts/deploy.sh が `mise which node` で解決した絶対パスを
+// export し、古い /usr/bin/node v18 が PATH 先頭に来た場合の --env-file 起動失敗
+// を防ぐ。直接 `pm2 start` する場合 (ローカル動作確認等) はフォールバックで "node"。
+//
+// 設定ファイル単体で防衛するため、PM2_INTERPRETER が指定されている場合は
+// 絶対パスであることを assert する。空文字や相対パスは早期に潰す。
+function resolveInterpreter() {
+  const raw = process.env.PM2_INTERPRETER;
+  if (raw === undefined || raw === "") return "node";
+  if (!path.isAbsolute(raw)) {
+    throw new Error(
+      `PM2_INTERPRETER must be an absolute path, got: ${JSON.stringify(raw)}`,
+    );
+  }
+  return raw;
+}
+const interpreter = resolveInterpreter();
 
 module.exports = {
   apps: [

--- a/packages/server/ecosystem.config.cjs
+++ b/packages/server/ecosystem.config.cjs
@@ -4,6 +4,11 @@ const path = require("node:path");
 // data/sessions.db や logs/ は従来通りリポジトリルート基準で保持する。
 const projectRoot = path.resolve(__dirname, "..", "..");
 
+// interpreter は PM2_INTERPRETER 環境変数があればその絶対パスを使う。
+// scripts/deploy.sh が `mise which node` で解決して export する。
+// 古い /usr/bin/node v18 が PATH 先頭に来た場合の --env-file 起動失敗を防ぐ。
+const interpreter = process.env.PM2_INTERPRETER || "node";
+
 module.exports = {
   apps: [
     {
@@ -12,7 +17,7 @@ module.exports = {
       // cwd は projectRoot に固定し、data/ などのパス解決を維持する。
       script: path.join(__dirname, "dist", "cli.js"),
       cwd: projectRoot,
-      interpreter: "node",
+      interpreter,
       node_args: "--env-file=.env.production",
       args: "--remote",
       exec_mode: "fork",

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -9,9 +9,16 @@
  * このファイルは経由しない。
  */
 
-// Node バージョンガード: --env-file は 20.6+ で利用可。古い Node が PATH 先頭に
-// 紛れ込むと "bad option: --env-file" でクラッシュループするため、import より
-// 前に明示的なエラーを出して exit する。
+// Node バージョンガード（直接実行時の補助）。
+//
+// 本番 pm2 経路では `node_args: "--env-file=.env.production"` が付くため、
+// 20.6 未満の Node は本ファイルに到達する前に `bad option: --env-file` で
+// 死ぬ。そちらの主防衛線は scripts/deploy.sh の resolve_node_interpreter
+// (絶対パス + バージョン検証 → PM2_INTERPRETER) で担保している。
+//
+// このガードは deploy.sh をバイパスして `node packages/server/dist/cli.js`
+// を直接実行した場合や、systemd の PATH が予期せず古い node を引いた場合に
+// 「アプリの最低 Node 要件」を import 前に明示する第二防衛線。
 {
   const required = { major: 20, minor: 6 };
   const [major, minor] = process.versions.node.split(".").map(Number);

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -9,6 +9,24 @@
  * このファイルは経由しない。
  */
 
+// Node バージョンガード: --env-file は 20.6+ で利用可。古い Node が PATH 先頭に
+// 紛れ込むと "bad option: --env-file" でクラッシュループするため、import より
+// 前に明示的なエラーを出して exit する。
+{
+  const required = { major: 20, minor: 6 };
+  const [major, minor] = process.versions.node.split(".").map(Number);
+  if (
+    major < required.major ||
+    (major === required.major && minor < required.minor)
+  ) {
+    process.stderr.write(
+      `Ark requires Node.js >= ${required.major}.${required.minor} ` +
+        `but got ${process.versions.node} at ${process.execPath}\n`
+    );
+    process.exit(1);
+  }
+}
+
 import { startServer } from "./index.js";
 
 function parseArgs(): {

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -111,10 +111,14 @@ resolve_node_interpreter() {
     # 解決した node が 20.6+ であることを確認（--env-file 必須要件）。
     local node_version
     node_version="$("${node_path}" --version)"
-    local major
-    major="$(echo "${node_version}" | sed -E 's/^v([0-9]+)\..*/\1/')"
-    local minor
-    minor="$(echo "${node_version}" | sed -E 's/^v[0-9]+\.([0-9]+)\..*/\1/')"
+
+    # `vX.Y.Z` 形式を厳密にパース。壊れた shim や予期せぬ出力時に分かりにくい
+    # shell エラーにならないよう、major/minor が数値であることを正規表現で確認。
+    if [[ ! "${node_version}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+        log_error "node --version の出力を解釈できません: ${node_version} (${node_path})"
+    fi
+    local major="${BASH_REMATCH[1]}"
+    local minor="${BASH_REMATCH[2]}"
 
     if [[ "${major}" -lt 20 ]] || { [[ "${major}" -eq 20 ]] && [[ "${minor}" -lt 6 ]]; }; then
         log_error "node ${node_version} は要件 (>=20.6) を満たしません: ${node_path}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -114,7 +114,7 @@ resolve_node_interpreter() {
 
     # `vX.Y.Z` 形式を厳密にパース。壊れた shim や予期せぬ出力時に分かりにくい
     # shell エラーにならないよう、major/minor が数値であることを正規表現で確認。
-    if [[ ! "${node_version}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+    if [[ ! "${node_version}" =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
         log_error "node --version の出力を解釈できません: ${node_version} (${node_path})"
     fi
     local major="${BASH_REMATCH[1]}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -84,6 +84,46 @@ check_prerequisites() {
     log_success "前提条件のチェック完了"
 }
 
+# Node の絶対パスを解決して PM2_INTERPRETER を export する。
+#
+# pm2 の interpreter:"node" は spawn 時の PATH に依存する。
+# 過去 /usr/bin/node v18.19.1 が PATH 先頭に来て --env-file=.env.production を
+# 受け付けず、本番がクラッシュループに陥った（2026-05-13）。
+# `mise which node` で mise が解決する絶対パスを取得し、ecosystem.config.cjs に
+# 環境変数経由で渡す。mise 非利用環境では `command -v node` にフォールバック。
+resolve_node_interpreter() {
+    log_info "node の絶対パスを解決しています..."
+
+    local node_path=""
+
+    if command -v mise &> /dev/null; then
+        node_path="$(mise which node 2>/dev/null || true)"
+    fi
+
+    if [[ -z "${node_path}" ]]; then
+        node_path="$(command -v node || true)"
+    fi
+
+    if [[ -z "${node_path}" || ! -x "${node_path}" ]]; then
+        log_error "node の絶対パスを解決できませんでした (mise which / command -v 双方失敗)"
+    fi
+
+    # 解決した node が 20.6+ であることを確認（--env-file 必須要件）。
+    local node_version
+    node_version="$("${node_path}" --version)"
+    local major
+    major="$(echo "${node_version}" | sed -E 's/^v([0-9]+)\..*/\1/')"
+    local minor
+    minor="$(echo "${node_version}" | sed -E 's/^v[0-9]+\.([0-9]+)\..*/\1/')"
+
+    if [[ "${major}" -lt 20 ]] || { [[ "${major}" -eq 20 ]] && [[ "${minor}" -lt 6 ]]; }; then
+        log_error "node ${node_version} は要件 (>=20.6) を満たしません: ${node_path}"
+    fi
+
+    export PM2_INTERPRETER="${node_path}"
+    log_success "PM2_INTERPRETER=${PM2_INTERPRETER} (${node_version})"
+}
+
 # Git pull
 git_pull() {
     log_info "最新のコードを取得しています..."
@@ -196,6 +236,9 @@ main() {
 
     # 前提条件チェック
     check_prerequisites
+
+    # node 絶対パスを解決し PM2_INTERPRETER として export
+    resolve_node_interpreter
 
     # デプロイ処理
     git_pull


### PR DESCRIPTION
## Summary

本番ダウン (2026-05-13) の根本原因が `ecosystem.config.cjs` の `interpreter: "node"` で、`/usr/bin/node` v18.19.1 が PATH 先頭に来た結果 `--env-file=.env.production` を受け付けずクラッシュループに陥っていた。再発防止として interpreter 解決を 3 段階で仕組み化する。

- **scripts/deploy.sh**: `mise which node` (fallback: `command -v`) で絶対パスを解決し、出力を `vX.Y.Z` 形式で厳密にパースして 20.6+ を検証してから `PM2_INTERPRETER` として export
- **packages/server/ecosystem.config.cjs**: `PM2_INTERPRETER` を反映、設定単体でも `path.isAbsolute()` で絶対パスを assert
- **packages/server/src/cli.ts**: 直接実行/PATH 事故時の第二防衛線として Node ≥20.6 のランタイムガード

## インシデント記録

- 本番URL: https://ccm.ignission.tech/
- 復旧時刻: 2026-05-13 05:15 JST（VM 上で `pnpm rebuild better-sqlite3` + `pm2 kill` → mise shim PATH で `pm2 start` → `pm2 save`）
- 直接原因: pm2 が PATH から `/usr/bin/node` v18 を引き当て、`--env-file` 不対応で `bad option` クラッシュ
- 付随原因: better-sqlite3 が Node 18 用 NODE_MODULE_VERSION 108 のまま（Node 24 で 137 必要）

## Test plan

- [ ] CI 緑
- [ ] CodeRabbit レビュー対応
- [ ] マージ後 VM で `bash scripts/deploy.sh` を実行し、`PM2_INTERPRETER=/.../node` ログが出ること
- [ ] `pm2 describe claude-code-ark` で `interpreter` が絶対パスになっていること
- [ ] `https://ccm.ignission.tech/` が 302（Cloudflare Access）を返すこと
- [ ] `sudo systemctl restart pm2-admin.service` で systemd-resurrect 経路でも問題なく起動すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js version requirement to 20.6 or higher for improved stability and compatibility.
  * Enhanced runtime configuration validation during deployment to ensure the correct Node.js interpreter is used.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ignission/claude-code-ark/pull/179)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->