### PR TITLE
docs(readme): macOS install を --no-quarantine 必須に更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,49 @@ Arkは、Agent SDKではなく **tmux + ttyd によるターミナル転送方�
 
 ### macOS (.app, Apple Silicon)
 
-> [!NOTE]
-> .app 配布は実装中 (F1-F7 進行中)。実 release tag は F4-F6 完了後に公開予定。
-> 詳細は `plans/macos-app-implementation-plan.md` を参照。
+Homebrew Cask:
 
 ```bash
-# Homebrew tap 経由 (推奨)
-brew tap ignission/tap
-brew install --cask ark
-
-# または GitHub Releases から直接ダウンロード:
-# https://github.com/ignission/claude-code-ark/releases
+brew install --cask ignission/tap/ark
 ```
 
-要件: macOS 14 (Sonoma) 以降、arm64 (Apple Silicon)。
+または GitHub Releases から直接ダウンロード: <https://github.com/ignission/claude-code-ark/releases>
+
+要件: macOS 12 (Monterey) 以降、arm64 (Apple Silicon)。Cask の `depends_on macos: ">= :monterey"` に合わせており、これ未満は未検証です。
+
+#### 初回起動で「Ark は壊れているため開けません」と表示された場合
+
+現在の `.app` は **Developer ID 署名・Apple notarization が未対応** (追跡 issue: [#193](https://github.com/ignission/claude-code-ark/issues/193))。
+このため macOS は Homebrew 経由でダウンロードした `.app` を quarantine 対象として "damaged" 判定します。
+
+> [!CAUTION]
+> 以下の手順は Gatekeeper の検証を意図的に迂回します。実行前に **入手元が正規であること** を必ず確認してください:
+>
+> - 配布元が `https://github.com/ignission/claude-code-ark/releases` であること
+> - Homebrew Cask 経由でインストールした場合、`brew` が `.zip` の sha256 を Cask 定義 ([`Casks/ark.rb`](https://github.com/ignission/homebrew-tap/blob/main/Casks/ark.rb)) と自動照合しているため、改ざんは検知されています
+> - 直接ダウンロードした場合は GitHub Releases ページ掲載の sha256 と `shasum -a 256 Ark-*.zip` 出力を手元で比較してください
+
+署名対応完了までは以下のいずれかで対処してください:
+
+**対処 A: quarantine 属性を事後削除**
+
+```bash
+# Cask の install 先 (/Applications/Ark.app) 前提。別パスにある場合は読み替え。
+APP="/Applications/Ark.app"
+if [ ! -d "$APP" ]; then
+  echo "ERROR: $APP が見つかりません。インストール先を確認してください。" >&2
+  exit 1
+fi
+xattr -dr com.apple.quarantine "$APP"
+```
+
+**対処 B: 再インストール時に quarantine を付けない**
+
+```bash
+brew reinstall --cask --no-quarantine ignission/tap/ark
+```
+
+`--no-quarantine` は Homebrew Cask が install 時に quarantine 属性付与を skip するフラグです。
 
 ### Linux / 開発環境 (ソースから起動)
 


### PR DESCRIPTION
## 概要

v1.2.0 リリースで `.app` 配布が開始されたが、未署名配布のため Homebrew Cask 経由で
インストールすると初回起動で「Ark は壊れているため開けません」と表示される。
README の Quick Start に対処手順を明記する。

## 変更点

### macOS セクション
- 過時 NOTE (`.app 配布は実装中 (F1-F7 進行中)`) を削除
- 標準コマンド `brew install --cask ignission/tap/ark` を主推奨に維持
- 初回起動で "damaged" 表示が出た場合の対処を別小見出しに分離:
  - **対処 A**: `xattr -dr com.apple.quarantine` (事後削除)
  - **対処 B**: `brew reinstall --cask --no-quarantine` (再インストール時に quarantine 付与 skip)
- 入手元の真正性確認手順 (sha256 自動照合) を CAUTION 注記で明示
- 追跡 issue (#193) へのリンクを追加
- macOS 要件を Cask 定義に合わせて `>= Monterey (12)` に修正 (元: Sonoma 14)

## 設計判断

codex review で `--no-quarantine` を主推奨にする初案を 「Gatekeeper 保護を default 推奨してしまう」 と
`[high]` 指摘されたため、標準フローを通常コマンドに戻し、"damaged" 表示時の暫定回避策として
別小見出しに分離する構成に変更済み。署名対応 (#193) 完了時には本節を簡素化する。

## 関連

- 署名/notarization 対応: #193
- v1.2.0 リリース: https://github.com/ignission/claude-code-ark/releases/tag/v1.2.0
- Cask 定義: https://github.com/ignission/homebrew-tap/blob/main/Casks/ark.rb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * macOSインストール手順を更新し、Homebrew Caskサポートを追加しました
  * GitHubリリースページからの直接ダウンロードオプションを追加しました
  * Gatekeeper/Quarantine関連のトラブルシューティング手順を追加し、具体的な解決方法を提供しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ignission/claude-code-ark/pull/194)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->