### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-ark",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/desktop",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/main.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/server",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/shared",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "main": "./src/types.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/web",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Ark v1.2.0

v1.1.0 から **108 PR** を経て、macOS ネイティブ `.app` 版・Beacon (MCP) 統合・worktree プロファイル切替などの大型機能を中心に大幅アップデート。

### 主要機能

#### macOS ネイティブアプリ (.app)

- **macOS `.app` 版を追加** — Electron ベースで Ark をネイティブ配布。tmux / ttyd / claude を同梱しゼロセットアップで起動 (#178)
- リリースタグ push で `.app (arm64)` を自動ビルド・GitHub Releases に upload する CI を整備 (#182)
- 同梱 SDK `claude` バイナリの smoke test を CI に追加し、リグレッションを事前検知 (#182)

#### Beacon (Claude Code との MCP ブリッジ)

- 外部 **MCP server (OAuth 2.1) サポート** を追加 (#164)
- Beacon にホスト情報 MCP ツールを追加 (#162)
- claude.ai Connector 許可・Phase 1b 直接取得・worktree プロファイル選択 (#176)
- Beacon 応答中にキャンセルできる停止ボタンを追加 (#171)
- Beacon パネルの表示切替とリサイズ機能 (#149)
- Beacon 履歴の DB 永続化 + 表示順安定化 + repoPath 不整合修正 (#137)
- Bridge ダッシュボード + リポジトリ別セッショングリッドビュー (#160)
- PC サイドバー下端に SystemStatusBar を表示 (#161)
- Bridge の CPU メーターを補間して滑らかに描画 (#170)
- SystemStatusBar クリックで Bridge を別タブで開く (#169)

#### Worktree / プロファイル管理 (Linux)

- リポジトリ単位の `CLAUDE_CONFIG_DIR` 切替機能を追加 (#150)
- worktree 個別のカスタム表示名・プロファイル選択 UI を追加 (#177)
- サイドバーのリポジトリヘッダーから直接 Worktree を追加 (#153)
- サイドバーからリポジトリを非表示にする機能 (#138)
- スキャンパス選択をフォルダ選択ダイアログ化 (#151)
- 全プロファイル Claude Code 使用量サマリ機能 (Linux 限定) (#154)

#### モバイル / セッション体験

- モバイルのセッション状態を永続化しタブ間で保持 (#167)
- メッセージショートカット機能を追加 (#166)
- ファイルアップロードを汎用化（画像 / PDF / テキスト対応）(#127)
- 自走型 `/flow` skill を ark 用に統合 (#165)
- リロード時にリポジトリスキャン結果を自動復元 (#59)
- `/tmp` ファイルアクセス許可と画像プレビュー対応 (#61)
- Claude Code 起動時に `CLAUDE_CODE_NO_FLICKER=1` を設定

#### HTML ビューワー / その他

- 汎用 HTML ビューワータブ機能 (#119)
- HTML ビューワーから PNG 画像をエクスポートする機能 (#156)
- noVNC 方式によるリモートブラウザ機能 (#63, 設計 #62)
- ピクセルペット育成システム (Ark Pets) (#128)
- FrontLine ゲームプレイ刷新 + 武器バランス調整 + 狙撃銃貫通 (#133, #135)

### 主な修正

- macOS `.app` での起動エラーと Beacon hang を修正 (#180)
- pm2 interpreter を絶対パス解決して旧 Node 混入を防ぐ (#179)
- ttyd の同時接続数を `-m 5` に制限し高 CPU 事象を保護 (#174)
- ターミナル内 URL クリックで 2 タブ開くバグを WebLinksAddon / OSC 8 / クリック世代 dedup で根本修正 (#130, #131, #132, #134)
- ターミナル内 URL タップの精度向上・折り返し URL のリンク検出改善 (#172, post-tag)
- ターミナル内ローカルファイルリンクの HTML パス対応とタブ遷移修正 (#175)
- モバイルでのターミナルリンクタップと HTML ビューワー描画を修正 (#168)
- リロード時のセッション選択保持とモバイルファイル添付の Portal 競合修正 (#163)
- モバイルスクロールを WheelEvent dispatch 方式に変更 (#126)
- `/usage` 画面のレイアウト変更 / rate limit 対応で全プロファイル timeout を解消 (#155)
- BrowserManager 起動時に孤立 Xvfb / x11vnc / websockify / Chromium を掃除 (#152)
- サイドバーリサイズハンドルのクイッククリックで UI がフリーズするバグを修正 (#124)
- worktree ブロードキャスト化・dev 環境設定改善 (#114)
- `file:///` パスの HTML ビューワー 400 エラー修正 (#121)
- esbuild バンドル時の DB パス解決バグを修正 (#116, #117)
- Express 5 の path-to-regexp v8 で無名ワイルドカードが廃止された問題を修正 (#111)
- モバイル・PC で「セッションを削除」アクションを統合 (#125)

### 開発基盤

- デフォルトポートを 3000 系から 4000 系に変更 (#115)
- `pre-push-review` を Codex CLI に一本化 (#118)
- CodeRabbit 設定ファイルを追加 (#109)
- Renovate config を追加 (#103)
- pet 機能のサーバー側を完全削除 (#136)
- Insights 分析に基づく CLAUDE.md ルール強化・スキル追加・hook 改善 (#122)

### 依存関係の主要アップデート

- Node.js v24 (#98), TypeScript v6 (#107), Vite v8 (#95), Vitest v4 (#96), Express v5 (#99), Vue/React monorepo 19.2.x, esbuild 0.28 (#77), pnpm 10.33.x

### Breaking / 注意点

- デフォルトポートが **3000 系から 4000 系** に変更 (`PORT=4001` がデフォルト)。既存環境変数・リバースプロキシ設定を要確認 (#115)
- Express 5 に upgrade。カスタムルーティング・middleware を拡張している場合は path-to-regexp v8 構文を確認 (#111)
- Node.js **v20.6.0 以上** が必須 (`engines.node`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * パッケージバージョンをすべて 1.2.0 に更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ignission/claude-code-ark/pull/189)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->