### PR TITLE
fix(release): electron-builder の不正な `zip` 位置引数を削除

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,13 @@ jobs:
           # F0:B-1 確定: 未署名配布 (Apple Developer 登録なし)。
           # electron-builder の auto signing を無効化し、identity 探索をスキップする。
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-        run: pnpm --filter @ark/desktop exec electron-builder --mac --arm64 zip
+        # target は electron-builder.yml の mac.target で dmg + zip を定義済み。
+        # arch は CLI フラグ (--arm64) で渡す (electron-builder 25 の慣例的な指定)。
+        # 旧コマンドは末尾に `zip` を位置引数として渡していたが、electron-builder 25 の
+        # yargs は target 名を位置引数で受けず `Unknown argument: zip` で exit 1 する。
+        # zip 成果物の欠落は下流 `Compute artifact metadata` step が
+        # `ls packages/desktop/release/Ark-*-arm64.zip` で検出して fail する。
+        run: pnpm --filter @ark/desktop exec electron-builder --mac --arm64
 
       - name: Smoke test .app bootstrap
         # PR #180 で fix した 2 系統のバグの regression を tag release 前に検知する:


### PR DESCRIPTION
## 概要

v1.2.0 タグ push でトリガーした release.yml が `Package .app (arm64 zip)` step で
`electron-builder: Unknown argument: zip` により exit 1。

## 原因

`packages/desktop/electron-builder.yml` の `mac.target` で既に dmg + zip + arm64 を
定義済みのため、CLI に `zip` を末尾の位置引数として渡す必要がない。
electron-builder 25.x の yargs は target 名を位置引数で受けず弾く。

## 修正

`electron-builder --mac --arm64 zip` → `electron-builder --mac --arm64` に変更。
config 側で zip は自動生成される。zip 成果物の欠落は下流 `Compute artifact metadata`
step が `ls packages/desktop/release/Ark-*-arm64.zip` で検出して fail する。

## マージ後

main HEAD で v1.2.0 タグを再作成・push して release.yml を再走させる。

## 関連

- 失敗 run: https://github.com/ignission/claude-code-ark/actions/runs/25775794073
