### PR TITLE
fix(desktop): macOS .app での起動エラーと beacon hang を修正

### DIFF
--- a/packages/desktop/build.mjs
+++ b/packages/desktop/build.mjs
@@ -49,6 +49,15 @@ await build({
     // Node 標準モジュール代替の有無を esbuild に判断させない
     "fsevents",
   ],
+  // ESM 出力に CJS の `require` shim を埋め込む。
+  // bundle 対象の依存 (electron-log 等) が内部で `require("electron")` を
+  // 呼ぶ場合、esbuild が生成する `__require2` shim では dynamic require が
+  // サポートされず "Dynamic require of \"electron\" is not supported" で
+  // 起動時に throw する。`createRequire(import.meta.url)` で本物の CJS
+  // require を再生して電子モジュール解決を担保する。
+  banner: {
+    js: "import { createRequire as __arkCreateRequire } from 'node:module';const require = __arkCreateRequire(import.meta.url);",
+  },
 });
 
 // F8: preload script を別エントリで bundle する。

--- a/packages/server/src/lib/beacon-manager.ts
+++ b/packages/server/src/lib/beacon-manager.ts
@@ -22,7 +22,7 @@ import { z } from "zod";
 import { db } from "./database.js";
 import { getErrorMessage } from "./errors.js";
 import { buildAuthenticatedExternalMcps } from "./mcp-oauth/build-mcp-servers.js";
-import { resolvePm2Path } from "./system.js";
+import { resolveClaudePath, resolvePm2Path } from "./system.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -1384,7 +1384,17 @@ export class BeaconManager extends EventEmitter {
       ...beaconArkMcpTools,
     ]);
 
