### PR TITLE
feat(build-bin): tmux/ttyd を macOS .app に同梱 (#185)

### DIFF
--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -63,12 +63,24 @@ jobs:
           brew update
           brew install jq cmake autoconf automake libtool pkg-config
 
-      - name: Compute manifest cache key
+      - name: Compute cache key
         id: cache-key
+        # manifest.json (依存バージョン + SHA256) と build スクリプト群 (common.sh /
+        # build-tmux.sh / build-ttyd.sh / collect-licenses.sh) の両方を hash 対象に
+        # 含める。スクリプトを変えただけで manifest が同じ場合に古い
+        # ${PREFIX}/.built.<name> stamp を再利用して新しい configure flag が
+        # 効かないままになる事故を防ぐ (codex review P1 指摘対応)。
         run: |
-          hash=$(shasum -a 256 packages/desktop/scripts/build-bin/manifest.json | cut -d' ' -f1)
+          hash=$(shasum -a 256 \
+            packages/desktop/scripts/build-bin/manifest.json \
+            packages/desktop/scripts/build-bin/common.sh \
+            packages/desktop/scripts/build-bin/build-tmux.sh \
+            packages/desktop/scripts/build-bin/build-ttyd.sh \
+            packages/desktop/scripts/build-bin/collect-licenses.sh \
+            | shasum -a 256 \
+            | cut -d' ' -f1)
           echo "hash=${hash}" >> "${GITHUB_OUTPUT}"
-          echo "Computed cache key from manifest.json: ${hash}"
+          echo "Computed cache key (manifest + scripts): ${hash}"
 
       - name: Restore build cache
         if: ${{ inputs.force_rebuild != 'true' }}

--- a/.github/workflows/build-bin.yml
+++ b/.github/workflows/build-bin.yml
@@ -5,12 +5,20 @@ name: build-bin (macOS arm64 tmux/ttyd)
 # packages/desktop/build-assets/{bin,Frameworks,licenses}/ に成果物を配置する。
 # manifest.json の hash でビルド成果物を actions/cache にキャッシュする。
 #
-# **現状は workflow_dispatch (手動起動) 限定**。build-tmux.sh / build-ttyd.sh は
-# skeleton 状態で実 build ステップ (configure/make/install_name_tool 等) が未実装。
-# 自動起動 (push tag, pull_request) を有効化するのは F4-followup で実 build スクリプトを
-# 完成させてから (現状のままだと skeleton の verify step が必ず fail するため)。
+# 呼び出し経路:
+#   - workflow_call: release.yml の Build .app job が依存ジョブとして呼ぶ。
+#     成果物は actions/upload-artifact で公開され、呼び出し側 job が download する。
+#   - pull_request: build-bin スクリプト / manifest 変更時のみ自動 build (パス filter で限定)。
+#   - workflow_dispatch: 開発時の手動再ビルド用 (cache bust も可)。
 
 on:
+  workflow_call:
+    inputs:
+      force_rebuild:
+        description: "Skip cache and rebuild from scratch"
+        required: false
+        default: "false"
+        type: string
   workflow_dispatch:
     inputs:
       force_rebuild:
@@ -18,14 +26,10 @@ on:
         required: false
         default: "false"
         type: string
-  # 以下は build-tmux.sh / build-ttyd.sh の skeleton を実装で置き換えた後に有効化。
-  # push:
-  #   tags:
-  #     - "v*"
-  # pull_request:
-  #   paths:
-  #     - "packages/desktop/scripts/build-bin/**"
-  #     - ".github/workflows/build-bin.yml"
+  pull_request:
+    paths:
+      - "packages/desktop/scripts/build-bin/**"
+      - ".github/workflows/build-bin.yml"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,10 +33,23 @@ permissions:
   contents: write
 
 jobs:
+  # tmux / ttyd / 関連 OSS deps を arm64 native build し
+  # ark-bin-macos-arm64 artifact を生成する依存ジョブ。
+  # build-bin.yml の workflow_call トリガーで起動し、manifest.json hash で
+  # actions/cache を共有するため、変更が無い限り 2 回目以降は高速 (~1 分)。
+  build-bin:
+    name: Build tmux/ttyd binaries
+    uses: ./.github/workflows/build-bin.yml
+
   build:
     name: Build .app (macOS arm64)
     runs-on: macos-14
     timeout-minutes: 60
+    # tmux/ttyd 同梱バイナリを取得した後でないと electron-builder が
+    # extraResources で参照する build-assets/bin が空になり、配布した .app から
+    # bundled tmux/ttyd が解決できなくなる (system PATH の Homebrew tmux に
+    # 暗黙フォールバックして、非エンジニア向け配布の前提が崩れる) ため必須。
+    needs: build-bin
 
     # update-cask ジョブから参照するメタデータ。
     # sha256 は Cask の sha256 値を更新するため必須。
@@ -82,17 +95,35 @@ jobs:
           node-version: "20"
           cache: "pnpm"
 
-      # F4 (build-bin.yml) の artifact から tmux/ttyd を取得する想定。
-      # build-bin.yml は現状 workflow_dispatch 限定で artifact 未生成のため、
-      # 取得失敗時も build を継続できる構造 (continue-on-error) にしている。
-      # F4 完了後に actions/download-artifact@v4 で取得する形に書き換える。
-      #
-      # - name: Download tmux/ttyd artifact
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: ark-bin-macos-arm64
-      #     path: packages/desktop/build-assets
-      #   continue-on-error: true
+      # build-bin ジョブが upload した artifact (tmux / ttyd / Frameworks / licenses)
+      # を packages/desktop/build-assets/ 直下に展開する。
+      # electron-builder.yml の extraResources / extraFiles はここを参照する想定なので、
+      # download 後はファイル系構造が以下になっている必要がある:
+      #   packages/desktop/build-assets/bin/{tmux,ttyd}
+      #   packages/desktop/build-assets/licenses/{INDEX.json, <pkg>/LICENSE}
+      #   packages/desktop/build-assets/Frameworks/* (静的リンク済なら空)
+      # artifact 名 (ark-bin-macos-arm64) は build-bin.yml の upload-artifact name と一致。
+      - name: Download tmux/ttyd artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ark-bin-macos-arm64
+          path: packages/desktop/build-assets
+
+      # 同梱バイナリが揃っていることを electron-builder 起動前に assert する
+      # (build-bin の verify step を二重チェック)。
+      - name: Verify bundled binaries
+        run: |
+          set -euo pipefail
+          for bin in tmux ttyd; do
+            BIN_PATH="packages/desktop/build-assets/bin/${bin}"
+            if [ ! -x "${BIN_PATH}" ]; then
+              echo "::error::Bundled ${bin} missing or not executable at ${BIN_PATH}"
+              ls -la packages/desktop/build-assets/bin/ || true
+              exit 1
+            fi
+            file "${BIN_PATH}"
+          done
+          echo "::notice::Bundled tmux/ttyd ready for electron-builder"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -286,6 +317,36 @@ jobs:
           fi
           echo "Bootstrap smoke passed (port=${ARK_PORT} http=${HTTP})"
           # cleanup は trap EXIT に委譲
+
+      - name: Smoke test bundled tmux/ttyd binaries
+        # issue #185: .app に同梱した tmux / ttyd が
+        # `Resources/bin/` 配下で実行可能であることを確認する。
+        # asarUnpack ルール変更・extraResources パス変更で binary 配置が崩れた場合に
+        # ここで fail させる。version 出力で起動経路自体も smoke 検証する。
+        # 同梱が無いと server 側の resolveTmuxPath は PATH の tmux に
+        # 暗黙フォールバックするため、非エンジニア向け配布の前提が崩れる。
+        run: |
+          set -euo pipefail
+          BIN_ROOT="packages/desktop/release/mac-arm64/Ark.app/Contents/Resources/bin"
+          for tool in tmux ttyd; do
+            BIN="${BIN_ROOT}/${tool}"
+            if [ ! -x "${BIN}" ]; then
+              echo "::error::Bundled ${tool} not found at ${BIN}"
+              ls -la "${BIN_ROOT}" 2>&1 || echo "(bin directory not found)"
+              exit 1
+            fi
+            file "${BIN}"
+            # tmux は `-V`、ttyd は `--version`。両方とも network/auth 不要で即終了する safe な smoke。
+            if [ "${tool}" = "tmux" ]; then
+              VER=$("${BIN}" -V 2>&1 | head -1)
+            else
+              VER=$("${BIN}" --version 2>&1 | head -1)
+            fi
+            END_TOKEN="ark-${tool}-version-$(uuidgen)"
+            echo "::stop-commands::${END_TOKEN}"
+            echo "Bundled ${tool} OK: ${VER}"
+            echo "::${END_TOKEN}::"
+          done
 
       - name: Smoke test bundled SDK claude binary
         # PR #180 の root cause だった「SDK 付属 claude バイナリが asar 内パスで

--- a/packages/desktop/scripts/build-bin/build-tmux.sh
+++ b/packages/desktop/scripts/build-bin/build-tmux.sh
@@ -32,14 +32,28 @@ echo "===== build-tmux.sh: macOS ${ARCH} =====" >&2
 NCURSES_URL=$(manifest_get '.dependencies.ncurses.url')
 NCURSES_SHA=$(manifest_get '.dependencies.ncurses.sha256')
 fetch_and_extract "ncurses" "${NCURSES_URL}" "${NCURSES_SHA}"
-build_autoconf "ncurses" \
-  --without-shared \
-  --enable-static \
-  --without-debug \
-  --without-ada \
-  --enable-widec \
-  --with-default-terminfo-dir=/usr/share/terminfo \
-  --with-terminfo-dirs="/usr/share/terminfo:/usr/share/lib/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/etc/terminfo"
+# ncurses は `make install` で /usr/share/terminfo へ tic 経由で書き込もうとして
+# permission denied で fail する (--with-default-terminfo-dir に system path を
+# 指定すると `make install.data` の install target がそこを使う)。
+# runtime は --with-default-terminfo-dir で指定した system terminfo を読みに行く
+# ので、ビルド時に terminfo を埋める必要はない。よって install を
+# `install.libs + install.includes` に絞り込み、terminfo install をスキップする。
+if [[ ! -f "${PREFIX}/.built.ncurses" ]]; then
+  NCURSES_SRC=$(source_dir "ncurses")
+  pushd "${NCURSES_SRC}" >/dev/null
+  ./configure --prefix="${PREFIX}" \
+    --without-shared \
+    --enable-static \
+    --without-debug \
+    --without-ada \
+    --enable-widec \
+    --with-default-terminfo-dir=/usr/share/terminfo \
+    --with-terminfo-dirs="/usr/share/terminfo:/usr/share/lib/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/etc/terminfo"
+  make -j"$(build_jobs)"
+  make install.libs install.includes
+  popd >/dev/null
+  : > "${PREFIX}/.built.ncurses"
+fi
 
 # ncurses widec ABI は libncursesw.a / libtinfow.a を出力するが、tmux の configure は
 # libncurses / libtinfo を探す。後者を前者へ symlink して configure を通す。

--- a/packages/desktop/scripts/build-bin/build-tmux.sh
+++ b/packages/desktop/scripts/build-bin/build-tmux.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
-# F4: macOS arm64 向け tmux クロスビルドスクリプト (skeleton)
+# F4: macOS arm64 向け tmux クロスビルドスクリプト
 #
-# 依存: libevent, ncurses (manifest.json 参照)。
-# 出力: ${PREFIX}/bin/tmux と動的依存 dylib (Frameworks/ 候補)。
+# 依存: ncurses, libevent (manifest.json 参照)。
+# 出力: ${PREFIX}/bin/tmux (全 deps を static link した self-contained binary)。
 #
-# CI からは `bash build-tmux.sh` を呼ぶだけで再現可能なビルドにする想定。
-# 詳細実装は CI で iterative に詰める前提で、最低限の skeleton + 依存導出順を記述。
+# 設計: 全依存を `--disable-shared` で .a のみ生成し、tmux は最終的に
+# system dylib (libSystem) のみに依存する形に纏める。これで
+# install_name_tool による rpath 調整も Frameworks/ 同梱も不要になる。
 #
 # 参考:
-#   - tmux build instructions: https://github.com/tmux/tmux/wiki/Installing
-#   - configure flags の経験的設定: --enable-static, --disable-shared
+#   - tmux build: https://github.com/tmux/tmux/wiki/Installing
+#   - ncurses + macOS: terminfo の搭載先 (`--enable-pc-files`) が rpath 無しでも
+#     動くよう $TERMINFO_DIRS にデフォルトを含める
 
 set -euo pipefail
 
@@ -19,41 +21,84 @@ source "${SCRIPT_DIR}/common.sh"
 
 echo "===== build-tmux.sh: macOS ${ARCH} =====" >&2
 
-# ----- 依存ライブラリの取得とビルド -----
-# 順序: ncurses → libevent → tmux
+# ----- 依存ライブラリの取得 + ビルド (静的) -----
 
 # 1. ncurses
+#    --without-shared / --enable-static で .a のみ。
+#    --without-debug でビルド速度 + サイズを優先。
+#    --without-ada はランタイム不要 (依存に Ada が要る環境のみ).
+#    --with-default-terminfo-dir + --with-terminfo-dirs で binary が
+#    /usr/share/terminfo (システム既定) + 自ビルド両方を見にいく。
 NCURSES_URL=$(manifest_get '.dependencies.ncurses.url')
 NCURSES_SHA=$(manifest_get '.dependencies.ncurses.sha256')
 fetch_and_extract "ncurses" "${NCURSES_URL}" "${NCURSES_SHA}"
+build_autoconf "ncurses" \
+  --without-shared \
+  --enable-static \
+  --without-debug \
+  --without-ada \
+  --enable-widec \
+  --with-default-terminfo-dir=/usr/share/terminfo \
+  --with-terminfo-dirs="/usr/share/terminfo:/usr/share/lib/terminfo:/usr/lib/terminfo:/usr/local/share/terminfo:/etc/terminfo"
+
+# ncurses widec ABI は libncursesw.a / libtinfow.a を出力するが、tmux の configure は
+# libncurses / libtinfo を探す。後者を前者へ symlink して configure を通す。
+# (configure 引数で --with-ncurses-includes を渡しても解決できるが、
+#  link 時の -lncurses 解決まで含めるならファイルレベルの alias の方が頑健。)
+for libname in ncurses tinfo form menu panel; do
+  if [[ -f "${PREFIX}/lib/lib${libname}w.a" && ! -f "${PREFIX}/lib/lib${libname}.a" ]]; then
+    ln -sf "lib${libname}w.a" "${PREFIX}/lib/lib${libname}.a"
+  fi
+done
+# include alias: ncursesw/curses.h → ncurses/curses.h を兼ねる
+if [[ -d "${PREFIX}/include/ncursesw" && ! -d "${PREFIX}/include/ncurses" ]]; then
+  ln -sf "ncursesw" "${PREFIX}/include/ncurses"
+fi
 
 # 2. libevent
+#    --disable-shared でstatic only。
+#    --disable-openssl: tmux 経路では SSL 不要なので絞り込み。
+#    --disable-debug-mode はパフォーマンス重視。
 LIBEVENT_URL=$(manifest_get '.dependencies.libevent.url')
 LIBEVENT_SHA=$(manifest_get '.dependencies.libevent.sha256')
 fetch_and_extract "libevent" "${LIBEVENT_URL}" "${LIBEVENT_SHA}"
-
-# TODO (CI): 各 lib の configure --prefix=${PREFIX} --disable-shared --enable-static && make && make install
+build_autoconf "libevent" \
+  --disable-shared \
+  --enable-static \
+  --disable-openssl \
+  --disable-debug-mode \
+  --disable-samples
 
 # 3. tmux 本体
+#    CPPFLAGS / LDFLAGS 経由で ${PREFIX}/include と ${PREFIX}/lib を優先解決させる。
+#    LIBEVENT_CFLAGS / LIBEVENT_LIBS を明示して pkg-config 不在時も link を成立させる。
+#    --enable-static は tmux 1.8 以降の慣例的フラグ (libevent / ncurses を埋め込む)。
 TMUX_URL=$(manifest_get '.tmux.url')
 TMUX_SHA=$(manifest_get '.tmux.sha256')
 fetch_and_extract "tmux" "${TMUX_URL}" "${TMUX_SHA}"
 
-# TODO (CI):
-#   pushd ${SRC_DIR}/tmux/tmux-*/
-#   ./configure --prefix=${PREFIX} --enable-static \
-#     CPPFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncurses" \
-#     LDFLAGS="${LDFLAGS}"
-#   make -j$(sysctl -n hw.ncpu)
-#   make install
-#   popd
+# tmux の configure に渡す追加フラグを export 経由で組み立てる。
+# CFLAGS は common.sh で既に -arch / -I${PREFIX}/include を持つ。
+# tmux configure は `libevent` を pkg-config or 環境変数で見つける必要あり。
+TMUX_CONFIG_FLAGS=(
+  --enable-static
+  LIBEVENT_CFLAGS="-I${PREFIX}/include"
+  LIBEVENT_LIBS="-L${PREFIX}/lib -levent"
+  LIBNCURSES_CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncurses"
+  LIBNCURSES_LIBS="-L${PREFIX}/lib -lncurses"
+  LIBTINFO_CFLAGS="-I${PREFIX}/include"
+  LIBTINFO_LIBS="-L${PREFIX}/lib -ltinfo"
+)
+build_autoconf "tmux" "${TMUX_CONFIG_FLAGS[@]}"
 
 # ----- 出力検証 -----
-if [[ -x "${PREFIX}/bin/tmux" ]]; then
-  echo "===== build-tmux.sh: success ====="
-  "${PREFIX}/bin/tmux" -V
-  inspect_deps "${PREFIX}/bin/tmux"
-else
-  echo "[skeleton] tmux binary not built (configure/make steps are TODO)"
-  exit 0
+TMUX_BIN="${PREFIX}/bin/tmux"
+if [[ ! -x "${TMUX_BIN}" ]]; then
+  echo "[error] tmux binary not built at ${TMUX_BIN}"
+  exit 1
 fi
+
+echo "===== build-tmux.sh: success ====="
+"${TMUX_BIN}" -V
+inspect_deps "${TMUX_BIN}"
+assert_self_contained "${TMUX_BIN}"

--- a/packages/desktop/scripts/build-bin/build-tmux.sh
+++ b/packages/desktop/scripts/build-bin/build-tmux.sh
@@ -117,6 +117,12 @@ fetch_and_extract "tmux" "${TMUX_URL}" "${TMUX_SHA}"
 # LIBTINFO_LIBS は libtinfo.a が ncurses build で生成された場合のみ渡す
 # (生成されない構成では `-ltinfo` 解決がホスト側に流れる事故を避けるため空のまま)。
 TMUX_CONFIG_FLAGS=(
+  # tmux 3.5a は utf8proc 連携の有無を configure 時に明示要求する
+  # (default が無いと configure が fail する)。
+  # --disable-utf8proc で内蔵 UTF-8 解析にフォールバック (一部絵文字の幅判定が
+  # ライブラリ版より粗い程度で、ターミナル運用には実害なし)。utf8proc を同梱
+  # する場合は manifest に追加して --enable-utf8proc に差し替える。
+  --disable-utf8proc
   LIBEVENT_CFLAGS="-I${PREFIX}/include"
   LIBEVENT_LIBS="-L${PREFIX}/lib -levent"
   LIBNCURSES_CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncurses"

--- a/packages/desktop/scripts/build-bin/build-tmux.sh
+++ b/packages/desktop/scripts/build-bin/build-tmux.sh
@@ -55,6 +55,21 @@ if [[ -d "${PREFIX}/include/ncursesw" && ! -d "${PREFIX}/include/ncurses" ]]; th
   ln -sf "ncursesw" "${PREFIX}/include/ncurses"
 fi
 
+# ncurses build の出力を assertive に確認: tmux 側で -lncurses を解決するために
+# libncurses.a (上の symlink 後の名前) が ${PREFIX}/lib に存在する必要がある。
+# libtinfo は ncurses build の構成によっては libncurses.a に内蔵される場合があるため、
+# 存在しない場合は LIBTINFO_LIBS を空に倒して `-ltinfo` 解決のためにホスト側を
+# 探索する経路を完全に塞ぐ (assert_self_contained の検証で漏れも検知される)。
+if [[ ! -f "${PREFIX}/lib/libncurses.a" ]]; then
+  echo "[error] libncurses.a not found after ncurses build" >&2
+  ls -la "${PREFIX}/lib/" >&2
+  exit 1
+fi
+HAS_TINFO=0
+if [[ -f "${PREFIX}/lib/libtinfo.a" ]]; then
+  HAS_TINFO=1
+fi
+
 # 2. libevent
 #    --disable-shared でstatic only。
 #    --disable-openssl: tmux 経路では SSL 不要なので絞り込み。
@@ -80,15 +95,21 @@ fetch_and_extract "tmux" "${TMUX_URL}" "${TMUX_SHA}"
 # tmux の configure に渡す追加フラグを export 経由で組み立てる。
 # CFLAGS は common.sh で既に -arch / -I${PREFIX}/include を持つ。
 # tmux configure は `libevent` を pkg-config or 環境変数で見つける必要あり。
+# LIBTINFO_LIBS は libtinfo.a が ncurses build で生成された場合のみ渡す
+# (生成されない構成では `-ltinfo` 解決がホスト側に流れる事故を避けるため空のまま)。
 TMUX_CONFIG_FLAGS=(
   --enable-static
   LIBEVENT_CFLAGS="-I${PREFIX}/include"
   LIBEVENT_LIBS="-L${PREFIX}/lib -levent"
   LIBNCURSES_CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncurses"
   LIBNCURSES_LIBS="-L${PREFIX}/lib -lncurses"
-  LIBTINFO_CFLAGS="-I${PREFIX}/include"
-  LIBTINFO_LIBS="-L${PREFIX}/lib -ltinfo"
 )
+if [[ "${HAS_TINFO}" = "1" ]]; then
+  TMUX_CONFIG_FLAGS+=(
+    LIBTINFO_CFLAGS="-I${PREFIX}/include"
+    LIBTINFO_LIBS="-L${PREFIX}/lib -ltinfo"
+  )
+fi
 build_autoconf "tmux" "${TMUX_CONFIG_FLAGS[@]}"
 
 # ----- 出力検証 -----

--- a/packages/desktop/scripts/build-bin/build-tmux.sh
+++ b/packages/desktop/scripts/build-bin/build-tmux.sh
@@ -106,13 +106,17 @@ TMUX_URL=$(manifest_get '.tmux.url')
 TMUX_SHA=$(manifest_get '.tmux.sha256')
 fetch_and_extract "tmux" "${TMUX_URL}" "${TMUX_SHA}"
 
-# tmux の configure に渡す追加フラグを export 経由で組み立てる。
-# CFLAGS は common.sh で既に -arch / -I${PREFIX}/include を持つ。
-# tmux configure は `libevent` を pkg-config or 環境変数で見つける必要あり。
+# tmux の configure に渡す追加フラグ。
+# `--enable-static` は **明示的に外す**: tmux の configure は macOS で
+# このオプションを「全 syslib も含めて static link せよ」と解釈し
+# `static linking is not supported on macOS` で fail する (macOS は libSystem の
+# dynamic link が必須なため、本来的に fully-static binary は作れない)。
+# LIBEVENT_LIBS / LIBNCURSES_LIBS が .a への絶対パス相当を指しているので、
+# tmux の link 時にこれらの static archive が選択され、bundled deps は自動的に
+# 静的リンクされる構成になる (system libSystem 等のみ dynamic、これは設計通り)。
 # LIBTINFO_LIBS は libtinfo.a が ncurses build で生成された場合のみ渡す
 # (生成されない構成では `-ltinfo` 解決がホスト側に流れる事故を避けるため空のまま)。
 TMUX_CONFIG_FLAGS=(
-  --enable-static
   LIBEVENT_CFLAGS="-I${PREFIX}/include"
   LIBEVENT_LIBS="-L${PREFIX}/lib -levent"
   LIBNCURSES_CFLAGS="-I${PREFIX}/include -I${PREFIX}/include/ncurses"

--- a/packages/desktop/scripts/build-bin/build-ttyd.sh
+++ b/packages/desktop/scripts/build-bin/build-ttyd.sh
@@ -85,7 +85,8 @@ build_cmake "json-c" \
   -DBUILD_SHARED_LIBS=OFF \
   -DBUILD_STATIC_LIBS=ON \
   -DDISABLE_WERROR=ON \
-  -DBUILD_TESTING=OFF
+  -DBUILD_TESTING=OFF \
+  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
 
 # 5. libwebsockets (4.3 系)
 #    cmake + OpenSSL/zlib/libuv 指定 + STATIC のみ。

--- a/packages/desktop/scripts/build-bin/build-ttyd.sh
+++ b/packages/desktop/scripts/build-bin/build-ttyd.sh
@@ -78,8 +78,8 @@ build_autoconf "libuv" \
 # 4. json-c (ttyd 1.7.x の必須依存)
 #    cmake、static lib のみ。BUILD_SHARED_LIBS=OFF + DISABLE_WERROR=ON で
 #    macos の -Werror=deprecated を回避。
-JSONC_URL=$(manifest_get '."json-c".url')
-JSONC_SHA=$(manifest_get '."json-c".sha256')
+JSONC_URL=$(manifest_get '.dependencies."json-c".url')
+JSONC_SHA=$(manifest_get '.dependencies."json-c".sha256')
 fetch_and_extract "json-c" "${JSONC_URL}" "${JSONC_SHA}"
 build_cmake "json-c" \
   -DBUILD_SHARED_LIBS=OFF \

--- a/packages/desktop/scripts/build-bin/build-ttyd.sh
+++ b/packages/desktop/scripts/build-bin/build-ttyd.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
-# F4: macOS arm64 向け ttyd クロスビルドスクリプト (skeleton)
+# F4: macOS arm64 向け ttyd クロスビルドスクリプト
 #
-# 依存: libwebsockets (4.3+, OpenSSL 3.x), libuv, OpenSSL, zlib (manifest.json 参照)。
-# 出力: ${PREFIX}/bin/ttyd と動的依存 dylib (Frameworks/ 候補)。
+# 依存: zlib, OpenSSL 3.x, libuv, libwebsockets 4.3 系 (manifest.json 参照)。
+# 出力: ${PREFIX}/bin/ttyd (全 deps を static link した self-contained binary)。
 #
 # 落とし穴:
-#   - libwebsockets 4.3 系を pin (4.4 以降は ttyd 1.7.x との API 差異あり)
-#   - OpenSSL は --no-shared で組まないと libwebsockets が静的リンクできない
+#   - libwebsockets 4.3 系を pin (4.4+ は ttyd 1.7.x との API 差異あり)
+#   - OpenSSL 3.x は `no-shared` で組まないと libwebsockets が static link できない
+#   - zlib は Makefile を生成する `configure` が独自方言、--static フラグだけ通る
 #
 # 参考: https://github.com/tsl0922/ttyd#build-from-source
 
@@ -18,66 +19,117 @@ source "${SCRIPT_DIR}/common.sh"
 
 echo "===== build-ttyd.sh: macOS ${ARCH} =====" >&2
 
-# ----- 依存ライブラリの取得とビルド -----
-# 順序: zlib → OpenSSL → libuv → libwebsockets → ttyd
+# ----- 依存ライブラリの取得 + ビルド (静的) -----
 
 # 1. zlib
+#    `./configure --static --prefix=...` で .a のみ生成。
+#    autoconf 系の標準フローでは無いので build_autoconf は使えず手動 build。
 ZLIB_URL=$(manifest_get '.dependencies.zlib.url')
 ZLIB_SHA=$(manifest_get '.dependencies.zlib.sha256')
 fetch_and_extract "zlib" "${ZLIB_URL}" "${ZLIB_SHA}"
+if [[ ! -f "${PREFIX}/.built.zlib" ]]; then
+  ZLIB_SRC=$(source_dir "zlib")
+  pushd "${ZLIB_SRC}" >/dev/null
+  ./configure --prefix="${PREFIX}" --static
+  make -j"$(build_jobs)"
+  make install
+  popd >/dev/null
+  : > "${PREFIX}/.built.zlib"
+fi
 
 # 2. OpenSSL 3.x
+#    `./Configure darwin64-arm64-cc no-shared` で .a のみ。
+#    `make install_sw` で manpage 等を含めない (build 時間短縮)。
 OPENSSL_URL=$(manifest_get '.dependencies.openssl.url')
 OPENSSL_SHA=$(manifest_get '.dependencies.openssl.sha256')
 fetch_and_extract "openssl" "${OPENSSL_URL}" "${OPENSSL_SHA}"
-# TODO (CI):
-#   pushd ${SRC_DIR}/openssl/openssl-*/
-#   ./Configure darwin64-arm64-cc no-shared --prefix=${PREFIX} \
-#     -mmacosx-version-min=${DEPLOYMENT_TARGET}
-#   make -j$(sysctl -n hw.ncpu)
-#   make install_sw
-#   popd
+if [[ ! -f "${PREFIX}/.built.openssl" ]]; then
+  OPENSSL_SRC=$(source_dir "openssl")
+  pushd "${OPENSSL_SRC}" >/dev/null
+  ./Configure darwin64-arm64-cc \
+    no-shared \
+    --prefix="${PREFIX}" \
+    --openssldir="${PREFIX}/etc/openssl" \
+    -mmacosx-version-min="${DEPLOYMENT_TARGET}"
+  make -j"$(build_jobs)"
+  make install_sw
+  popd >/dev/null
+  : > "${PREFIX}/.built.openssl"
+fi
 
 # 3. libuv
+#    autoconf + libtool。--disable-shared で .a のみ。
 LIBUV_URL=$(manifest_get '.dependencies.libuv.url')
 LIBUV_SHA=$(manifest_get '.dependencies.libuv.sha256')
 fetch_and_extract "libuv" "${LIBUV_URL}" "${LIBUV_SHA}"
+# libuv の tarball は autogen.sh で configure を生成する必要あり
+if [[ ! -f "${PREFIX}/.built.libuv" ]]; then
+  LIBUV_SRC=$(source_dir "libuv")
+  if [[ ! -f "${LIBUV_SRC}/configure" ]]; then
+    pushd "${LIBUV_SRC}" >/dev/null
+    sh autogen.sh
+    popd >/dev/null
+  fi
+fi
+build_autoconf "libuv" \
+  --disable-shared \
+  --enable-static
 
 # 4. libwebsockets (4.3 系)
+#    cmake + OpenSSL/zlib/libuv 指定 + STATIC のみ。
+#    LWS_WITH_SHARED=OFF: .dylib を出力しない。
+#    LWS_WITH_STATIC=ON: .a を出力。
+#    LWS_WITH_LIBUV=ON: ttyd は libwebsockets 経由で libuv を使う。
+#    LWS_OPENSSL_SUPPORT=ON で OpenSSL 必須。
 LWS_URL=$(manifest_get '.dependencies.libwebsockets.url')
 LWS_SHA=$(manifest_get '.dependencies.libwebsockets.sha256')
 fetch_and_extract "libwebsockets" "${LWS_URL}" "${LWS_SHA}"
-# TODO (CI): cmake で OpenSSL/zlib 指定し --static link
+build_cmake "libwebsockets" \
+  -DLWS_WITH_SHARED=OFF \
+  -DLWS_WITH_STATIC=ON \
+  -DLWS_WITHOUT_TESTAPPS=ON \
+  -DLWS_WITHOUT_TEST_SERVER=ON \
+  -DLWS_WITHOUT_TEST_SERVER_EXTPOLL=ON \
+  -DLWS_WITHOUT_TEST_PING=ON \
+  -DLWS_WITHOUT_TEST_CLIENT=ON \
+  -DLWS_WITH_LIBUV=ON \
+  -DLWS_LIBUV_LIBRARIES="${PREFIX}/lib/libuv.a" \
+  -DLWS_LIBUV_INCLUDE_DIRS="${PREFIX}/include" \
+  -DLWS_OPENSSL_SUPPORT=ON \
+  -DOPENSSL_ROOT_DIR="${PREFIX}" \
+  -DOPENSSL_INCLUDE_DIR="${PREFIX}/include" \
+  -DOPENSSL_SSL_LIBRARY="${PREFIX}/lib/libssl.a" \
+  -DOPENSSL_CRYPTO_LIBRARY="${PREFIX}/lib/libcrypto.a" \
+  -DZLIB_ROOT="${PREFIX}" \
+  -DZLIB_LIBRARY="${PREFIX}/lib/libz.a" \
+  -DZLIB_INCLUDE_DIR="${PREFIX}/include" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}"
 
 # 5. ttyd 本体
+#    cmake で libwebsockets/json-c/zlib を ${PREFIX} から拾わせる。
+#    static link を強制するため CMAKE_FIND_LIBRARY_SUFFIXES を .a 限定にする。
 TTYD_URL=$(manifest_get '.ttyd.url')
 TTYD_SHA=$(manifest_get '.ttyd.sha256')
 fetch_and_extract "ttyd" "${TTYD_URL}" "${TTYD_SHA}"
-# TODO (CI):
-#   pushd ${SRC_DIR}/ttyd/ttyd-*/
-#   mkdir build && cd build
-#   cmake -DCMAKE_BUILD_TYPE=Release \
-#     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
-#     -DCMAKE_OSX_DEPLOYMENT_TARGET=${DEPLOYMENT_TARGET} \
-#     -DCMAKE_OSX_ARCHITECTURES=${ARCH} \
-#     -DOPENSSL_ROOT_DIR=${PREFIX} \
-#     -DZLIB_ROOT=${PREFIX} \
-#     -DLIBWEBSOCKETS_INCLUDE_DIRS=${PREFIX}/include \
-#     -DLIBWEBSOCKETS_LIBRARIES=${PREFIX}/lib/libwebsockets.a \
-#     ..
-#   make -j$(sysctl -n hw.ncpu)
-#   make install
-#   popd
+build_cmake "ttyd" \
+  -DCMAKE_PREFIX_PATH="${PREFIX}" \
+  -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \
+  -DLIBWEBSOCKETS_INCLUDE_DIRS="${PREFIX}/include" \
+  -DLIBWEBSOCKETS_LIBRARIES="${PREFIX}/lib/libwebsockets.a" \
+  -DOPENSSL_ROOT_DIR="${PREFIX}" \
+  -DOPENSSL_SSL_LIBRARY="${PREFIX}/lib/libssl.a" \
+  -DOPENSSL_CRYPTO_LIBRARY="${PREFIX}/lib/libcrypto.a" \
+  -DZLIB_ROOT="${PREFIX}" \
+  -DZLIB_LIBRARY="${PREFIX}/lib/libz.a"
 
 # ----- 出力検証 -----
-if [[ -x "${PREFIX}/bin/ttyd" ]]; then
-  echo "===== build-ttyd.sh: success ====="
-  "${PREFIX}/bin/ttyd" --version
-  inspect_deps "${PREFIX}/bin/ttyd"
-  # TODO (CI): otool -L で /usr/lib/.. 以外の dylib があれば
-  # install_name_tool -change で @executable_path/../Frameworks/<name> に書き換え、
-  # 該当 dylib を ${PREFIX}/Frameworks/ にコピー。
-else
-  echo "[skeleton] ttyd binary not built (configure/make steps are TODO)"
-  exit 0
+TTYD_BIN="${PREFIX}/bin/ttyd"
+if [[ ! -x "${TTYD_BIN}" ]]; then
+  echo "[error] ttyd binary not built at ${TTYD_BIN}"
+  exit 1
 fi
+
+echo "===== build-ttyd.sh: success ====="
+"${TTYD_BIN}" --version
+inspect_deps "${TTYD_BIN}"
+assert_self_contained "${TTYD_BIN}"

--- a/packages/desktop/scripts/build-bin/build-ttyd.sh
+++ b/packages/desktop/scripts/build-bin/build-ttyd.sh
@@ -85,8 +85,7 @@ build_cmake "json-c" \
   -DBUILD_SHARED_LIBS=OFF \
   -DBUILD_STATIC_LIBS=ON \
   -DDISABLE_WERROR=ON \
-  -DBUILD_TESTING=OFF \
-  -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+  -DBUILD_TESTING=OFF
 
 # 5. libwebsockets (4.3 系)
 #    cmake + OpenSSL/zlib/libuv 指定 + STATIC のみ。

--- a/packages/desktop/scripts/build-bin/build-ttyd.sh
+++ b/packages/desktop/scripts/build-bin/build-ttyd.sh
@@ -123,6 +123,22 @@ build_cmake "libwebsockets" \
 TTYD_URL=$(manifest_get '.ttyd.url')
 TTYD_SHA=$(manifest_get '.ttyd.sha256')
 fetch_and_extract "ttyd" "${TTYD_URL}" "${TTYD_SHA}"
+
+# ttyd 1.7.7 の CMakeLists.txt は `target_link_libraries(ttyd PRIVATE websockets_shared)`
+# と書かれているが、`LWS_WITH_SHARED=OFF` で組んだ libwebsockets には
+# `websockets_shared` ターゲットが存在せず ld でリンク失敗する (静的版の
+# ターゲット名は `websockets`)。ttyd の静的ビルドで一般的な workaround として
+# CMakeLists.txt の `websockets_shared` → `websockets` を sed 書換する。
+# (idempotent: build_cmake stamp で 2 回目以降は skip されるが、明示的に check)
+if [[ ! -f "${PREFIX}/.built.ttyd" ]]; then
+  TTYD_SRC=$(source_dir "ttyd")
+  TTYD_CMAKELIST="${TTYD_SRC}/CMakeLists.txt"
+  if grep -qF 'websockets_shared' "${TTYD_CMAKELIST}"; then
+    # macOS BSD sed は `-i` の引数に空文字を要求する (`sed -i '' ...`)
+    sed -i '' 's/websockets_shared/websockets/g' "${TTYD_CMAKELIST}"
+    echo "[patch] ttyd CMakeLists.txt: websockets_shared -> websockets (static link)"
+  fi
+fi
 build_cmake "ttyd" \
   -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \

--- a/packages/desktop/scripts/build-bin/build-ttyd.sh
+++ b/packages/desktop/scripts/build-bin/build-ttyd.sh
@@ -117,6 +117,26 @@ build_cmake "libwebsockets" \
   -DZLIB_INCLUDE_DIR="${PREFIX}/include" \
   -DCMAKE_PREFIX_PATH="${PREFIX}"
 
+# libwebsockets が install する exported cmake config (libwebsockets-config.cmake) は
+# `set(LIBWEBSOCKETS_LIBRARIES websockets websockets_shared)` と shared/static 両方を
+# 列挙する。`LWS_WITH_SHARED=OFF` でビルドした静的版には `websockets_shared` ターゲットが
+# 存在せず、ttyd の find_package(Libwebsockets) が解決した結果として
+# `-lwebsockets_shared` が linker に渡って `library not found` で失敗する。
+# 静的ビルドのみが必要なため、install 済みの config から `websockets_shared` を除去する。
+# 配置場所は libwebsockets バージョンによって異なる (lib/cmake/, share/cmake/, lib/cmake/libwebsockets/ 等)
+# ため find ベースで対象ファイルを列挙する。
+LWS_CONFIG_FILES=$(find "${PREFIX}" -name 'libwebsockets-config.cmake' 2>/dev/null || true)
+if [[ -n "${LWS_CONFIG_FILES}" ]]; then
+  echo "${LWS_CONFIG_FILES}" | while read -r cfg; do
+    if grep -qF 'websockets_shared' "${cfg}"; then
+      # macOS BSD sed: in-place 編集は `-i ''` が必須。
+      # `websockets websockets_shared` または `websockets_shared` 単独どちらも `websockets` に正規化。
+      sed -i '' -E 's/websockets[[:space:]]+websockets_shared/websockets/g; s/websockets_shared/websockets/g' "${cfg}"
+      echo "[patch] ${cfg}: removed websockets_shared (static-only build)"
+    fi
+  done
+fi
+
 # 6. ttyd 本体
 #    cmake で libwebsockets/json-c/zlib を ${PREFIX} から拾わせる。
 #    static link を強制するため CMAKE_FIND_LIBRARY_SUFFIXES を .a 限定にする。
@@ -124,21 +144,6 @@ TTYD_URL=$(manifest_get '.ttyd.url')
 TTYD_SHA=$(manifest_get '.ttyd.sha256')
 fetch_and_extract "ttyd" "${TTYD_URL}" "${TTYD_SHA}"
 
-# ttyd 1.7.7 の CMakeLists.txt は `target_link_libraries(ttyd PRIVATE websockets_shared)`
-# と書かれているが、`LWS_WITH_SHARED=OFF` で組んだ libwebsockets には
-# `websockets_shared` ターゲットが存在せず ld でリンク失敗する (静的版の
-# ターゲット名は `websockets`)。ttyd の静的ビルドで一般的な workaround として
-# CMakeLists.txt の `websockets_shared` → `websockets` を sed 書換する。
-# (idempotent: build_cmake stamp で 2 回目以降は skip されるが、明示的に check)
-if [[ ! -f "${PREFIX}/.built.ttyd" ]]; then
-  TTYD_SRC=$(source_dir "ttyd")
-  TTYD_CMAKELIST="${TTYD_SRC}/CMakeLists.txt"
-  if grep -qF 'websockets_shared' "${TTYD_CMAKELIST}"; then
-    # macOS BSD sed は `-i` の引数に空文字を要求する (`sed -i '' ...`)
-    sed -i '' 's/websockets_shared/websockets/g' "${TTYD_CMAKELIST}"
-    echo "[patch] ttyd CMakeLists.txt: websockets_shared -> websockets (static link)"
-  fi
-fi
 build_cmake "ttyd" \
   -DCMAKE_PREFIX_PATH="${PREFIX}" \
   -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \

--- a/packages/desktop/scripts/build-bin/build-ttyd.sh
+++ b/packages/desktop/scripts/build-bin/build-ttyd.sh
@@ -75,7 +75,19 @@ build_autoconf "libuv" \
   --disable-shared \
   --enable-static
 
-# 4. libwebsockets (4.3 系)
+# 4. json-c (ttyd 1.7.x の必須依存)
+#    cmake、static lib のみ。BUILD_SHARED_LIBS=OFF + DISABLE_WERROR=ON で
+#    macos の -Werror=deprecated を回避。
+JSONC_URL=$(manifest_get '."json-c".url')
+JSONC_SHA=$(manifest_get '."json-c".sha256')
+fetch_and_extract "json-c" "${JSONC_URL}" "${JSONC_SHA}"
+build_cmake "json-c" \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DBUILD_STATIC_LIBS=ON \
+  -DDISABLE_WERROR=ON \
+  -DBUILD_TESTING=OFF
+
+# 5. libwebsockets (4.3 系)
 #    cmake + OpenSSL/zlib/libuv 指定 + STATIC のみ。
 #    LWS_WITH_SHARED=OFF: .dylib を出力しない。
 #    LWS_WITH_STATIC=ON: .a を出力。
@@ -105,7 +117,7 @@ build_cmake "libwebsockets" \
   -DZLIB_INCLUDE_DIR="${PREFIX}/include" \
   -DCMAKE_PREFIX_PATH="${PREFIX}"
 
-# 5. ttyd 本体
+# 6. ttyd 本体
 #    cmake で libwebsockets/json-c/zlib を ${PREFIX} から拾わせる。
 #    static link を強制するため CMAKE_FIND_LIBRARY_SUFFIXES を .a 限定にする。
 TTYD_URL=$(manifest_get '.ttyd.url')
@@ -116,6 +128,8 @@ build_cmake "ttyd" \
   -DCMAKE_FIND_LIBRARY_SUFFIXES=".a" \
   -DLIBWEBSOCKETS_INCLUDE_DIRS="${PREFIX}/include" \
   -DLIBWEBSOCKETS_LIBRARIES="${PREFIX}/lib/libwebsockets.a" \
+  -DJSON-C_INCLUDE_DIRS="${PREFIX}/include/json-c" \
+  -DJSON-C_LIBRARIES="${PREFIX}/lib/libjson-c.a" \
   -DOPENSSL_ROOT_DIR="${PREFIX}" \
   -DOPENSSL_SSL_LIBRARY="${PREFIX}/lib/libssl.a" \
   -DOPENSSL_CRYPTO_LIBRARY="${PREFIX}/lib/libcrypto.a" \

--- a/packages/desktop/scripts/build-bin/collect-licenses.sh
+++ b/packages/desktop/scripts/build-bin/collect-licenses.sh
@@ -25,13 +25,27 @@ LICENSES_DIR="${BUILD_DIR}/licenses"
 mkdir -p "${LICENSES_DIR}"
 
 # fetch_license <name> <url>
+# LICENSE を取得できなかった場合は **必ず fail させる**。
+# 旧実装は `|| echo "[warn]"` で curl 失敗を黙って継続していたが、それでは
+# LICENSE 未収集のまま INDEX.json に package を列挙し、コンプライアンス上の
+# リスクが残る (CodeRabbit Major 指摘)。
+# URL の version / 日付サフィックスが間違っている / 上流リポジトリ構造が変わった
+# 等の検知漏れも防ぐ。
 fetch_license() {
   local name="$1"
   local url="$2"
+  local out="${LICENSES_DIR}/${name}/LICENSE"
   mkdir -p "${LICENSES_DIR}/${name}"
   echo "[license] ${name}: ${url}"
-  curl -fsSL --retry 3 -o "${LICENSES_DIR}/${name}/LICENSE" "${url}" || \
-    echo "[warn] ${name}: failed to fetch LICENSE (network?)"
+  if ! curl -fsSL --retry 3 -o "${out}" "${url}"; then
+    echo "[error] ${name}: LICENSE 取得失敗 (url=${url})" >&2
+    exit 1
+  fi
+  # `curl -f` は HTTP エラーで非 0 終了するが、念のため空ファイルを assert。
+  if [[ ! -s "${out}" ]]; then
+    echo "[error] ${name}: LICENSE ファイルが空 (url=${url})" >&2
+    exit 1
+  fi
 }
 
 # 各 license は GitHub tag URL から raw 取得する (manifest.json のバージョンと整合)。

--- a/packages/desktop/scripts/build-bin/collect-licenses.sh
+++ b/packages/desktop/scripts/build-bin/collect-licenses.sh
@@ -79,9 +79,10 @@ fetch_license "json-c" \
 fetch_license "zlib" \
   "https://raw.githubusercontent.com/madler/zlib/v1.3.1/LICENSE"
 
-# ncurses (invisible-mirror が一次配布元; GitHub mirror から取得)
+# ncurses (Thomas Dickey が upstream maintainer; GitHub mirror に v6.5 tag が無く 404 になるため
+# Thomas の snapshots リポジトリ master の COPYING を取得。license は MIT-like で長期安定。)
 fetch_license "ncurses" \
-  "https://raw.githubusercontent.com/mirror/ncurses/v6.5/COPYING"
+  "https://raw.githubusercontent.com/ThomasDickey/ncurses-snapshots/master/COPYING"
 
 # 各 package の SUMMARY.json を生成 (UI 側 AboutDialog 用)
 cat > "${LICENSES_DIR}/INDEX.json" <<EOF

--- a/packages/desktop/scripts/build-bin/collect-licenses.sh
+++ b/packages/desktop/scripts/build-bin/collect-licenses.sh
@@ -57,7 +57,7 @@ fetch_license "libevent" \
 fetch_license "openssl" \
   "https://raw.githubusercontent.com/openssl/openssl/openssl-3.3.2/LICENSE.txt"
 
-JSONC_VERSION=$(manifest_get '."json-c".version')
+JSONC_VERSION=$(manifest_get '.dependencies."json-c".version')
 fetch_license "json-c" \
   "https://raw.githubusercontent.com/json-c/json-c/json-c-${JSONC_VERSION}-20240915/COPYING"
 

--- a/packages/desktop/scripts/build-bin/collect-licenses.sh
+++ b/packages/desktop/scripts/build-bin/collect-licenses.sh
@@ -57,6 +57,10 @@ fetch_license "libevent" \
 fetch_license "openssl" \
   "https://raw.githubusercontent.com/openssl/openssl/openssl-3.3.2/LICENSE.txt"
 
+JSONC_VERSION=$(manifest_get '."json-c".version')
+fetch_license "json-c" \
+  "https://raw.githubusercontent.com/json-c/json-c/json-c-${JSONC_VERSION}-20240915/COPYING"
+
 # zlib (本家 README に license 全文がある)
 fetch_license "zlib" \
   "https://raw.githubusercontent.com/madler/zlib/v1.3.1/LICENSE"
@@ -74,6 +78,7 @@ cat > "${LICENSES_DIR}/INDEX.json" <<EOF
     { "name": "ttyd", "version": "${TTYD_VERSION}", "license": "MIT" },
     { "name": "libwebsockets", "version": "${LWS_VERSION}", "license": "MIT" },
     { "name": "libuv", "version": "${LIBUV_VERSION}", "license": "MIT" },
+    { "name": "json-c", "version": "${JSONC_VERSION}", "license": "MIT" },
     { "name": "libevent", "version": "${LIBEVENT_VERSION}", "license": "3-clause BSD" },
     { "name": "openssl", "version": "$(manifest_get '.dependencies.openssl.version')", "license": "Apache-2.0" },
     { "name": "ncurses", "version": "$(manifest_get '.dependencies.ncurses.version')", "license": "MIT-like" },

--- a/packages/desktop/scripts/build-bin/common.sh
+++ b/packages/desktop/scripts/build-bin/common.sh
@@ -84,3 +84,102 @@ inspect_deps() {
   echo "==> otool -L ${bin}"
   otool -L "${bin}" || true
 }
+
+# build スレッド数。GHA macos-14 runner では sysctl で取得した値を使う。
+build_jobs() {
+  sysctl -n hw.ncpu 2>/dev/null || echo "4"
+}
+
+# 展開済みディレクトリのパス。`fetch_and_extract` 直後のソース木 (configure / CMakeLists.txt
+# を持つ第 1 階層) を返す。tarball によって直下構成が異なる (e.g. libuv は
+# `libuv-v1.49.2/`、ttyd は `ttyd-1.7.7/`) ので一意に解決する。
+source_dir() {
+  local name="$1"
+  local src
+  src=$(find "${SRC_DIR}/${name}" -mindepth 1 -maxdepth 1 -type d | head -n1)
+  if [[ -z "${src}" ]]; then
+    echo "[error] source_dir(${name}): no extracted directory under ${SRC_DIR}/${name}" >&2
+    return 1
+  fi
+  printf '%s\n' "${src}"
+}
+
+# autoconf 系 (configure && make && make install) の標準ビルダ。
+# 引数: $1 name (manifest キーと一致), $2.. configure flags
+# 既に ${PREFIX}/.built.<name> が存在すれば skip (cache hit 時の重複 build 防止)。
+build_autoconf() {
+  local name="$1"
+  shift
+  local stamp="${PREFIX}/.built.${name}"
+  if [[ -f "${stamp}" ]]; then
+    echo "[skip] ${name}: already built (stamp=${stamp})"
+    return 0
+  fi
+  local src
+  src=$(source_dir "${name}") || return 1
+  echo "===== build_autoconf ${name} (src=${src}) ====="
+  pushd "${src}" >/dev/null
+  ./configure --prefix="${PREFIX}" "$@"
+  make -j"$(build_jobs)"
+  make install
+  popd >/dev/null
+  : > "${stamp}"
+}
+
+# cmake 系 (mkdir build && cmake && make && make install) の標準ビルダ。
+# 引数: $1 name, $2.. cmake -D flags
+# CMAKE_BUILD_TYPE / CMAKE_OSX_DEPLOYMENT_TARGET / CMAKE_OSX_ARCHITECTURES /
+# CMAKE_INSTALL_PREFIX は固定で付与。
+build_cmake() {
+  local name="$1"
+  shift
+  local stamp="${PREFIX}/.built.${name}"
+  if [[ -f "${stamp}" ]]; then
+    echo "[skip] ${name}: already built (stamp=${stamp})"
+    return 0
+  fi
+  local src
+  src=$(source_dir "${name}") || return 1
+  echo "===== build_cmake ${name} (src=${src}) ====="
+  local builddir="${src}/build"
+  mkdir -p "${builddir}"
+  pushd "${builddir}" >/dev/null
+  cmake \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
+    -DCMAKE_OSX_DEPLOYMENT_TARGET="${DEPLOYMENT_TARGET}" \
+    -DCMAKE_OSX_ARCHITECTURES="${ARCH}" \
+    "$@" \
+    ..
+  make -j"$(build_jobs)"
+  make install
+  popd >/dev/null
+  : > "${stamp}"
+}
+
+# 同梱バイナリの dyld 依存をチェック。
+# system path (`/usr/lib/*`, `/System/Library/*`) 以外の dylib が混入していたら
+# それは static link の漏れか rpath 解決失敗を意味するので fail させる。
+# self-contained な binary であることを assertive に保証する。
+assert_self_contained() {
+  local bin="$1"
+  echo "==> assert_self_contained ${bin}"
+  if [[ ! -x "${bin}" ]]; then
+    echo "[error] ${bin} not executable"
+    return 1
+  fi
+  local nonsystem
+  # otool -L は header 行を出すので tail で除去。インデント先頭がパス。
+  nonsystem=$(otool -L "${bin}" \
+    | tail -n +2 \
+    | awk '{print $1}' \
+    | grep -vE '^(/usr/lib/|/System/Library/|@rpath/|@loader_path/|@executable_path/)' \
+    || true)
+  if [[ -n "${nonsystem}" ]]; then
+    echo "[error] ${bin} has non-system dylib deps:"
+    printf '  %s\n' "${nonsystem}"
+    echo "static link が漏れているか rpath 未解決。build スクリプトを見直すこと。"
+    return 1
+  fi
+  echo "OK: ${bin} は self-contained (system dylib のみに依存)"
+}

--- a/packages/desktop/scripts/build-bin/common.sh
+++ b/packages/desktop/scripts/build-bin/common.sh
@@ -93,15 +93,24 @@ build_jobs() {
 # 展開済みディレクトリのパス。`fetch_and_extract` 直後のソース木 (configure / CMakeLists.txt
 # を持つ第 1 階層) を返す。tarball によって直下構成が異なる (e.g. libuv は
 # `libuv-v1.49.2/`、ttyd は `ttyd-1.7.7/`) ので一意に解決する。
+# 候補ディレクトリが 0 件 / 2 件以上はビルド状態の異常なので fail させる
+# (非決定性を回避し、cache 汚染や二重展開で誤ったソース木を選ぶリスクを排除)。
 source_dir() {
   local name="$1"
-  local src
-  src=$(find "${SRC_DIR}/${name}" -mindepth 1 -maxdepth 1 -type d | head -n1)
-  if [[ -z "${src}" ]]; then
+  local candidates
+  candidates=$(find "${SRC_DIR}/${name}" -mindepth 1 -maxdepth 1 -type d)
+  local count
+  count=$(printf '%s\n' "${candidates}" | grep -c . || true)
+  if [[ "${count}" -eq 0 ]]; then
     echo "[error] source_dir(${name}): no extracted directory under ${SRC_DIR}/${name}" >&2
     return 1
   fi
-  printf '%s\n' "${src}"
+  if [[ "${count}" -gt 1 ]]; then
+    echo "[error] source_dir(${name}): expected exactly 1 extracted dir, got ${count}:" >&2
+    printf '  %s\n' ${candidates} >&2
+    return 1
+  fi
+  printf '%s\n' "${candidates}"
 }
 
 # autoconf 系 (configure && make && make install) の標準ビルダ。
@@ -158,9 +167,12 @@ build_cmake() {
 }
 
 # 同梱バイナリの dyld 依存をチェック。
-# system path (`/usr/lib/*`, `/System/Library/*`) 以外の dylib が混入していたら
-# それは static link の漏れか rpath 解決失敗を意味するので fail させる。
-# self-contained な binary であることを assertive に保証する。
+# `/usr/lib/*` および `/System/Library/*` (= Apple 純正の system dylib) のみを
+# 許可し、他はすべて fail させる。`@rpath/`、`@loader_path/`、`@executable_path/`
+# も拒否する: これらは Frameworks/ 同梱が前提の解決経路で、本ビルドは「全 deps を
+# static link で纏める」設計なので絶対に出現してはならない (出ているなら
+# build スクリプトの static-only 設定が破れている)。
+# 自身の install_name (otool -L の 1 行目) は対象外として除外する。
 assert_self_contained() {
   local bin="$1"
   echo "==> assert_self_contained ${bin}"
@@ -168,18 +180,25 @@ assert_self_contained() {
     echo "[error] ${bin} not executable"
     return 1
   fi
+  # otool -L 出力は最初の行が header (path:)、2 行目が install_name (自身)、
+  # 3 行目以降が外部依存。実行可能バイナリは install_name を持たないことが多いが、
+  # 念のため abs path + バイナリ自身の basename と一致する行も除外する。
+  local self_basename
+  self_basename=$(basename "${bin}")
   local nonsystem
-  # otool -L は header 行を出すので tail で除去。インデント先頭がパス。
   nonsystem=$(otool -L "${bin}" \
     | tail -n +2 \
     | awk '{print $1}' \
-    | grep -vE '^(/usr/lib/|/System/Library/|@rpath/|@loader_path/|@executable_path/)' \
+    | grep -vE '^(/usr/lib/|/System/Library/)' \
+    | grep -v "/${self_basename}:?\$" \
     || true)
   if [[ -n "${nonsystem}" ]]; then
-    echo "[error] ${bin} has non-system dylib deps:"
+    echo "[error] ${bin} has non-system / non-static dylib deps:"
     printf '  %s\n' "${nonsystem}"
-    echo "static link が漏れているか rpath 未解決。build スクリプトを見直すこと。"
+    echo "本ビルドは全依存 static link を契約としているため、@rpath/@loader_path"
+    echo "経由の解決も含めて非 system 依存は全て拒否します。"
+    echo "static link が漏れているか build script の構成を見直してください。"
     return 1
   fi
-  echo "OK: ${bin} は self-contained (system dylib のみに依存)"
+  echo "OK: ${bin} は self-contained (Apple system dylib のみに依存)"
 }

--- a/packages/desktop/scripts/build-bin/common.sh
+++ b/packages/desktop/scripts/build-bin/common.sh
@@ -138,7 +138,12 @@ build_autoconf() {
 # cmake 系 (mkdir build && cmake && make && make install) の標準ビルダ。
 # 引数: $1 name, $2.. cmake -D flags
 # CMAKE_BUILD_TYPE / CMAKE_OSX_DEPLOYMENT_TARGET / CMAKE_OSX_ARCHITECTURES /
-# CMAKE_INSTALL_PREFIX は固定で付与。
+# CMAKE_INSTALL_PREFIX / CMAKE_POLICY_VERSION_MINIMUM は固定で付与。
+# CMAKE_POLICY_VERSION_MINIMUM=3.5: 現代の cmake (4.x) は < 3.5 互換を完全に削除し、
+# `cmake_minimum_required(VERSION 2.x)` を持つ古い CMakeLists.txt が
+# "Compatibility with CMake < 3.5 has been removed from CMake" で fail する。
+# json-c 0.18 の apps/ subdir、libwebsockets 4.3.3 等が該当。本 build は全 deps の
+# 互換 policy を 3.5 に持ち上げて configure を通す (実害なし、API 動作は同じ)。
 build_cmake() {
   local name="$1"
   shift
@@ -158,6 +163,7 @@ build_cmake() {
     -DCMAKE_INSTALL_PREFIX="${PREFIX}" \
     -DCMAKE_OSX_DEPLOYMENT_TARGET="${DEPLOYMENT_TARGET}" \
     -DCMAKE_OSX_ARCHITECTURES="${ARCH}" \
+    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     "$@" \
     ..
   make -j"$(build_jobs)"

--- a/packages/desktop/scripts/build-bin/manifest.json
+++ b/packages/desktop/scripts/build-bin/manifest.json
@@ -38,6 +38,12 @@
       "url": "https://dist.libuv.org/dist/v1.49.2/libuv-v1.49.2.tar.gz",
       "sha256": "8c10706bd2cf129045c42b94799a92df9aaa75d05f07e99cf083507239bae5a8"
     },
+    "json-c": {
+      "_note": "ttyd 1.7.x の必須依存。CMake で組み LWS が解決時に拾うパスへ install する。",
+      "version": "0.18",
+      "url": "https://s3.amazonaws.com/json-c_releases/releases/json-c-0.18.tar.gz",
+      "sha256": "876ab046479166b869afc6896d288183bbc0e5843f141200c677b3e8dfb11724"
+    },
     "libevent": {
       "version": "2.1.12-stable",
       "url": "https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz",

--- a/packages/desktop/scripts/build-bin/manifest.json
+++ b/packages/desktop/scripts/build-bin/manifest.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "F4: tmux / ttyd 同梱バイナリの依存ライブラリのバージョン pin。各 SHA256 は手動 curl で計算 (shasum -a 256 <tarball>)。Renovate では更新しない (CI 実行時の build cache が無効化される)。",
+  "_comment": "F4: tmux / ttyd 同梱バイナリの依存ライブラリのバージョン pin。各 SHA256 は `curl -fsSL <url> | shasum -a 256` で計算済み。Renovate では更新しない (CI 実行時の build cache が無効化される)。",
   "target": {
     "arch": "arm64",
     "platform": "darwin",
@@ -8,44 +8,45 @@
   "tmux": {
     "version": "3.5a",
     "url": "https://github.com/tmux/tmux/releases/download/3.5a/tmux-3.5a.tar.gz",
-    "sha256": "PLACEHOLDER_TMUX_SHA256"
+    "sha256": "16216bd0877170dfcc64157085ba9013610b12b082548c7c9542cc0103198951"
   },
   "ttyd": {
     "version": "1.7.7",
     "url": "https://github.com/tsl0922/ttyd/archive/refs/tags/1.7.7.tar.gz",
-    "sha256": "PLACEHOLDER_TTYD_SHA256"
+    "sha256": "039dd995229377caee919898b7bd54484accec3bba49c118e2d5cd6ec51e3650"
   },
   "dependencies": {
     "openssl": {
       "version": "3.3.2",
       "url": "https://www.openssl.org/source/openssl-3.3.2.tar.gz",
-      "sha256": "PLACEHOLDER_OPENSSL_SHA256"
+      "sha256": "2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
     },
     "zlib": {
+      "_note": "1.3.1 は zlib.net/fossils/ に retire 済み (最新は zlib.net 直下にミラー)。fossils URL を pin して将来の retire でも壊れないようにする。",
       "version": "1.3.1",
-      "url": "https://zlib.net/zlib-1.3.1.tar.gz",
-      "sha256": "PLACEHOLDER_ZLIB_SHA256"
+      "url": "https://zlib.net/fossils/zlib-1.3.1.tar.gz",
+      "sha256": "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
     },
     "libwebsockets": {
       "_note": "ttyd 1.7.x は libwebsockets 4.3 系を要求。OpenSSL 3.x と組む際は --no-shared 必須",
       "version": "4.3.3",
       "url": "https://github.com/warmcat/libwebsockets/archive/refs/tags/v4.3.3.tar.gz",
-      "sha256": "PLACEHOLDER_LWS_SHA256"
+      "sha256": "6fd33527b410a37ebc91bb64ca51bdabab12b076bc99d153d7c5dd405e4bdf90"
     },
     "libuv": {
       "version": "1.49.2",
       "url": "https://dist.libuv.org/dist/v1.49.2/libuv-v1.49.2.tar.gz",
-      "sha256": "PLACEHOLDER_LIBUV_SHA256"
+      "sha256": "8c10706bd2cf129045c42b94799a92df9aaa75d05f07e99cf083507239bae5a8"
     },
     "libevent": {
       "version": "2.1.12-stable",
       "url": "https://github.com/libevent/libevent/releases/download/release-2.1.12-stable/libevent-2.1.12-stable.tar.gz",
-      "sha256": "PLACEHOLDER_LIBEVENT_SHA256"
+      "sha256": "92e6de1be9ec176428fd2367677e61ceffc2ee1cb119035037a27d346b0403bb"
     },
     "ncurses": {
       "version": "6.5",
       "url": "https://invisible-mirror.net/archives/ncurses/ncurses-6.5.tar.gz",
-      "sha256": "PLACEHOLDER_NCURSES_SHA256"
+      "sha256": "136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6"
     }
   }
 }

--- a/packages/desktop/scripts/build-bin/manifest.json
+++ b/packages/desktop/scripts/build-bin/manifest.json
@@ -22,9 +22,9 @@
       "sha256": "2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281"
     },
     "zlib": {
-      "_note": "1.3.1 は zlib.net/fossils/ に retire 済み (最新は zlib.net 直下にミラー)。fossils URL を pin して将来の retire でも壊れないようにする。",
+      "_note": "GitHub release ミラー経由で取得 (zlib.net は GHA runner からの DNS 解決が時々失敗するため)。tarball の sha256 は zlib.net/fossils/ 配下と同一。",
       "version": "1.3.1",
-      "url": "https://zlib.net/fossils/zlib-1.3.1.tar.gz",
+      "url": "https://github.com/madler/zlib/releases/download/v1.3.1/zlib-1.3.1.tar.gz",
       "sha256": "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
     },
     "libwebsockets": {


### PR DESCRIPTION
## 概要

issue #185 対応。F4 で skeleton 状態だった tmux / ttyd の macOS arm64 native build を実装し、
.app に同梱する。これで非エンジニア向け配布の前提だった `brew install tmux ttyd` を不要にする。

## 変更

### manifest.json
- tmux 3.5a / ttyd 1.7.7 / 全依存 (ncurses, libevent, openssl, zlib, libwebsockets, libuv, json-c) の
  バージョン + SHA256 を pin (placeholder を実値で埋め)
- zlib URL は GHA runner からの DNS 解決安定性のため GitHub release ミラーに変更
- json-c (ttyd 1.7.x 必須依存) を新規追加

### common.sh (build script helpers)
- `build_autoconf` / `build_cmake`: configure → make → install の標準フロー (stamp で再 build skip)
- `source_dir`: tarball 展開後のソース木を一意に解決 (0/2+件は fail)
- `assert_self_contained`: otool -L で system dylib (`/usr/lib/*` `/System/Library/*`) 以外の依存を全て fail
  (@rpath/@loader_path/@executable_path も拒否、全 deps static link 契約を強制)
- `build_cmake` のデフォルトに `CMAKE_POLICY_VERSION_MINIMUM=3.5` を付与
  (現代 cmake で `cmake_minimum_required(<3.5)` を持つ古い CMakeLists.txt が fail するのを回避)

### build-tmux.sh
- ncurses: widec ABI で .a のみ生成、make install を `install.libs install.includes` に絞り
  `/usr/share/terminfo` 書き込み権限不足を回避
- libtinfo は ncurses build 構成に応じて存在を assert し、LIBTINFO_LIBS を条件付きで付与
- libevent: --disable-shared --disable-openssl で最小静的ビルド
- tmux: --disable-utf8proc (内蔵 UTF-8 解析にフォールバック)、--enable-static は macOS で
  「全 syslib も static」と誤解釈され fail するため明示的に渡さない

### build-ttyd.sh
- zlib: `./configure --static` で .a のみ (autoconf 非標準フローを手動 build)
- openssl: `Configure darwin64-arm64-cc no-shared` で .a のみ、`install_sw` で man 除外
- libuv: autogen.sh で configure 生成 → --disable-shared
- libwebsockets: cmake `LWS_WITH_SHARED=OFF` で静的のみ、OpenSSL/libuv/zlib を ${PREFIX} から明示参照
- json-c: cmake `BUILD_SHARED_LIBS=OFF`
- ttyd: cmake `CMAKE_FIND_LIBRARY_SUFFIXES=.a` で .so/.dylib を解決経路から排除
- **post-install patch**: `libwebsockets-config.cmake` から `websockets_shared` を除去
  (LWS exported config が `set(LIBWEBSOCKETS_LIBRARIES websockets websockets_shared)` で
  両方 hardcode、静的版に存在しない target を ttyd の find_package が拾うと linker が fail)

### .github/workflows/build-bin.yml
- on: `workflow_call` + `workflow_dispatch` + `pull_request` (paths filter) の 3 経路に拡張
- actions/cache のキーを manifest hash 単独から **script 群を含めた合成 hash** に変更
  (script 変更だけで manifest 同じなら古い stamp を再利用する事故を防ぐ)

### .github/workflows/release.yml
- 新 build-bin ジョブを `uses: ./.github/workflows/build-bin.yml` で呼び出し
- build (.app) ジョブに `needs: build-bin` を追加し artifact 準備を保証
- `Download tmux/ttyd artifact` step を有効化
- `Verify bundled binaries` step で electron-builder 起動前に二重チェック
- 新 `Smoke test bundled tmux/ttyd binaries` step で `.app/Contents/Resources/bin/{tmux,ttyd}` の起動確認

## 動作確認

workflow_dispatch で build-bin を 9 回 iteration して全 build を成功させた:
- run: <https://github.com/ignission/claude-code-ark/actions/runs/25788026986>
- artifact `ark-bin-macos-arm64` (3.4MB) 生成済み

## codex review

P1 (高) 5 件・P2 (中) 1 件の指摘を反映済み (json-c 追加、assert_self_contained 厳格化、
libtinfo 条件付き、cache key 強化、source_dir 一意性)。

## 関連

- 上流 issue: #185
- Epic: #184
- 残り Epic 子: #186 (SDK claude binary を tmux でも使う), #187 (OAuth Tray ガイド), #183 (F5 installer), #193 (notarization)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * デスクトップアプリケーションのビルド自動化が改善されました
  * バンドルされたバイナリの自動生成と検証機能が実装されました
  * ライセンス管理プロセスが最適化されました
  * リリースパイプラインの信頼性と品質検証が向上しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ignission/claude-code-ark/pull/198)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->