### PR TITLE
fix(mcp): 保存済み Atlassian URL を /v1/mcp へ起動時マイグレーション (#203 追補)

### DIFF
--- a/packages/server/src/lib/database.test.ts
+++ b/packages/server/src/lib/database.test.ts
@@ -470,7 +470,7 @@ describe("SessionDatabase - mcp_servers URL マイグレーション", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  function insertAtlassianRow(url: string): void {
+  function insertMcpServerRow(url: string): void {
     // 旧バージョンで保存されたレコードを再現する (raw SQLite で直接 INSERT)
     const raw = new Database(dbPath);
     raw
@@ -497,33 +497,42 @@ describe("SessionDatabase - mcp_servers URL マイグレーション", () => {
   it("旧 /v1/sse の保存済み URL が起動時に /v1/mcp へ正規化される", () => {
     // スキーマだけ作って閉じる → 旧 URL レコードを注入 → 再オープンで migration
     new SessionDatabase(dbPath).close();
-    insertAtlassianRow("https://mcp.atlassian.com/v1/sse");
+    insertMcpServerRow("https://mcp.atlassian.com/v1/sse");
 
     const db2 = new SessionDatabase(dbPath);
-    const server = db2.getMcpServer("atlassian-test01");
-    expect(server?.url).toBe("https://mcp.atlassian.com/v1/mcp");
-    db2.close();
+    try {
+      const server = db2.getMcpServer("atlassian-test01");
+      expect(server?.url).toBe("https://mcp.atlassian.com/v1/mcp");
+    } finally {
+      db2.close();
+    }
   });
 
   it("既に /v1/mcp のレコードはそのまま (冪等)", () => {
     new SessionDatabase(dbPath).close();
-    insertAtlassianRow("https://mcp.atlassian.com/v1/mcp");
+    insertMcpServerRow("https://mcp.atlassian.com/v1/mcp");
 
     const db2 = new SessionDatabase(dbPath);
-    expect(db2.getMcpServer("atlassian-test01")?.url).toBe(
-      "https://mcp.atlassian.com/v1/mcp"
-    );
-    db2.close();
+    try {
+      expect(db2.getMcpServer("atlassian-test01")?.url).toBe(
+        "https://mcp.atlassian.com/v1/mcp"
+      );
+    } finally {
+      db2.close();
+    }
   });
 
   it("無関係な URL のレコードには触れない", () => {
     new SessionDatabase(dbPath).close();
-    insertAtlassianRow("https://mcp.linear.app/sse");
+    insertMcpServerRow("https://mcp.linear.app/sse");
 
     const db2 = new SessionDatabase(dbPath);
-    expect(db2.getMcpServer("atlassian-test01")?.url).toBe(
-      "https://mcp.linear.app/sse"
-    );
-    db2.close();
+    try {
+      expect(db2.getMcpServer("atlassian-test01")?.url).toBe(
+        "https://mcp.linear.app/sse"
+      );
+    } finally {
+      db2.close();
+    }
   });
 });

--- a/packages/server/src/lib/database.test.ts
+++ b/packages/server/src/lib/database.test.ts
@@ -452,3 +452,78 @@ describe("SessionDatabase - profiles / repo_profile_links", () => {
     });
   });
 });