-    // V1 query() にAsyncIterableを渡してマルチターン会話を確立する
+    // V1 query() にAsyncIterableを渡してマルチターン会話を確立する。
+    //
+    // pathToClaudeCodeExecutable: 未指定だと SDK は
+    // `require.resolve("@anthropic-ai/claude-agent-sdk-<platform>-<arch>")`
+    // で同梱バイナリを解決する。Electron .app 配下では `app.asar/...` を返すが、
+    // Electron は `child_process.spawn` を asar 透過化しないため ENOTDIR で fail
+    // する (asar は単一ファイルなので path component として辿れない)。
+    // `system.ts:resolveClaudePath()` が `app.asar.unpacked/` 側の実体パス →
+    // F5 同梱版 → system claude の優先順で解決する。Linux サーバ版では
+    // resourcesPath が未設定なので従来通り system claude にフォールバックする。
+    const claudeExecutable = resolveClaudePath() ?? undefined;
     const q = query({
       prompt: queue,
       options: {
@@ -1392,6 +1402,9 @@ export class BeaconManager extends EventEmitter {
         model: "sonnet",
         allowedTools: allowedToolsList,
         permissionMode: "default",
+        ...(claudeExecutable
+          ? { pathToClaudeCodeExecutable: claudeExecutable }
+          : {}),
         // canUseTool は SDK 仕様上 allowedTools に含まれない tool 呼び出し
         // について発火する。defensive に「allowedTools と同じ const から
         // 導出した allow-list (set + externalAllowedTools wildcard)」

--- a/packages/server/src/lib/beacon-manager.ts
+++ b/packages/server/src/lib/beacon-manager.ts
@@ -1394,6 +1394,12 @@ export class BeaconManager extends EventEmitter {
     // `system.ts:resolveClaudePath()` が `app.asar.unpacked/` 側の実体パス →
     // F5 同梱版 → system claude の優先順で解決する。Linux サーバ版では
     // resourcesPath が未設定なので従来通り system claude にフォールバックする。
+    //
+    // 契約: `resolveClaudePath()` は **存在するパス** を返す保証はあるが
+    // **spawn 可能性** までは保証しない (PATH 由来 / candidate 配列等は
+    // existsSync のみ)。`app.asar.unpacked` 経路だけは isFile + X_OK まで
+    // assert 済み。null なら SDK の auto-resolve に委ねる (=Electron .app では
+    // 失敗するが、その場合は claude-installer が同梱版を入れる方針)。
     const claudeExecutable = resolveClaudePath() ?? undefined;
     const q = query({
       prompt: queue,

--- a/packages/server/src/lib/system.ts
+++ b/packages/server/src/lib/system.ts
@@ -15,7 +15,13 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
+import {
+  accessSync,
+  constants,
+  existsSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { getBundledBinDir } from "./paths.js";
@@ -83,8 +89,9 @@ function existsInVersionedDirs(baseDir: string, suffix: string): boolean {
 
 /**
  * `@anthropic-ai/claude-agent-sdk` の query() に `pathToClaudeCodeExecutable`
- * として渡す claude バイナリの絶対パスを返す。Electron .app の
- * `app.asar.unpacked/` 配下に同梱されている SDK 付属バイナリを最優先する。
+ * として渡す、Electron .app の `app.asar.unpacked/` 配下に同梱された SDK
+ * 付属 claude バイナリの絶対パスを返す。**spawn 可能であることが確認できた
+ * 場合のみ非 null を返す** (existsSync + isFile + X_OK)。
  *
  * SDK は内部で `require.resolve("@anthropic-ai/claude-agent-sdk-<platform>-<arch>")`
  * から binary パスを得るが、Electron .app では `app.asar/...` を返す。Electron は
@@ -94,10 +101,22 @@ function existsInVersionedDirs(baseDir: string, suffix: string): boolean {
  *
  * Linux サーバ版 / non-Electron では `process.resourcesPath` が undefined のため
  * このフォールバックはスキップされる。
+ *
+ * spawn 可能性まで確認することで、`pathToClaudeCodeExecutable` を信用する側
+ * (`@ark/server` の query() 呼び出し) が「return non-null = spawn 安全」と
+ * 仮定できる。candidate が directory / 権限なし / 壊れたリンクの場合は null
+ * を返し、上位の system claude フォールバックに委ねる。
+ *
+ * Windows (`.exe` サフィックス) は現状 Ark .app の build target に含まれない
+ * ため未対応。将来 Windows 版を出す際は `.exe` を加味した分岐をここに追加する。
  */
-function resolveBundledSdkClaudePath(): string | null {
+function resolveUnpackedSdkClaudeExecutablePath(): string | null {
   const resourcesPath = (process as { resourcesPath?: string }).resourcesPath;
   if (!resourcesPath) return null;
+  // Windows ターゲットは未サポート (Ark .app は darwin / linux のみ build する)
+  if (process.platform !== "darwin" && process.platform !== "linux") {
+    return null;
+  }
   const candidate = path.join(
     resourcesPath,
     "app.asar.unpacked",
@@ -107,7 +126,10 @@ function resolveBundledSdkClaudePath(): string | null {
     "claude"
   );
   try {
-    return existsSync(candidate) ? candidate : null;
+    if (!existsSync(candidate)) return null;
+    if (!statSync(candidate).isFile()) return null;
+    accessSync(candidate, constants.X_OK);
+    return candidate;
   } catch {
     return null;
   }
@@ -122,7 +144,8 @@ function resolveBundledSdkClaudePath(): string | null {
 export function resolveClaudePath(): string | null {
   // -1. Electron .app の `app.asar.unpacked` に同梱された SDK 付属バイナリ。
   // SDK と version が揃っており、prompt protocol (JSONL) 互換性が保証される。
-  const bundledSdkBin = resolveBundledSdkClaudePath();
+  // 戻り値は spawn 可能性まで確認済み (isFile + X_OK)、null なら下流に委譲。
+  const bundledSdkBin = resolveUnpackedSdkClaudeExecutablePath();
   if (bundledSdkBin) return bundledSdkBin;
 
   // 0. F5 同梱版: `<userData>/claude-runtime/bin/claude` を最優先

--- a/packages/server/src/lib/system.ts
+++ b/packages/server/src/lib/system.ts
@@ -82,12 +82,49 @@ function existsInVersionedDirs(baseDir: string, suffix: string): boolean {
 }
 
 /**
+ * `@anthropic-ai/claude-agent-sdk` の query() に `pathToClaudeCodeExecutable`
+ * として渡す claude バイナリの絶対パスを返す。Electron .app の
+ * `app.asar.unpacked/` 配下に同梱されている SDK 付属バイナリを最優先する。
+ *
+ * SDK は内部で `require.resolve("@anthropic-ai/claude-agent-sdk-<platform>-<arch>")`
+ * から binary パスを得るが、Electron .app では `app.asar/...` を返す。Electron は
+ * `child_process.spawn` に対して asar 透過化を **行わない** ため、その path を
+ * spawn すると ENOTDIR で fail する (asar は単一ファイルなので path component
+ * として辿れない)。`app.asar.unpacked/` 側の実体パスを明示的に渡す必要がある。
+ *
+ * Linux サーバ版 / non-Electron では `process.resourcesPath` が undefined のため
+ * このフォールバックはスキップされる。
+ */
+function resolveBundledSdkClaudePath(): string | null {
+  const resourcesPath = (process as { resourcesPath?: string }).resourcesPath;
+  if (!resourcesPath) return null;
+  const candidate = path.join(
+    resourcesPath,
+    "app.asar.unpacked",
+    "node_modules",
+    "@anthropic-ai",
+    `claude-agent-sdk-${process.platform}-${process.arch}`,
+    "claude"
+  );
+  try {
+    return existsSync(candidate) ? candidate : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * `claude` コマンドの絶対パスを解決する。利用不可なら null。
  * 解決ロジックは checkClaudeCommandExists と同じ順序。tmux send-keys に
  * 絶対パスで claude を送ることで、pm2/systemd の PATH に claude が無い
  * 環境でも「command not found」にならないようにする。
  */
 export function resolveClaudePath(): string | null {
+  // -1. Electron .app の `app.asar.unpacked` に同梱された SDK 付属バイナリ。
+  // SDK と version が揃っており、prompt protocol (JSONL) 互換性が保証される。
+  const bundledSdkBin = resolveBundledSdkClaudePath();
+  if (bundledSdkBin) return bundledSdkBin;
+
   // 0. F5 同梱版: `<userData>/claude-runtime/bin/claude` を最優先
   // Electron desktop でユーザに余計なセットアップを求めずに済むよう、
   // システム claude より前に同梱インストール版をチェックする。


### PR DESCRIPTION
## Summary

PR #178 で実機未検証だった macOS .app に存在した 2 つのバグを修正する。

### 1. main プロセス起動時の `Dynamic require of \"electron\" is not supported`

`packages/desktop/build.mjs` の esbuild 出力は ESM (`format: \"esm\"`) だが、bundle 対象に含まれる electron-log v5 が内部で `require(\"electron\")` を呼ぶ。esbuild が生成する `__require2` shim は dynamic require をサポートしないため .app 起動直後に例外で死ぬ。

`banner.js` で `createRequire(import.meta.url)` を inject し、bundled CJS からの require/dynamic require を本物の Node require に解決させる。

### 2. beacon の query() が `spawn ENOTDIR` で silent fail

`@anthropic-ai/claude-agent-sdk` の query() は内部で `require.resolve(\"@anthropic-ai/claude-agent-sdk-<platform>-<arch>\")` を呼んで同梱 claude バイナリを spawn する。Electron .app では asar 内パス (`app.asar/node_modules/.../claude`) が返るが、Electron は `child_process.spawn` を [asar 透過化しない](https://www.electronjs.org/docs/latest/tutorial/asar-archives) ため OS が `app.asar` を directory として辿ろうとして ENOTDIR で fail する。エラーは socket handler の try/catch に silent に拾われ UI 上では「送信したが反応しない」状態だった。

`pathToClaudeCodeExecutable` を query() options に明示的に渡すよう変更し、`resolveClaudePath()` に `app.asar.unpacked/` 側の実体パスを最優先で解決する `resolveUnpackedSdkClaudeExecutablePath()` を追加。Linux サーバ版では `process.resourcesPath` が未設定のため従来通り F5 同梱版 → system claude にフォールバック。

P5 codex review [P1] 指摘対応として、戻り値が spawn 可能であること (`isFile + accessSync(X_OK)`) まで assert している (candidate が directory / 権限なし / 壊れたリンクの場合は null フォールバック)。

## Test plan

- [x] \`pnpm --filter @ark/server check\` (tsc -b) 通過
- [x] \`pnpm --filter @ark/server test\` 104 tests pass
- [x] \`pnpm --filter @ark/desktop package:dir\` build 通過
- [x] .app 起動 → beacon タブから送信 → claude が \`app.asar.unpacked/.../claude-agent-sdk-darwin-arm64/claude\` で spawn され返信ストリーミング表示まで動作確認
- [x] MCP server (backlog, chrome-devtools, slack-task, datadog) が grandchild として正常起動
- [x] codex review P5 ゲート PASS (指摘なし)

## 関連

- PR #178 (macOS .app 版追加) で実機未検証だった初期化経路で見つかったバグの fix
- `mac 実機での .app build` / `mac 実機での .app 起動 (Tray/Dock/Menu 表示確認)` のタスクは本 PR で確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * Electron アプリケーションのスタートアップ失敗を防ぐため、モジュール互換性の問題を解決しました。

* **改善**
  * Claude 実行可能ファイルの解決ロジックを強化し、バンドルされた実行可能ファイルの自動検出に対応しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ignission/claude-code-ark/pull/180)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->