### PR TITLE
fix(release): electron-builder の macOS zip 出力名 `-mac.zip` に追従 + multi-match ガード

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,14 +279,32 @@ jobs:
 
       - name: Compute artifact metadata
         id: artifact
-        # release/Ark-{version}-arm64.zip の絶対パスと SHA256 を抽出する。
+        # electron-builder 25 の macOS zip target はデフォルトで
+        # `Ark-{version}-arm64-mac.zip` (`-mac` 接尾辞付き) を出力する。
+        # 旧 glob `Ark-*-arm64.zip` ではこのファイル名にマッチせず
+        # `ls: No such file or directory` で fail していたため、
+        # `Ark-*-arm64-mac.zip` を期待値として明示する。
+        # 同じディレクトリに `.blockmap` も生成されるが拡張子で除外される。
         # update-cask ジョブで Caskfile の sha256 を置換するために GITHUB_OUTPUT に書き込む。
         run: |
           set -euo pipefail
-          ZIP=$(ls packages/desktop/release/Ark-*-arm64.zip | head -n1)
-          if [[ -z "${ZIP}" ]] || [[ ! -f "${ZIP}" ]]; then
+          shopt -s nullglob
+          # 期待 zip は 1 件のみ。0 件 or 2 件以上はビルド設定崩れの兆候として fail させる
+          # (2 件以上を黙って先頭採用すると意図しない artifact の sha256 を Cask に流す)。
+          ZIPS=(packages/desktop/release/Ark-*-arm64-mac.zip)
+          if [[ "${#ZIPS[@]}" -eq 0 ]]; then
             echo "::error::Expected zip artifact not found in packages/desktop/release/"
             ls -la packages/desktop/release/ || true
+            exit 1
+          fi
+          if [[ "${#ZIPS[@]}" -gt 1 ]]; then
+            echo "::error::Multiple zip artifacts matched (count=${#ZIPS[@]}). 期待は 1 件のみ。"
+            printf '  %s\n' "${ZIPS[@]}"
+            exit 1
+          fi
+          ZIP="${ZIPS[0]}"
+          if [[ ! -f "${ZIP}" ]]; then
+            echo "::error::Matched path is not a regular file: ${ZIP}"
             exit 1
           fi
           SHA=$(shasum -a 256 "${ZIP}" | awk '{print $1}')


### PR DESCRIPTION
## 概要

v1.2.0 タグ再走 (run `25776135085`) で `Compute artifact metadata` step が
`ls: packages/desktop/release/Ark-*-arm64.zip: No such file or directory` で fail。

## 原因

`electron-builder` 25 の macOS zip target はデフォルトで
`Ark-{version}-arm64-mac.zip` (`-mac` 接尾辞付き) を出力する。
workflow の glob は `Ark-*-arm64.zip` でこのファイル名にマッチしなかった。

build run の actual output:
```
• building target=DMG arch=arm64 file=release/Ark-1.2.0-arm64.dmg
• building target=macOS zip arch=arm64 file=release/Ark-1.2.0-arm64-mac.zip
```

Smoke test (.app bootstrap + bundled SDK claude) は両方 PASS、artifact 名の glob のみ問題。

## 修正

1. glob を `Ark-*-arm64-mac.zip` に変更
2. codex review の指摘 (`[中]`) を反映: bash array で取得し **0 件 / 2 件以上を fail**、1 件のみ通過させる Assertive Programming に変更

## マージ後

main HEAD で v1.2.0 タグを再作成して push → release.yml 再走 → Release 作成。

## 関連

- 前 fix (electron-builder zip 引数): #190
- 失敗 run: https://github.com/ignission/claude-code-ark/actions/runs/25776135085