+
+// ============================================================
+// mcp_servers URL マイグレーション (#203 追補)
+// ============================================================
+
+describe("SessionDatabase - mcp_servers URL マイグレーション", () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "ark-db-mig-test-"));
+    dbPath = path.join(tmpDir, "test.db");
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function insertAtlassianRow(url: string): void {
+    // 旧バージョンで保存されたレコードを再現する (raw SQLite で直接 INSERT)
+    const raw = new Database(dbPath);
+    raw
+      .prepare(
+        `INSERT INTO mcp_servers
+           (id, name, url, authorization_endpoint, token_endpoint, client_id,
+            scopes, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        "atlassian-test01",
+        "Atlassian #1",
+        url,
+        "https://auth.atlassian.com/authorize",
+        "https://auth.atlassian.com/oauth/token",
+        "client-x",
+        "[]",
+        Date.now(),
+        Date.now()
+      );
+    raw.close();
+  }
+
+  it("旧 /v1/sse の保存済み URL が起動時に /v1/mcp へ正規化される", () => {
+    // スキーマだけ作って閉じる → 旧 URL レコードを注入 → 再オープンで migration
+    new SessionDatabase(dbPath).close();
+    insertAtlassianRow("https://mcp.atlassian.com/v1/sse");
+
+    const db2 = new SessionDatabase(dbPath);
+    const server = db2.getMcpServer("atlassian-test01");
+    expect(server?.url).toBe("https://mcp.atlassian.com/v1/mcp");
+    db2.close();
+  });
+
+  it("既に /v1/mcp のレコードはそのまま (冪等)", () => {
+    new SessionDatabase(dbPath).close();
+    insertAtlassianRow("https://mcp.atlassian.com/v1/mcp");
+
+    const db2 = new SessionDatabase(dbPath);
+    expect(db2.getMcpServer("atlassian-test01")?.url).toBe(
+      "https://mcp.atlassian.com/v1/mcp"
+    );
+    db2.close();
+  });
+
+  it("無関係な URL のレコードには触れない", () => {
+    new SessionDatabase(dbPath).close();
+    insertAtlassianRow("https://mcp.linear.app/sse");
+
+    const db2 = new SessionDatabase(dbPath);
+    expect(db2.getMcpServer("atlassian-test01")?.url).toBe(
+      "https://mcp.linear.app/sse"
+    );
+    db2.close();
+  });
+});

--- a/packages/server/src/lib/database.ts
+++ b/packages/server/src/lib/database.ts
@@ -438,6 +438,17 @@ export class SessionDatabase {
       "CREATE INDEX IF NOT EXISTS idx_mcp_servers_provider_id ON mcp_servers(provider_id)"
     );
 
+    // マイグレーション: Atlassian の HTTP+SSE エンドポイント廃止 (2026/6/30)
+    // に伴い providers.ts のデフォルトは /v1/mcp (streamable-HTTP) へ移行済み
+    // (#203)。しかし保存済みレコードの url は接続時点の値のまま残るため、
+    // 旧 /v1/sse を指していると build-mcp-servers が {type:"http"} + SSE
+    // エンドポイントというプロトコル不一致の mcp-config を生成し、Beacon 等で
+    // Atlassian ツールが一切利用できなくなる (実環境で発生)。
+    // 全読み出し経路に効くよう起動時にレコード自体を正規化する (冪等)。
+    this.db.exec(
+      "UPDATE mcp_servers SET url = 'https://mcp.atlassian.com/v1/mcp' WHERE url = 'https://mcp.atlassian.com/v1/sse'"
+    );
+
     // フロントライン記録テーブル
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS frontline_records (


### PR DESCRIPTION
## 概要

#203 は providers.ts のデフォルト URL を streamable-HTTP の `/v1/mcp` へ移行したが、**DB (`mcp_servers`) に保存済みの接続レコードの url は接続時点の旧 `/v1/sse` のまま残っていた**。

build-mcp-servers は provider のデフォルトではなく保存レコードの url で mcp-config を合成するため、`{type:"http"}` + SSE エンドポイントというプロトコル不一致になり、**Beacon の常駐 claude が Atlassian MCP に接続できずツールが一切利用できない**状態が発生していた。

### 実環境での症状 (2026-06-12 発生)

- Beacon のタスク着手フロー (Jira URL) が「接続済みの Atlassian MCP がセッションで利用できない」で失敗
- access token は有効・mcp-config への合成も成功しているのに、セッション内でツールが見えない (C-B1 / #202 とは別原因)

## 変更

- 起動時マイグレーションとして旧 URL のレコードを `/v1/mcp` へ UPDATE (冪等・無関係 URL には不干渉)
- テスト 3 件追加 (正規化 / 冪等 / 無関係 URL 不干渉)

## 検証

- ✅ codex P5 レビュー 2 回 (指摘 P2×2 を修正後、指摘なし)
- ✅ database.test.ts 28 件パス、pnpm check クリーン
- ✅ 実環境で同等の UPDATE を手動適用し、Beacon リセット後に Atlassian ツールが復旧することを確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * サーバー起動時に既存データベースのURL形式を自動的に正規化する機能を追加しました。

* **Tests**
  * URL正規化の動作を検証するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->