### PR TITLE
fix(tmux): NODE_ENV を新規セッションで空文字リセットする

### DIFF
--- a/packages/server/src/lib/tmux-manager.test.ts
+++ b/packages/server/src/lib/tmux-manager.test.ts
@@ -118,6 +118,8 @@ describe("TmuxManager.createSession - options互換", () => {
       "CLAUDECODE=",
       "-e",
       "CLAUDE_CODE_NO_FLICKER=1",
+      "-e",
+      "NODE_ENV=",
     ]);
 
     // send-keysにclaudeが渡される
@@ -160,6 +162,29 @@ describe("TmuxManager.createSession - options互換", () => {
     // 各 KEY=VALUE の直前は -e
     expect(args[fooIdx - 1]).toBe("-e");
     expect(args[bazIdx - 1]).toBe("-e");
+  });
+
+  it("NODE_ENV= でリセットされ、options.env で明示上書きすれば last-wins で反映される", async () => {
+    // tmux の -e は同じキーが複数指定された場合 last-wins で評価される (man tmux)。
+    // デフォルトでベースの -e NODE_ENV= (空文字) が入り、その後ろに
+    // 利用者が options.env で NODE_ENV=test を指定した場合は last-wins で test が
+    // 採用される。これにより、特殊なテスト用セッションでは値を上書きできる。
+    await manager.createSession("/path/to/worktree", {
+      env: { NODE_ENV: "test" },
+    });
+
+    const args = findNewSessionArgs();
+    if (!args) throw new Error("new-session args not found");
+
+    // ベースの -e NODE_ENV= が含まれる
+    const baseNodeEnvIdx = args.indexOf("NODE_ENV=");
+    expect(baseNodeEnvIdx).toBeGreaterThan(-1);
+    expect(args[baseNodeEnvIdx - 1]).toBe("-e");
+
+    // 利用者指定の -e NODE_ENV=test が後に追加される
+    const overrideIdx = args.indexOf("NODE_ENV=test");
+    expect(overrideIdx).toBeGreaterThan(baseNodeEnvIdx);
+    expect(args[overrideIdx - 1]).toBe("-e");
   });
 
   it("options.namePrefix でセッション名のプレフィックスが変わる", async () => {

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -290,6 +290,11 @@ export class TmuxManager extends EventEmitter {
       // -e で環境変数をシェルに直接渡す（set-environmentと異なり即座に反映）
       // CLAUDECODE を空にしてネストされたセッション検出を回避
       // CLAUDE_CODE_NO_FLICKER=1 でttydフリッカー抑制
+      // NODE_ENV を空文字でリセットして、Ark を PM2 で起動した際の
+      // NODE_ENV=production が子セッション (claude → shell → pnpm 等) に
+      // 継承されるのを防ぐ。Storybook dev mode 等が development 前提で
+      // 動作するため、production が継承されると DefinePlugin の NODE_ENV
+      // conflict 等で React Refresh が壊れる ($RefreshSig$ is not defined)
       const newSessionResult = spawnSync(
         TMUX_BINARY_PATH,
         [
@@ -303,6 +308,8 @@ export class TmuxManager extends EventEmitter {
           "CLAUDECODE=",
           "-e",
           "CLAUDE_CODE_NO_FLICKER=1",
+          "-e",
+          "NODE_ENV=",
           ...extraEnvArgs,
         ],
         { stdio: "pipe" }


### PR DESCRIPTION
## 概要

Ark を PM2 で起動した際の `NODE_ENV=production` が、tmux → claude → shell → 子コマンド (pnpm 等) と継承され、Claude Code セッション内で実行されるツールが production モードで動いてしまう問題を修正する。

`tmux new-session` に `-e NODE_ENV=` を恒久的に付与し、子セッションの `NODE_ENV` を空文字でリセットする。

## 原因の連鎖

1. `packages/server/ecosystem.config.cjs` で `env: { NODE_ENV: "production" }` を明示
2. PM2 → Ark server (node) → \`spawnSync('tmux', ['new-session', ...])\` で tmux セッション作成
3. tmux はサーバープロセスの環境変数を子セッションに継承 (`-e` で明示しない限り)
4. tmux → claude → shell と継承され、シェル内で実行される全コマンドの `NODE_ENV=production` になる

## 影響していた具体例

`pnpm storybook` (storybook dev) が壊れる:

- `@storybook/nextjs` 10.x dev mode は webpack の DefinePlugin で `process.env.NODE_ENV` を 'development' と (NODE_ENV=production が継承されているため) 'production' の両方に define し、'production' が後勝ち
- 結果 `next/dist/compiled/react/jsx-dev-runtime` が production 版に解決
- SWC が dev mode で生成した \`jsxDEV()\` / \`\$RefreshSig\$()\` / \`\$RefreshReg\$()\` 呼び出しが全て参照不能
- 全 story が \`ReferenceError: \$RefreshSig\$ is not defined\` で描画不能

(別リポジトリ promarche の PMDEV-500 / PR #795 で対症療法が試みられていたが、本 PR が根本対応)

## 修正

\`packages/server/src/lib/tmux-manager.ts\` の \`createSession\` 内、\`tmux new-session\` 引数列に以下を追加:

\`\`\`diff
   "-e",
   "CLAUDE_CODE_NO_FLICKER=1",
+  "-e",
+  "NODE_ENV=",
   ...extraEnvArgs,
\`\`\`

tmux \`-e\` は同キーで last-wins のため、\`options.env\` で明示的に上書きする利用者には影響しない。

## テスト

\`packages/server/src/lib/tmux-manager.test.ts\`:
- 既存「optionsを省略した場合、既存と同じargsで tmux new-session が呼ばれる」の expected args に \`"-e", "NODE_ENV="\` を追加
- 新規「NODE_ENV= でリセットされ、options.env で明示上書きすれば last-wins で反映される」を追加

114/114 tests pass。

## 検証

- \`codex review --base main\`: クリア (No discrete actionable bugs)
- 既存 \`pnpm --filter server test\`: 全 pass

## 既知のスコープ外

- \`packages/server/src/lib/usage-collector.ts\` も同じく \`new-session\` を呼んでいるが、こちらは内部で claude を起動するだけで利用者コマンド (Storybook 等) を実行しないため、本 PR では触らない。対称性のため別 PR で対応する余地あり。

## デプロイ後の確認

- \`pnpm build && pm2 restart claude-code-ark\` 後、**新規** ark セッションでのみ反映 (既存 tmux セッションは tmux 再作成まで継承)
- 検証: 新規セッションで \`echo "\$NODE_ENV"\` が空文字を返すこと

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * セッション管理における環境変数の処理を改善しました。
  
* **Tests**
  * 環境変数の処理に関するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ignission/claude-code-ark/pull/200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->