### PR TITLE
docs(readme): --no-quarantine 案内を削除 (Homebrew 4.5 で廃止)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,7 @@ brew install --cask ignission/tap/ark
 > - Homebrew Cask 経由でインストールした場合、`brew` が `.zip` の sha256 を Cask 定義 ([`Casks/ark.rb`](https://github.com/ignission/homebrew-tap/blob/main/Casks/ark.rb)) と自動照合しているため、改ざんは検知されています
 > - 直接ダウンロードした場合は GitHub Releases ページ掲載の sha256 と `shasum -a 256 Ark-*.zip` 出力を手元で比較してください
 
-署名対応完了までは以下のいずれかで対処してください:
-
-**対処 A: quarantine 属性を事後削除**
+署名対応完了までは、**上記 CAUTION の真正性確認 (Cask 経由なら自動 sha256 照合済み、それ以外なら手動照合) を済ませた上で**、インストール後に quarantine 属性を手動で削除してください:
 
 ```bash
 # Cask の install 先 (/Applications/Ark.app) 前提。別パスにある場合は読み替え。
@@ -78,13 +76,9 @@ fi
 xattr -dr com.apple.quarantine "$APP"
 ```
 
-**対処 B: 再インストール時に quarantine を付けない**
-
-```bash
-brew reinstall --cask --no-quarantine ignission/tap/ark
-```
-
-`--no-quarantine` は Homebrew Cask が install 時に quarantine 属性付与を skip するフラグです。
+> [!NOTE]
+> Homebrew 4.5 で `--no-quarantine` switch および `HOMEBREW_CASK_OPTS=--no-quarantine` 環境変数が **代替なしで廃止** されたため、現状 install 時点での回避はできません。`xattr -dr` で事後削除する手順のみが残された対処です。
+> 参考: <https://github.com/Homebrew/brew/pull/19046>
 
 ### Linux / 開発環境 (ソースから起動)
 


### PR DESCRIPTION
## 概要

PR #194 で書いた `brew reinstall --cask --no-quarantine ignission/tap/ark` の案内が
現行 Homebrew では動かない:

```
Error: Calling the `--[no-]quarantine` switch is disabled! There is no replacement.
```

Homebrew 4.5 で `--no-quarantine` switch と `HOMEBREW_CASK_OPTS=--no-quarantine`
環境変数の両方が **代替なしで廃止** された ([Homebrew/brew#19046](https://github.com/Homebrew/brew/pull/19046))。

## 修正

- 「対処 A / 対処 B」の二択から **`xattr -dr` 一択** に絞る
- NOTE で `--no-quarantine` 廃止の事実と参考 PR リンクを補足
- xattr 手順の直前に「sha256 照合済みであることを前提」と再強調 (codex `[High]` 指摘反映)

## 関連

- 前 README 更新: #194
- 署名対応 (#193) 完了時にはこのセクション自体を削除予定


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated macOS Quick Start guide with instructions for verifying authenticity and removing quarantine attributes after installation
  * Added notes about Homebrew 4.5+ compatibility changes affecting installation methods

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ignission/claude-code-ark/pull/196)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->