### PR TITLE
fix(mcp): Atlassian を /v1/sse から streamable-HTTP /v1/mcp へ移行

### DIFF
--- a/packages/server/src/lib/mcp-oauth/providers.ts
+++ b/packages/server/src/lib/mcp-oauth/providers.ts
@@ -28,8 +28,9 @@ export interface McpProviderEntry {
   url: string;
   /**
    * SDK transport の種別。
-   * - "sse": MCP 1.0 (SSE) — URL が `/sse` 終わりの provider はこちら (例: Atlassian)
-   * - "http": MCP streamable-HTTP (2025-) — 新しい仕様の provider はこちら
+   * - "sse": MCP 1.0 (SSE) — URL が `/sse` 終わりのレガシー provider はこちら。
+   *   Atlassian は 2026/6/30 で /v1/sse 廃止のため "http" + /v1/mcp へ移行済み。
+   * - "http": MCP streamable-HTTP (2025-) — 現行仕様。新規 provider はこちら
    */
   transport: "sse" | "http";
   /**
@@ -130,8 +131,11 @@ export const MCP_PROVIDERS: Record<string, McpProviderEntry> = {
     id: "atlassian",
     name: "Atlassian",
     description: "Jira / Confluence (Cloud)",
-    url: "https://mcp.atlassian.com/v1/sse",
-    transport: "sse",
+    // 2026/6/30 以降 HTTP+SSE エンドポイント (/v1/sse) は非対応となるため、
+    // streamable-HTTP の /v1/mcp へ移行する。OAuth 認可サーバ / audience は同一の
+    // ため既存トークンは有効な見込みだが、失敗時はユーザーに再接続を促す。
+    url: "https://mcp.atlassian.com/v1/mcp",
+    transport: "http",
     prompt: "consent",
     resolveAccountLabel: atlassianResolveAccountLabel,
   },


### PR DESCRIPTION
## 背景

Atlassian の HTTP+SSE エンドポイント `/v1/sse` は **2026/6/30 以降非対応**（Atlassian からの通知）。streamable-HTTP の `/v1/mcp` へ移行する。

## 変更

- `packages/server/src/lib/mcp-oauth/providers.ts` の Atlassian エントリ
  - `url`: `https://mcp.atlassian.com/v1/sse` → `https://mcp.atlassian.com/v1/mcp`
  - `transport`: `"sse"` → `"http"`
- `build-mcp-servers.ts` の transport 分岐が `{ type: "http", ... }` を生成（streamable-HTTP 対応済み）
- OAuth discovery は path-scoped → origin-wide フォールバックで `/v1/mcp` でも機能

## 注意

- 認可サーバ / audience は同一のため既存トークンは有効な見込み。失敗時は Ark UI から Atlassian を再接続
- **C-B1**: 稼働中の Beacon は launch 時の MCP 構成を保持するため、反映にはデプロイ後に Beacon リセットが必要

## 検証

- codex review (P5 ゲート): PASS（P0/P1/P2 指摘なし）
- `biome check` / `tsc --noEmit`: 通過
- 既存テスト 6 件（`build-mcp-servers.test.ts`）: 通過

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Atlassian プロバイダーのエンドポイント URL と通信プロトコルを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->