### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-ark",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "license": "MIT",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/desktop",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/main.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/server",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/shared",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "main": "./src/types.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/web",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Ark v1.3.0

v1.2.0 から **リリース基盤の自動化** + **インストール導線の明確化** を中心としたメンテナンスリリース。ユーザーコードに変更はない。

### Highlights

- **Homebrew Cask 自動更新**: タグ push をトリガーに `ignission/homebrew-tap` の `Casks/ark.rb` を自動で bump (#192)
- macOS `.app` ビルド経路の安定化 (#190, #191)
- README の macOS install 手順を整備 (#194)

### CI / リリース基盤

- `release.yml` の `electron-builder` が `Unknown argument: zip` で落ちていた問題を修正 (#190)
- macOS zip artifact のファイル名 (`Ark-{version}-arm64-mac.zip`) に glob を追従させ、multi-match 検知も追加 (#191)
- `update-cask` ジョブを新規追加 (#192):
  - `HOMEBREW_TAP_TOKEN` secret が設定されていればタグ push 時に自動で Cask の version + sha256 を bump
  - tag / sha256 形式の sanity check、zip basename と url パターンの整合検証、downgrade 拒否、retry 時の invariant 再検証など Assertive Programming で防御

### ドキュメント

- README の macOS Quick Start を `.app` 配布版に合わせて更新 (#194):
  - "Ark は壊れているため開けません" 表示時の対処 (`xattr -dr` または `--no-quarantine` 再インストール)
  - sha256 自動照合による真正性確認手順
  - 過時 NOTE (F1-F7 進行中) を削除
  - macOS 要件を Monterey (12) 以降に修正

### 追跡中

- macOS `.app` の Developer ID 署名 + Apple notarization 対応 ([#193](https://github.com/ignission/claude-code-ark/issues/193))。完了すれば quarantine 関連の手順は不要になる。
