### PR TITLE
feat: チャットビュー (JSONL tail) を PC デフォルト UI 化 — ターミナル転送からの移行 v3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,25 +8,49 @@
 
 ## アーキテクチャ
 
-### tmux + ttyd によるターミナル転送方式
+### チャットビュー (JSONL tail) + tmux 方式
 
-Claude Codeとの対話は **Agent SDK経由ではなく、tmux + ttyd によるターミナル転送** で実現している。
+PC のデフォルト UI はチャットビュー (`SplitViewPane`)。Claude Code が永続化する
+JSONL transcript を tail して会話を描画し、入力は tmux send-keys で行う。
+ttyd の生ターミナルは「🖥 ターミナル」トグルで on-demand 表示 (旧来の
+TerminalPane 単独表示は `?view=classic`)。エンジンは従来どおり tmux 上の
+対話版 claude (プラン枠課金を維持。Agent SDK / claude -p は使わない)。
 
 ```
-ブラウザ(iframe) ←→ ttyd(WebSocket) ←→ tmux(セッション) ←→ claude CLI
+表示: <configDir>/projects/<encoded-cwd>/*.jsonl → JsonlTailManager → Socket.IO → チャット描画
+入力: チャット入力欄 → Socket.IO → tmux send-keys → claude CLI
+補助: tmux(セッション) ←→ ttyd(WebSocket) ←→ iframe (on-demand トグル)
 ```
+
+**情報源分離の原則 (チャット UI v3 の核心)**: 会話内容は 100% JSONL transcript
+から取得する。tmux capture-pane は busy/AWAITING の existence チェック
+(`session:previews` の bridgeStatus) のみに使い、**画面テキストから内容を
+パースすることは全面禁止** (過去 2 回の挑戦の断念原因)。
 
 1. **tmux**: Claude CLIプロセスをdetachedセッションで管理。サーバー再起動後もセッションが永続化される
-2. **ttyd**: tmuxセッションにWebターミナルアクセスを提供。各セッションに独立したttydプロセスが起動する
-3. **SessionOrchestrator**: tmuxとttydを統合管理し、セッションのライフサイクルを制御する
-4. **クライアント**: ttydが提供するWebターミナルをiframeで表示。メッセージ送信はSocket.IO経由でtmux send-keysを使用
+2. **JsonlTailManager**: worktree 毎の JSONL を fs.watch + 1 秒 polling で tail し、新規行を購読 socket に push。/clear のファイル切替は onReset → 空 snapshot で追従
+3. **ttyd**: tmuxセッションにWebターミナルアクセスを提供 (チャットビューではトグル表示)
+4. **SessionOrchestrator**: tmuxとttydを統合管理し、セッションのライフサイクルを制御する
 
 ### メッセージ送信の流れ
 
-1. クライアントが `session:send` イベントでメッセージを送信
+1. クライアントが `session:send` イベントでメッセージを送信 (送信直後は pending bubble を楽観表示)
 2. サーバーの `SessionOrchestrator.sendMessage()` が `tmuxManager.sendKeys()` を呼び出す
-3. tmuxの `send-keys -l` でリテラル入力 + `Enter` キーを送信
-4. Claude CLIが入力を受け取り、ttyd経由でブラウザのiframeにリアルタイム表示
+3. tmuxの `C-u` (入力欄クリア) → `send-keys -l` でリテラル入力 + `Enter` キーを送信
+4. claude が transcript (JSONL) に追記 → tail がクライアントへ push → pending と reconcile して確定描画
+
+### AskUserQuestion (重要な実機知見)
+
+対話版 claude は AUQ の tool_use を**回答/拒否が確定した瞬間**に tool_result と
+まとめて JSONL へ書く (質問表示中は JSONL に何も出ない)。そのため:
+
+- **質問のリアルタイム検出**: セッション起動時に `--settings` で注入する
+  PreToolUse hook (`auq-hook-bridge.ts`) が tool_input.questions を
+  `/api/internal/auq-event` へ POST → `session:auq` でカード表示
+- **回答**: カードから tmux キー送出 (単問 single = digit 一発 / multiSelect =
+  digit トグル → Right → Review digit 1 / 自由入力 = digit → literal → Enter)
+- **カードを閉じる**: JSONL に解決イベントが出現したとき (`hasResolvedAuqSince`)
+- permission prompt 等は AWAITING バナー (+[1][2] クイックキー + ターミナル誘導)
 
 ### セッション永続化
 
@@ -41,7 +65,8 @@ Claude Codeとの対話は **Agent SDK経由ではなく、tmux + ttyd による
 | リポジトリスキャン     | 指定パス配下のGitリポジトリを探索（fd/findコマンド使用）                    |
 | Git Worktree管理       | 一覧表示、作成、削除                                                        |
 | セッション管理         | tmux + ttydベースの起動、停止、復元、状態管理                               |
-| Webターミナル          | ttyd iframeによるフルターミナル体験                                         |
+| チャットビュー (PC デフォルト) | JSONL tail ベースの会話描画 + pending reconcile + AskUserQuestion カード + slash 補完 + busy/AWAITING 表示 (`?view=classic` で旧表示) |
+| Webターミナル          | ttyd iframeによるフルターミナル体験（チャットビューではトグル表示）         |
 | マルチペインビュー     | 複数セッションの同時表示（1列 / 2x2グリッド切り替え）                       |
 | モバイル対応           | セッション一覧/詳細の画面遷移、Quick Keys、スクロールモード、キーボード対応 |
 | 特殊キー送信           | Enter, Ctrl+C, Ctrl+D, y, n, S-Tab, Escape, スクロール等                    |
@@ -281,6 +306,11 @@ claude-code-ark/
 | `session:key`     | `{ sessionId, key: SpecialKey }`        | 特殊キー送信                     |
 | `session:copy`    | `sessionId, callback`                   | tmuxバッファ取得（コールバック） |
 | `session:restore` | `worktreePath: string`                  | セッション復元                   |
+| `session:jsonl-subscribe` | `sessionId: string`             | JSONL 履歴の購読開始（snapshot + 増分 push）|
+| `session:jsonl-unsubscribe` | `sessionId: string`           | JSONL 購読解除                   |
+| `session:jsonl-load-more` | `{ sessionId, limit }`          | 過去履歴を limit 行で snapshot 再送 |
+| `session:send-literal` | `{ sessionId, text }`              | Enter 無しの literal 送信（AUQ 自由入力用）|
+| `slash:list`      | `sessionId, callback`                   | slash command 候補一覧（コールバック）|
 | `tunnel:start`    | `{ port? }`                             | Quick Tunnel起動                 |
 | `tunnel:stop`     | -                                       | トンネル停止                     |
 | `ports:scan`      | -                                       | ポートスキャン                   |
@@ -311,6 +341,9 @@ claude-code-ark/
 | `session:stopped`        | `sessionId: string`            | セッション停止                   |
 | `session:restored`       | `ManagedSession`               | セッション復元完了               |
 | `session:restore_failed` | `{ worktreePath, error }`      | セッション復元失敗               |
+| `session:jsonl-snapshot` | `{ sessionId, lines }`         | JSONL 履歴 snapshot（/clear 切替時は空配列）|
+| `session:jsonl-line`     | `{ sessionId, line }`          | JSONL 新規行 push                |
+| `session:auq`            | `{ sessionId, at, questions }` | 回答待ち AskUserQuestion（PreToolUse hook 由来）|
 | `session:error`          | `{ sessionId, error }`         | セッションエラー                 |
 | `tunnel:started`         | `{ url, token }`               | トンネル開始                     |
 | `tunnel:stopped`         | -                              | トンネル停止                     |

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -494,6 +494,9 @@ export async function startServer(
   // 「質問が表示された」のリアルタイム検出はこの hook が唯一の情報源。
   app.post(AUQ_EVENT_PATH, (req, res) => {
     if (!auqHookBridge.verifyToken(req.headers[AUQ_TOKEN_HEADER])) {
+      // 旧 token を保持したままの常駐 claude などからの hook。
+      // token は DB 永続化しているので通常は起きないが、調査の手がかりに残す
+      console.warn("[AuqHook] 403: token 不一致の hook を拒否しました");
       res.status(403).json({ error: "forbidden" });
       return;
     }
@@ -508,12 +511,16 @@ export async function startServer(
       !body.tool_input ||
       typeof body.tool_input !== "object"
     ) {
+      console.warn(
+        `[AuqHook] 400: 想定外 payload (tool=${String(body?.tool_name)})`
+      );
       res.status(400).json({ error: "bad request" });
       return;
     }
     const session = sessionOrchestrator.getSessionByWorktree(body.cwd);
     if (!session) {
       // Ark 管理外の claude (ユーザーが手動起動した等) からの hook は無視
+      console.log(`[AuqHook] 管理外 cwd からの hook を無視: ${body.cwd}`);
       res.status(204).end();
       return;
     }
@@ -526,6 +533,7 @@ export async function startServer(
       at: entry.at,
       questions: entry.questions,
     });
+    console.log(`[AuqHook] session:auq 配信: ${session.id} (${body.cwd})`);
     res.status(204).end();
   });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -83,6 +83,7 @@ import {
 import { getListeningPorts } from "./lib/port-scanner.js";
 import { printRemoteAccessInfo } from "./lib/qrcode.js";
 import { sessionOrchestrator } from "./lib/session-orchestrator.js";
+import { listSlashCommands } from "./lib/slash-command-scanner.js";
 import { detectMultiProfileSupported } from "./lib/system.js";
 import { tmuxManager } from "./lib/tmux-manager.js";
 import { TunnelManager } from "./lib/tunnel.js";
@@ -1862,6 +1863,26 @@ export async function startServer(
       if (unsub) {
         unsub();
         jsonlUnsubscribers.delete(sessionId);
+      }
+    });
+
+    // ===== Slash command 候補列挙 =====
+    // チャットビュー入力欄の `/` 補完用。worktree + プロファイル configDir の
+    // `.claude/commands/*.md` を集約して返す。callback パターン (1 回限り)
+    socket.on("slash:list", async (sessionId, callback) => {
+      try {
+        const session = sessionOrchestrator.getSession(sessionId);
+        if (!session) {
+          callback({ error: "Session not found" });
+          return;
+        }
+        const commands = await listSlashCommands(
+          session.worktreePath,
+          session.profileConfigDir ?? null
+        );
+        callback({ commands });
+      } catch (err) {
+        callback({ error: getErrorMessage(err) });
       }
     });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -31,6 +31,11 @@ import {
 import httpProxy from "http-proxy";
 import { nanoid } from "nanoid";
 import { Server, type Socket } from "socket.io";
+import {
+  AUQ_EVENT_PATH,
+  AUQ_TOKEN_HEADER,
+  auqHookBridge,
+} from "./lib/auq-hook-bridge.js";
 import { authManager } from "./lib/auth.js";
 import { beaconManager } from "./lib/beacon-manager.js";
 import {
@@ -480,6 +485,48 @@ export async function startServer(
 
   // JSON body parser（Settings API用）
   app.use(express.json({ limit: "10kb" }));
+
+  // ===== AskUserQuestion hook 受け口 =====
+  // セッション内 claude の PreToolUse hook (auq-hook-bridge が --settings で
+  // 注入) から、回答待ち質問の構造化データが POST される。
+  // 対話版 claude は AUQ の tool_use を回答確定までJSONLに書かないため、
+  // 「質問が表示された」のリアルタイム検出はこの hook が唯一の情報源。
+  app.post(AUQ_EVENT_PATH, (req, res) => {
+    if (!auqHookBridge.verifyToken(req.headers[AUQ_TOKEN_HEADER])) {
+      res.status(403).json({ error: "forbidden" });
+      return;
+    }
+    const body = req.body as {
+      cwd?: unknown;
+      tool_name?: unknown;
+      tool_input?: { questions?: unknown };
+    };
+    if (
+      body?.tool_name !== "AskUserQuestion" ||
+      typeof body.cwd !== "string" ||
+      !body.tool_input ||
+      typeof body.tool_input !== "object"
+    ) {
+      res.status(400).json({ error: "bad request" });
+      return;
+    }
+    const session = sessionOrchestrator.getSessionByWorktree(body.cwd);
+    if (!session) {
+      // Ark 管理外の claude (ユーザーが手動起動した等) からの hook は無視
+      res.status(204).end();
+      return;
+    }
+    const entry = auqHookBridge.setPending(
+      session.id,
+      body.tool_input.questions
+    );
+    io.emit("session:auq", {
+      sessionId: session.id,
+      at: entry.at,
+      questions: entry.questions,
+    });
+    res.status(204).end();
+  });
 
   // セキュリティヘッダー
   app.use((_req, res, next) => {
@@ -1796,6 +1843,18 @@ export async function startServer(
         },
       });
       jsonlUnsubscribers.set(sessionId, unsubscribe);
+
+      // 回答待ちの AskUserQuestion があれば再送する (リロード/再接続対応)。
+      // 既に回答済みかどうかはクライアントが JSONL の解決イベント timestamp
+      // と at を比較して判定する
+      const pendingAuq = auqHookBridge.getPending(sessionId);
+      if (pendingAuq) {
+        socket.emit("session:auq", {
+          sessionId,
+          at: pendingAuq.at,
+          questions: pendingAuq.questions,
+        });
+      }
     });
 
     socket.on("session:jsonl-unsubscribe", (sessionId: string) => {
@@ -3306,6 +3365,18 @@ export async function startServer(
   });
 
   console.log(`Ark server running on http://localhost:${port}/`);
+
+  // AskUserQuestion hook 入りの claude 用 settings を書き出し、以降の
+  // セッション起動コマンドに --settings として注入する (listen 後 = port 確定後)
+  try {
+    const hookSettingsPath = auqHookBridge.writeSettingsFile(port);
+    tmuxManager.setClaudeSettingsPath(hookSettingsPath);
+    console.log(`[AuqHook] settings: ${hookSettingsPath}`);
+  } catch (err) {
+    // hook が無くてもセッション自体は動く (AUQ カードが出ないだけ) ので
+    // 起動は継続する
+    console.error("[AuqHook] settings 書き出しに失敗:", getErrorMessage(err));
+  }
 
   // Start Quick Tunnel if enabled
   // 注: enableQuick は --quick コマンドラインオプションによるトンネル起動。

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1798,12 +1798,23 @@ export async function startServer(
 
     // literal テキストのみ送信 (Enter を付けない)。
     // AskUserQuestion の自由入力モードで「1 文字ずつタイプ」する用途。
-    socket.on("session:send-literal", ({ sessionId, text }) => {
+    // payload は外部入力なので分割代入の前に型検証する (不正 payload での
+    // ハンドラ内 throw を防ぐ)
+    socket.on("session:send-literal", (data: unknown) => {
+      const d = data as { sessionId?: unknown; text?: unknown } | null;
+      if (
+        !d ||
+        typeof d !== "object" ||
+        typeof d.sessionId !== "string" ||
+        typeof d.text !== "string"
+      ) {
+        return;
+      }
       try {
-        tmuxManager.sendLiteral(sessionId, text);
+        tmuxManager.sendLiteral(d.sessionId, d.text);
       } catch (error) {
         socket.emit("session:error", {
-          sessionId,
+          sessionId: d.sessionId,
           error: getErrorMessage(error),
         });
       }
@@ -1814,7 +1825,8 @@ export async function startServer(
     // セッションだけを購読する想定 (非表示ペインの分は購読しない)。
     const jsonlUnsubscribers = new Map<string, () => void>();
 
-    socket.on("session:jsonl-subscribe", (sessionId: string) => {
+    socket.on("session:jsonl-subscribe", (sessionId: unknown) => {
+      if (typeof sessionId !== "string") return;
       if (jsonlUnsubscribers.has(sessionId)) return;
       const session = sessionOrchestrator.getSession(sessionId);
       if (!session) {
@@ -1828,30 +1840,29 @@ export async function startServer(
       const configDir = session.profileConfigDir ?? null;
 
       try {
-        const snapshot = jsonlTailManager.readCurrentSnapshot(
-          worktreePath,
-          configDir
-        );
+        // 購読 (offset 確定) と snapshot を原子的に行う。別々に行うと
+        // その間の追記行が snapshot にも onLine にも入らず欠落する
+        const { snapshot, unsubscribe } =
+          jsonlTailManager.subscribeWithSnapshot(worktreePath, configDir, {
+            onLine: line => {
+              socket.emit("session:jsonl-line", { sessionId, line: line.raw });
+            },
+            onReset: () => {
+              // `/clear` 等で JSONL ファイルが切り替わったタイミング。
+              // 空 snapshot を送ることでクライアント側 events が空配列に置換され、
+              // 旧会話履歴が UI から消える。新ファイルの行は後続の onLine で届く。
+              socket.emit("session:jsonl-snapshot", { sessionId, lines: [] });
+            },
+          });
         socket.emit("session:jsonl-snapshot", {
           sessionId,
           lines: snapshot.map(l => l.raw),
         });
+        jsonlUnsubscribers.set(sessionId, unsubscribe);
       } catch (err) {
-        console.error("[JsonlTail] Snapshot error:", getErrorMessage(err));
+        console.error("[JsonlTail] Subscribe error:", getErrorMessage(err));
+        return;
       }
-
-      const unsubscribe = jsonlTailManager.subscribe(worktreePath, configDir, {
-        onLine: line => {
-          socket.emit("session:jsonl-line", { sessionId, line: line.raw });
-        },
-        onReset: () => {
-          // `/clear` 等で JSONL ファイルが切り替わったタイミング。
-          // 空 snapshot を送ることでクライアント側 events が空配列に置換され、
-          // 旧会話履歴が UI から消える。新ファイルの行は後続の onLine で届く。
-          socket.emit("session:jsonl-snapshot", { sessionId, lines: [] });
-        },
-      });
-      jsonlUnsubscribers.set(sessionId, unsubscribe);
 
       // 回答待ちの AskUserQuestion があれば再送する (リロード/再接続対応)。
       // 既に回答済みかどうかはクライアントが JSONL の解決イベント timestamp
@@ -1866,7 +1877,8 @@ export async function startServer(
       }
     });
 
-    socket.on("session:jsonl-unsubscribe", (sessionId: string) => {
+    socket.on("session:jsonl-unsubscribe", (sessionId: unknown) => {
+      if (typeof sessionId !== "string") return;
       const unsub = jsonlUnsubscribers.get(sessionId);
       if (unsub) {
         unsub();
@@ -1876,33 +1888,53 @@ export async function startServer(
 
     // ===== Slash command 候補列挙 =====
     // チャットビュー入力欄の `/` 補完用。worktree + プロファイル configDir の
-    // `.claude/commands/*.md` を集約して返す。callback パターン (1 回限り)
-    socket.on("slash:list", async (sessionId, callback) => {
+    // `.claude/commands/*.md` を集約して返す。callback パターン (1 回限り)。
+    // ack callback は外部入力なので関数であることを検証してから呼ぶ
+    socket.on("slash:list", async (sessionId: unknown, callback: unknown) => {
+      if (typeof callback !== "function") return;
+      const reply = callback as (response: {
+        commands?: unknown;
+        error?: string;
+      }) => void;
       try {
+        if (typeof sessionId !== "string") {
+          reply({ error: "Invalid sessionId" });
+          return;
+        }
         const session = sessionOrchestrator.getSession(sessionId);
         if (!session) {
-          callback({ error: "Session not found" });
+          reply({ error: "Session not found" });
           return;
         }
         const commands = await listSlashCommands(
           session.worktreePath,
           session.profileConfigDir ?? null
         );
-        callback({ commands });
+        reply({ commands });
       } catch (err) {
-        callback({ error: getErrorMessage(err) });
+        try {
+          reply({ error: getErrorMessage(err) });
+        } catch {
+          // ack が二重呼び出し等で throw しても落とさない
+        }
       }
     });
 
     // 過去履歴をより多く読み直す。snapshot を limit 付きで再送する。
-    socket.on("session:jsonl-load-more", ({ sessionId, limit }) => {
+    // payload は外部入力なので分割代入の前に型検証する
+    socket.on("session:jsonl-load-more", (data: unknown) => {
+      const d = data as { sessionId?: unknown; limit?: unknown } | null;
+      if (!d || typeof d !== "object" || typeof d.sessionId !== "string") {
+        return;
+      }
+      const sessionId = d.sessionId;
       const session = sessionOrchestrator.getSession(sessionId);
       if (!session) return;
       const worktreePath = session.worktreePath;
       const configDir = session.profileConfigDir ?? null;
       try {
         // クライアント指定の limit をそのまま fs 読みに使わないようガード
-        const capped = Math.max(1, Math.min(Number(limit) || 0, 2000));
+        const capped = Math.max(1, Math.min(Number(d.limit) || 0, 2000));
         const snapshot = jsonlTailManager.readCurrentSnapshot(
           worktreePath,
           configDir,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -67,6 +67,7 @@ import {
 import { hostMetrics } from "./lib/host-metrics.js";
 import { validateHtmlPath } from "./lib/html-path-validator.js";
 import { htmlScreenshotter } from "./lib/html-screenshotter.js";
+import { jsonlTailManager } from "./lib/jsonl-tail-manager.js";
 import { DiscoveryError } from "./lib/mcp-oauth/discovery.js";
 import { mcpOAuthOrchestrator } from "./lib/mcp-oauth/oauth-flow-orchestrator.js";
 import {
@@ -1739,6 +1740,95 @@ export async function startServer(
       }
     });
 
+    // literal テキストのみ送信 (Enter を付けない)。
+    // AskUserQuestion の自由入力モードで「1 文字ずつタイプ」する用途。
+    socket.on("session:send-literal", ({ sessionId, text }) => {
+      try {
+        tmuxManager.sendLiteral(sessionId, text);
+      } catch (error) {
+        socket.emit("session:error", {
+          sessionId,
+          error: getErrorMessage(error),
+        });
+      }
+    });
+
+    // ===== JSONL tail（チャットビューの会話データソース） =====
+    // socket ごとに購読を管理する。クライアントはアクティブ表示中の
+    // セッションだけを購読する想定 (非表示ペインの分は購読しない)。
+    const jsonlUnsubscribers = new Map<string, () => void>();
+
+    socket.on("session:jsonl-subscribe", (sessionId: string) => {
+      if (jsonlUnsubscribers.has(sessionId)) return;
+      const session = sessionOrchestrator.getSession(sessionId);
+      if (!session) {
+        socket.emit("session:error", {
+          sessionId,
+          error: "Session not found for JSONL tail",
+        });
+        return;
+      }
+      const worktreePath = session.worktreePath;
+      const configDir = session.profileConfigDir ?? null;
+
+      try {
+        const snapshot = jsonlTailManager.readCurrentSnapshot(
+          worktreePath,
+          configDir
+        );
+        socket.emit("session:jsonl-snapshot", {
+          sessionId,
+          lines: snapshot.map(l => l.raw),
+        });
+      } catch (err) {
+        console.error("[JsonlTail] Snapshot error:", getErrorMessage(err));
+      }
+
+      const unsubscribe = jsonlTailManager.subscribe(worktreePath, configDir, {
+        onLine: line => {
+          socket.emit("session:jsonl-line", { sessionId, line: line.raw });
+        },
+        onReset: () => {
+          // `/clear` 等で JSONL ファイルが切り替わったタイミング。
+          // 空 snapshot を送ることでクライアント側 events が空配列に置換され、
+          // 旧会話履歴が UI から消える。新ファイルの行は後続の onLine で届く。
+          socket.emit("session:jsonl-snapshot", { sessionId, lines: [] });
+        },
+      });
+      jsonlUnsubscribers.set(sessionId, unsubscribe);
+    });
+
+    socket.on("session:jsonl-unsubscribe", (sessionId: string) => {
+      const unsub = jsonlUnsubscribers.get(sessionId);
+      if (unsub) {
+        unsub();
+        jsonlUnsubscribers.delete(sessionId);
+      }
+    });
+
+    // 過去履歴をより多く読み直す。snapshot を limit 付きで再送する。
+    socket.on("session:jsonl-load-more", ({ sessionId, limit }) => {
+      const session = sessionOrchestrator.getSession(sessionId);
+      if (!session) return;
+      const worktreePath = session.worktreePath;
+      const configDir = session.profileConfigDir ?? null;
+      try {
+        // クライアント指定の limit をそのまま fs 読みに使わないようガード
+        const capped = Math.max(1, Math.min(Number(limit) || 0, 2000));
+        const snapshot = jsonlTailManager.readCurrentSnapshot(
+          worktreePath,
+          configDir,
+          capped
+        );
+        socket.emit("session:jsonl-snapshot", {
+          sessionId,
+          lines: snapshot.map(l => l.raw),
+        });
+      } catch (err) {
+        console.error("[JsonlTail] LoadMore error:", getErrorMessage(err));
+      }
+    });
+
     // コピー: tmuxバッファの内容をクライアントに返す（コールバックパターン）
     socket.on("session:copy", (sessionId, callback) => {
       try {
@@ -3162,6 +3252,14 @@ export async function startServer(
     socket.on("disconnect", () => {
       console.log(`Client disconnected: ${socket.id}`);
       clearInterval(previewInterval);
+      for (const unsub of jsonlUnsubscribers.values()) {
+        try {
+          unsub();
+        } catch (err) {
+          console.error("[JsonlTail] Unsubscribe error:", getErrorMessage(err));
+        }
+      }
+      jsonlUnsubscribers.clear();
       // socket.leave は disconnect 時に Socket.IO が自動で行うので room の明示的な
       // クリーンアップは不要
 

--- a/packages/server/src/lib/ark-mcp-server.ts
+++ b/packages/server/src/lib/ark-mcp-server.ts
@@ -185,6 +185,7 @@ export function createArkMcpServer(deps: BeaconDeps): McpServer {
         Escape: true,
         Up: true,
         Down: true,
+        Right: true,
         Space: true,
         "1": true,
         "2": true,

--- a/packages/server/src/lib/ark-mcp-server.ts
+++ b/packages/server/src/lib/ark-mcp-server.ts
@@ -168,7 +168,7 @@ export function createArkMcpServer(deps: BeaconDeps): McpServer {
         key: z
           .string()
           .describe(
-            "送信するキー（y, n, C-c, C-d, Escape, Enter, S-Tab, Up, Down）"
+            "送信するキー（y, n, C-c, C-d, Escape, Enter, S-Tab, Up, Down, Space, 1〜9）"
           ),
       },
     },
@@ -185,6 +185,16 @@ export function createArkMcpServer(deps: BeaconDeps): McpServer {
         Escape: true,
         Up: true,
         Down: true,
+        Space: true,
+        "1": true,
+        "2": true,
+        "3": true,
+        "4": true,
+        "5": true,
+        "6": true,
+        "7": true,
+        "8": true,
+        "9": true,
       };
       const validKeys = new Set<string>(Object.keys(SPECIAL_KEYS));
       if (!validKeys.has(args.key)) {

--- a/packages/server/src/lib/auq-hook-bridge.ts
+++ b/packages/server/src/lib/auq-hook-bridge.ts
@@ -99,6 +99,10 @@ export class AuqHookBridge {
     fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, {
       mode: 0o600,
     });
+    // writeFileSync の mode は新規作成時にしか適用されないため、
+    // 既存ファイル (前回起動の生成物) の permission も明示的に矯正する
+    // (token を含むファイルなので 0600 を assert する)
+    fs.chmodSync(settingsPath, 0o600);
     this.settingsPath = settingsPath;
     return settingsPath;
   }

--- a/packages/server/src/lib/auq-hook-bridge.ts
+++ b/packages/server/src/lib/auq-hook-bridge.ts
@@ -22,7 +22,7 @@
  *   - リモートクライアント (tunnel 経由) からの偽装 POST は token 不一致で拒否
  */
 
-import { randomBytes } from "node:crypto";
+import { randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { db } from "./database.js";
@@ -69,9 +69,12 @@ export class AuqHookBridge {
   /** worktreePath や sessionId をキーにしない: 受け口で解決した sessionId で保持 */
   private pending = new Map<string, PendingAuq>();
 
-  /** hook 認証 token の検証 */
+  /** hook 認証 token の検証 (タイミング攻撃を避ける定数時間比較) */
   verifyToken(value: unknown): boolean {
-    return typeof value === "string" && value === this.token;
+    if (typeof value !== "string") return false;
+    const a = Buffer.from(value);
+    const b = Buffer.from(this.token);
+    return a.length === b.length && timingSafeEqual(a, b);
   }
 
   /**

--- a/packages/server/src/lib/auq-hook-bridge.ts
+++ b/packages/server/src/lib/auq-hook-bridge.ts
@@ -25,6 +25,7 @@
 import { randomBytes } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { db } from "./database.js";
 import { getDataDir } from "./paths.js";
 
 export const AUQ_EVENT_PATH = "/api/internal/auq-event";
@@ -39,9 +40,31 @@ export interface PendingAuq {
 }
 
 const PENDING_TTL_MS = 10 * 60 * 1000;
+const TOKEN_SETTING_KEY = "auq_hook_token";
+
+/**
+ * hook token は DB (settings テーブル) に永続化して再利用する。
+ * 対話版 claude は起動時に読んだ settings (hook command 内の token) を
+ * 生存中ずっと保持するため、サーバー再起動で token が変わると既存
+ * セッションの hook がすべて 403 になる (Beacon の C-B3 と同じ構造)。
+ */
+function loadOrCreateToken(): string {
+  try {
+    const saved = db.getSetting(TOKEN_SETTING_KEY);
+    if (typeof saved === "string" && /^[a-f0-9]{32,}$/.test(saved)) {
+      return saved;
+    }
+    const fresh = randomBytes(24).toString("hex");
+    db.setSetting(TOKEN_SETTING_KEY, fresh);
+    return fresh;
+  } catch {
+    // DB が使えない場合は ephemeral にフォールバック (この起動中のみ有効)
+    return randomBytes(24).toString("hex");
+  }
+}
 
 export class AuqHookBridge {
-  private token = randomBytes(24).toString("hex");
+  private token = loadOrCreateToken();
   private settingsPath: string | null = null;
   /** worktreePath や sessionId をキーにしない: 受け口で解決した sessionId で保持 */
   private pending = new Map<string, PendingAuq>();

--- a/packages/server/src/lib/auq-hook-bridge.ts
+++ b/packages/server/src/lib/auq-hook-bridge.ts
@@ -1,0 +1,115 @@
+/**
+ * auq-hook-bridge - AskUserQuestion の PreToolUse hook 連携
+ *
+ * 背景 (チャット UI v3):
+ *   対話版 claude は AskUserQuestion の tool_use を「ユーザーが回答/拒否した
+ *   瞬間」に tool_result とまとめて transcript (JSONL) へ書く。質問が画面に
+ *   表示されている間、JSONL には何も出ない。そのため回答待ちの質問を
+ *   リアルタイムにチャット UI へ出すには JSONL 以外の情報源が必要になる。
+ *
+ * 方式:
+ *   セッション起動時の claude コマンドに `--settings <このモジュールが生成
+ *   する JSON>` を注入し、PreToolUse (matcher: AskUserQuestion) hook で
+ *   tool_input を Ark の HTTP エンドポイント (/api/internal/auq-event) へ
+ *   POST させる。hook の stdin には { session_id, cwd, tool_name, tool_input }
+ *   の構造化 JSON が来るため、tmux 画面のパースは一切不要。
+ *   (2026-06-10 実機検証: 質問表示とほぼ同時に発火、--dangerously-skip-
+ *   permissions と共存可)
+ *
+ * セキュリティ:
+ *   - エンドポイントは起動毎に生成するランダム token を要求する
+ *   - token は settings ファイル (0600) の hook コマンドにのみ埋め込まれる
+ *   - リモートクライアント (tunnel 経由) からの偽装 POST は token 不一致で拒否
+ */
+
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { getDataDir } from "./paths.js";
+
+export const AUQ_EVENT_PATH = "/api/internal/auq-event";
+export const AUQ_TOKEN_HEADER = "x-ark-auq-token";
+
+/** hook 受信した回答待ち質問 (セッション毎に最新 1 件) */
+export interface PendingAuq {
+  /** サーバー受信時刻 epoch ms */
+  at: number;
+  /** tool_input.questions の生データ */
+  questions: unknown;
+}
+
+const PENDING_TTL_MS = 10 * 60 * 1000;
+
+export class AuqHookBridge {
+  private token = randomBytes(24).toString("hex");
+  private settingsPath: string | null = null;
+  /** worktreePath や sessionId をキーにしない: 受け口で解決した sessionId で保持 */
+  private pending = new Map<string, PendingAuq>();
+
+  /** hook 認証 token の検証 */
+  verifyToken(value: unknown): boolean {
+    return typeof value === "string" && value === this.token;
+  }
+
+  /**
+   * hook 定義入りの claude 用 settings JSON を data dir に書き出し、
+   * そのパスを返す (claude 起動コマンドの --settings に渡す)。
+   * port はサーバーの実 listen port。
+   */
+  writeSettingsFile(port: number): string {
+    const dataDir = getDataDir();
+    fs.mkdirSync(dataDir, { recursive: true });
+    const settingsPath = path.join(dataDir, "ark-claude-settings.json");
+    // curl: -m 3 で TUI をブロックしない / 失敗は無視 (hook が claude の
+    // 進行を止めないことを最優先)。stdin の JSON をそのまま転送する。
+    const command = `curl -s -m 3 -X POST 'http://127.0.0.1:${port}${AUQ_EVENT_PATH}' -H 'Content-Type: application/json' -H '${AUQ_TOKEN_HEADER}: ${this.token}' --data-binary @- >/dev/null 2>&1 || true`;
+    const settings = {
+      hooks: {
+        PreToolUse: [
+          {
+            matcher: "AskUserQuestion",
+            hooks: [{ type: "command", command }],
+          },
+        ],
+      },
+    };
+    fs.writeFileSync(settingsPath, `${JSON.stringify(settings, null, 2)}\n`, {
+      mode: 0o600,
+    });
+    this.settingsPath = settingsPath;
+    return settingsPath;
+  }
+
+  getSettingsPath(): string | null {
+    return this.settingsPath;
+  }
+
+  /** hook 受信を記録する (同一セッションの古い質問は上書き) */
+  setPending(sessionId: string, questions: unknown): PendingAuq {
+    const entry: PendingAuq = { at: Date.now(), questions };
+    this.pending.set(sessionId, entry);
+    return entry;
+  }
+
+  /**
+   * セッションの回答待ち質問を返す (TTL 超過は破棄して null)。
+   * クライアントの jsonl-subscribe 時の再送に使う。表示すべきかの最終判定
+   * (すでに回答済みか) は、クライアントが JSONL の AUQ 解決イベント
+   * timestamp と `at` を比較して行う。
+   */
+  getPending(sessionId: string): PendingAuq | null {
+    const entry = this.pending.get(sessionId);
+    if (!entry) return null;
+    if (Date.now() - entry.at > PENDING_TTL_MS) {
+      this.pending.delete(sessionId);
+      return null;
+    }
+    return entry;
+  }
+
+  clearPending(sessionId: string): void {
+    this.pending.delete(sessionId);
+  }
+}
+
+export const auqHookBridge = new AuqHookBridge();

--- a/packages/server/src/lib/bridge-collector.ts
+++ b/packages/server/src/lib/bridge-collector.ts
@@ -441,10 +441,16 @@ function detectStatus(tail: string[]): BridgeSessionStatus {
 function detectAwaiting(tail: string[]): boolean {
   // 直近 15 行に絞って探す (古い発話に含まれる質問文での誤発火を避ける)
   const window = tail.slice(-15);
-  return window.some(l =>
-    /\(y\/n\)|\[y\/N\]|\[Y\/n\]|Do you want to|Tool use approval|approval required/i.test(
-      l
-    )
+  return window.some(
+    l =>
+      /\(y\/n\)|\[y\/N\]|\[Y\/n\]|Do you want to|Tool use approval|approval required/i.test(
+        l
+      ) ||
+      // AskUserQuestion / trust prompt 等の選択 UI フッタ。
+      // 行頭限定にして、ツール結果引用 (⎿ 付き) 内の同文言では発火させない。
+      // チャットビューはこれを AWAITING フォールバックバナーに使う
+      // (hook 未注入の旧セッションで AUQ カードが出せないケースの第二防衛線)
+      /^\s{0,2}Enter to (select|confirm)\b/.test(l)
   );
 }
 

--- a/packages/server/src/lib/claude-projects.test.ts
+++ b/packages/server/src/lib/claude-projects.test.ts
@@ -115,10 +115,21 @@ describe("pickLatestJsonl", () => {
     expect(pickLatestJsonl(dir, "/a/b")).toBe(mine);
   });
 
-  it("cwd フィールドの無いファイルは検証不能 = 一致扱いで採用しうる", () => {
+  it("cwd フィールドの無いファイルは一致候補が無い場合のみ採用される", () => {
     const noCwd = path.join(dir, "no-cwd.jsonl");
     fs.writeFileSync(noCwd, '{"type":"summary"}\n');
     expect(pickLatestJsonl(dir, "/wt")).toBe(noCwd);
+  });
+
+  it("cwd 不明の新しいファイルより cwd 一致の古いファイルを優先する", () => {
+    // 書きかけの新規ファイル (cwd 行なし) が encode 衝突した別 worktree の
+    // ものである可能性があるため、検証できた一致を必ず優先する
+    const mine = path.join(dir, "mine.jsonl");
+    const unknown = path.join(dir, "unknown.jsonl");
+    fs.writeFileSync(mine, '{"cwd":"/wt","type":"user"}\n');
+    fs.writeFileSync(unknown, '{"type":"summary"}\n');
+    setMtime(mine, -60); // unknown の方が新しい
+    expect(pickLatestJsonl(dir, "/wt")).toBe(mine);
   });
 
   it("expectedCwd 一致が無ければ mtime 最新へフォールバック", () => {

--- a/packages/server/src/lib/claude-projects.test.ts
+++ b/packages/server/src/lib/claude-projects.test.ts
@@ -1,0 +1,142 @@
+/**
+ * claude-projects の単体テスト。
+ *
+ * encodeProjectDir / projectsDirFor はピュア関数。pickLatestJsonl は
+ * os.tmpdir() 配下に一時ディレクトリを作って実ファイルで検証する。
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  clearCwdCache,
+  encodeProjectDir,
+  pickLatestJsonl,
+  projectsDirFor,
+} from "./claude-projects.js";
+
+describe("encodeProjectDir", () => {
+  it("絶対パスの / を - に置換する", () => {
+    expect(encodeProjectDir("/home/admin/dev/foo")).toBe("-home-admin-dev-foo");
+  });
+
+  it("ドットも - に置換する (github.com 等)", () => {
+    expect(encodeProjectDir("/home/admin/dev/github.com/org/repo")).toBe(
+      "-home-admin-dev-github-com-org-repo"
+    );
+  });
+
+  it("アンダースコアも - に置換する (haus_3rd regression)", () => {
+    expect(encodeProjectDir("/home/admin/dev/MATLyS-Co-Ltd/haus_3rd")).toBe(
+      "-home-admin-dev-MATLyS-Co-Ltd-haus-3rd"
+    );
+  });
+
+  it("空白や + @ などの記号もすべて - に置換する (全非英数置換)", () => {
+    // Claude Code 本体は全非英数を '-' にする。部分的な置換実装だと
+    // こうしたパスで JSONL ディレクトリが見つからない
+    expect(encodeProjectDir("/wt/my app+v2@dev")).toBe("-wt-my-app-v2-dev");
+  });
+
+  it("英大文字は保持する", () => {
+    expect(encodeProjectDir("/home/admin/MATLyS-Co-Ltd")).toBe(
+      "-home-admin-MATLyS-Co-Ltd"
+    );
+  });
+
+  it("既存のハイフンはそのまま残す", () => {
+    expect(encodeProjectDir("/home/admin/foo-bar-baz")).toBe(
+      "-home-admin-foo-bar-baz"
+    );
+  });
+});
+
+describe("projectsDirFor", () => {
+  it("configDir を渡すとその配下の projects を返す", () => {
+    expect(projectsDirFor("/custom/config")).toBe("/custom/config/projects");
+  });
+
+  it("configDir 未指定なら ~/.claude/projects", () => {
+    expect(projectsDirFor(null)).toBe(
+      path.join(os.homedir(), ".claude", "projects")
+    );
+  });
+});
+
+describe("pickLatestJsonl", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "ark-claude-projects-test-"));
+    clearCwdCache();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  /** mtime を相対秒で設定するヘルパー */
+  function setMtime(file: string, offsetSec: number): void {
+    const t = new Date(Date.now() + offsetSec * 1000);
+    fs.utimesSync(file, t, t);
+  }
+
+  it("ディレクトリが無ければ null", () => {
+    expect(pickLatestJsonl(path.join(dir, "nope"))).toBeNull();
+  });
+
+  it(".jsonl が無ければ null", () => {
+    fs.writeFileSync(path.join(dir, "other.txt"), "x");
+    expect(pickLatestJsonl(dir)).toBeNull();
+  });
+
+  it("mtime 最新の .jsonl を返す", () => {
+    const a = path.join(dir, "a.jsonl");
+    const b = path.join(dir, "b.jsonl");
+    fs.writeFileSync(a, '{"cwd":"/wt"}\n');
+    fs.writeFileSync(b, '{"cwd":"/wt"}\n');
+    setMtime(a, -60);
+    expect(pickLatestJsonl(dir)).toBe(b);
+  });
+
+  it("expectedCwd 一致を mtime 降順で優先する (encode 衝突対策)", () => {
+    // /a/b と /a.b は同じ encodeProjectDir になる。mtime 最新が別 cwd の
+    // transcript でも、cwd 一致側を選ぶ
+    const mine = path.join(dir, "mine.jsonl");
+    const other = path.join(dir, "other.jsonl");
+    fs.writeFileSync(mine, '{"cwd":"/a/b","type":"user"}\n');
+    fs.writeFileSync(other, '{"cwd":"/a.b","type":"user"}\n');
+    setMtime(mine, -60); // other の方が新しい
+    expect(pickLatestJsonl(dir, "/a/b")).toBe(mine);
+  });
+
+  it("cwd フィールドの無いファイルは検証不能 = 一致扱いで採用しうる", () => {
+    const noCwd = path.join(dir, "no-cwd.jsonl");
+    fs.writeFileSync(noCwd, '{"type":"summary"}\n');
+    expect(pickLatestJsonl(dir, "/wt")).toBe(noCwd);
+  });
+
+  it("expectedCwd 一致が無ければ mtime 最新へフォールバック", () => {
+    const other = path.join(dir, "other.jsonl");
+    fs.writeFileSync(other, '{"cwd":"/different","type":"user"}\n');
+    expect(pickLatestJsonl(dir, "/wt")).toBe(other);
+  });
+
+  it("先頭行が cwd 無しでも後続行の cwd で検証する", () => {
+    // 実 transcript はサマリ行などが先頭に来ることがある
+    const f = path.join(dir, "s.jsonl");
+    fs.writeFileSync(
+      f,
+      '{"type":"summary","summary":"t"}\n{"cwd":"/wt","type":"user"}\n'
+    );
+    const g = path.join(dir, "g.jsonl");
+    fs.writeFileSync(g, '{"cwd":"/other","type":"user"}\n');
+    setMtime(f, -60); // g の方が新しいが cwd 不一致
+    expect(pickLatestJsonl(dir, "/wt")).toBe(f);
+  });
+});

--- a/packages/server/src/lib/claude-projects.test.ts
+++ b/packages/server/src/lib/claude-projects.test.ts
@@ -132,10 +132,10 @@ describe("pickLatestJsonl", () => {
     expect(pickLatestJsonl(dir, "/wt")).toBe(mine);
   });
 
-  it("expectedCwd 一致が無ければ mtime 最新へフォールバック", () => {
+  it("既知の不一致ファイルしか無ければ null (別 worktree の会話を出さない)", () => {
     const other = path.join(dir, "other.jsonl");
     fs.writeFileSync(other, '{"cwd":"/different","type":"user"}\n');
-    expect(pickLatestJsonl(dir, "/wt")).toBe(other);
+    expect(pickLatestJsonl(dir, "/wt")).toBeNull();
   });
 
   it("先頭行が cwd 無しでも後続行の cwd で検証する", () => {

--- a/packages/server/src/lib/claude-projects.ts
+++ b/packages/server/src/lib/claude-projects.ts
@@ -1,0 +1,118 @@
+/**
+ * claude-projects.ts - Claude Code が会話 transcript (JSONL) を永続化する
+ * `<configDir>/projects/` ディレクトリに関する純粋ヘルパー群。
+ *
+ * beacon-cli-session.ts にも同等のロジック (encodeProjectDir / locateJsonl)
+ * があるが、あちらは Beacon のターン同期と密結合しているため共通化しない
+ * (実機調整済みコードを不可侵に保つ)。将来寄せる場合はこのモジュールを正とする。
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * セッションごとに CLAUDE_CONFIG_DIR が異なるため、明示的に渡せる形にする。
+ * プロファイル未設定なら ~/.claude/projects/ がデフォルト。
+ */
+export function projectsDirFor(configDir?: string | null): string {
+  const base = configDir ?? path.join(os.homedir(), ".claude");
+  return path.join(base, "projects");
+}
+
+/**
+ * cwd 絶対パスを Claude Code の project ディレクトリ名へエンコードする。
+ * Claude Code 本体は **すべての非英数字** を `-` に置換する。
+ * 過去に `/` `.` `_` だけ置換する実装で `+` や空白を含むパスを取りこぼした
+ * regression があるため、必ず全非英数置換にする (beacon-cli-session.ts と同一)。
+ */
+export function encodeProjectDir(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+/**
+ * ファイル → 「最初に cwd フィールドを持つ行」の cwd 値キャッシュ。
+ * transcript の cwd は不変なので一度読めれば再読不要。
+ * (pickLatestJsonl は polling から繰り返し呼ばれるため、毎回のファイル読みを避ける)
+ */
+const cwdCache = new Map<string, string>();
+
+/** テスト用: cwd キャッシュを破棄する */
+export function clearCwdCache(): void {
+  cwdCache.clear();
+}
+
+/**
+ * JSONL ファイル先頭付近 (64KB) から最初の cwd フィールドを読む。
+ * 見つからない/読めない場合は null (検証不能)。
+ * cwd が確定したときのみキャッシュする (書きかけファイルで null を固定しない)。
+ */
+function readFileCwd(filePath: string): string | null {
+  const cached = cwdCache.get(filePath);
+  if (cached !== undefined) return cached;
+  try {
+    const fd = fs.openSync(filePath, "r");
+    try {
+      const buf = Buffer.alloc(64 * 1024);
+      const n = fs.readSync(fd, buf, 0, buf.length, 0);
+      const head = buf.toString("utf-8", 0, n);
+      for (const line of head.split("\n")) {
+        if (line === "") continue;
+        try {
+          const parsed = JSON.parse(line) as { cwd?: unknown };
+          if (typeof parsed.cwd === "string") {
+            cwdCache.set(filePath, parsed.cwd);
+            return parsed.cwd;
+          }
+        } catch {
+          // 読み込み境界で切れた行など。次の行へ
+        }
+      }
+      return null;
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * ディレクトリ内で mtime 最新の .jsonl を返す。なければ null。
+ *
+ * `expectedCwd` を渡すと、各ファイル先頭の cwd フィールドが一致するものを
+ * mtime 降順で優先する (encodeProjectDir の衝突対策。例: `/a/b` と `/a.b` は
+ * 同じディレクトリ名になる)。cwd が読めないファイルは「検証不能 = 一致扱い」、
+ * 一致が 1 つも無ければ mtime 最新へフォールバックする
+ * (beacon-cli-session.ts の locateJsonl と同じセマンティクス)。
+ */
+export function pickLatestJsonl(
+  dir: string,
+  expectedCwd?: string
+): string | null {
+  try {
+    const entries = fs.readdirSync(dir);
+    const candidates: { path: string; mtimeMs: number }[] = [];
+    for (const name of entries) {
+      if (!name.endsWith(".jsonl")) continue;
+      const full = path.join(dir, name);
+      try {
+        const st = fs.statSync(full);
+        if (!st.isFile()) continue;
+        candidates.push({ path: full, mtimeMs: st.mtimeMs });
+      } catch {
+        // stat 失敗 (削除レース等) はスキップ
+      }
+    }
+    candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
+    if (expectedCwd) {
+      for (const c of candidates) {
+        const cwd = readFileCwd(c.path);
+        if (cwd === null || cwd === expectedCwd) return c.path;
+      }
+    }
+    return candidates[0]?.path ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/server/src/lib/claude-projects.ts
+++ b/packages/server/src/lib/claude-projects.ts
@@ -85,9 +85,9 @@ function readFileCwd(filePath: string): string | null {
  * 同じディレクトリ名になる)。優先順位:
  *   1. cwd が expectedCwd に一致するファイル (mtime 降順)
  *   2. cwd が読めないファイル (書きかけ等。検証不能のため fallback 扱い)
- *   3. mtime 最新 (全ファイルが別 cwd だった場合の最後の砦)
- * cwd 不明を一致より先に採用すると、encode 衝突時に別 worktree の transcript
- * を表示し得るため、必ず一致を先に探す。
+ * **既知の不一致ファイルには決してフォールバックしない** (別 worktree の
+ * 会話を表示する情報漏えいになるため null を返し、一致ファイルの出現を
+ * 呼び出し側の polling に委ねる)。
  */
 export function pickLatestJsonl(
   dir: string,
@@ -115,7 +115,7 @@ export function pickLatestJsonl(
         if (cwd === expectedCwd) return c.path;
         if (cwd === null && unknown === null) unknown = c.path;
       }
-      if (unknown) return unknown;
+      return unknown;
     }
     return candidates[0]?.path ?? null;
   } catch {

--- a/packages/server/src/lib/claude-projects.ts
+++ b/packages/server/src/lib/claude-projects.ts
@@ -82,9 +82,12 @@ function readFileCwd(filePath: string): string | null {
  *
  * `expectedCwd` を渡すと、各ファイル先頭の cwd フィールドが一致するものを
  * mtime 降順で優先する (encodeProjectDir の衝突対策。例: `/a/b` と `/a.b` は
- * 同じディレクトリ名になる)。cwd が読めないファイルは「検証不能 = 一致扱い」、
- * 一致が 1 つも無ければ mtime 最新へフォールバックする
- * (beacon-cli-session.ts の locateJsonl と同じセマンティクス)。
+ * 同じディレクトリ名になる)。優先順位:
+ *   1. cwd が expectedCwd に一致するファイル (mtime 降順)
+ *   2. cwd が読めないファイル (書きかけ等。検証不能のため fallback 扱い)
+ *   3. mtime 最新 (全ファイルが別 cwd だった場合の最後の砦)
+ * cwd 不明を一致より先に採用すると、encode 衝突時に別 worktree の transcript
+ * を表示し得るため、必ず一致を先に探す。
  */
 export function pickLatestJsonl(
   dir: string,
@@ -106,10 +109,13 @@ export function pickLatestJsonl(
     }
     candidates.sort((a, b) => b.mtimeMs - a.mtimeMs);
     if (expectedCwd) {
+      let unknown: string | null = null;
       for (const c of candidates) {
         const cwd = readFileCwd(c.path);
-        if (cwd === null || cwd === expectedCwd) return c.path;
+        if (cwd === expectedCwd) return c.path;
+        if (cwd === null && unknown === null) unknown = c.path;
       }
+      if (unknown) return unknown;
     }
     return candidates[0]?.path ?? null;
   } catch {

--- a/packages/server/src/lib/jsonl-tail-manager.test.ts
+++ b/packages/server/src/lib/jsonl-tail-manager.test.ts
@@ -1,0 +1,312 @@
+/**
+ * JsonlTailManager の単体テスト。
+ *
+ * fs を絡めるため os.tmpdir() 配下に一時ディレクトリを作って実ファイルで
+ * 検証する。fs.watch のイベント発火は OS 依存でテスト不安定なので、
+ * polling 経由で動く部分 (1 秒間隔の自動 drain / 自己回復) を待ち合わせる方針。
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { clearCwdCache, encodeProjectDir } from "./claude-projects.js";
+import { JsonlTailManager } from "./jsonl-tail-manager.js";
+
+describe("JsonlTailManager", () => {
+  let baseDir: string;
+  let configDir: string;
+  let manager: JsonlTailManager;
+
+  // 各テストで CLAUDE_CONFIG_DIR 相当の一時ディレクトリを切り出し、
+  // その配下に projects/<encoded-cwd>/ を作って .jsonl を置く。
+  beforeEach(() => {
+    baseDir = fs.mkdtempSync(path.join(os.tmpdir(), "ark-jsonl-test-"));
+    configDir = baseDir;
+    manager = new JsonlTailManager();
+    clearCwdCache();
+  });
+
+  afterEach(() => {
+    manager.cleanup();
+    try {
+      fs.rmSync(baseDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  function setupEncodedDir(worktreePath: string): string {
+    const dir = path.join(
+      configDir,
+      "projects",
+      encodeProjectDir(worktreePath)
+    );
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  describe("readCurrentSnapshot", () => {
+    it("encoded ディレクトリが無いケースは空配列", () => {
+      const snap = manager.readCurrentSnapshot("/no/such/worktree", configDir);
+      expect(snap).toEqual([]);
+    });
+
+    it("最新の .jsonl から末尾行を limit 件読む", () => {
+      const wt = "/wt/proj_a";
+      const dir = setupEncodedDir(wt);
+      const file = path.join(dir, "session1.jsonl");
+      const lines = ['{"a":1}', '{"a":2}', '{"a":3}'];
+      fs.writeFileSync(file, `${lines.join("\n")}\n`);
+
+      const snap = manager.readCurrentSnapshot(wt, configDir, 100);
+      expect(snap.map(l => l.raw)).toEqual(lines);
+      expect(snap[0].parsed).toEqual({ a: 1 });
+      expect(snap[0].filePath).toBe(file);
+    });
+
+    it("limit より多い行があれば末尾 limit 件だけ返す", () => {
+      const wt = "/wt/proj_b";
+      const dir = setupEncodedDir(wt);
+      const file = path.join(dir, "s.jsonl");
+      const all = Array.from({ length: 50 }, (_, i) => `{"i":${i}}`);
+      fs.writeFileSync(file, `${all.join("\n")}\n`);
+
+      const snap = manager.readCurrentSnapshot(wt, configDir, 10);
+      expect(snap).toHaveLength(10);
+      expect(snap[0].raw).toBe('{"i":40}');
+      expect(snap[9].raw).toBe('{"i":49}');
+    });
+
+    it("mtime 最新の .jsonl ファイルが選ばれる", () => {
+      const wt = "/wt/proj_c";
+      const dir = setupEncodedDir(wt);
+      const older = path.join(dir, "old.jsonl");
+      const newer = path.join(dir, "new.jsonl");
+      fs.writeFileSync(older, '{"label":"old"}\n');
+      // mtime 差を確実に出すため明示的に過去日時にする
+      const past = new Date(Date.now() - 60_000);
+      fs.utimesSync(older, past, past);
+      fs.writeFileSync(newer, '{"label":"new"}\n');
+
+      const snap = manager.readCurrentSnapshot(wt, configDir);
+      expect(snap[0].parsed).toEqual({ label: "new" });
+      expect(snap[0].filePath).toBe(newer);
+    });
+
+    it("cwd 不一致の最新ファイルより cwd 一致ファイルを優先する (encode 衝突対策)", () => {
+      const wt = "/wt/proj_cd";
+      const dir = setupEncodedDir(wt);
+      const mine = path.join(dir, "mine.jsonl");
+      const other = path.join(dir, "other.jsonl");
+      fs.writeFileSync(mine, `{"cwd":"${wt}","label":"mine"}\n`);
+      const past = new Date(Date.now() - 60_000);
+      fs.utimesSync(mine, past, past);
+      // encode が衝突する別 cwd の transcript (mtime はこちらが新しい)
+      fs.writeFileSync(other, '{"cwd":"/wt/proj.cd","label":"other"}\n');
+
+      const snap = manager.readCurrentSnapshot(wt, configDir);
+      expect(snap[0].parsed).toEqual({ cwd: wt, label: "mine" });
+    });
+
+    it("不正な JSON 行も raw として返し parsed は undefined", () => {
+      const wt = "/wt/proj_d";
+      const dir = setupEncodedDir(wt);
+      const file = path.join(dir, "s.jsonl");
+      fs.writeFileSync(file, "not json\n");
+
+      const snap = manager.readCurrentSnapshot(wt, configDir);
+      expect(snap[0].raw).toBe("not json");
+      expect(snap[0].parsed).toBeUndefined();
+    });
+  });
+
+  describe("subscribe で追記行を listener に通知する", () => {
+    it("subscribe 後にファイルへ追記した行が onLine で届く", async () => {
+      const wt = "/wt/proj_e";
+      const dir = setupEncodedDir(wt);
+      const file = path.join(dir, "s.jsonl");
+      fs.writeFileSync(file, '{"seq":1}\n');
+
+      const lines: string[] = [];
+      const unsub = manager.subscribe(wt, configDir, {
+        onLine: line => {
+          lines.push(line.raw);
+        },
+      });
+
+      // subscribe は末尾までシークしているので 既存の {"seq":1} は流れない。
+      // 追記した分だけが届く想定。
+      fs.appendFileSync(file, '{"seq":2}\n{"seq":3}\n');
+      // 1 秒間隔の polling を 1 回以上待つ
+      await new Promise(r => setTimeout(r, 1300));
+
+      expect(lines).toEqual(['{"seq":2}', '{"seq":3}']);
+      unsub();
+    });
+
+    it("既存ファイル末尾の改行未完了行は次回追記で連結して処理される", async () => {
+      const wt = "/wt/proj_f";
+      const dir = setupEncodedDir(wt);
+      const file = path.join(dir, "s.jsonl");
+      fs.writeFileSync(file, "");
+
+      const lines: string[] = [];
+      const unsub = manager.subscribe(wt, configDir, {
+        onLine: line => lines.push(line.raw),
+      });
+
+      // 改行で終わっていない断片 → polling では未確定として保留される
+      fs.appendFileSync(file, '{"part":');
+      await new Promise(r => setTimeout(r, 1300));
+      expect(lines).toEqual([]);
+
+      // 改行が来てはじめて確定行として通知される
+      fs.appendFileSync(file, "1}\n");
+      await new Promise(r => setTimeout(r, 1300));
+      expect(lines).toEqual(['{"part":1}']);
+
+      unsub();
+    });
+  });
+
+  describe("dir / file が購読後に出現するケース (自己回復)", () => {
+    it("subscribe 時に encoded ディレクトリが無くても、後から作られた .jsonl を拾う", async () => {
+      const wt = "/wt/proj_late_dir";
+      // setupEncodedDir をあえて呼ばず、dir 不在のまま購読する
+      const lines: string[] = [];
+      let resets = 0;
+      const unsub = manager.subscribe(wt, configDir, {
+        onLine: line => lines.push(line.raw),
+        onReset: () => {
+          resets++;
+        },
+      });
+
+      await new Promise(r => setTimeout(r, 200));
+      // Claude Code 初回起動相当: dir + .jsonl が後から出現
+      const dir = setupEncodedDir(wt);
+      const file = path.join(dir, "s.jsonl");
+      fs.writeFileSync(file, '{"first":1}\n');
+
+      // polling の自己回復 (1 秒間隔) を待つ
+      await new Promise(r => setTimeout(r, 1500));
+
+      // 新規出現ファイルは先頭から読まれる
+      expect(lines).toEqual(['{"first":1}']);
+      // 初回発見は「切替」ではないので onReset は不要
+      expect(resets).toBe(0);
+      unsub();
+    });
+
+    it("subscribe 時に dir はあるが .jsonl が無くても、後から作られたファイルを拾う", async () => {
+      const wt = "/wt/proj_late_file";
+      const dir = setupEncodedDir(wt);
+
+      const lines: string[] = [];
+      const unsub = manager.subscribe(wt, configDir, {
+        onLine: line => lines.push(line.raw),
+      });
+
+      await new Promise(r => setTimeout(r, 200));
+      const file = path.join(dir, "s.jsonl");
+      fs.writeFileSync(file, '{"hello":1}\n');
+
+      await new Promise(r => setTimeout(r, 1500));
+      expect(lines).toEqual(['{"hello":1}']);
+      unsub();
+    });
+  });
+
+  describe("ファイル切替 (/clear 相当) で onReset コールバックが呼ばれる", () => {
+    it("ディレクトリに新規 .jsonl が出現すると onReset 発火、以降は新ファイルから", async () => {
+      const wt = "/wt/proj_g";
+      const dir = setupEncodedDir(wt);
+      const file1 = path.join(dir, "s1.jsonl");
+      fs.writeFileSync(file1, '{"old":1}\n');
+
+      const lines: string[] = [];
+      let resetCount = 0;
+      const unsub = manager.subscribe(wt, configDir, {
+        onLine: line => lines.push(line.raw),
+        onReset: () => {
+          resetCount++;
+          // onReset の時点では旧履歴は破棄されている想定なので、
+          // 受信ログもクリアしてあとに来る new ファイル行だけが残るか確認しやすくする
+          lines.length = 0;
+        },
+      });
+
+      // mtime 差を確実に出すため file1 を過去時刻に
+      const past = new Date(Date.now() - 60_000);
+      fs.utimesSync(file1, past, past);
+
+      // 新セッション開始相当: 新しい .jsonl がディレクトリに登場
+      const file2 = path.join(dir, "s2.jsonl");
+      fs.writeFileSync(file2, '{"new":1}\n');
+
+      // dirWatcher + polling の発火を待つ
+      await new Promise(r => setTimeout(r, 1500));
+
+      expect(resetCount).toBeGreaterThanOrEqual(1);
+      expect(lines).toEqual(['{"new":1}']);
+
+      unsub();
+    });
+  });
+
+  describe("unsubscribe", () => {
+    it("最後の listener が外れたら tail を停止して、以降の追記は流れない", async () => {
+      const wt = "/wt/proj_h";
+      const dir = setupEncodedDir(wt);
+      const file = path.join(dir, "s.jsonl");
+      fs.writeFileSync(file, "");
+
+      const lines: string[] = [];
+      const unsub = manager.subscribe(wt, configDir, {
+        onLine: line => lines.push(line.raw),
+      });
+
+      fs.appendFileSync(file, '{"a":1}\n');
+      await new Promise(r => setTimeout(r, 1300));
+      expect(lines).toHaveLength(1);
+
+      unsub();
+
+      // unsubscribe 後の追記は届かないはず
+      fs.appendFileSync(file, '{"a":2}\n');
+      await new Promise(r => setTimeout(r, 1300));
+      expect(lines).toHaveLength(1);
+    });
+
+    it("同一 worktree を複数 listener で購読し、片方解除しても残った listener には届く", async () => {
+      const wt = "/wt/proj_i";
+      const dir = setupEncodedDir(wt);
+      const file = path.join(dir, "s.jsonl");
+      fs.writeFileSync(file, "");
+
+      const a: string[] = [];
+      const b: string[] = [];
+      const unsubA = manager.subscribe(wt, configDir, {
+        onLine: line => a.push(line.raw),
+      });
+      const unsubB = manager.subscribe(wt, configDir, {
+        onLine: line => b.push(line.raw),
+      });
+
+      fs.appendFileSync(file, '{"x":1}\n');
+      await new Promise(r => setTimeout(r, 1300));
+      expect(a).toEqual(['{"x":1}']);
+      expect(b).toEqual(['{"x":1}']);
+
+      unsubA();
+
+      fs.appendFileSync(file, '{"x":2}\n');
+      await new Promise(r => setTimeout(r, 1300));
+      expect(a).toEqual(['{"x":1}']); // 解除済みは増えない
+      expect(b).toEqual(['{"x":1}', '{"x":2}']);
+
+      unsubB();
+    });
+  });
+});

--- a/packages/server/src/lib/jsonl-tail-manager.ts
+++ b/packages/server/src/lib/jsonl-tail-manager.ts
@@ -83,7 +83,9 @@ export class JsonlTailManager {
   private tails = new Map<string, ActiveTail>();
 
   private keyOf(worktreePath: string, configDir: string | null | undefined) {
-    return `${worktreePath} ${configDir ?? ""}`;
+    // 空白区切りの単純連結だと空白を含む path/configDir で衝突し、
+    // 別セッションの tail/listener が混線するため衝突しない表現にする
+    return JSON.stringify([worktreePath, configDir ?? null]);
   }
 
   /**
@@ -331,10 +333,13 @@ export class JsonlTailManager {
     }
     const fd = fs.openSync(tail.currentFile, "r");
     try {
-      const length = size - tail.readOffset;
+      // 巨大な一括追記 (resume での過去ログ流入等) でも一度に確保する
+      // バッファを上限内に抑える。残りは直後の setImmediate で続きを処理する
+      const MAX_DRAIN_BYTES = 4 * 1024 * 1024;
+      const length = Math.min(size - tail.readOffset, MAX_DRAIN_BYTES);
       const buf = Buffer.alloc(length);
       fs.readSync(fd, buf, 0, length, tail.readOffset);
-      tail.readOffset = size;
+      tail.readOffset += length;
       const chunk = tail.lineBuffer + buf.toString("utf-8");
       const lines = chunk.split("\n");
       // 最後の要素は改行で終わっていない可能性 → バッファに残す
@@ -352,6 +357,15 @@ export class JsonlTailManager {
       }
     } finally {
       fs.closeSync(fd);
+    }
+    // 上限で打ち切った読み残しを即時に続行する (1 tick あたりの処理量は
+    // 上限内に保ちつつ、次の polling まで読み残しを放置しない)。
+    // 各回で readOffset が必ず前進するため有限回で収束する
+    if (size > tail.readOffset) {
+      setImmediate(() => {
+        // 続行前に購読が解除されていれば何もしない
+        if (tail.listeners.size > 0) this.drainNewLines(tail);
+      });
     }
   }
 

--- a/packages/server/src/lib/jsonl-tail-manager.ts
+++ b/packages/server/src/lib/jsonl-tail-manager.ts
@@ -117,6 +117,35 @@ export class JsonlTailManager {
   }
 
   /**
+   * 購読開始と初期 snapshot の取得を原子的に行う。
+   *
+   * subscribe (tail の読み出し offset 確定) と snapshot 読みを別々に行うと、
+   * その間に追記された行が snapshot にも onLine にも入らず欠落する。
+   * ここでは同一同期処理内で tail の確定 offset を先に固定し、その offset
+   * までの末尾 `limit` 行を snapshot として返す。offset 以降の追記は必ず
+   * onLine で届くため、snapshot と増分が隙間なく連続する。
+   */
+  subscribeWithSnapshot(
+    worktreePath: string,
+    configDir: string | null | undefined,
+    listener: JsonlListener,
+    limit = 100
+  ): { snapshot: JsonlLine[]; unsubscribe: () => void } {
+    const unsubscribe = this.subscribe(worktreePath, configDir, listener);
+    const tail = this.tails.get(this.keyOf(worktreePath, configDir));
+    let snapshot: JsonlLine[] = [];
+    if (tail?.currentFile) {
+      // readOffset には lineBuffer (改行未到達の断片) のバイト数も含まれる。
+      // 断片が snapshot 末尾に不完全 JSON 行として混入しないよう、
+      // 確定行境界までを snapshot の上限にする
+      const settled =
+        tail.readOffset - Buffer.byteLength(tail.lineBuffer, "utf-8");
+      snapshot = this.readTailLines(tail.currentFile, limit, settled);
+    }
+    return { snapshot, unsubscribe };
+  }
+
+  /**
    * 購読中のすべてのファイルを閉じる (サーバ終了時など)
    */
   cleanup(): void {
@@ -337,15 +366,22 @@ export class JsonlTailManager {
   /**
    * 現行ファイルの末尾 `limit` 行を返す (初回 snapshot 用)。
    * 巨大ファイルでも先に全行 split せず、末尾から逆方向にチャンク読みする。
+   * `upToBytes` を渡すとそのバイト位置までを「末尾」として扱う
+   * (subscribeWithSnapshot が tail offset と snapshot を一致させるために使う)。
    */
-  private readTailLines(filePath: string, limit: number): JsonlLine[] {
+  private readTailLines(
+    filePath: string,
+    limit: number,
+    upToBytes?: number
+  ): JsonlLine[] {
     try {
       const stat = fs.statSync(filePath);
-      if (stat.size === 0 || limit <= 0) return [];
+      const end = Math.max(0, Math.min(upToBytes ?? stat.size, stat.size));
+      if (end === 0 || limit <= 0) return [];
       const fd = fs.openSync(filePath, "r");
       try {
         const CHUNK = 64 * 1024;
-        let pos = stat.size;
+        let pos = end;
         let buffer = "";
         let newlineCount = 0;
         // 末尾から CHUNK ごとに読みつつ、改行が `limit` 件以上含まれるまで遡る

--- a/packages/server/src/lib/jsonl-tail-manager.ts
+++ b/packages/server/src/lib/jsonl-tail-manager.ts
@@ -1,0 +1,386 @@
+/**
+ * JsonlTailManager - Claude Code が永続化する JSONL セッションログを
+ * リアルタイム tail し、新規行をコールバックで通知する。
+ *
+ * 背景:
+ *   Claude Code は対話履歴を `<configDir>/projects/<encoded-cwd>/<uuid>.jsonl`
+ *   に永続化する。tmux 画面パースよりも遥かに情報量の多い構造化データ
+ *   (tool_use の input 全文、tool_result 全長、AskUserQuestion の質問/回答など)
+ *   が含まれるため、チャットビューのデータソースとして利用する。
+ *   **会話内容の情報源はこの JSONL のみ** とし、tmux capture-pane から内容を
+ *   パースすることはしない (チャット UI v3 の設計原則)。
+ *
+ * 仕組み:
+ *   - worktreePath を encodeProjectDir して projects 配下のディレクトリを特定
+ *   - そのディレクトリ内で mtime 最新の *.jsonl を「現行ファイル」として選ぶ
+ *     (encode 衝突対策として先頭行の cwd フィールド検証つき)
+ *   - fs.watch (file) + 1 秒 polling で増分読み。fs.watch だけだと Claude CLI
+ *     のバッファリングで追記イベントを取りこぼすため polling を併用する
+ *   - ディレクトリに新しい *.jsonl が出現したら mtime 比較で切り替える
+ *     (/clear や resume で新セッションが始まったケース)。切替時は onReset を
+ *     先に通知してから新ファイル先頭の行を流す
+ *   - polling は tail 単位で常時起動する。subscribe 時点で encoded ディレクトリ
+ *     や .jsonl が未作成でも、後から出現した時点で自動的に拾う
+ *     (旧実装は未作成だと watcher が起動せず購読が死ぬバグがあった)
+ *   - 1 tail = 1 (worktreePath, configDir)。複数 socket が同じ worktree を
+ *     購読する場合は refcount で共有する
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import {
+  encodeProjectDir,
+  pickLatestJsonl,
+  projectsDirFor,
+} from "./claude-projects.js";
+
+export interface JsonlLine {
+  /** 行の元 JSON 文字列 (失敗時はパース不可な生文字列が入る) */
+  raw: string;
+  /** パース成功時の JSON (失敗時 undefined) */
+  parsed?: unknown;
+  /** どの .jsonl ファイルから来たか (ファイル切替の検出用) */
+  filePath: string;
+}
+
+/**
+ * 購読者に渡す listener。`/clear` や resume で JSONL ファイルが切り替わると
+ * onReset が先に呼ばれ、続いて新ファイル先頭からの行が onLine で流れる。
+ * onReset を実装する側は「これまで蓄積した行を破棄する」責務を持つ。
+ */
+export interface JsonlListener {
+  onLine: (line: JsonlLine) => void;
+  onReset?: () => void;
+}
+
+interface ActiveTail {
+  worktreePath: string;
+  encodedDir: string;
+  /** 現行 .jsonl ファイル絶対パス。null なら未発見 */
+  currentFile: string | null;
+  /** 現行ファイルで読み込み済みのバイト数 (増分読み出し位置) */
+  readOffset: number;
+  /** 現行ファイルの行ぶった切り防止用バッファ */
+  lineBuffer: string;
+  /** ディレクトリ watcher (新 .jsonl 出現の即時検知用。polling が保険) */
+  dirWatcher: fs.FSWatcher | null;
+  /** ファイル watcher (fs.watch ベース。Linux で追記イベント取りこぼしあり) */
+  fileWatcher: fs.FSWatcher | null;
+  /**
+   * polling fallback。tail 単位で常時起動し、
+   * - 現行ファイルの増分 drain (fs.watch の取りこぼし対策)
+   * - encoded dir / .jsonl が後から出現したときの自己回復
+   * - dirWatcher が起動できなかった場合のファイル切替検知
+   * を兼ねる。
+   */
+  pollTimer: NodeJS.Timeout | null;
+  /** このセッションを購読中の listener 集合 */
+  listeners: Set<JsonlListener>;
+}
+
+export class JsonlTailManager {
+  /** key = `${worktreePath} ${configDir ?? ""}` (同一 worktree でも configDir 違いは別 tail) */
+  private tails = new Map<string, ActiveTail>();
+
+  private keyOf(worktreePath: string, configDir: string | null | undefined) {
+    return `${worktreePath} ${configDir ?? ""}`;
+  }
+
+  /**
+   * worktree の JSONL を購読する。listener.onLine が新規行ごとに呼ばれる。
+   * `/clear` 等で JSONL ファイルが切り替わると onReset が先に呼ばれ、
+   * その後 onLine で新ファイル先頭からの行が流れる。
+   * configDir はセッションごとに異なる CLAUDE_CONFIG_DIR を反映するため必須。
+   * 戻り値はクリーンアップ関数 (購読解除)。
+   */
+  subscribe(
+    worktreePath: string,
+    configDir: string | null | undefined,
+    listener: JsonlListener
+  ): () => void {
+    const key = this.keyOf(worktreePath, configDir);
+    let tail = this.tails.get(key);
+    if (!tail) {
+      tail = this.startTail(worktreePath, configDir);
+      this.tails.set(key, tail);
+    }
+    tail.listeners.add(listener);
+
+    return () => {
+      const t = this.tails.get(key);
+      if (!t) return;
+      t.listeners.delete(listener);
+      if (t.listeners.size === 0) {
+        this.stopTail(key);
+      }
+    };
+  }
+
+  /**
+   * 購読中のすべてのファイルを閉じる (サーバ終了時など)
+   */
+  cleanup(): void {
+    for (const key of this.tails.keys()) {
+      this.stopTail(key);
+    }
+  }
+
+  /**
+   * 初回購読時に過去履歴を一括取得したい場合に使う。
+   * 現行ファイルの末尾 `limit` 行 (デフォルト 100) を listener なしで返す。
+   * 長い履歴で初回ロードが重くなるのを避けるため全行ではなく末尾を返す。
+   */
+  readCurrentSnapshot(
+    worktreePath: string,
+    configDir: string | null | undefined,
+    limit = 100
+  ): JsonlLine[] {
+    const encodedDir = path.join(
+      projectsDirFor(configDir),
+      encodeProjectDir(worktreePath)
+    );
+    const current = pickLatestJsonl(encodedDir, worktreePath);
+    if (!current) return [];
+    return this.readTailLines(current, limit);
+  }
+
+  // ===== internal =====
+
+  private startTail(
+    worktreePath: string,
+    configDir: string | null | undefined
+  ): ActiveTail {
+    const encodedDir = path.join(
+      projectsDirFor(configDir),
+      encodeProjectDir(worktreePath)
+    );
+    const tail: ActiveTail = {
+      worktreePath,
+      encodedDir,
+      currentFile: null,
+      readOffset: 0,
+      lineBuffer: "",
+      dirWatcher: null,
+      fileWatcher: null,
+      pollTimer: null,
+      listeners: new Set(),
+    };
+
+    // 最新 .jsonl を選んで、末尾までシークしておく
+    // (購読開始後の「新規行」のみ流すため。過去履歴は readCurrentSnapshot 経由で取得)
+    const latest = pickLatestJsonl(encodedDir, worktreePath);
+    if (latest) {
+      tail.currentFile = latest;
+      try {
+        tail.readOffset = fs.statSync(latest).size;
+      } catch {
+        tail.readOffset = 0;
+      }
+      this.startFileWatcher(tail);
+    }
+
+    this.tryStartDirWatcher(tail);
+
+    // tail 単位の常時 polling (増分 drain + dir/file 後発出現の自己回復)
+    tail.pollTimer = setInterval(() => {
+      this.pollTick(tail);
+    }, 1000);
+
+    return tail;
+  }
+
+  private stopTail(key: string): void {
+    const tail = this.tails.get(key);
+    if (!tail) return;
+    this.stopFileWatcher(tail);
+    tail.dirWatcher?.close();
+    tail.dirWatcher = null;
+    if (tail.pollTimer) {
+      clearInterval(tail.pollTimer);
+      tail.pollTimer = null;
+    }
+    this.tails.delete(key);
+  }
+
+  /**
+   * ディレクトリ watcher を起動する。encoded ディレクトリがまだ無い場合は
+   * 失敗のまま (pollTick が後から再試行する)。
+   */
+  private tryStartDirWatcher(tail: ActiveTail): void {
+    if (tail.dirWatcher) return;
+    try {
+      tail.dirWatcher = fs.watch(tail.encodedDir, () => {
+        this.checkFileSwitch(tail);
+      });
+    } catch {
+      tail.dirWatcher = null;
+    }
+  }
+
+  /**
+   * 1 秒ごとの polling 本体。
+   * - dirWatcher が未起動なら再試行 (encoded dir が後から作られたケース)
+   * - 現行ファイル未発見なら再評価し、見つかれば先頭から読む
+   * - 現行ファイルがあればファイル切替チェック + 増分 drain
+   */
+  private pollTick(tail: ActiveTail): void {
+    if (!tail.dirWatcher) this.tryStartDirWatcher(tail);
+    if (!tail.currentFile) {
+      const latest = pickLatestJsonl(tail.encodedDir, tail.worktreePath);
+      if (latest) {
+        // 購読開始時には存在しなかったファイル = 新規セッションなので先頭から読む
+        tail.currentFile = latest;
+        tail.readOffset = 0;
+        tail.lineBuffer = "";
+        this.startFileWatcher(tail);
+        this.drainNewLines(tail);
+      }
+      return;
+    }
+    // dirWatcher が機能していないプラットフォームでも切替を検知できるよう
+    // polling 側でも軽量チェックする (readdir + stat 程度)
+    this.checkFileSwitch(tail);
+    this.drainNewLines(tail);
+  }
+
+  /**
+   * ディレクトリ内の最新 .jsonl が現行ファイルと異なれば切り替える
+   * (/clear / resume で新セッションが始まったケース)。
+   * listener には onReset を先に通知してから新ファイル先頭の行を流す。
+   * 順序が逆だと新ファイルの先頭行が旧 events 末尾に append されてしまう。
+   */
+  private checkFileSwitch(tail: ActiveTail): void {
+    const newest = pickLatestJsonl(tail.encodedDir, tail.worktreePath);
+    if (!newest || newest === tail.currentFile) return;
+    this.stopFileWatcher(tail);
+    tail.currentFile = newest;
+    tail.readOffset = 0;
+    tail.lineBuffer = "";
+    for (const listener of tail.listeners) {
+      try {
+        listener.onReset?.();
+      } catch (err) {
+        console.error("[JsonlTail] reset listener error:", err);
+      }
+    }
+    this.startFileWatcher(tail);
+    this.drainNewLines(tail);
+  }
+
+  private startFileWatcher(tail: ActiveTail): void {
+    if (!tail.currentFile) return;
+    try {
+      tail.fileWatcher = fs.watch(tail.currentFile, () => {
+        this.drainNewLines(tail);
+      });
+    } catch {
+      tail.fileWatcher = null;
+    }
+  }
+
+  private stopFileWatcher(tail: ActiveTail): void {
+    tail.fileWatcher?.close();
+    tail.fileWatcher = null;
+  }
+
+  private drainNewLines(tail: ActiveTail): void {
+    if (!tail.currentFile) return;
+    let size: number;
+    try {
+      size = fs.statSync(tail.currentFile).size;
+    } catch {
+      return;
+    }
+    if (size <= tail.readOffset) {
+      // truncate/rotate された場合はリセットしてもう一度読む
+      if (size < tail.readOffset) {
+        tail.readOffset = 0;
+        tail.lineBuffer = "";
+      } else {
+        return;
+      }
+    }
+    const fd = fs.openSync(tail.currentFile, "r");
+    try {
+      const length = size - tail.readOffset;
+      const buf = Buffer.alloc(length);
+      fs.readSync(fd, buf, 0, length, tail.readOffset);
+      tail.readOffset = size;
+      const chunk = tail.lineBuffer + buf.toString("utf-8");
+      const lines = chunk.split("\n");
+      // 最後の要素は改行で終わっていない可能性 → バッファに残す
+      tail.lineBuffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line === "") continue;
+        const event = this.parseLine(line, tail.currentFile);
+        for (const l of tail.listeners) {
+          try {
+            l.onLine(event);
+          } catch (err) {
+            console.error("[JsonlTail] listener error:", err);
+          }
+        }
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  private parseLine(raw: string, filePath: string): JsonlLine {
+    try {
+      return { raw, parsed: JSON.parse(raw), filePath };
+    } catch {
+      return { raw, filePath };
+    }
+  }
+
+  /**
+   * 現行ファイルの末尾 `limit` 行を返す (初回 snapshot 用)。
+   * 巨大ファイルでも先に全行 split せず、末尾から逆方向にチャンク読みする。
+   */
+  private readTailLines(filePath: string, limit: number): JsonlLine[] {
+    try {
+      const stat = fs.statSync(filePath);
+      if (stat.size === 0 || limit <= 0) return [];
+      const fd = fs.openSync(filePath, "r");
+      try {
+        const CHUNK = 64 * 1024;
+        let pos = stat.size;
+        let buffer = "";
+        let newlineCount = 0;
+        // 末尾から CHUNK ごとに読みつつ、改行が `limit` 件以上含まれるまで遡る
+        while (pos > 0 && newlineCount <= limit) {
+          const readSize = Math.min(CHUNK, pos);
+          pos -= readSize;
+          const buf = Buffer.alloc(readSize);
+          fs.readSync(fd, buf, 0, readSize, pos);
+          const chunk = buf.toString("utf-8");
+          buffer = chunk + buffer;
+          newlineCount = 0;
+          for (let i = 0; i < buffer.length; i++) {
+            if (buffer.charCodeAt(i) === 10) newlineCount++;
+          }
+        }
+        const all = buffer.split("\n");
+        // 先頭行が読み込み境界で切れている可能性 → ファイル先頭まで遡っていなければ捨てる
+        if (pos > 0 && all.length > 0) all.shift();
+        // 末尾の空要素 (ファイル末尾の \n 由来) は実体行ではないので落としてから
+        // スライスする。これをやらないと limit-1 件しか返らない off-by-one になる。
+        while (all.length > 0 && all[all.length - 1] === "") all.pop();
+        const sliced = all.slice(Math.max(0, all.length - limit));
+        const out: JsonlLine[] = [];
+        for (const line of sliced) {
+          if (line === "") continue;
+          out.push(this.parseLine(line, filePath));
+        }
+        return out;
+      } finally {
+        fs.closeSync(fd);
+      }
+    } catch {
+      return [];
+    }
+  }
+}
+
+export const jsonlTailManager = new JsonlTailManager();

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -109,25 +109,15 @@ export class SessionOrchestrator extends EventEmitter {
         const restoredProfile =
           dbSession.profileId && dbSession.profileConfigDir
             ? { id: dbSession.profileId, configDir: dbSession.profileConfigDir }
-            : null;
+            : this.detectEnvProfile(tmuxSession);
         this.sessionProfiles.set(dbSession.id, restoredProfile);
       } else {
         // DB に対応レコードなし (例: data dir を別パスに移行した直後)。
-        // tmux env から CLAUDE_CONFIG_DIR を読み取って sessionProfiles に
-        // 反映し、JsonlTailManager が正しいプロファイル配下の JSONL を
-        // 見つけられるようにする (profileId は不明なので configDir のみ)。
-        const envConfigDir = tmuxManager.getEnv(
-          tmuxSession.id,
-          "CLAUDE_CONFIG_DIR"
-        );
-        if (envConfigDir) {
-          this.sessionProfiles.set(tmuxSession.id, {
-            id: "__env__", // 識別用ダミー (UI 側のプロファイル管理とは紐付かない)
-            configDir: envConfigDir,
-          });
-          console.log(
-            `[Orchestrator] Restored profile from tmux env: ${tmuxSession.tmuxSessionName} -> ${envConfigDir}`
-          );
+        // env から CLAUDE_CONFIG_DIR を補完し、JsonlTailManager が正しい
+        // プロファイル配下の JSONL を見つけられるようにする。
+        const envProfile = this.detectEnvProfile(tmuxSession);
+        if (envProfile) {
+          this.sessionProfiles.set(tmuxSession.id, envProfile);
         }
       }
 
@@ -215,6 +205,33 @@ export class SessionOrchestrator extends EventEmitter {
       profileConfigDir: current?.configDir ?? null,
       staleProfile,
     };
+  }
+
+  /**
+   * 復元したセッションの「事実上の CLAUDE_CONFIG_DIR」を env から検出する。
+   *
+   * DB にプロファイル記録が無い (または null の) セッションでも、
+   * - 旧コードで起動され tmux サーバー env から CLAUDE_CONFIG_DIR を継承した
+   * - data dir 移行で DB レコードが消えた
+   * 等で claude が別プロファイル配下に transcript を書いていることがある。
+   * その場合 JsonlTailManager がデフォルト ~/.claude/projects を見てしまい、
+   * チャットビューに会話が一切表示されない。
+   * tmux session env (`show-environment`) → pane プロセス environ (/proc) の
+   * 順で実際の値を探し、見つかれば configDir のみのダミープロファイルとして
+   * 反映する (profileId は管理 UI と紐付かない `__env__`)。
+   */
+  private detectEnvProfile(tmuxSession: {
+    id: string;
+    tmuxSessionName: string;
+  }): { id: string; configDir: string } | null {
+    const envConfigDir =
+      tmuxManager.getEnv(tmuxSession.id, "CLAUDE_CONFIG_DIR") ??
+      tmuxManager.getPaneEnv(tmuxSession.id, "CLAUDE_CONFIG_DIR");
+    if (!envConfigDir) return null;
+    console.log(
+      `[Orchestrator] Restored profile from env: ${tmuxSession.tmuxSessionName} -> ${envConfigDir}`
+    );
+    return { id: "__env__", configDir: envConfigDir };
   }
 
   /**

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -111,6 +111,24 @@ export class SessionOrchestrator extends EventEmitter {
             ? { id: dbSession.profileId, configDir: dbSession.profileConfigDir }
             : null;
         this.sessionProfiles.set(dbSession.id, restoredProfile);
+      } else {
+        // DB に対応レコードなし (例: data dir を別パスに移行した直後)。
+        // tmux env から CLAUDE_CONFIG_DIR を読み取って sessionProfiles に
+        // 反映し、JsonlTailManager が正しいプロファイル配下の JSONL を
+        // 見つけられるようにする (profileId は不明なので configDir のみ)。
+        const envConfigDir = tmuxManager.getEnv(
+          tmuxSession.id,
+          "CLAUDE_CONFIG_DIR"
+        );
+        if (envConfigDir) {
+          this.sessionProfiles.set(tmuxSession.id, {
+            id: "__env__", // 識別用ダミー (UI 側のプロファイル管理とは紐付かない)
+            configDir: envConfigDir,
+          });
+          console.log(
+            `[Orchestrator] Restored profile from tmux env: ${tmuxSession.tmuxSessionName} -> ${envConfigDir}`
+          );
+        }
       }
 
       // ttydも自動起動（起動完了後にクライアントへ通知）
@@ -192,6 +210,9 @@ export class SessionOrchestrator extends EventEmitter {
       ttydPort: ttydInstance?.port || null,
       ttydUrl: ttydInstance ? `/ttyd/${tmuxSession.id}/` : null,
       profileId: current?.id ?? null,
+      // JSONL tail (チャットビュー) がプロファイル配下の
+      // <configDir>/projects を参照するために必要
+      profileConfigDir: current?.configDir ?? null,
       staleProfile,
     };
   }

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -755,6 +755,7 @@ export class SessionOrchestrator extends EventEmitter {
     activityText: string;
     status: SessionStatus;
     bridgeStatus: BridgeSessionStatus;
+    awaitingText?: string;
     timestamp: number;
   }> {
     const allSessions = tmuxManager.getAllSessions();
@@ -764,6 +765,7 @@ export class SessionOrchestrator extends EventEmitter {
       activityText: string;
       status: SessionStatus;
       bridgeStatus: BridgeSessionStatus;
+      awaitingText?: string;
       timestamp: number;
     }> = [];
 
@@ -843,12 +845,27 @@ export class SessionOrchestrator extends EventEmitter {
         db.updateSessionStatus(session.id, status);
       }
 
+      // AWAITING (ユーザー判断待ち) のときは、確認 UI の生テキストを添える。
+      // チャットビューのバナーが「何を聞かれているか」をそのまま表示するため。
+      // 構造のパースはせず ANSI 除去済みの末尾をミラーするだけ (壊れない)
+      let awaitingText: string | undefined;
+      if (bridgeStatus === "AWAITING") {
+        const rawLines = stripAnsi(raw)
+          .split("\n")
+          .map(l => l.replace(/\s+$/, ""));
+        while (rawLines.length > 0 && rawLines[rawLines.length - 1] === "") {
+          rawLines.pop();
+        }
+        awaitingText = rawLines.slice(-18).join("\n");
+      }
+
       previews.push({
         sessionId: session.id,
         text,
         activityText: activityLine,
         status,
         bridgeStatus,
+        awaitingText,
         timestamp: Date.now(),
       });
     }

--- a/packages/server/src/lib/slash-command-scanner.ts
+++ b/packages/server/src/lib/slash-command-scanner.ts
@@ -48,18 +48,31 @@ const BUILT_IN: SlashCommandInfo[] = [
 const FRONTMATTER_DESC_RE = /^---[\r\n]+([\s\S]*?)^---[\r\n]+/m;
 const DESCRIPTION_LINE_RE = /^description:\s*(.+?)\s*$/m;
 
+/**
+ * frontmatter 抽出に必要な分だけ読む上限。
+ * `.claude/commands/*.md` は入力境界として信用できない (巨大ファイルや
+ * 巨大ファイルへの symlink が置かれ得る) ため、全読みせず先頭のみ読む。
+ */
+const FRONTMATTER_READ_LIMIT = 4 * 1024;
+
 async function readDescriptionFromMd(
   filePath: string
 ): Promise<string | undefined> {
+  let fh: Awaited<ReturnType<typeof fs.open>> | undefined;
   try {
-    const buf = await fs.readFile(filePath, "utf-8");
-    const fm = buf.match(FRONTMATTER_DESC_RE);
+    fh = await fs.open(filePath, "r");
+    const buf = Buffer.alloc(FRONTMATTER_READ_LIMIT);
+    const { bytesRead } = await fh.read(buf, 0, FRONTMATTER_READ_LIMIT, 0);
+    const head = buf.toString("utf-8", 0, bytesRead);
+    const fm = head.match(FRONTMATTER_DESC_RE);
     if (!fm) return undefined;
     const desc = fm[1].match(DESCRIPTION_LINE_RE);
     if (!desc) return undefined;
     return desc[1].replace(/^["'`]|["'`]$/g, "").trim() || undefined;
   } catch {
     return undefined;
+  } finally {
+    await fh?.close().catch(() => {});
   }
 }
 

--- a/packages/server/src/lib/slash-command-scanner.ts
+++ b/packages/server/src/lib/slash-command-scanner.ts
@@ -1,0 +1,145 @@
+/**
+ * Slash command 候補を以下の情報源から収集する:
+ *   - 組み込みコマンド (ハードコード)
+ *   - `<configDir>/commands/*.md` (グローバル / プロファイル毎)
+ *   - `<worktreePath>/.claude/commands/*.md` (プロジェクト固有)
+ *
+ * 各 .md ファイル名 (拡張子除く) が `/<name>` になる。frontmatter の
+ * `description:` があれば短い説明として添える。重複はソース優先順位で除外:
+ *   project > global > plugin > built-in
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { SlashCommandInfo } from "@ark/shared";
+
+const BUILT_IN: SlashCommandInfo[] = [
+  { name: "/clear", description: "会話履歴をクリア", source: "built-in" },
+  { name: "/compact", description: "履歴を要約して短縮", source: "built-in" },
+  { name: "/help", description: "ヘルプを表示", source: "built-in" },
+  { name: "/init", description: "CLAUDE.md を作成", source: "built-in" },
+  { name: "/review", description: "PR をレビュー", source: "built-in" },
+  {
+    name: "/install-github-app",
+    description: "GitHub App をセットアップ",
+    source: "built-in",
+  },
+  {
+    name: "/login",
+    description: "Anthropic アカウントにログイン",
+    source: "built-in",
+  },
+  { name: "/logout", description: "ログアウト", source: "built-in" },
+  { name: "/config", description: "設定を表示/編集", source: "built-in" },
+  {
+    name: "/cost",
+    description: "セッション中のコストを表示",
+    source: "built-in",
+  },
+  { name: "/model", description: "使用モデルを切替", source: "built-in" },
+  { name: "/permissions", description: "権限を確認/変更", source: "built-in" },
+  {
+    name: "/resume",
+    description: "前回のセッションを再開",
+    source: "built-in",
+  },
+];
+
+const FRONTMATTER_DESC_RE = /^---[\r\n]+([\s\S]*?)^---[\r\n]+/m;
+const DESCRIPTION_LINE_RE = /^description:\s*(.+?)\s*$/m;
+
+async function readDescriptionFromMd(
+  filePath: string
+): Promise<string | undefined> {
+  try {
+    const buf = await fs.readFile(filePath, "utf-8");
+    const fm = buf.match(FRONTMATTER_DESC_RE);
+    if (!fm) return undefined;
+    const desc = fm[1].match(DESCRIPTION_LINE_RE);
+    if (!desc) return undefined;
+    return desc[1].replace(/^["'`]|["'`]$/g, "").trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function scanCommandsDir(
+  dir: string,
+  source: "global" | "project" | "plugin"
+): Promise<SlashCommandInfo[]> {
+  const out: SlashCommandInfo[] = [];
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) continue;
+    const stem = entry.slice(0, -3);
+    if (!stem) continue;
+    const full = path.join(dir, entry);
+    let stat: import("node:fs").Stats;
+    try {
+      stat = await fs.stat(full);
+    } catch {
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    const description = await readDescriptionFromMd(full);
+    out.push({ name: `/${stem}`, description, source });
+  }
+  return out;
+}
+
+async function scanPluginsCommands(
+  configDir: string
+): Promise<SlashCommandInfo[]> {
+  const pluginsRoot = path.join(configDir, "plugins");
+  const out: SlashCommandInfo[] = [];
+  let pluginEntries: string[];
+  try {
+    pluginEntries = await fs.readdir(pluginsRoot);
+  } catch {
+    return out;
+  }
+  for (const plugin of pluginEntries) {
+    if (plugin.startsWith(".")) continue;
+    const commandsDir = path.join(pluginsRoot, plugin, "commands");
+    const cmds = await scanCommandsDir(commandsDir, "plugin");
+    out.push(...cmds);
+  }
+  return out;
+}
+
+/**
+ * 指定 worktree + configDir で利用可能な slash command 候補を集める。
+ * 優先順位: project > global > plugin > built-in。同名は上位を採用。
+ */
+export async function listSlashCommands(
+  worktreePath: string,
+  configDir: string | null
+): Promise<SlashCommandInfo[]> {
+  const project = await scanCommandsDir(
+    path.join(worktreePath, ".claude", "commands"),
+    "project"
+  );
+  const global = configDir
+    ? await scanCommandsDir(path.join(configDir, "commands"), "global")
+    : [];
+  const plugin = configDir ? await scanPluginsCommands(configDir) : [];
+
+  // 優先順位順に集約。先勝ち
+  const merged = new Map<string, SlashCommandInfo>();
+  for (const c of [...project, ...global, ...plugin, ...BUILT_IN]) {
+    if (!merged.has(c.name)) merged.set(c.name, c);
+  }
+  // 並び順: project → global → plugin → built-in
+  return Array.from(merged.values()).sort((a, b) => {
+    const rank = (s: SlashCommandInfo["source"]) =>
+      s === "project" ? 0 : s === "global" ? 1 : s === "plugin" ? 2 : 3;
+    const r = rank(a.source) - rank(b.source);
+    if (r !== 0) return r;
+    return a.name.localeCompare(b.name);
+  });
+}

--- a/packages/server/src/lib/slash-command-scanner.ts
+++ b/packages/server/src/lib/slash-command-scanner.ts
@@ -94,11 +94,14 @@ async function scanCommandsDir(
     const full = path.join(dir, entry);
     let stat: import("node:fs").Stats;
     try {
-      stat = await fs.stat(full);
+      // lstat で symlink を追従せずに判定する。コマンドディレクトリは
+      // 入力境界として信用できないため、symlink 経由で許可ディレクトリ外の
+      // 任意ファイル先頭 (description 行) が slash 補完へ露出するのを防ぐ
+      stat = await fs.lstat(full);
     } catch {
       continue;
     }
-    if (!stat.isFile()) continue;
+    if (!stat.isFile() || stat.isSymbolicLink()) continue;
     const description = await readDescriptionFromMd(full);
     out.push({ name: `/${stem}`, description, source });
   }

--- a/packages/server/src/lib/tmux-manager.test.ts
+++ b/packages/server/src/lib/tmux-manager.test.ts
@@ -320,3 +320,134 @@ describe("TmuxManager.createSession - options互換", () => {
     );
   });
 });
+
+/**
+ * sendKeys / sendSpecialKey / sendLiteral の挙動を検証する。
+ * sendKeys は Esc 後の重複送信を防ぐため、リテラル送信前に C-u
+ * (kill-line) を送って tmux pane の入力欄をクリアする必要がある。
+ */
+describe("TmuxManager - 入力系メソッド", () => {
+  let manager: TmuxManager;
+  let sessionId: string;
+  let tmuxSessionName: string;
+
+  beforeEach(async () => {
+    mockedSpawnSync.mockReset();
+    mockedExecSync.mockReset();
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (typeof cmd === "string" && cmd.includes("list-sessions")) {
+        return Buffer.from("");
+      }
+      return Buffer.from("");
+    });
+    mockedSpawnSync.mockReturnValue(successResult as never);
+
+    manager = new TmuxManager();
+    const session = await manager.createSession("/wt");
+    sessionId = session.id;
+    tmuxSessionName = session.tmuxSessionName;
+
+    // createSession 中に積まれた send-keys 呼び出しは別検証なので、
+    // ここで mock の履歴をクリアして以降は sendKeys 呼び出しだけを検証する
+    mockedSpawnSync.mockClear();
+  });
+
+  /** spawnSync 呼び出し履歴から tmux send-keys の引数だけを抽出 */
+  function sendKeysCalls(): string[][] {
+    return mockedSpawnSync.mock.calls
+      .map(call => call[1])
+      .filter((args): args is string[] => Array.isArray(args))
+      .filter(args => args[0] === "send-keys");
+  }
+
+  describe("sendKeys (Enter 付き送信)", () => {
+    it("リテラル送信の前に C-u を送って tmux pane の入力欄をクリアする", () => {
+      manager.sendKeys(sessionId, "hello");
+
+      const calls = sendKeysCalls();
+      // 想定: 1) C-u クリア, 2) -l hello, 3) Enter
+      expect(calls).toHaveLength(3);
+      expect(calls[0]).toEqual(["send-keys", "-t", tmuxSessionName, "C-u"]);
+      expect(calls[1]).toEqual([
+        "send-keys",
+        "-t",
+        tmuxSessionName,
+        "-l",
+        "hello",
+      ]);
+      expect(calls[2]).toEqual(["send-keys", "-t", tmuxSessionName, "Enter"]);
+    });
+
+    it("送信順序: C-u → -l → Enter を厳密に守る", () => {
+      // Esc 後の状態を模した重複防止フローの肝。
+      // この順番が崩れると Claude 側に "残骸 + 新メッセージ" が連結されたり、
+      // クリアが効かなかったりするので順序の固定化が重要。
+      manager.sendKeys(sessionId, "msg");
+      const calls = sendKeysCalls();
+      const keys = calls.map(c =>
+        c.includes("-l") ? "literal" : c[c.length - 1]
+      );
+      expect(keys).toEqual(["C-u", "literal", "Enter"]);
+    });
+
+    it("マルチバイト文字も -l でリテラル送信される", () => {
+      manager.sendKeys(sessionId, "中止テスト");
+      const calls = sendKeysCalls();
+      expect(calls[1]).toEqual([
+        "send-keys",
+        "-t",
+        tmuxSessionName,
+        "-l",
+        "中止テスト",
+      ]);
+    });
+
+    it("不明なセッション ID なら例外", () => {
+      expect(() => manager.sendKeys("unknown", "x")).toThrow(
+        "Session not found"
+      );
+    });
+  });
+
+  describe("sendLiteral (Enter 無し送信)", () => {
+    it("Enter も C-u も付与せずリテラルだけ送る", () => {
+      manager.sendLiteral(sessionId, "abc");
+      const calls = sendKeysCalls();
+      expect(calls).toEqual([
+        ["send-keys", "-t", tmuxSessionName, "-l", "abc"],
+      ]);
+    });
+  });
+
+  describe("sendSpecialKey", () => {
+    it("ホワイトリストの Escape は tmux に直接渡る", () => {
+      manager.sendSpecialKey(sessionId, "Escape");
+      const calls = sendKeysCalls();
+      expect(calls).toEqual([["send-keys", "-t", tmuxSessionName, "Escape"]]);
+    });
+
+    it("S-Tab は tmux 用の BTab にマップされる", () => {
+      manager.sendSpecialKey(sessionId, "S-Tab");
+      const calls = sendKeysCalls();
+      expect(calls[0]).toEqual(["send-keys", "-t", tmuxSessionName, "BTab"]);
+    });
+
+    it("数字キー (AskUserQuestion 選択肢) はそのまま送信される", () => {
+      manager.sendSpecialKey(sessionId, "3");
+      const calls = sendKeysCalls();
+      expect(calls).toEqual([["send-keys", "-t", tmuxSessionName, "3"]]);
+    });
+
+    it("Space (multiSelect トグル) はそのまま送信される", () => {
+      manager.sendSpecialKey(sessionId, "Space");
+      const calls = sendKeysCalls();
+      expect(calls).toEqual([["send-keys", "-t", tmuxSessionName, "Space"]]);
+    });
+
+    it("ホワイトリスト外のキーは例外", () => {
+      expect(() =>
+        manager.sendSpecialKey(sessionId, "DangerousKey" as never)
+      ).toThrow();
+    });
+  });
+});

--- a/packages/server/src/lib/tmux-manager.test.ts
+++ b/packages/server/src/lib/tmux-manager.test.ts
@@ -122,14 +122,15 @@ describe("TmuxManager.createSession - options互換", () => {
       "NODE_ENV=",
     ]);
 
-    // send-keysにclaudeが渡される
+    // send-keysにclaudeが渡される。プロファイル未指定なので、tmux サーバー
+    // env からの CLAUDE_CONFIG_DIR 継承を断つ unset が前置される
     const sendKeys = findCommandSendKeysArgs();
     expect(sendKeys).toBeDefined();
     expect(sendKeys).toEqual([
       "send-keys",
       "-t",
       "ark-testid01",
-      "claude",
+      "unset CLAUDE_CONFIG_DIR; claude",
       "Enter",
     ]);
 
@@ -241,7 +242,19 @@ describe("TmuxManager.createSession - options互換", () => {
 
     const sendKeys = findCommandSendKeysArgs();
     if (!sendKeys) throw new Error("send-keys args not found");
-    expect(sendKeys[3]).toBe("claude --dangerously-skip-permissions");
+    expect(sendKeys[3]).toBe(
+      "unset CLAUDE_CONFIG_DIR; claude --dangerously-skip-permissions"
+    );
+  });
+
+  it("options.env に CLAUDE_CONFIG_DIR がある場合 (プロファイル) は unset を前置しない", async () => {
+    await manager.createSession("/path/to/worktree", {
+      env: { CLAUDE_CONFIG_DIR: "/home/user/.claude-work" },
+    });
+
+    const sendKeys = findCommandSendKeysArgs();
+    if (!sendKeys) throw new Error("send-keys args not found");
+    expect(sendKeys[3]).toBe("claude");
   });
 
   it("resolveClaudePath が絶対パスを返したら send-keys に POSIX single-quote 付きで渡る (issue #186)", async () => {
@@ -256,7 +269,7 @@ describe("TmuxManager.createSession - options互換", () => {
     if (!sendKeys) throw new Error("send-keys args not found");
     // POSIX single-quote で wrap した絶対パスがそのまま送られる
     // ($, `, \, " 等の shell メタ文字解釈を完全に抑止するため double-quote ではなく single-quote)
-    expect(sendKeys[3]).toBe(`'${bundledClaudePath}'`);
+    expect(sendKeys[3]).toBe(`unset CLAUDE_CONFIG_DIR; '${bundledClaudePath}'`);
   });
 
   it("空白を含むパス + skipPermissions=true で single-quote + フラグが付く (issue #186)", async () => {
@@ -271,7 +284,7 @@ describe("TmuxManager.createSession - options互換", () => {
     const sendKeys = findCommandSendKeysArgs();
     if (!sendKeys) throw new Error("send-keys args not found");
     expect(sendKeys[3]).toBe(
-      `'${bundledClaudePath}' --dangerously-skip-permissions`
+      `unset CLAUDE_CONFIG_DIR; '${bundledClaudePath}' --dangerously-skip-permissions`
     );
   });
 
@@ -284,7 +297,9 @@ describe("TmuxManager.createSession - options互換", () => {
 
     const sendKeys = findCommandSendKeysArgs();
     if (!sendKeys) throw new Error("send-keys args not found");
-    expect(sendKeys[3]).toBe("'/tmp/it'\\''s a/claude'");
+    expect(sendKeys[3]).toBe(
+      "unset CLAUDE_CONFIG_DIR; '/tmp/it'\\''s a/claude'"
+    );
   });
 
   it("resolveClaudePath が相対パスを返した場合はセッション作成自体を throw する (PATH 汚染への信頼境界拡張を拒否)", async () => {

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -81,6 +81,8 @@ const ALLOWED_SPECIAL_KEYS = new Set<SpecialKey>([
   "Escape",
   "Up",
   "Down",
+  // AskUserQuestion multiSelect の Submit タブ移動に使用
+  "Right",
   // multiSelect 選択肢のトグルに使用
   "Space",
   // 数字キー (AskUserQuestion の選択肢直接ジャンプに使用)
@@ -127,6 +129,8 @@ export class TmuxManager extends EventEmitter {
   private readonly SESSION_PREFIX = "ark-";
   /** パーミッションスキップフラグ（--dangerously-skip-permissions を付与するか） */
   private skipPermissions = false;
+  /** claude 起動時に --settings で注入する settings JSON のパス (AUQ hook 用) */
+  private claudeSettingsPath: string | null = null;
 
   constructor() {
     super();
@@ -141,6 +145,15 @@ export class TmuxManager extends EventEmitter {
    */
   setSkipPermissions(value: boolean): void {
     this.skipPermissions = value;
+  }
+
+  /**
+   * claude 起動コマンドに `--settings <path>` で注入する settings JSON を
+   * 設定する (AskUserQuestion の PreToolUse hook 等)。
+   * サーバー起動時 (listen 後、port 確定後) に呼ばれる。
+   */
+  setClaudeSettingsPath(value: string | null): void {
+    this.claudeSettingsPath = value;
   }
 
   /**
@@ -298,11 +311,27 @@ export class TmuxManager extends EventEmitter {
     const claudeBinary = resolveValidatedClaudePath();
     const claudeArg =
       claudeBinary === "claude" ? "claude" : posixShellQuote(claudeBinary);
+    // AskUserQuestion hook 等を注入する claude 用 settings (--settings)。
+    // サーバー起動時に setClaudeSettingsPath で設定される。
+    const settingsArg = this.claudeSettingsPath
+      ? ` --settings ${posixShellQuote(this.claudeSettingsPath)}`
+      : "";
+    // プロファイル未指定のセッションが、Ark サーバープロセス (やその親、
+    // tmux サーバー) の CLAUDE_CONFIG_DIR を意図せず継承すると、transcript が
+    // 想定外の config dir 配下に書かれ、JSONL tail (チャットビュー) が
+    // 参照する <profileConfigDir ?? ~/.claude>/projects と不整合になる。
+    // tmux の -e は空文字設定しかできず、claude は空文字 CLAUDE_CONFIG_DIR を
+    // 「cwd を config dir に使う」と解釈して worktree 内に projects/ 等を
+    // 作ってしまう (実機確認済み) ため、シェル変数ごと unset してから起動する。
+    const hasProfileEnv =
+      options?.env != null && "CLAUDE_CONFIG_DIR" in options.env;
+    const envPrefix = hasProfileEnv ? "" : "unset CLAUDE_CONFIG_DIR; ";
+    const skipFlag = this.skipPermissions
+      ? " --dangerously-skip-permissions"
+      : "";
     const claudeCmd =
       options?.commandLine ??
-      (this.skipPermissions
-        ? `${claudeArg} --dangerously-skip-permissions`
-        : claudeArg);
+      `${envPrefix}${claudeArg}${skipFlag}${settingsArg}`;
 
     let tmuxCreated = false;
 

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -7,6 +7,7 @@
 
 import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
+import fs from "node:fs";
 import path from "node:path";
 import type { SpecialKey } from "@ark/shared";
 import { nanoid } from "nanoid";
@@ -583,6 +584,41 @@ export class TmuxManager extends EventEmitter {
       const eq = line.indexOf("=");
       if (eq < 0) return null;
       return line.slice(eq + 1);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * pane のシェルプロセスの環境変数を /proc/<pane_pid>/environ から読む。
+   * Linux 限定 (/proc が無い環境では null)。
+   *
+   * tmux session env (`show-environment`) に変数が無くても、tmux サーバー
+   * プロセスの env を継承してシェル/claude に変数が渡っているケースがある
+   * (旧コードで起動されたセッションの CLAUDE_CONFIG_DIR 継承等)。
+   * 「claude が実際にどの env で動いているか」の事実はプロセス environ が
+   * 唯一の情報源なので、復元時のプロファイル補完フォールバックに使う。
+   */
+  getPaneEnv(sessionId: string, name: string): string | null {
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+    try {
+      const result = spawnSync(
+        TMUX_BINARY_PATH,
+        ["list-panes", "-t", session.tmuxSessionName, "-F", "#{pane_pid}"],
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+      );
+      if (result.status !== 0) return null;
+      const pid = Number.parseInt(
+        (result.stdout ?? "").trim().split("\n")[0] ?? "",
+        10
+      );
+      if (!Number.isFinite(pid) || pid <= 0) return null;
+      const environ = fs.readFileSync(`/proc/${pid}/environ`, "utf-8");
+      for (const entry of environ.split("\0")) {
+        if (entry.startsWith(`${name}=`)) return entry.slice(name.length + 1);
+      }
+      return null;
     } catch {
       return null;
     }

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -533,6 +533,33 @@ export class TmuxManager extends EventEmitter {
   }
 
   /**
+   * 指定セッションの tmux 環境変数を取得する。未定義/未取得は null。
+   *
+   * `tmux show-environment -t <session> <NAME>` を使用。変数名指定は
+   * 該当変数が無い場合に exit code 非 0 になるので、ステータスのみ判定する。
+   */
+  getEnv(sessionId: string, name: string): string | null {
+    const session = this.sessions.get(sessionId);
+    if (!session) return null;
+    try {
+      const result = spawnSync(
+        TMUX_BINARY_PATH,
+        ["show-environment", "-t", session.tmuxSessionName, name],
+        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
+      );
+      if (result.status !== 0) return null;
+      const line = (result.stdout ?? "").trim();
+      // 出力形式: `NAME=value` または `-NAME` (unset)
+      if (line.startsWith("-")) return null;
+      const eq = line.indexOf("=");
+      if (eq < 0) return null;
+      return line.slice(eq + 1);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * tmuxのペーストバッファの内容を取得
    */
   getBuffer(sessionId: string): string | null {

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -81,6 +81,18 @@ const ALLOWED_SPECIAL_KEYS = new Set<SpecialKey>([
   "Escape",
   "Up",
   "Down",
+  // multiSelect 選択肢のトグルに使用
+  "Space",
+  // 数字キー (AskUserQuestion の選択肢直接ジャンプに使用)
+  "1",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
 ]);
 
 export interface TmuxSession {
@@ -393,6 +405,21 @@ export class TmuxManager extends EventEmitter {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error("Session not found");
 
+    // Esc 後に Claude 側の入力欄へ直前メッセージが復元されているケース等、
+    // tmux pane の入力バッファに既存テキストが残っていると Ark から送る
+    // テキストと連結されて重複送信になる。事前に C-u (kill line) を送って
+    // 入力をクリアしてからリテラル送信する。入力が空なら C-u は no-op。
+    const clearResult = spawnSync(
+      TMUX_BINARY_PATH,
+      ["send-keys", "-t", session.tmuxSessionName, "C-u"],
+      { stdio: "pipe" }
+    );
+    if (clearResult.error) throw clearResult.error;
+    if (clearResult.status !== 0)
+      throw new Error(
+        `tmux send-keys C-u exited with status ${clearResult.status}`
+      );
+
     // send-keys -l でリテラル送信（spawnSyncなのでシェルエスケープ不要）
     const literalResult = spawnSync(
       TMUX_BINARY_PATH,
@@ -417,6 +444,24 @@ export class TmuxManager extends EventEmitter {
         `tmux send-keys Enter exited with status ${enterResult.status}`
       );
 
+    session.lastActivity = new Date();
+  }
+
+  /**
+   * tmux に literal テキストのみ送信する (Enter を付けない)
+   * AskUserQuestion の Type something モードで「1 文字ずつタイプ」したいときに使う。
+   */
+  sendLiteral(sessionId: string, input: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) throw new Error("Session not found");
+    const result = spawnSync(
+      TMUX_BINARY_PATH,
+      ["send-keys", "-t", session.tmuxSessionName, "-l", input],
+      { stdio: "pipe" }
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0)
+      throw new Error(`tmux send-keys -l exited with status ${result.status}`);
     session.lastActivity = new Date();
   }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -114,6 +114,18 @@ export interface McpAuthFlow {
   authorizationUrl: string;
 }
 
+/**
+ * Slash command 候補。チャットビュー入力欄の補完で使う。
+ *  - `name`: `/foo` 形式 (先頭の `/` 含む)
+ *  - `description`: 1 行説明 (frontmatter `description:` または組み込み定義)
+ *  - `source`: どこから拾ったか (UI のバッジ表示用)
+ */
+export interface SlashCommandInfo {
+  name: string;
+  description?: string;
+  source: "built-in" | "global" | "project" | "plugin";
+}
+
 export interface Worktree {
   id: string;
   path: string;
@@ -306,7 +318,17 @@ export type SpecialKey =
   | "S-Tab"
   | "Escape"
   | "Up"
-  | "Down";
+  | "Down"
+  | "Space"
+  | "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "6"
+  | "7"
+  | "8"
+  | "9";
 
 // WebSocket event types
 export interface ServerToClientEvents {
@@ -349,6 +371,19 @@ export interface ServerToClientEvents {
   "session:updated": (session: ManagedSession) => void;
   "session:stopped": (sessionId: string) => void;
   "session:error": (data: { sessionId: string; error: string }) => void;
+
+  /**
+   * `session:jsonl-subscribe` の初回応答。既存履歴を一括で返す。
+   * `lines` は JSONL 1 行 = 1 要素の生 JSON 文字列配列。
+   * /clear 等で JSONL ファイルが切り替わったときは空配列で再送される。
+   */
+  "session:jsonl-snapshot": (data: {
+    sessionId: string;
+    lines: string[];
+  }) => void;
+
+  /** 購読中の JSONL ファイルに新規行が追記されたときの push */
+  "session:jsonl-line": (data: { sessionId: string; line: string }) => void;
   "session:restored": (session: ManagedSession) => void;
   "session:restore_failed": (data: {
     worktreePath: string;
@@ -533,6 +568,41 @@ export interface ClientToServerEvents {
     callback: (response: { text?: string; error?: string }) => void
   ) => void;
   "session:restore": (worktreePath: string) => void;
+
+  /**
+   * tmux に literal テキストのみ送信する (Enter を付けない)。
+   * AskUserQuestion の自由入力モードで「1 文字ずつタイプ」する用途。
+   */
+  "session:send-literal": (data: { sessionId: string; text: string }) => void;
+
+  /**
+   * Claude Code が永続化する JSONL 履歴 (~/.claude/projects/<encoded-cwd>/*.jsonl)
+   * を購読する。チャットビューの会話描画に使用する。
+   */
+  "session:jsonl-subscribe": (sessionId: string) => void;
+  "session:jsonl-unsubscribe": (sessionId: string) => void;
+
+  /**
+   * 既存購読中の JSONL について、過去履歴をより多く読み直す。
+   * サーバは末尾 `limit` 行で snapshot を再送する。
+   */
+  "session:jsonl-load-more": (data: {
+    sessionId: string;
+    limit: number;
+  }) => void;
+
+  /**
+   * 指定セッションで使える slash command 一覧をリクエスト。
+   * サーバは組み込みコマンド + `<configDir>/commands/*.md` +
+   * `<worktreePath>/.claude/commands/*.md` を集めて返す。
+   */
+  "slash:list": (
+    sessionId: string,
+    callback: (response: {
+      commands?: SlashCommandInfo[];
+      error?: string;
+    }) => void
+  ) => void;
 
   // Repository commands
   "repo:scan": (basePath: string) => void;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -417,6 +417,11 @@ export interface ServerToClientEvents {
        * サイドバードット色 (SessionCard) や RepoGridView と表示を統一するための情報。
        */
       bridgeStatus: BridgeSessionStatus;
+      /**
+       * AWAITING のときのみ: 確認 UI の生テキスト (ANSI 除去済み画面末尾)。
+       * チャットビューのバナーで「何を聞かれているか」をそのまま表示する
+       */
+      awaitingText?: string;
       timestamp: number;
     }>
   ) => void;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -319,6 +319,7 @@ export type SpecialKey =
   | "Escape"
   | "Up"
   | "Down"
+  | "Right"
   | "Space"
   | "1"
   | "2"
@@ -384,6 +385,20 @@ export interface ServerToClientEvents {
 
   /** 購読中の JSONL ファイルに新規行が追記されたときの push */
   "session:jsonl-line": (data: { sessionId: string; line: string }) => void;
+
+  /**
+   * AskUserQuestion が表示された通知 (PreToolUse hook 由来)。
+   * 対話版 claude は AUQ の tool_use を「回答確定時」まで transcript に
+   * 書かないため、回答待ちのリアルタイム検出は hook で行う。
+   * 回答確定 (カードを閉じる) は JSONL の tool_result 出現で判定する。
+   */
+  "session:auq": (data: {
+    sessionId: string;
+    /** サーバーが hook を受信した epoch ms (JSONL 解決イベントとの前後比較用) */
+    at: number;
+    /** tool_input.questions の生データ (クライアント側で構造検証する) */
+    questions: unknown;
+  }) => void;
   "session:restored": (session: ManagedSession) => void;
   "session:restore_failed": (data: {
     worktreePath: string;

--- a/packages/web/src/components/AskUserQuestionCard.tsx
+++ b/packages/web/src/components/AskUserQuestionCard.tsx
@@ -1,0 +1,357 @@
+/**
+ * AskUserQuestionCard - 回答待ち AskUserQuestion の入力欄上パネル
+ *
+ * データソースは JSONL の tool_use.input.questions のみ (画面パース無し)。
+ * 回答は tmux へのキー送出列 (buildKeySequence) で行い、確定は JSONL に
+ * tool_result が出現したこと (= 親が activeAuq を null にしてアンマウント)
+ * で検知する。ターミナル直接操作と競合しても JSONL が唯一の真実なので
+ * 必ず収束する。
+ *
+ * - 単問 single-select: 選択肢クリックで即送出 (1 タップ)
+ * - multiSelect / 複数質問: 全問選択 → 「回答を送信」で一括送出
+ * - 送出列の各 wait 後に確定済みチェック (余分なキーの誤爆防止)
+ * - 送出完了から 10 秒 tool_result が来なければ desync 警告 + ターミナル誘導
+ */
+
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents,
+  SpecialKey,
+} from "@ark/shared";
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
+import {
+  type ActiveAuq,
+  type AuqAnswer,
+  type AuqKeyStep,
+  buildKeySequence,
+  freeTextDigit,
+} from "@/lib/ask-user-question-state";
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+interface AskUserQuestionCardProps {
+  socket: TypedSocket | null;
+  sessionId: string;
+  auq: ActiveAuq;
+  onSendKey: (key: SpecialKey) => void;
+  /** desync 時の「ターミナルで確認」(ttyd を開く)。未指定なら文言のみ */
+  onOpenTerminal?: () => void;
+}
+
+const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
+
+type Phase = "selecting" | "submitting" | "desync";
+
+/** 質問ごとの選択途中状態 */
+type Draft =
+  | { kind: "options"; indexes: number[] }
+  | { kind: "free"; text: string }
+  | null;
+
+export function AskUserQuestionCard({
+  socket,
+  sessionId,
+  auq,
+  onSendKey,
+  onOpenTerminal,
+}: AskUserQuestionCardProps) {
+  const [phase, setPhase] = useState<Phase>("selecting");
+  const [drafts, setDrafts] = useState<Draft[]>(() =>
+    auq.questions.map(() => null)
+  );
+
+  // 送出ループの中止判定用。toolUseId が変わる = 別の質問 (このカードは
+  // key={toolUseId} で作り直される想定だが保険)。アンマウントでも中止。
+  const aliveRef = useRef(true);
+  const desyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    aliveRef.current = true;
+    return () => {
+      aliveRef.current = false;
+      if (desyncTimerRef.current) clearTimeout(desyncTimerRef.current);
+    };
+  }, []);
+
+  const dispatchStep = (step: AuqKeyStep) => {
+    switch (step.kind) {
+      case "digit":
+        onSendKey(step.value as SpecialKey);
+        break;
+      case "key":
+        onSendKey(step.value);
+        break;
+      case "literal":
+        socket?.emit("session:send-literal", { sessionId, text: step.value });
+        break;
+      case "wait":
+        break; // runSequence 側で await する
+    }
+  };
+
+  const runSequence = async (steps: AuqKeyStep[]) => {
+    setPhase("submitting");
+    for (const step of steps) {
+      // tool_result 出現で親が null を渡しアンマウントされる → 残りを中止
+      if (!aliveRef.current) return;
+      if (step.kind === "wait") {
+        await sleep(step.ms);
+      } else {
+        dispatchStep(step);
+      }
+    }
+    if (!aliveRef.current) return;
+    // 送出完了。通常は数百 ms で tool_result が JSONL に書かれて
+    // カードごと消える。来なければ TUI と desync している
+    desyncTimerRef.current = setTimeout(() => {
+      if (aliveRef.current) setPhase("desync");
+    }, 10_000);
+  };
+
+  const submitAnswers = (answers: AuqAnswer[]) => {
+    const steps = buildKeySequence(auq.questions, answers);
+    if (!steps) {
+      setPhase("desync"); // 送出列を構築できない (選択肢 10 個超等) → ターミナル誘導
+      return;
+    }
+    void runSequence(steps);
+  };
+
+  /** 単問 single-select: クリック即送出 */
+  const isInstantMode =
+    auq.questions.length === 1 && !auq.questions[0].multiSelect;
+
+  const handleInstantOption = (index: number) => {
+    if (phase === "submitting") return;
+    submitAnswers([{ kind: "options", indexes: [index] }]);
+  };
+
+  const handleInstantFree = (text: string) => {
+    const value = text.trim();
+    if (!value || phase === "submitting") return;
+    submitAnswers([{ kind: "free", text: value }]);
+  };
+
+  /** 複数質問 / multiSelect: ドラフトを編集して一括送出 */
+  const setDraft = (qi: number, draft: Draft) => {
+    setDrafts(prev => prev.map((d, i) => (i === qi ? draft : d)));
+  };
+
+  const toggleMultiOption = (qi: number, index: number) => {
+    setDrafts(prev =>
+      prev.map((d, i) => {
+        if (i !== qi) return d;
+        const cur = d?.kind === "options" ? d.indexes : [];
+        const next = cur.includes(index)
+          ? cur.filter(x => x !== index)
+          : [...cur, index];
+        return next.length > 0 ? { kind: "options", indexes: next } : null;
+      })
+    );
+  };
+
+  const allAnswered = drafts.every(d => {
+    if (!d) return false;
+    if (d.kind === "free") return d.text.trim().length > 0;
+    return d.indexes.length > 0;
+  });
+
+  const handleSubmitAll = () => {
+    if (!allAnswered || phase === "submitting") return;
+    const answers: AuqAnswer[] = drafts.map(d => {
+      if (!d) throw new Error("unreachable: allAnswered checked");
+      return d.kind === "free" ? { kind: "free", text: d.text.trim() } : d;
+    });
+    submitAnswers(answers);
+  };
+
+  const handleCancel = () => {
+    if (phase === "submitting") return;
+    onSendKey("Escape");
+  };
+
+  return (
+    <div className="border-t border-border bg-muted/30 px-3 py-2.5 shrink-0 max-h-[45%] overflow-y-auto">
+      {phase === "desync" && (
+        <div className="mb-2 text-[13px] bg-amber-500/15 text-amber-700 dark:text-amber-300 rounded-md px-2.5 py-1.5 flex items-center justify-between gap-2">
+          <span>
+            回答を確認できませんでした。ターミナル側の状態を確認してください
+          </span>
+          {onOpenTerminal && (
+            <button
+              type="button"
+              onClick={onOpenTerminal}
+              className="shrink-0 underline font-medium"
+            >
+              ターミナルで確認
+            </button>
+          )}
+        </div>
+      )}
+
+      {auq.questions.map((q, qi) => {
+        const draft = drafts[qi];
+        return (
+          <div key={`${auq.toolUseId}:${qi}`} className="mb-2 last:mb-0">
+            <div className="text-sm font-medium text-foreground mb-2 flex items-start gap-2">
+              <span className="shrink-0 leading-[1.4]">❓</span>
+              <span className="break-words min-w-0">
+                {q.header && (
+                  <span className="inline-block text-[11px] bg-muted text-muted-foreground rounded px-1.5 py-0.5 mr-1.5 align-middle">
+                    {q.header}
+                  </span>
+                )}
+                {q.question}
+                {q.multiSelect && (
+                  <span className="text-[11px] text-muted-foreground ml-1.5">
+                    (複数選択可)
+                  </span>
+                )}
+              </span>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              {q.options.map((opt, oi) => {
+                const selected =
+                  draft?.kind === "options" && draft.indexes.includes(oi);
+                return (
+                  <button
+                    key={`${oi}-${opt.label}`}
+                    type="button"
+                    disabled={phase === "submitting"}
+                    onClick={() => {
+                      if (isInstantMode) {
+                        handleInstantOption(oi);
+                      } else if (q.multiSelect) {
+                        toggleMultiOption(qi, oi);
+                      } else {
+                        setDraft(qi, { kind: "options", indexes: [oi] });
+                      }
+                    }}
+                    className={`text-sm border rounded-md px-2.5 py-1.5 flex items-start gap-2 transition-colors text-left disabled:opacity-50 ${
+                      selected
+                        ? "bg-primary/10 border-primary text-foreground"
+                        : "bg-background hover:bg-accent hover:text-accent-foreground border-border"
+                    }`}
+                    title={`${oi + 1}. ${opt.label}`}
+                  >
+                    <span className="font-mono text-muted-foreground shrink-0">
+                      {q.multiSelect ? (selected ? "☑" : "☐") : `${oi + 1}.`}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block">{opt.label}</span>
+                      {opt.description && (
+                        <span className="block text-xs text-muted-foreground mt-0.5">
+                          {opt.description}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                );
+              })}
+              {/* 自由入力 (Type something.)。digit が 9 を超える構成では
+                  buildKeySequence が null になるため表示しない */}
+              {freeTextDigit(q) <= 9 && (
+                <FreeTextRow
+                  digitLabel={freeTextDigit(q)}
+                  disabled={phase === "submitting"}
+                  value={draft?.kind === "free" ? draft.text : ""}
+                  onChange={text =>
+                    setDraft(qi, text ? { kind: "free", text } : null)
+                  }
+                  onSubmit={
+                    isInstantMode ? text => handleInstantFree(text) : undefined
+                  }
+                />
+              )}
+            </div>
+          </div>
+        );
+      })}
+
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <button
+          type="button"
+          onClick={handleCancel}
+          disabled={phase === "submitting"}
+          className="text-[13px] text-muted-foreground hover:text-foreground px-2 py-0.5 transition-colors disabled:opacity-50"
+          title="キャンセル (Esc)"
+        >
+          キャンセル
+        </button>
+        <div className="flex items-center gap-2">
+          {phase === "submitting" && (
+            <span className="text-[12px] text-muted-foreground flex items-center gap-1.5">
+              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+              送信中...
+            </span>
+          )}
+          {!isInstantMode && phase !== "submitting" && (
+            <button
+              type="button"
+              onClick={handleSubmitAll}
+              disabled={!allAnswered}
+              className="text-[13px] bg-primary text-primary-foreground rounded-md px-3 py-1 font-medium disabled:opacity-30 disabled:cursor-not-allowed"
+            >
+              回答を送信
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function FreeTextRow({
+  digitLabel,
+  disabled,
+  value,
+  onChange,
+  onSubmit,
+}: {
+  digitLabel: number;
+  disabled: boolean;
+  value: string;
+  onChange: (text: string) => void;
+  /** 単問 single-select のとき Enter / ボタンで即送出 */
+  onSubmit?: (text: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 bg-background border border-border rounded-md px-2.5 py-1.5 focus-within:border-primary">
+      <span className="font-mono text-muted-foreground text-sm shrink-0">
+        {digitLabel}.
+      </span>
+      <input
+        type="text"
+        value={value}
+        disabled={disabled}
+        onChange={e => onChange(e.target.value)}
+        onKeyDown={e => {
+          if (
+            e.key === "Enter" &&
+            !e.nativeEvent.isComposing &&
+            onSubmit &&
+            value.trim()
+          ) {
+            e.preventDefault();
+            onSubmit(value);
+          }
+        }}
+        placeholder={
+          onSubmit ? "自由に入力 (Enter で送信)" : "自由に入力 (任意)"
+        }
+        className="flex-1 text-sm bg-transparent focus:outline-none placeholder:text-muted-foreground disabled:opacity-50"
+      />
+      {onSubmit && (
+        <button
+          type="button"
+          onClick={() => onSubmit(value)}
+          disabled={!value.trim() || disabled}
+          className="text-[10px] bg-primary text-primary-foreground rounded px-2 py-0.5 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          送信
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -1,0 +1,628 @@
+/**
+ * SplitChatPane - JSONL ベースの会話チャットビュー
+ *
+ * Claude Code が永続化する JSONL transcript を唯一の会話データソースとして
+ * 描画する (assistant text は markdown レンダリング、user input は bubble、
+ * tool call は軽量 chip)。**tmux 画面パースは行わない** (チャット UI v3 の
+ * 設計原則。busy/AWAITING 等の状態は session:previews の bridgeStatus を使う)。
+ *
+ * 入力欄は最下部に固定。送信は tmux send-keys 経由 (onSendMessage)。
+ * ファイルアップロード (D&D / ペースト / 選択) に対応。
+ */
+
+import type {
+  ClientToServerEvents,
+  ManagedSession,
+  ServerToClientEvents,
+  SpecialKey,
+} from "@ark/shared";
+import { ArrowDown, Loader2, Paperclip, Send } from "lucide-react";
+import {
+  type FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import type { Socket } from "socket.io-client";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { fileToBase64, validateFile } from "@/hooks/useFileUpload";
+import { useSessionJsonl } from "@/hooks/useSessionJsonl";
+import type { JsonlParsedEvent } from "@/lib/jsonl-event-parser";
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+interface SplitChatPaneProps {
+  socket: TypedSocket | null;
+  session: ManagedSession;
+  /**
+   * このペインが現在表示中か。false の間は JSONL を購読しない
+   * (全セッションのペインが hidden マウントされるため、無条件購読だと
+   * セッション数ぶんの tail が常時走ってしまう)
+   */
+  isActive: boolean;
+  onSendMessage: (message: string) => void;
+  /** AskUserQuestion のキャンセル (Esc) 等で使用 */
+  onSendKey: (key: SpecialKey) => void;
+  /** ファイルアップロード。返値の path は `@path` で本文に挿入される */
+  onUploadFile?: (data: {
+    base64Data: string;
+    mimeType: string;
+    originalFilename?: string;
+  }) => Promise<{ path: string; filename: string; originalFilename?: string }>;
+  /** 右側 ttyd の表示状態 (ヘッダのトグルボタンを ON/OFF 表示するために使う) */
+  showTerminal?: boolean;
+  /** ターミナルの表示切替 (undefined のとき トグルボタンを描画しない) */
+  onToggleTerminal?: () => void;
+}
+
+// ===== JSONL イベントカード =====
+
+function UserInputCard({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end px-4 pt-4 pb-2">
+      <div className="max-w-[85%] bg-primary text-primary-foreground rounded-2xl rounded-tr-md px-4 py-2.5 text-[16px] leading-relaxed whitespace-pre-wrap break-words shadow-sm">
+        {text}
+      </div>
+    </div>
+  );
+}
+
+function SlashCommandCard({ name, args }: { name: string; args?: string }) {
+  return (
+    <div className="flex justify-end px-4 pt-4 pb-2">
+      <div className="bg-emerald-500/15 text-emerald-700 dark:text-emerald-300 rounded-full px-3 py-1 text-sm font-mono">
+        {name}
+        {args ? ` ${args}` : ""}
+      </div>
+    </div>
+  );
+}
+
+function AssistantTextCard({ text }: { text: string }) {
+  return (
+    <div className="px-4 py-2">
+      <div className="md-prose text-[16px] text-foreground leading-[1.65]">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+/** /compact 実行で会話が要約されたことを示すセパレータ */
+function CompactMarkerCard() {
+  return (
+    <div className="flex items-center gap-3 px-6 py-3 select-none">
+      <div className="flex-1 border-t border-dashed border-border" />
+      <span className="text-[11px] text-muted-foreground shrink-0">
+        ✂ 会話を要約しました (/compact)
+      </span>
+      <div className="flex-1 border-t border-dashed border-border" />
+    </div>
+  );
+}
+
+function AskUserQuestionResultCard({
+  input,
+  result,
+  structuredResult,
+  isError,
+}: {
+  input: Record<string, unknown>;
+  result: string | undefined;
+  structuredResult?: unknown;
+  isError?: boolean;
+}) {
+  const questions =
+    (input.questions as { question: string }[] | undefined) ?? [];
+  // 回答の第一情報源は tool_result と同一レコードの toolUseResult
+  // (構造化 JSON、自由入力の回答もそのまま入る)。取れない場合は
+  // tool_result content の "Q"="A" テキストへフォールバックする。
+  const answers = useMemo(() => {
+    const map = new Map<string, string>();
+    const structured = structuredResult as
+      | { answers?: Record<string, unknown> }
+      | undefined;
+    if (
+      structured &&
+      typeof structured === "object" &&
+      structured.answers &&
+      typeof structured.answers === "object"
+    ) {
+      for (const [q, a] of Object.entries(structured.answers)) {
+        if (typeof a === "string") map.set(q, a);
+      }
+      if (map.size > 0) return map;
+    }
+    if (!result) return map;
+    const re = /"([^"]+)"="([^"]+)"/g;
+    let m: RegExpExecArray | null;
+    m = re.exec(result);
+    while (m !== null) {
+      map.set(m[1], m[2]);
+      m = re.exec(result);
+    }
+    return map;
+  }, [result, structuredResult]);
+  const isDecline =
+    isError === true || (result?.includes("User declined") ?? false);
+
+  return (
+    <div className="px-4 py-2.5">
+      <div className="text-sm text-muted-foreground mb-1.5 flex items-center gap-1.5">
+        <span>❓</span>
+        <span className="font-medium">
+          {result
+            ? isDecline
+              ? "質問はキャンセルされました"
+              : "質問への回答:"
+            : "AskUserQuestion"}
+        </span>
+      </div>
+      <div className="text-base space-y-1">
+        {questions.map((q, i) => {
+          const answer = answers.get(q.question);
+          return (
+            <div
+              key={`${i}-${q.question}`}
+              className="flex gap-1.5 items-start"
+            >
+              <span className="text-muted-foreground shrink-0">·</span>
+              <div className="min-w-0 flex-1">
+                <span className="text-foreground">{q.question}</span>
+                {answer && (
+                  <>
+                    <span className="text-muted-foreground"> → </span>
+                    <span className="font-medium text-primary">{answer}</span>
+                  </>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function ToolCallCard({
+  tool,
+  input,
+  result,
+  structuredResult,
+  isError,
+}: {
+  tool: string;
+  input: Record<string, unknown>;
+  result: string | undefined;
+  structuredResult?: unknown;
+  isError?: boolean;
+}) {
+  // 1 行サマリを抽出: file_path / command / pattern / url など、最初に見つかった "らしい" 値
+  const summary = useMemo(() => {
+    const keys = [
+      "file_path",
+      "command",
+      "pattern",
+      "query",
+      "url",
+      "path",
+      "description",
+      "prompt",
+    ];
+    for (const k of keys) {
+      const v = input[k];
+      if (typeof v === "string" && v.length > 0) {
+        return v.length > 100 ? `${v.slice(0, 100)}…` : v;
+      }
+    }
+    return "";
+  }, [input]);
+
+  // AskUserQuestion は専用レンダリング
+  if (tool === "AskUserQuestion") {
+    return (
+      <AskUserQuestionResultCard
+        input={input}
+        result={result}
+        structuredResult={structuredResult}
+        isError={isError}
+      />
+    );
+  }
+
+  return (
+    <div className="px-4 py-1">
+      <div className="inline-flex items-center gap-2 text-xs text-muted-foreground max-w-full">
+        <span className="opacity-60 shrink-0">⚙</span>
+        <span className="font-mono text-foreground shrink-0">{tool}</span>
+        {summary && (
+          <span className="font-mono opacity-70 truncate min-w-0">
+            {summary}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EventCard({ event }: { event: JsonlParsedEvent }) {
+  switch (event.kind) {
+    case "user-input":
+      return <UserInputCard text={event.text} />;
+    case "slash-command":
+      return <SlashCommandCard name={event.name} args={event.args} />;
+    case "assistant-text":
+      return <AssistantTextCard text={event.text} />;
+    case "compact-marker":
+      return <CompactMarkerCard />;
+    case "tool-call":
+      return (
+        <ToolCallCard
+          tool={event.tool}
+          input={event.input}
+          result={event.result}
+          structuredResult={event.structuredResult}
+          isError={event.isError}
+        />
+      );
+    case "thinking":
+      return null;
+    default:
+      return null;
+  }
+}
+
+// ===== 本体 =====
+
+export function SplitChatPane({
+  socket,
+  session,
+  isActive,
+  onSendMessage,
+  onSendKey: _onSendKey,
+  onUploadFile,
+  showTerminal,
+  onToggleTerminal,
+}: SplitChatPaneProps) {
+  const [inputValue, setInputValue] = useState("");
+
+  // JSONL: 会話の構造化履歴 (markdown レンダリング用)。アクティブ時のみ購読
+  const {
+    events,
+    isSubscribed: jsonlSubscribed,
+    loadMore,
+    hasMore,
+  } = useSessionJsonl(socket, isActive ? session.id : null);
+
+  // ===== スクロール追従 + 上端で過去読み込み =====
+  const jsonlScrollRef = useRef<HTMLDivElement>(null);
+  const [isNearBottom, setIsNearBottom] = useState(true);
+  // 「過去読み込み中」を ref で持つ。同じスクロールイベントで多重発火させないため
+  const loadingMoreRef = useRef(false);
+  // 過去読み込み発火時の scrollHeight / scrollTop。受信後に新しい高さとの差を
+  // 足してスクロール位置を視覚的に固定する
+  const prevScrollMetricsRef = useRef<{ height: number; top: number } | null>(
+    null
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies(events): イベント追加 (高さ変化) のたびに末尾追従スクロールを再実行するための意図的な依存
+  useEffect(() => {
+    const el = jsonlScrollRef.current;
+    if (!el) return;
+    // 過去読み込み直後はスクロール位置を保存値 + 高さ差分に補正 (視覚的に固定)
+    if (prevScrollMetricsRef.current) {
+      const { height, top } = prevScrollMetricsRef.current;
+      const diff = el.scrollHeight - height;
+      el.scrollTop = top + diff;
+      prevScrollMetricsRef.current = null;
+      loadingMoreRef.current = false;
+      return;
+    }
+    if (isNearBottom) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [events, isNearBottom]);
+
+  // 「下までジャンプ」ボタン用。一気に末尾へ飛ばす副作用ハンドラ。
+  // isNearBottom も true にしておくことで以降の自動追従も復活する。
+  const scrollToBottom = useCallback(() => {
+    const el = jsonlScrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    setIsNearBottom(true);
+  }, []);
+
+  useEffect(() => {
+    const el = jsonlScrollRef.current;
+    if (!el) return;
+    const onScroll = () => {
+      const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+      setIsNearBottom(distance < 100);
+      // 上端に近づいたら過去履歴を自動ロード
+      if (
+        el.scrollTop < 200 &&
+        hasMore &&
+        !loadingMoreRef.current &&
+        events.length > 0
+      ) {
+        loadingMoreRef.current = true;
+        prevScrollMetricsRef.current = {
+          height: el.scrollHeight,
+          top: el.scrollTop,
+        };
+        loadMore();
+      }
+    };
+    onScroll();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [hasMore, loadMore, events.length]);
+
+  // ===== 送信 =====
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const value = inputValue.trim();
+    if (!value) return;
+    onSendMessage(value);
+    setInputValue("");
+  };
+
+  // ===== ファイルアップロード =====
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [uploadingCount, setUploadingCount] = useState(0);
+  const recentUploadsRef = useRef<Map<string, number>>(new Map());
+
+  const uploadAndAppend = useCallback(
+    async (files: File[]) => {
+      if (!onUploadFile || files.length === 0) return;
+      const now = Date.now();
+      const DEDUP_MS = 5000;
+      const dedup: File[] = [];
+      for (const [k, ts] of recentUploadsRef.current) {
+        if (now - ts > 60_000) recentUploadsRef.current.delete(k);
+      }
+      for (const f of files) {
+        const key = `${f.name}|${f.size}|${f.type}|${f.lastModified}`;
+        const last = recentUploadsRef.current.get(key) ?? 0;
+        if (now - last < DEDUP_MS) continue;
+        recentUploadsRef.current.set(key, now);
+        dedup.push(f);
+      }
+      if (dedup.length === 0) return;
+      setUploadingCount(c => c + dedup.length);
+      try {
+        for (const file of dedup) {
+          const v = validateFile(file);
+          if (!v.ok) {
+            toast.error(v.reason ?? `${file.name}: 未対応のファイル`);
+            continue;
+          }
+          try {
+            const { base64, mimeType, filename } = await fileToBase64(file);
+            const res = await onUploadFile({
+              base64Data: base64,
+              mimeType,
+              originalFilename: filename,
+            });
+            setInputValue(prev => {
+              const ref = `@${res.path}`;
+              if (prev.includes(ref)) return prev;
+              return prev.length === 0 || /\s$/.test(prev)
+                ? `${prev}${ref} `
+                : `${prev} ${ref} `;
+            });
+          } catch (err) {
+            toast.error(
+              `${file.name}: アップロード失敗 (${err instanceof Error ? err.message : String(err)})`
+            );
+          }
+        }
+      } finally {
+        setUploadingCount(c => Math.max(0, c - dedup.length));
+      }
+    },
+    [onUploadFile]
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      if (!onUploadFile) return;
+      const collected: File[] = [];
+      const seen = new Set<string>();
+      const push = (f: File | null) => {
+        if (!f) return;
+        const key = `${f.name}|${f.size}|${f.type}`;
+        if (seen.has(key)) return;
+        seen.add(key);
+        collected.push(f);
+      };
+      for (const f of Array.from(e.clipboardData.files)) push(f);
+      for (const item of Array.from(e.clipboardData.items)) {
+        if (item.kind === "file") push(item.getAsFile());
+      }
+      if (collected.length === 0) return;
+      e.preventDefault();
+      uploadAndAppend(collected);
+    },
+    [onUploadFile, uploadAndAppend]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragging(false);
+      if (!onUploadFile) return;
+      const files = Array.from(e.dataTransfer.files);
+      if (files.length > 0) uploadAndAppend(files);
+    },
+    [onUploadFile, uploadAndAppend]
+  );
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      handleSubmit(e as unknown as FormEvent);
+    }
+  };
+
+  return (
+    <div className="h-full flex flex-col bg-background">
+      <header className="border-b border-border px-4 py-2.5 flex items-center justify-between shrink-0">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-base">💬</span>
+          <div className="min-w-0">
+            <div className="font-bold text-sm text-foreground truncate">
+              会話
+            </div>
+            <div className="text-[11px] text-muted-foreground truncate">
+              {session.worktreePath.split("/").pop() ?? "session"} ·{" "}
+              {events.length} イベント
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span
+            className={`w-1.5 h-1.5 rounded-full ${jsonlSubscribed ? "bg-emerald-500" : "bg-slate-400"}`}
+            title={jsonlSubscribed ? "JSONL 購読中" : "未購読"}
+          />
+          {onToggleTerminal && (
+            <button
+              type="button"
+              onClick={onToggleTerminal}
+              className={`text-[11px] px-2 py-1 rounded-md font-medium flex items-center gap-1 transition-colors ${
+                showTerminal
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-muted hover:bg-muted/70 text-foreground"
+              }`}
+              title={showTerminal ? "ターミナルを閉じる" : "ターミナルを開く"}
+            >
+              <span>🖥</span>
+              <span>{showTerminal ? "閉じる" : "ターミナル"}</span>
+            </button>
+          )}
+        </div>
+      </header>
+
+      {/* JSONL イベントリスト (上段、flex-1)。
+          relative ラッパーで囲み「下へジャンプ」ボタンをスクロール領域に
+          重ねて配置する。スクロール領域自体は absolute inset-0 で内側を埋める。 */}
+      <div className="flex-1 min-h-0 relative">
+        <div
+          ref={jsonlScrollRef}
+          className="absolute inset-0 overflow-y-auto py-2"
+        >
+          {events.length === 0 ? (
+            <div className="text-center text-sm text-muted-foreground pt-8">
+              このセッションの履歴はまだありません
+            </div>
+          ) : (
+            <>
+              {hasMore && (
+                <div className="flex justify-center py-2 text-sm text-muted-foreground">
+                  読み込み中...
+                </div>
+              )}
+              {events.map(ev => (
+                <EventCard key={ev.id} event={ev} />
+              ))}
+            </>
+          )}
+        </div>
+        {!isNearBottom && (
+          <button
+            type="button"
+            onClick={scrollToBottom}
+            className="absolute bottom-3 left-1/2 -translate-x-1/2 w-9 h-9 rounded-full bg-foreground/85 text-background shadow-lg hover:bg-foreground flex items-center justify-center transition-colors"
+            title="最新まで一気にスクロール"
+            aria-label="最新まで一気にスクロール"
+          >
+            <ArrowDown className="w-4 h-4" />
+          </button>
+        )}
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        onDragEnter={e => {
+          if (!onUploadFile) return;
+          e.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragOver={e => {
+          if (!onUploadFile) return;
+          e.preventDefault();
+        }}
+        onDragLeave={e => {
+          if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+          setIsDragging(false);
+        }}
+        onDrop={handleDrop}
+        className={`border-t border-border px-3 py-2.5 shrink-0 flex gap-2 items-end relative ${
+          isDragging ? "ring-2 ring-primary/50 bg-primary/5" : ""
+        }`}
+      >
+        {onUploadFile && (
+          <>
+            <input
+              ref={fileInputRef}
+              type="file"
+              multiple
+              accept="image/*,application/pdf,text/*,.md,.json,.csv"
+              className="hidden"
+              onChange={e => {
+                const files = Array.from(e.target.files ?? []);
+                if (files.length > 0) uploadAndAppend(files);
+                if (fileInputRef.current) fileInputRef.current.value = "";
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="p-2 rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground transition-colors self-end"
+              title="ファイル添付 (D&D / ペーストも可)"
+              disabled={uploadingCount > 0}
+            >
+              {uploadingCount > 0 ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <Paperclip className="w-4 h-4" />
+              )}
+            </button>
+          </>
+        )}
+        <textarea
+          value={inputValue}
+          onChange={e => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onPaste={onUploadFile ? handlePaste : undefined}
+          placeholder={
+            onUploadFile
+              ? "メッセージを入力 (Enter で送信、Shift+Enter で改行、画像は D&D / ペーストも可)"
+              : "メッセージを入力 (Enter で送信、Shift+Enter で改行)"
+          }
+          rows={1}
+          className="flex-1 px-3 py-2 text-sm bg-muted/40 border border-border rounded-lg focus:outline-none focus:border-primary placeholder:text-muted-foreground resize-none min-h-[36px] max-h-32"
+        />
+        <Button
+          type="submit"
+          size="sm"
+          disabled={!inputValue.trim()}
+          className="self-end"
+        >
+          <Send className="w-3.5 h-3.5" />
+        </Button>
+        {isDragging && onUploadFile && (
+          <div className="absolute inset-0 bg-background/80 backdrop-blur-sm border-2 border-dashed border-primary rounded-lg flex items-center justify-center text-sm font-medium text-primary pointer-events-none">
+            ここにドロップ
+          </div>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -62,6 +62,11 @@ interface SplitChatPaneProps {
    * prompt 等の AWAITING フォールバックバナーに使う
    */
   bridgeStatus?: BridgeSessionStatus;
+  /**
+   * AWAITING 時の確認 UI 生テキスト (ANSI 除去済み画面末尾のミラー)。
+   * 「何を聞かれているか」をバナーにそのまま表示する。構造のパースはしない
+   */
+  awaitingText?: string;
   onSendMessage: (message: string) => void;
   /** AskUserQuestion のキャンセル (Esc) 等で使用 */
   onSendKey: (key: SpecialKey) => void;
@@ -374,6 +379,7 @@ export function SplitChatPane({
   session,
   isActive,
   bridgeStatus,
+  awaitingText,
   onSendMessage,
   onSendKey,
   onUploadFile,
@@ -883,39 +889,50 @@ export function SplitChatPane({
 
       {/* permission prompt 等のユーザー判断待ちフォールバック。
           AskUserQuestion は専用カードが出る (hook 経由) ため、カード表示中
-          は出さない。hook が取りこぼされた場合のセーフティネットも兼ねる */}
+          は出さない。hook が取りこぼされた場合のセーフティネットも兼ねる。
+          「何を聞かれているか」は確認 UI の生テキストをそのまま表示する */}
       {bridgeStatus === "AWAITING" && !activeAuq && (
-        <div className="border-t border-border bg-amber-500/10 px-3 py-2 shrink-0 flex items-center justify-between gap-2">
-          <span className="text-[13px] text-amber-700 dark:text-amber-300 min-w-0">
-            ⏳ Claude が入力を求めています
-          </span>
-          <div className="flex items-center gap-1.5 shrink-0">
-            <button
-              type="button"
-              onClick={() => onSendKey("1")}
-              className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
-              title="1 を送信"
-            >
-              1
-            </button>
-            <button
-              type="button"
-              onClick={() => onSendKey("2")}
-              className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
-              title="2 を送信"
-            >
-              2
-            </button>
-            {onToggleTerminal && !showTerminal && (
+        <div className="border-t border-border bg-amber-500/10 px-3 py-2 shrink-0 max-h-[45%] overflow-y-auto">
+          <div className="flex items-center justify-between gap-2">
+            <span className="text-[13px] text-amber-700 dark:text-amber-300 min-w-0 font-medium">
+              ⏳ Claude が入力を求めています
+            </span>
+            <div className="flex items-center gap-1.5 shrink-0">
+              {(["1", "2", "3"] as const).map(d => (
+                <button
+                  key={d}
+                  type="button"
+                  onClick={() => onSendKey(d)}
+                  className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
+                  title={`${d} を送信`}
+                >
+                  {d}
+                </button>
+              ))}
               <button
                 type="button"
-                onClick={onToggleTerminal}
-                className="text-[12px] underline text-amber-700 dark:text-amber-300 px-1"
+                onClick={() => onSendKey("Enter")}
+                className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
+                title="Enter を送信 (フォーカス中の項目を選択)"
               >
-                ターミナルで確認
+                Enter
               </button>
-            )}
+              {onToggleTerminal && !showTerminal && (
+                <button
+                  type="button"
+                  onClick={onToggleTerminal}
+                  className="text-[12px] underline text-amber-700 dark:text-amber-300 px-1"
+                >
+                  ターミナルで確認
+                </button>
+              )}
+            </div>
           </div>
+          {awaitingText && (
+            <pre className="mt-1.5 text-[11px] leading-[1.5] font-mono bg-background/70 border border-border rounded-md px-2.5 py-2 overflow-x-auto whitespace-pre text-foreground/80">
+              {awaitingText}
+            </pre>
+          )}
         </div>
       )}
 

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -278,6 +278,58 @@ function ToolCallCard({
   );
 }
 
+/**
+ * subagent (isSidechain) の連続イベントを 1 ブロックに集約した折りたたみ表示。
+ * 大量のツール呼び出しがメイン会話を埋めないようにする。
+ */
+function SidechainGroupCard({ events }: { events: JsonlParsedEvent[] }) {
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className="px-4 py-1">
+      <button
+        type="button"
+        onClick={() => setExpanded(v => !v)}
+        className="inline-flex items-center gap-2 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <span>{expanded ? "▾" : "▸"}</span>
+        <span>🧵 サブエージェント ({events.length} イベント)</span>
+      </button>
+      {expanded && (
+        <div className="mt-1 border-l-2 border-border pl-2 opacity-80">
+          {events.map(ev => (
+            <EventCard key={ev.id} event={ev} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 連続する sidechain イベントを 1 グループに畳む */
+function groupSidechain(events: JsonlParsedEvent[]): (
+  | { kind: "event"; event: JsonlParsedEvent }
+  | {
+      kind: "sidechain";
+      id: string;
+      events: JsonlParsedEvent[];
+    }
+)[] {
+  const out: ReturnType<typeof groupSidechain> = [];
+  for (const ev of events) {
+    if (ev.isSidechain === true) {
+      const last = out[out.length - 1];
+      if (last && last.kind === "sidechain") {
+        last.events.push(ev);
+      } else {
+        out.push({ kind: "sidechain", id: `sc:${ev.id}`, events: [ev] });
+      }
+    } else {
+      out.push({ kind: "event", event: ev });
+    }
+  }
+  return out;
+}
+
 function EventCard({ event }: { event: JsonlParsedEvent }) {
   switch (event.kind) {
     case "user-input":
@@ -473,6 +525,9 @@ export function SplitChatPane({
   }, [events, hookAuq]);
 
   const activeAuq = hookAuq?.auq ?? null;
+
+  // 連続する subagent イベントを折りたたみグループへ
+  const groupedEvents = useMemo(() => groupSidechain(events), [events]);
 
   // ===== スクロール追従 + 上端で過去読み込み =====
   const jsonlScrollRef = useRef<HTMLDivElement>(null);
@@ -784,9 +839,13 @@ export function SplitChatPane({
                   読み込み中...
                 </div>
               )}
-              {events.map(ev => (
-                <EventCard key={ev.id} event={ev} />
-              ))}
+              {groupedEvents.map(g =>
+                g.kind === "sidechain" ? (
+                  <SidechainGroupCard key={g.id} events={g.events} />
+                ) : (
+                  <EventCard key={g.event.id} event={g.event} />
+                )
+              )}
               {localSlashCommands.map(c => (
                 <SlashCommandCard key={c.id} name={c.name} args={c.args} />
               ))}

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -33,6 +33,8 @@ import { Button } from "@/components/ui/button";
 import { fileToBase64, validateFile } from "@/hooks/useFileUpload";
 import { useSessionJsonl } from "@/hooks/useSessionJsonl";
 import type { JsonlParsedEvent } from "@/lib/jsonl-event-parser";
+import { reconcileEscape } from "@/lib/reconcile-escape";
+import { reconcilePending } from "@/lib/reconcile-pending";
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
@@ -67,6 +69,17 @@ function UserInputCard({ text }: { text: string }) {
     <div className="flex justify-end px-4 pt-4 pb-2">
       <div className="max-w-[85%] bg-primary text-primary-foreground rounded-2xl rounded-tr-md px-4 py-2.5 text-[16px] leading-relaxed whitespace-pre-wrap break-words shadow-sm">
         {text}
+      </div>
+    </div>
+  );
+}
+
+function PendingMessageCard({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end px-4 pt-4 pb-2">
+      <div className="max-w-[85%] bg-primary/70 text-primary-foreground rounded-2xl rounded-tr-md px-4 py-2.5 text-[16px] leading-relaxed whitespace-pre-wrap break-words shadow-sm flex items-start gap-2">
+        <Loader2 className="w-3.5 h-3.5 animate-spin mt-1 shrink-0 opacity-80" />
+        <span className="min-w-0">{text}</span>
       </div>
     </div>
   );
@@ -284,7 +297,7 @@ export function SplitChatPane({
   session,
   isActive,
   onSendMessage,
-  onSendKey: _onSendKey,
+  onSendKey,
   onUploadFile,
   showTerminal,
   onToggleTerminal,
@@ -298,6 +311,23 @@ export function SplitChatPane({
     loadMore,
     hasMore,
   } = useSessionJsonl(socket, isActive ? session.id : null);
+
+  // Claude 処理中に送ったメッセージを即時表示するための pending state。
+  // JSONL に同じテキストの user-input が現れたら自動で消える。
+  const [pending, setPending] = useState<
+    { id: string; text: string; sentAt: number }[]
+  >([]);
+
+  // events 更新のたびに pending を整理: マッチしたものを除去。ロジックは
+  // テスト容易性のため reconcilePending に純粋関数として切り出してある。
+  useEffect(() => {
+    setPending(prev => reconcilePending(prev, events, Date.now()));
+  }, [events]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies(session.id): セッション切替を検知して pending を破棄するための意図的な依存
+  useEffect(() => {
+    setPending([]);
+  }, [session.id]);
 
   // ===== スクロール追従 + 上端で過去読み込み =====
   const jsonlScrollRef = useRef<HTMLDivElement>(null);
@@ -364,11 +394,25 @@ export function SplitChatPane({
   }, [hasMore, loadMore, events.length]);
 
   // ===== 送信 =====
+  // 直近に送信したテキストを保持する。Esc 押下時に Claude Code 本体と同じく
+  // 「中断 + 入力欄に直前のテキストを復元」を再現するため。
+  // 復元したら ref をクリアし、次の submit で上書きされる。
+  const lastSubmittedRef = useRef<string>("");
+
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     const value = inputValue.trim();
     if (!value) return;
+    lastSubmittedRef.current = value;
     onSendMessage(value);
+    setPending(prev => [
+      ...prev,
+      {
+        id: `p:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+        text: value,
+        sentAt: Date.now(),
+      },
+    ]);
     setInputValue("");
   };
 
@@ -465,6 +509,33 @@ export function SplitChatPane({
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Esc は Claude Code 本体と同じ挙動 (4 分岐) を reconcileEscape に委譲する。
+    // 副作用 (setState / tmux 送信) はここで action 種別に応じて発火させる。
+    // slashOpen は slash 補完実装 (Step 9) までは常に false。
+    if (e.key === "Escape" && !e.nativeEvent.isComposing) {
+      e.preventDefault();
+      const action = reconcileEscape({
+        inputValue,
+        slashOpen: false,
+        lastSubmitted: lastSubmittedRef.current,
+      });
+      if (action.kind === "close-slash") {
+        // slash 補完未実装のため到達しない
+      } else if (action.kind === "clear-input") {
+        setInputValue("");
+      } else {
+        onSendKey("Escape");
+        if (action.restore !== null) {
+          setInputValue(action.restore);
+          lastSubmittedRef.current = "";
+        }
+        if (action.removePendingText !== null) {
+          const norm = action.removePendingText.trim();
+          setPending(prev => prev.filter(p => p.text.trim() !== norm));
+        }
+      }
+      return;
+    }
     if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSubmit(e as unknown as FormEvent);
@@ -517,7 +588,7 @@ export function SplitChatPane({
           ref={jsonlScrollRef}
           className="absolute inset-0 overflow-y-auto py-2"
         >
-          {events.length === 0 ? (
+          {events.length === 0 && pending.length === 0 ? (
             <div className="text-center text-sm text-muted-foreground pt-8">
               このセッションの履歴はまだありません
             </div>
@@ -530,6 +601,9 @@ export function SplitChatPane({
               )}
               {events.map(ev => (
                 <EventCard key={ev.id} event={ev} />
+              ))}
+              {pending.map(p => (
+                <PendingMessageCard key={p.id} text={p.text} />
               ))}
             </>
           )}

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -11,6 +11,7 @@
  */
 
 import type {
+  BridgeSessionStatus,
   ClientToServerEvents,
   ManagedSession,
   ServerToClientEvents,
@@ -53,6 +54,12 @@ interface SplitChatPaneProps {
    * セッション数ぶんの tail が常時走ってしまう)
    */
   isActive: boolean;
+  /**
+   * session:previews 由来のセッション状態。capture-pane の existence
+   * チェックのみで導出される (内容パースなし)。busy 表示と、permission
+   * prompt 等の AWAITING フォールバックバナーに使う
+   */
+  bridgeStatus?: BridgeSessionStatus;
   onSendMessage: (message: string) => void;
   /** AskUserQuestion のキャンセル (Esc) 等で使用 */
   onSendKey: (key: SpecialKey) => void;
@@ -312,6 +319,7 @@ export function SplitChatPane({
   socket,
   session,
   isActive,
+  bridgeStatus,
   onSendMessage,
   onSendKey,
   onUploadFile,
@@ -617,6 +625,12 @@ export function SplitChatPane({
           </div>
         </div>
         <div className="flex items-center gap-1.5 shrink-0">
+          {(bridgeStatus === "THINK" || bridgeStatus === "TOOL") && (
+            <span className="text-[11px] text-muted-foreground flex items-center gap-1">
+              <Loader2 className="w-3 h-3 animate-spin" />
+              {bridgeStatus === "TOOL" ? "ツール実行中" : "考え中"}
+            </span>
+          )}
           <span
             className={`w-1.5 h-1.5 rounded-full ${jsonlSubscribed ? "bg-emerald-500" : "bg-slate-400"}`}
             title={jsonlSubscribed ? "JSONL 購読中" : "未購読"}
@@ -691,6 +705,44 @@ export function SplitChatPane({
             onToggleTerminal && !showTerminal ? onToggleTerminal : undefined
           }
         />
+      )}
+
+      {/* permission prompt 等のユーザー判断待ちフォールバック。
+          AskUserQuestion は専用カードが出る (hook 経由) ため、カード表示中
+          は出さない。hook が取りこぼされた場合のセーフティネットも兼ねる */}
+      {bridgeStatus === "AWAITING" && !activeAuq && (
+        <div className="border-t border-border bg-amber-500/10 px-3 py-2 shrink-0 flex items-center justify-between gap-2">
+          <span className="text-[13px] text-amber-700 dark:text-amber-300 min-w-0">
+            ⏳ Claude が入力を求めています
+          </span>
+          <div className="flex items-center gap-1.5 shrink-0">
+            <button
+              type="button"
+              onClick={() => onSendKey("1")}
+              className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
+              title="1 を送信"
+            >
+              1
+            </button>
+            <button
+              type="button"
+              onClick={() => onSendKey("2")}
+              className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
+              title="2 を送信"
+            >
+              2
+            </button>
+            {onToggleTerminal && !showTerminal && (
+              <button
+                type="button"
+                onClick={onToggleTerminal}
+                className="text-[12px] underline text-amber-700 dark:text-amber-300 px-1"
+              >
+                ターミナルで確認
+              </button>
+            )}
+          </div>
+        </div>
       )}
 
       <form

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -15,6 +15,7 @@ import type {
   ClientToServerEvents,
   ManagedSession,
   ServerToClientEvents,
+  SlashCommandInfo,
   SpecialKey,
 } from "@ark/shared";
 import { ArrowDown, Loader2, Paperclip, Send } from "lucide-react";
@@ -34,6 +35,7 @@ import { AskUserQuestionCard } from "@/components/AskUserQuestionCard";
 import { Button } from "@/components/ui/button";
 import { fileToBase64, validateFile } from "@/hooks/useFileUpload";
 import { useSessionJsonl } from "@/hooks/useSessionJsonl";
+import { useSlashCommands } from "@/hooks/useSlashCommands";
 import {
   type ActiveAuq,
   hasResolvedAuqSince,
@@ -348,10 +350,86 @@ export function SplitChatPane({
     setPending(prev => reconcilePending(prev, events, Date.now()));
   }, [events]);
 
+  // built-in slash command (/compact, /clear 等) は JSONL に user-input として
+  // 記録されないため、ローカルで永続的に表示する slash-command イベントを保持する。
+  const [localSlashCommands, setLocalSlashCommands] = useState<
+    { id: string; name: string; args?: string; sentAt: number }[]
+  >([]);
+
   // biome-ignore lint/correctness/useExhaustiveDependencies(session.id): セッション切替を検知して pending を破棄するための意図的な依存
   useEffect(() => {
     setPending([]);
+    setLocalSlashCommands([]);
   }, [session.id]);
+
+  // ===== Slash command 補完 =====
+  const { commands: slashCommands } = useSlashCommands(
+    socket,
+    isActive ? session.id : null
+  );
+  const [slashOpen, setSlashOpen] = useState(false);
+  const [slashIndex, setSlashIndex] = useState(0);
+  const filteredSlashCommands = useMemo(() => {
+    if (!slashOpen) return [];
+    const q = inputValue.trim().toLowerCase();
+    if (!q.startsWith("/")) return [];
+    return slashCommands
+      .filter(c => c.name.toLowerCase().startsWith(q))
+      .slice(0, 8);
+  }, [slashOpen, slashCommands, inputValue]);
+
+  useEffect(() => {
+    const firstLine = inputValue.split("\n")[0] ?? "";
+    const shouldOpen = firstLine.startsWith("/");
+    setSlashOpen(shouldOpen);
+    if (shouldOpen) setSlashIndex(0);
+  }, [inputValue]);
+
+  const appendLocalSlashCommand = useCallback((name: string, args?: string) => {
+    setLocalSlashCommands(prev => [
+      ...prev,
+      {
+        id: `lsc:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+        name,
+        args,
+        sentAt: Date.now(),
+      },
+    ]);
+  }, []);
+
+  const applySlashCommand = useCallback(
+    (cmd: SlashCommandInfo) => {
+      setSlashOpen(false);
+      if (cmd.source === "built-in") {
+        onSendMessage(cmd.name);
+        appendLocalSlashCommand(cmd.name);
+        setInputValue("");
+        return;
+      }
+      setInputValue(prev => {
+        const lines = prev.split("\n");
+        lines[0] = `${cmd.name} `;
+        return lines.join("\n");
+      });
+    },
+    [onSendMessage, appendLocalSlashCommand]
+  );
+
+  // 入力値が built-in slash command と一致するか判定する
+  const matchBuiltInSlashCommand = useCallback(
+    (value: string): { name: string; args?: string } | null => {
+      const firstLine = value.split("\n")[0]?.trim() ?? "";
+      if (!firstLine.startsWith("/")) return null;
+      const [head, ...rest] = firstLine.split(/\s+/);
+      const cmd = slashCommands.find(
+        c => c.source === "built-in" && c.name === head
+      );
+      if (!cmd) return null;
+      const args = rest.join(" ").trim();
+      return { name: cmd.name, args: args || undefined };
+    },
+    [slashCommands]
+  );
 
   // 回答待ちの AskUserQuestion。
   // 表示開始 = PreToolUse hook 由来の session:auq イベント (対話版 claude は
@@ -472,14 +550,22 @@ export function SplitChatPane({
     if (!value) return;
     lastSubmittedRef.current = value;
     onSendMessage(value);
-    setPending(prev => [
-      ...prev,
-      {
-        id: `p:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
-        text: value,
-        sentAt: Date.now(),
-      },
-    ]);
+    // built-in slash command (/compact, /clear 等) は JSONL に user-input として
+    // 記録されないため、pending bubble だと永遠に spinner が残る。
+    // 代わりにローカル slash-command カードを即時追加する。
+    const builtIn = matchBuiltInSlashCommand(value);
+    if (builtIn) {
+      appendLocalSlashCommand(builtIn.name, builtIn.args);
+    } else {
+      setPending(prev => [
+        ...prev,
+        {
+          id: `p:${Date.now()}:${Math.random().toString(36).slice(2, 8)}`,
+          text: value,
+          sentAt: Date.now(),
+        },
+      ]);
+    }
     setInputValue("");
   };
 
@@ -576,18 +662,42 @@ export function SplitChatPane({
   );
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (slashOpen && filteredSlashCommands.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSlashIndex(i => (i + 1) % filteredSlashCommands.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSlashIndex(
+          i =>
+            (i - 1 + filteredSlashCommands.length) %
+            filteredSlashCommands.length
+        );
+        return;
+      }
+      if (
+        (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) &&
+        !e.nativeEvent.isComposing
+      ) {
+        e.preventDefault();
+        const target = filteredSlashCommands[slashIndex];
+        if (target) applySlashCommand(target);
+        return;
+      }
+    }
     // Esc は Claude Code 本体と同じ挙動 (4 分岐) を reconcileEscape に委譲する。
     // 副作用 (setState / tmux 送信) はここで action 種別に応じて発火させる。
-    // slashOpen は slash 補完実装 (Step 9) までは常に false。
     if (e.key === "Escape" && !e.nativeEvent.isComposing) {
       e.preventDefault();
       const action = reconcileEscape({
         inputValue,
-        slashOpen: false,
+        slashOpen: slashOpen && filteredSlashCommands.length > 0,
         lastSubmitted: lastSubmittedRef.current,
       });
       if (action.kind === "close-slash") {
-        // slash 補完未実装のため到達しない
+        setSlashOpen(false);
       } else if (action.kind === "clear-input") {
         setInputValue("");
       } else {
@@ -661,7 +771,9 @@ export function SplitChatPane({
           ref={jsonlScrollRef}
           className="absolute inset-0 overflow-y-auto py-2"
         >
-          {events.length === 0 && pending.length === 0 ? (
+          {events.length === 0 &&
+          pending.length === 0 &&
+          localSlashCommands.length === 0 ? (
             <div className="text-center text-sm text-muted-foreground pt-8">
               このセッションの履歴はまだありません
             </div>
@@ -674,6 +786,9 @@ export function SplitChatPane({
               )}
               {events.map(ev => (
                 <EventCard key={ev.id} event={ev} />
+              ))}
+              {localSlashCommands.map(c => (
+                <SlashCommandCard key={c.id} name={c.name} args={c.args} />
               ))}
               {pending.map(p => (
                 <PendingMessageCard key={p.id} text={p.text} />
@@ -807,6 +922,48 @@ export function SplitChatPane({
           rows={1}
           className="flex-1 px-3 py-2 text-sm bg-muted/40 border border-border rounded-lg focus:outline-none focus:border-primary placeholder:text-muted-foreground resize-none min-h-[36px] max-h-32"
         />
+        {slashOpen && filteredSlashCommands.length > 0 && (
+          <div className="absolute left-3 right-3 bottom-full mb-1 bg-popover border border-border rounded-lg shadow-lg overflow-hidden z-20">
+            {filteredSlashCommands.map((cmd, i) => (
+              <button
+                type="button"
+                key={cmd.name}
+                onMouseDown={e => {
+                  e.preventDefault();
+                  applySlashCommand(cmd);
+                }}
+                onMouseEnter={() => setSlashIndex(i)}
+                className={`w-full text-left px-3 py-1.5 flex items-center gap-2 text-sm ${
+                  i === slashIndex
+                    ? "bg-accent text-accent-foreground"
+                    : "hover:bg-muted/50"
+                }`}
+              >
+                <span className="font-mono text-foreground shrink-0">
+                  {cmd.name}
+                </span>
+                {cmd.description && (
+                  <span className="text-xs text-muted-foreground truncate flex-1">
+                    {cmd.description}
+                  </span>
+                )}
+                <span
+                  className={`text-[9px] px-1.5 py-0.5 rounded font-medium shrink-0 ${
+                    cmd.source === "project"
+                      ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+                      : cmd.source === "global"
+                        ? "bg-blue-500/15 text-blue-700 dark:text-blue-300"
+                        : cmd.source === "plugin"
+                          ? "bg-violet-500/15 text-violet-700 dark:text-violet-300"
+                          : "bg-muted text-muted-foreground"
+                  }`}
+                >
+                  {cmd.source}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
         <Button
           type="submit"
           size="sm"

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -29,9 +29,15 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Socket } from "socket.io-client";
 import { toast } from "sonner";
+import { AskUserQuestionCard } from "@/components/AskUserQuestionCard";
 import { Button } from "@/components/ui/button";
 import { fileToBase64, validateFile } from "@/hooks/useFileUpload";
 import { useSessionJsonl } from "@/hooks/useSessionJsonl";
+import {
+  type ActiveAuq,
+  hasResolvedAuqSince,
+  parseAuqInput,
+} from "@/lib/ask-user-question-state";
 import type { JsonlParsedEvent } from "@/lib/jsonl-event-parser";
 import { reconcileEscape } from "@/lib/reconcile-escape";
 import { reconcilePending } from "@/lib/reconcile-pending";
@@ -274,6 +280,16 @@ function EventCard({ event }: { event: JsonlParsedEvent }) {
     case "compact-marker":
       return <CompactMarkerCard />;
     case "tool-call":
+      // 回答待ちの AskUserQuestion は入力欄上のアクティブカード
+      // (AskUserQuestionCard) が担当するので履歴側には出さない。
+      // tool_result が来て done になったら回答済みカードとして表示する
+      if (
+        event.tool === "AskUserQuestion" &&
+        event.status === "running" &&
+        event.isSidechain !== true
+      ) {
+        return null;
+      }
       return (
         <ToolCallCard
           tool={event.tool}
@@ -328,6 +344,49 @@ export function SplitChatPane({
   useEffect(() => {
     setPending([]);
   }, [session.id]);
+
+  // 回答待ちの AskUserQuestion。
+  // 表示開始 = PreToolUse hook 由来の session:auq イベント (対話版 claude は
+  // AUQ の tool_use を回答確定まで JSONL に書かないため hook が唯一の情報源)。
+  // カードを閉じる = JSONL に解決イベント (tool_use + tool_result) が出現。
+  const [hookAuq, setHookAuq] = useState<{
+    at: number;
+    auq: ActiveAuq;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handler = (data: {
+      sessionId: string;
+      at: number;
+      questions: unknown;
+    }) => {
+      if (data.sessionId !== session.id) return;
+      const questions = parseAuqInput({ questions: data.questions });
+      if (!questions) return;
+      setHookAuq({
+        at: data.at,
+        auq: { toolUseId: `hook:${data.at}`, questions },
+      });
+    };
+    socket.on("session:auq", handler);
+    return () => {
+      socket.off("session:auq", handler);
+    };
+  }, [socket, session.id]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies(session.id): セッション切替を検知して回答待ちカードを破棄するための意図的な依存
+  useEffect(() => {
+    setHookAuq(null);
+  }, [session.id]);
+
+  // JSONL に解決イベント (回答/Esc 拒否) が書かれたらカードを閉じる
+  useEffect(() => {
+    if (!hookAuq) return;
+    if (hasResolvedAuqSince(events, hookAuq.at)) setHookAuq(null);
+  }, [events, hookAuq]);
+
+  const activeAuq = hookAuq?.auq ?? null;
 
   // ===== スクロール追従 + 上端で過去読み込み =====
   const jsonlScrollRef = useRef<HTMLDivElement>(null);
@@ -620,6 +679,19 @@ export function SplitChatPane({
           </button>
         )}
       </div>
+
+      {activeAuq && (
+        <AskUserQuestionCard
+          key={activeAuq.toolUseId}
+          socket={socket}
+          sessionId={session.id}
+          auq={activeAuq}
+          onSendKey={onSendKey}
+          onOpenTerminal={
+            onToggleTerminal && !showTerminal ? onToggleTerminal : undefined
+          }
+        />
+      )}
 
       <form
         onSubmit={handleSubmit}

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -27,7 +27,7 @@ import {
   useRef,
   useState,
 } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type { Socket } from "socket.io-client";
 import { toast } from "sonner";
@@ -116,11 +116,42 @@ function SlashCommandCard({ name, args }: { name: string; args?: string }) {
   );
 }
 
+/**
+ * assistant text はモデル出力由来の信用できない Markdown。
+ * - 画像はレンダリングしない (外部 URL の自動読込によるトラッキング/
+ *   情報漏えいを防ぐ。alt テキストのプレースホルダ表示に置き換える)
+ * - リンクは http/https のみ許可し、新規タブ + noopener noreferrer で開く
+ */
+const MD_URL_TRANSFORM = (url: string): string =>
+  /^(https?:|#)/i.test(url) ? url : "";
+
+const MD_COMPONENTS: Components = {
+  img: ({ alt }) => (
+    <span
+      className="inline-block text-xs text-muted-foreground bg-muted rounded px-1.5 py-0.5"
+      title="モデル出力由来の外部画像は自動表示しません"
+    >
+      🖼 {alt || "画像"}
+    </span>
+  ),
+  a: ({ href, children }) => (
+    <a href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ),
+};
+
 function AssistantTextCard({ text }: { text: string }) {
   return (
     <div className="px-4 py-2">
       <div className="md-prose text-[16px] text-foreground leading-[1.65]">
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>{text}</ReactMarkdown>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          urlTransform={MD_URL_TRANSFORM}
+          components={MD_COMPONENTS}
+        >
+          {text}
+        </ReactMarkdown>
       </div>
     </div>
   );

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -284,6 +284,114 @@ function ToolCallCard({
 }
 
 /**
+ * AWAITING フォールバックのミニ操作パッド。
+ *
+ * hook 未注入セッション (AUQ カードが出ない) や permission prompt で、
+ * ターミナルを開かずに確認 UI を操作する。確認 UI の生テキスト表示 +
+ * キーパッド (数字ジャンプ/トグル・矢印・Space・Enter・Esc) +
+ * 自由入力 (Type something 用 literal 送信)。
+ * 画面の構造はパースしない: ユーザーが生テキストを読んでキーを選ぶ。
+ */
+function AwaitingPad({
+  socket,
+  sessionId,
+  awaitingText,
+  onSendKey,
+  onOpenTerminal,
+}: {
+  socket: TypedSocket | null;
+  sessionId: string;
+  awaitingText?: string;
+  onSendKey: (key: SpecialKey) => void;
+  onOpenTerminal?: () => void;
+}) {
+  const [freeText, setFreeText] = useState("");
+
+  const submitFreeText = () => {
+    const value = freeText;
+    if (!value.trim() || !socket) return;
+    // 「Type something」行にフォーカスした状態 (数字キーでジャンプ済み) で
+    // literal 送信 → Enter で確定する。C-u は送らない (選択 UI 上の
+    // 不要な端末操作になるため)。チャット入力欄の session:send を使わない
+    // のも同じ理由 (C-u + 即 Enter が確認 UI を誤操作する)
+    socket.emit("session:send-literal", { sessionId, text: value });
+    setTimeout(() => onSendKey("Enter"), 250);
+    setFreeText("");
+  };
+
+  const keyBtn = (label: string, key: SpecialKey, title: string) => (
+    <button
+      key={label}
+      type="button"
+      onClick={() => onSendKey(key)}
+      className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
+      title={title}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="border-t border-border bg-amber-500/10 px-3 py-2 shrink-0 max-h-[50%] overflow-y-auto">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[13px] text-amber-700 dark:text-amber-300 min-w-0 font-medium">
+          ⏳ Claude が入力を求めています
+        </span>
+        {onOpenTerminal && (
+          <button
+            type="button"
+            onClick={onOpenTerminal}
+            className="text-[12px] underline text-amber-700 dark:text-amber-300 px-1 shrink-0"
+          >
+            ターミナルで確認
+          </button>
+        )}
+      </div>
+      {awaitingText && (
+        <pre className="mt-1.5 text-[11px] leading-[1.5] font-mono bg-background/70 border border-border rounded-md px-2.5 py-2 overflow-x-auto whitespace-pre text-foreground/80">
+          {awaitingText}
+        </pre>
+      )}
+      <div className="mt-1.5 flex items-center gap-1 flex-wrap">
+        {(["1", "2", "3", "4", "5", "6"] as const).map(d =>
+          keyBtn(d, d, `${d} を送信 (選択肢ジャンプ/トグル)`)
+        )}
+        <span className="w-2" />
+        {keyBtn("↑", "Up", "フォーカスを上へ")}
+        {keyBtn("↓", "Down", "フォーカスを下へ")}
+        {keyBtn("→", "Right", "次のタブ / Submit へ")}
+        {keyBtn("Space", "Space", "チェックをトグル")}
+        {keyBtn("Enter", "Enter", "フォーカス中の項目を選択/確定")}
+        {keyBtn("Esc", "Escape", "キャンセル")}
+      </div>
+      <div className="mt-1.5 flex items-center gap-2 bg-background border border-border rounded-md px-2.5 py-1 focus-within:border-primary">
+        <input
+          type="text"
+          value={freeText}
+          onChange={e => setFreeText(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === "Enter" && !e.nativeEvent.isComposing) {
+              e.preventDefault();
+              submitFreeText();
+            }
+          }}
+          placeholder="自由入力 — 先に Type something の番号を押してから入力 (Enter で確定)"
+          className="flex-1 text-[12px] bg-transparent focus:outline-none placeholder:text-muted-foreground py-0.5"
+        />
+        <button
+          type="button"
+          onClick={submitFreeText}
+          disabled={!freeText.trim()}
+          className="text-[11px] bg-primary text-primary-foreground rounded px-2 py-0.5 disabled:opacity-30 disabled:cursor-not-allowed"
+        >
+          入力して確定
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/**
  * subagent (isSidechain) の連続イベントを 1 ブロックに集約した折りたたみ表示。
  * 大量のツール呼び出しがメイン会話を埋めないようにする。
  */
@@ -889,51 +997,17 @@ export function SplitChatPane({
 
       {/* permission prompt 等のユーザー判断待ちフォールバック。
           AskUserQuestion は専用カードが出る (hook 経由) ため、カード表示中
-          は出さない。hook が取りこぼされた場合のセーフティネットも兼ねる。
-          「何を聞かれているか」は確認 UI の生テキストをそのまま表示する */}
+          は出さない。hook が取りこぼされた場合のセーフティネットも兼ねる */}
       {bridgeStatus === "AWAITING" && !activeAuq && (
-        <div className="border-t border-border bg-amber-500/10 px-3 py-2 shrink-0 max-h-[45%] overflow-y-auto">
-          <div className="flex items-center justify-between gap-2">
-            <span className="text-[13px] text-amber-700 dark:text-amber-300 min-w-0 font-medium">
-              ⏳ Claude が入力を求めています
-            </span>
-            <div className="flex items-center gap-1.5 shrink-0">
-              {(["1", "2", "3"] as const).map(d => (
-                <button
-                  key={d}
-                  type="button"
-                  onClick={() => onSendKey(d)}
-                  className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
-                  title={`${d} を送信`}
-                >
-                  {d}
-                </button>
-              ))}
-              <button
-                type="button"
-                onClick={() => onSendKey("Enter")}
-                className="text-[12px] font-mono bg-background border border-border rounded px-2 py-0.5 hover:bg-accent transition-colors"
-                title="Enter を送信 (フォーカス中の項目を選択)"
-              >
-                Enter
-              </button>
-              {onToggleTerminal && !showTerminal && (
-                <button
-                  type="button"
-                  onClick={onToggleTerminal}
-                  className="text-[12px] underline text-amber-700 dark:text-amber-300 px-1"
-                >
-                  ターミナルで確認
-                </button>
-              )}
-            </div>
-          </div>
-          {awaitingText && (
-            <pre className="mt-1.5 text-[11px] leading-[1.5] font-mono bg-background/70 border border-border rounded-md px-2.5 py-2 overflow-x-auto whitespace-pre text-foreground/80">
-              {awaitingText}
-            </pre>
-          )}
-        </div>
+        <AwaitingPad
+          socket={socket}
+          sessionId={session.id}
+          awaitingText={awaitingText}
+          onSendKey={onSendKey}
+          onOpenTerminal={
+            onToggleTerminal && !showTerminal ? onToggleTerminal : undefined
+          }
+        />
       )}
 
       <form

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -1,0 +1,220 @@
+/**
+ * SplitViewPane - チャット UI 時代の PC 用セッションビュー
+ *
+ * 左ペイン (SplitChatPane = JSONL ベースの会話ビュー) を全幅表示し、
+ * 上部の「🖥 ターミナル」トグルで右に既存 TerminalPane (ttyd) を展開する。
+ * 旧来の TerminalPane 単独表示に戻したい場合は URL に `?view=classic` を付ける
+ * (Dashboard.tsx で分岐)。
+ *
+ * - ttyd は display 切替で残置 (unmount するとセッション再接続コストが発生)
+ * - 左右比 / ターミナル開閉状態は localStorage に永続化
+ */
+
+import type {
+  ClientToServerEvents,
+  ManagedSession,
+  MessageShortcut,
+  ServerToClientEvents,
+  SpecialKey,
+  Worktree,
+} from "@ark/shared";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
+import { SplitChatPane } from "./SplitChatPane";
+import { TerminalPane, type ViewerTab } from "./TerminalPane";
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+const LEFT_MIN_WIDTH = 280;
+const LEFT_MAX_RATIO = 0.6;
+const STORAGE_KEY_WIDTH = "ark-split-left-width";
+const STORAGE_KEY_TERMINAL = "ark-split-show-terminal";
+
+interface SplitViewPaneProps {
+  socket: TypedSocket | null;
+  session: ManagedSession;
+  /** このペインが現在表示中か (JSONL 購読をアクティブセッションに限定する) */
+  isActive: boolean;
+  worktree: Worktree | undefined;
+  repoName?: string;
+  tabs: ViewerTab[];
+  activeTabIndex: number;
+  onTabSelect: (index: number) => void;
+  onTabClose: (index: number) => void;
+  onSendMessage: (message: string) => void;
+  onSendKey: (key: SpecialKey) => void;
+  onDeleteSession: () => void;
+  onUploadFile?: (data: {
+    base64Data: string;
+    mimeType: string;
+    originalFilename?: string;
+  }) => Promise<{ path: string; filename: string; originalFilename?: string }>;
+  onCopyBuffer?: () => Promise<string | null>;
+  messageShortcuts: MessageShortcut[];
+  onCreateShortcut: (message: string) => void;
+  onUpdateShortcut: (id: string, patch: { message?: string }) => void;
+  onDeleteShortcut: (id: string) => void;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function readSavedLeftWidth(): number | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY_WIDTH);
+    if (!raw) return null;
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
+function readSavedShowTerminal(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY_TERMINAL) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function SplitViewPane(props: SplitViewPaneProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [leftWidth, setLeftWidth] = useState<number>(
+    () => readSavedLeftWidth() ?? 420
+  );
+  const [isDragging, setIsDragging] = useState(false);
+  const [showTerminal, setShowTerminal] = useState<boolean>(() =>
+    readSavedShowTerminal()
+  );
+
+  // コンテナ幅変化時に left を最大比率内に丸める (ターミナル表示中のみ意味あり)
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || !showTerminal) return;
+    const observer = new ResizeObserver(() => {
+      const total = el.clientWidth;
+      if (total <= 0) return;
+      const max = Math.floor(total * LEFT_MAX_RATIO);
+      setLeftWidth(prev => clamp(prev, LEFT_MIN_WIDTH, max));
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [showTerminal]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isDragging) return;
+    const onMove = (e: MouseEvent) => {
+      const el = containerRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const total = rect.width;
+      const next = e.clientX - rect.left;
+      const max = Math.floor(total * LEFT_MAX_RATIO);
+      const clamped = clamp(next, LEFT_MIN_WIDTH, max);
+      setLeftWidth(clamped);
+    };
+    const onUp = () => {
+      setIsDragging(false);
+      try {
+        localStorage.setItem(STORAGE_KEY_WIDTH, String(leftWidth));
+      } catch {
+        // ignore
+      }
+    };
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+    };
+  }, [isDragging, leftWidth]);
+
+  const handleToggleTerminal = useCallback(() => {
+    setShowTerminal(prev => {
+      const next = !prev;
+      try {
+        localStorage.setItem(STORAGE_KEY_TERMINAL, next ? "1" : "0");
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }, []);
+
+  return (
+    <div ref={containerRef} className="h-full flex relative">
+      <div
+        style={
+          showTerminal
+            ? { width: leftWidth, flexShrink: 0 }
+            : { flex: "1 1 auto", minWidth: 0 }
+        }
+        className={`h-full overflow-hidden ${showTerminal ? "border-r border-border" : ""}`}
+      >
+        <SplitChatPane
+          socket={props.socket}
+          session={props.session}
+          isActive={props.isActive}
+          onSendMessage={props.onSendMessage}
+          onSendKey={props.onSendKey}
+          onUploadFile={props.onUploadFile}
+          showTerminal={showTerminal}
+          onToggleTerminal={handleToggleTerminal}
+        />
+      </div>
+
+      {/* リサイザはターミナル表示時のみ */}
+      {showTerminal && (
+        <button
+          type="button"
+          aria-label="左右の幅を調整"
+          onMouseDown={handleMouseDown}
+          className={`relative w-1 shrink-0 cursor-col-resize bg-border hover:bg-primary/50 transition-colors ${
+            isDragging ? "bg-primary/70" : ""
+          }`}
+        >
+          <span className="absolute inset-y-0 -left-1 -right-1" />
+        </button>
+      )}
+
+      {/* TerminalPane は display 切替で永続マウント (ttyd の再接続コストを避ける) */}
+      <div
+        className={`h-full overflow-hidden ${
+          showTerminal ? "flex-1 min-w-0" : "hidden"
+        }`}
+      >
+        <div className={`h-full ${isDragging ? "pointer-events-none" : ""}`}>
+          <TerminalPane
+            session={props.session}
+            worktree={props.worktree}
+            repoName={props.repoName}
+            tabs={props.tabs}
+            activeTabIndex={props.activeTabIndex}
+            onTabSelect={props.onTabSelect}
+            onTabClose={props.onTabClose}
+            onSendMessage={props.onSendMessage}
+            onSendKey={props.onSendKey}
+            onDeleteSession={props.onDeleteSession}
+            onUploadFile={props.onUploadFile}
+            onCopyBuffer={props.onCopyBuffer}
+            messageShortcuts={props.messageShortcuts}
+            onCreateShortcut={props.onCreateShortcut}
+            onUpdateShortcut={props.onUpdateShortcut}
+            onDeleteShortcut={props.onDeleteShortcut}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -11,6 +11,7 @@
  */
 
 import type {
+  BridgeSessionStatus,
   ClientToServerEvents,
   ManagedSession,
   MessageShortcut,
@@ -35,6 +36,8 @@ interface SplitViewPaneProps {
   session: ManagedSession;
   /** このペインが現在表示中か (JSONL 購読をアクティブセッションに限定する) */
   isActive: boolean;
+  /** session:previews 由来のセッション状態 (busy/AWAITING 表示用) */
+  bridgeStatus?: BridgeSessionStatus;
   worktree: Worktree | undefined;
   repoName?: string;
   tabs: ViewerTab[];
@@ -166,6 +169,7 @@ export function SplitViewPane(props: SplitViewPaneProps) {
           socket={props.socket}
           session={props.session}
           isActive={props.isActive}
+          bridgeStatus={props.bridgeStatus}
           onSendMessage={props.onSendMessage}
           onSendKey={props.onSendKey}
           onUploadFile={props.onUploadFile}

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -38,6 +38,8 @@ interface SplitViewPaneProps {
   isActive: boolean;
   /** session:previews 由来のセッション状態 (busy/AWAITING 表示用) */
   bridgeStatus?: BridgeSessionStatus;
+  /** AWAITING 時の確認 UI 生テキスト (バナーに表示) */
+  awaitingText?: string;
   worktree: Worktree | undefined;
   repoName?: string;
   tabs: ViewerTab[];
@@ -170,6 +172,7 @@ export function SplitViewPane(props: SplitViewPaneProps) {
           session={props.session}
           isActive={props.isActive}
           bridgeStatus={props.bridgeStatus}
+          awaitingText={props.awaitingText}
           onSendMessage={props.onSendMessage}
           onSendKey={props.onSendKey}
           onUploadFile={props.onUploadFile}

--- a/packages/web/src/hooks/useSessionJsonl.ts
+++ b/packages/web/src/hooks/useSessionJsonl.ts
@@ -1,0 +1,119 @@
+/**
+ * useSessionJsonl - Claude Code の JSONL 履歴を購読し、構造化イベント列を返す。
+ *
+ * 差分パース方針: line イベントが届いたら 1 行だけパースして既存 events に
+ * 追加マージする。snapshot は一括パース。これにより毎回フルパースする
+ * CPU 消費を回避する (大規模履歴のセッションで顕著)。
+ *
+ * 状態管理:
+ *   - events: パース済みイベント配列 (描画用、安定参照を保つ)
+ *   - toolMapRef: tool_use → tool_result マージ用の Map (state ではなく ref に置く。
+ *     setState を経由させると差分マージが不必要に再描画を起こす)
+ */
+
+import type { ClientToServerEvents, ServerToClientEvents } from "@ark/shared";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Socket } from "socket.io-client";
+import {
+  type JsonlParsedEvent,
+  mergeJsonlLine,
+  parseJsonlEvents,
+} from "@/lib/jsonl-event-parser";
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+const INITIAL_LIMIT = 100;
+const LOAD_MORE_STEP = 100;
+
+export interface UseSessionJsonlResult {
+  events: JsonlParsedEvent[];
+  isSubscribed: boolean;
+  /** Snapshot 受信済みかどうか (true 以前はまだ過去履歴を読み込み中) */
+  hasSnapshot: boolean;
+  /** 過去履歴をさらに読み込む。サーバが limit 付きで snapshot を再送する */
+  loadMore: () => void;
+  /** 現在の取得 limit 行数 (UI 上の「さらに読み込む」ボタン disable 判定用) */
+  loadedLimit: number;
+  /** 取得した snapshot の行数が limit と等しい (まだ読める可能性が高い) か */
+  hasMore: boolean;
+}
+
+export function useSessionJsonl(
+  socket: TypedSocket | null,
+  sessionId: string | null
+): UseSessionJsonlResult {
+  const [events, setEvents] = useState<JsonlParsedEvent[]>([]);
+  const [isSubscribed, setIsSubscribed] = useState(false);
+  const [hasSnapshot, setHasSnapshot] = useState(false);
+  const [loadedLimit, setLoadedLimit] = useState(INITIAL_LIMIT);
+  const [hasMore, setHasMore] = useState(true);
+  // tool_use → tool_result のマッピング。再描画を発生させたくないので ref で保持
+  const toolMapRef = useRef(
+    new Map<string, Extract<JsonlParsedEvent, { kind: "tool-call" }>>()
+  );
+  // loadMore で次回 emit する limit を ref で保持 (useEffect 内 callback からアクセス)
+  const limitRef = useRef(INITIAL_LIMIT);
+
+  useEffect(() => {
+    if (!socket || !sessionId) {
+      setEvents([]);
+      setIsSubscribed(false);
+      setHasSnapshot(false);
+      setLoadedLimit(INITIAL_LIMIT);
+      setHasMore(true);
+      limitRef.current = INITIAL_LIMIT;
+      toolMapRef.current = new Map();
+      return;
+    }
+    setHasSnapshot(false);
+    setEvents([]);
+    setLoadedLimit(INITIAL_LIMIT);
+    setHasMore(true);
+    limitRef.current = INITIAL_LIMIT;
+    toolMapRef.current = new Map();
+
+    const handleSnapshot = (data: { sessionId: string; lines: string[] }) => {
+      if (data.sessionId !== sessionId) return;
+      const fresh = parseJsonlEvents(data.lines);
+      const map = new Map<
+        string,
+        Extract<JsonlParsedEvent, { kind: "tool-call" }>
+      >();
+      for (const ev of fresh) {
+        if (ev.kind === "tool-call") map.set(ev.toolUseId, ev);
+      }
+      toolMapRef.current = map;
+      setEvents(fresh);
+      setHasSnapshot(true);
+      // 受信行数 < 要求 limit ならファイル先頭まで到達したと判断
+      setHasMore(data.lines.length >= limitRef.current);
+    };
+
+    const handleLine = (data: { sessionId: string; line: string }) => {
+      if (data.sessionId !== sessionId) return;
+      setEvents(prev => mergeJsonlLine(prev, toolMapRef.current, data.line));
+    };
+
+    socket.on("session:jsonl-snapshot", handleSnapshot);
+    socket.on("session:jsonl-line", handleLine);
+    socket.emit("session:jsonl-subscribe", sessionId);
+    setIsSubscribed(true);
+
+    return () => {
+      socket.off("session:jsonl-snapshot", handleSnapshot);
+      socket.off("session:jsonl-line", handleLine);
+      socket.emit("session:jsonl-unsubscribe", sessionId);
+      setIsSubscribed(false);
+    };
+  }, [socket, sessionId]);
+
+  const loadMore = useCallback(() => {
+    if (!socket || !sessionId) return;
+    const next = limitRef.current + LOAD_MORE_STEP;
+    limitRef.current = next;
+    setLoadedLimit(next);
+    socket.emit("session:jsonl-load-more", { sessionId, limit: next });
+  }, [socket, sessionId]);
+
+  return { events, isSubscribed, hasSnapshot, loadMore, loadedLimit, hasMore };
+}

--- a/packages/web/src/hooks/useSlashCommands.ts
+++ b/packages/web/src/hooks/useSlashCommands.ts
@@ -1,0 +1,65 @@
+/**
+ * useSlashCommands - 指定セッションで利用可能な slash command 候補をサーバから取得。
+ *
+ * `slash:list` Socket.IO イベントを 1 回叩いてキャッシュ。
+ * セッション切替 / socket 再接続で再取得する。手動 reload も export。
+ */
+
+import type {
+  ClientToServerEvents,
+  ServerToClientEvents,
+  SlashCommandInfo,
+} from "@ark/shared";
+import { useCallback, useEffect, useState } from "react";
+import type { Socket } from "socket.io-client";
+
+type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+
+export interface UseSlashCommandsResult {
+  commands: SlashCommandInfo[];
+  isLoading: boolean;
+  error: string | null;
+  reload: () => void;
+}
+
+export function useSlashCommands(
+  socket: TypedSocket | null,
+  sessionId: string | null
+): UseSlashCommandsResult {
+  const [commands, setCommands] = useState<SlashCommandInfo[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  const reload = useCallback(() => setReloadKey(k => k + 1), []);
+
+  useEffect(() => {
+    // reloadKey は reload() からの再実行トリガとして deps に含めている。
+    // effect 内で実値を参照しないため `void` で明示的に使用した形にしておく
+    void reloadKey;
+    if (!socket || !sessionId) {
+      setCommands([]);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setIsLoading(true);
+    setError(null);
+    socket.emit("slash:list", sessionId, response => {
+      if (cancelled) return;
+      setIsLoading(false);
+      if (response.error) {
+        setError(response.error);
+        setCommands([]);
+        return;
+      }
+      setCommands(response.commands ?? []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [socket, sessionId, reloadKey]);
+
+  return { commands, isLoading, error, reload };
+}

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -149,6 +149,13 @@ interface UseSocketReturn {
    */
   sessionStatuses: Map<string, BridgeSessionStatus>;
 
+  /**
+   * sessionId → AWAITING 時の確認 UI 生テキスト。
+   * チャットビューのバナーで「何を聞かれているか」をそのまま表示する。
+   * AWAITING でないセッションはエントリ自体が無い
+   */
+  sessionAwaitingTexts: Map<string, string>;
+
   // Beacon
   beaconMessages: ChatMessage[];
   beaconStreaming: boolean;
@@ -313,6 +320,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   // サイドバードット色用。RepoGridView 購読の有無に関わらず常時更新される。
   const [sessionStatuses, setSessionStatuses] = useState<
     Map<string, BridgeSessionStatus>
+  >(new Map());
+
+  // AWAITING 時の確認 UI 生テキスト (チャットビューのバナーで内容を表示する)。
+  // AWAITING でないセッションは undefined になる
+  const [sessionAwaitingTexts, setSessionAwaitingTexts] = useState<
+    Map<string, string>
   >(new Map());
 
   // Browser session state
@@ -760,6 +773,17 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         const next = new Map(prev);
         for (const p of previews) {
           next.set(p.sessionId, p.bridgeStatus);
+        }
+        return next;
+      });
+      setSessionAwaitingTexts(prev => {
+        const next = new Map(prev);
+        for (const p of previews) {
+          if (p.awaitingText) {
+            next.set(p.sessionId, p.awaitingText);
+          } else {
+            next.delete(p.sessionId);
+          }
         }
         return next;
       });
@@ -1561,6 +1585,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     // Session previews
     sessionPreviews,
     sessionActivityTexts,
+    sessionAwaitingTexts,
     gridSnapshots,
     subscribeGrid,
     unsubscribeGrid,

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -323,3 +323,91 @@
   animation: level-up-flash 1s ease-out forwards;
   pointer-events: none;
 }
+
+/* ===== JSONL assistant text 用 markdown プロース =====
+ * react-markdown が出力する要素にチャットらしい spacing と code/blockquote 装飾を当てる */
+.md-prose {
+  line-height: 1.65;
+}
+.md-prose > * + * {
+  margin-top: 0.75em;
+}
+.md-prose > h1 + *,
+.md-prose > h2 + *,
+.md-prose > h3 + * {
+  margin-top: 0.35em;
+}
+.md-prose h1 {
+  font-size: 1.4em;
+  font-weight: 700;
+  margin-top: 1em;
+  letter-spacing: -0.01em;
+}
+.md-prose h2 {
+  font-size: 1.2em;
+  font-weight: 700;
+  margin-top: 0.9em;
+  letter-spacing: -0.01em;
+}
+.md-prose h3 {
+  font-size: 1.05em;
+  font-weight: 700;
+  margin-top: 0.8em;
+}
+.md-prose ul {
+  list-style: disc;
+  padding-left: 1.4em;
+}
+.md-prose ol {
+  list-style: decimal;
+  padding-left: 1.6em;
+}
+.md-prose li {
+  margin: 0.25em 0;
+}
+.md-prose li > p {
+  margin: 0;
+}
+.md-prose code {
+  font-family: ui-monospace, SFMono-Regular, "Menlo", monospace;
+  background: rgba(120, 120, 120, 0.15);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 0.9em;
+}
+.md-prose pre {
+  background: rgba(0, 0, 0, 0.06);
+  border: 1px solid rgba(120, 120, 120, 0.2);
+  border-radius: 6px;
+  padding: 10px 12px;
+  overflow-x: auto;
+}
+.dark .md-prose pre {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+.md-prose pre code {
+  background: transparent;
+  padding: 0;
+  font-size: 0.9em;
+}
+.md-prose blockquote {
+  border-left: 3px solid rgba(120, 120, 120, 0.4);
+  padding-left: 0.8em;
+  color: rgba(120, 120, 120, 0.9);
+}
+.md-prose a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+.dark .md-prose a {
+  color: #60a5fa;
+}
+.md-prose table {
+  border-collapse: collapse;
+}
+.md-prose th,
+.md-prose td {
+  border: 1px solid rgba(120, 120, 120, 0.3);
+  padding: 4px 8px;
+}

--- a/packages/web/src/lib/ask-user-question-state.test.ts
+++ b/packages/web/src/lib/ask-user-question-state.test.ts
@@ -269,6 +269,18 @@ describe("buildKeySequence", () => {
     ).not.toBeNull();
   });
 
+  it("範囲外の index (負数 / 選択肢数以上) は null", () => {
+    expect(
+      buildKeySequence([q3], [{ kind: "options", indexes: [-1] }])
+    ).toBeNull();
+    expect(
+      buildKeySequence([q3], [{ kind: "options", indexes: [3] }])
+    ).toBeNull();
+    expect(
+      buildKeySequence([q3multi], [{ kind: "options", indexes: [0, -1] }])
+    ).toBeNull();
+  });
+
   it("single-select で複数 index は null", () => {
     expect(
       buildKeySequence([q3], [{ kind: "options", indexes: [0, 1] }])

--- a/packages/web/src/lib/ask-user-question-state.test.ts
+++ b/packages/web/src/lib/ask-user-question-state.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AuqQuestion,
+  buildKeySequence,
+  freeTextDigit,
+  hasResolvedAuqSince,
+  needsReview,
+  parseAuqInput,
+} from "./ask-user-question-state";
+import { parseJsonlEvents } from "./jsonl-event-parser";
+
+function jsonl(...objs: unknown[]): string[] {
+  return objs.map(o => JSON.stringify(o));
+}
+
+const FRUIT_INPUT = {
+  questions: [
+    {
+      question: "どのフルーツ?",
+      header: "フルーツ",
+      multiSelect: false,
+      options: [
+        { label: "りんご", description: "赤い" },
+        { label: "ばなな" },
+        { label: "みかん" },
+      ],
+    },
+  ],
+};
+
+function auqToolUseLine(id: string, input: unknown, sidechain = false) {
+  return {
+    type: "assistant",
+    uuid: `a-${id}`,
+    isSidechain: sidechain,
+    message: {
+      role: "assistant",
+      content: [{ type: "tool_use", id, name: "AskUserQuestion", input }],
+    },
+  };
+}
+
+function auqResultLine(id: string, isError = false) {
+  return {
+    type: "user",
+    uuid: `u-${id}`,
+    toolUseResult: isError ? "User rejected tool use" : { answers: {} },
+    message: {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: id,
+          is_error: isError || undefined,
+          content: "...",
+        },
+      ],
+    },
+  };
+}
+
+describe("parseAuqInput", () => {
+  it("正常な input を正規化する", () => {
+    const qs = parseAuqInput(FRUIT_INPUT);
+    expect(qs).toHaveLength(1);
+    expect(qs?.[0].question).toBe("どのフルーツ?");
+    expect(qs?.[0].multiSelect).toBe(false);
+    expect(qs?.[0].options.map(o => o.label)).toEqual([
+      "りんご",
+      "ばなな",
+      "みかん",
+    ]);
+  });
+
+  it("questions が無い/空なら null", () => {
+    expect(parseAuqInput({})).toBeNull();
+    expect(parseAuqInput({ questions: [] })).toBeNull();
+  });
+
+  it("options の label が欠けていれば null", () => {
+    expect(
+      parseAuqInput({
+        questions: [{ question: "q", options: [{ description: "x" }] }],
+      })
+    ).toBeNull();
+  });
+});
+
+describe("hasResolvedAuqSince", () => {
+  // hook 受信時刻 (at) の後に解決イベントが書かれたか、の判定。
+  // 対話版 claude は tool_use + tool_result を回答確定の瞬間にまとめて書くため
+  // 「解決イベントの出現 = カードを閉じてよい」になる。
+  const AT = Date.parse("2026-06-10T12:00:00.000Z");
+  const after = "2026-06-10T12:00:30.000Z"; // at の 30 秒後に解決
+  const longBefore = "2026-06-10T11:50:00.000Z"; // at の 10 分前 (別の質問)
+
+  function resolvedAuqLines(id: string, ts: string, isError = false) {
+    return [
+      { ...auqToolUseLine(id, FRUIT_INPUT), timestamp: ts },
+      { ...auqResultLine(id, isError), timestamp: ts },
+    ];
+  }
+
+  it("at 以降に解決された AUQ があれば true (回答確定)", () => {
+    const events = parseJsonlEvents(jsonl(...resolvedAuqLines("t1", after)));
+    expect(hasResolvedAuqSince(events, AT)).toBe(true);
+  });
+
+  it("Esc 拒否 (is_error) の解決でも true", () => {
+    const events = parseJsonlEvents(
+      jsonl(...resolvedAuqLines("t1", after, true))
+    );
+    expect(hasResolvedAuqSince(events, AT)).toBe(true);
+  });
+
+  it("at より十分前の解決イベントしか無ければ false (過去の別質問)", () => {
+    const events = parseJsonlEvents(
+      jsonl(...resolvedAuqLines("t1", longBefore))
+    );
+    expect(hasResolvedAuqSince(events, AT)).toBe(false);
+  });
+
+  it("解決イベントが無ければ false (回答待ち継続)", () => {
+    const events = parseJsonlEvents(
+      jsonl({
+        type: "user",
+        uuid: "u1",
+        timestamp: after,
+        message: { role: "user", content: "普通の発言" },
+      })
+    );
+    expect(hasResolvedAuqSince(events, AT)).toBe(false);
+  });
+
+  it("sidechain (subagent) の解決イベントは無視する", () => {
+    const lines = resolvedAuqLines("t1", after).map(l => ({
+      ...l,
+      isSidechain: true,
+    }));
+    const events = parseJsonlEvents(jsonl(...lines));
+    expect(hasResolvedAuqSince(events, AT)).toBe(false);
+  });
+
+  it("古い解決の後に新しい解決があれば true (最後の AUQ で判定)", () => {
+    const events = parseJsonlEvents(
+      jsonl(
+        ...resolvedAuqLines("t1", longBefore),
+        ...resolvedAuqLines("t2", after)
+      )
+    );
+    expect(hasResolvedAuqSince(events, AT)).toBe(true);
+  });
+});
+
+describe("needsReview / freeTextDigit", () => {
+  const single: AuqQuestion = {
+    question: "q",
+    multiSelect: false,
+    options: [{ label: "a" }, { label: "b" }],
+  };
+  const multi: AuqQuestion = { ...single, multiSelect: true };
+
+  it("単問 single-select は Review 無し", () => {
+    expect(needsReview([single])).toBe(false);
+  });
+
+  it("multiSelect を含むと Review あり", () => {
+    expect(needsReview([multi])).toBe(true);
+  });
+
+  it("複数質問は Review あり", () => {
+    expect(needsReview([single, single])).toBe(true);
+  });
+
+  it("Type something. の番号は options.length+1", () => {
+    expect(freeTextDigit(single)).toBe(3);
+  });
+});
+
+describe("buildKeySequence", () => {
+  const q3: AuqQuestion = {
+    question: "どれ?",
+    multiSelect: false,
+    options: [{ label: "A" }, { label: "B" }, { label: "C" }],
+  };
+  const q3multi: AuqQuestion = { ...q3, multiSelect: true };
+
+  function digitsOf(steps: ReturnType<typeof buildKeySequence>): string[] {
+    return (steps ?? [])
+      .filter(s => s.kind !== "wait")
+      .map(s =>
+        s.kind === "digit"
+          ? s.value
+          : s.kind === "key"
+            ? `<${s.value}>`
+            : `"${s.value}"`
+      );
+  }
+
+  it("単問 single-select は digit 一発 (Review 無し)", () => {
+    const steps = buildKeySequence([q3], [{ kind: "options", indexes: [1] }]);
+    expect(digitsOf(steps)).toEqual(["2"]);
+  });
+
+  it("単問 multiSelect は digit トグル列 → Right → Review digit 1", () => {
+    const steps = buildKeySequence(
+      [q3multi],
+      [{ kind: "options", indexes: [0, 2] }]
+    );
+    expect(digitsOf(steps)).toEqual(["1", "3", "<Right>", "1"]);
+  });
+
+  it("自由入力は digit(len+1) → literal → Enter", () => {
+    const steps = buildKeySequence([q3], [{ kind: "free", text: "ぶどう" }]);
+    expect(digitsOf(steps)).toEqual(["4", '"ぶどう"', "<Enter>"]);
+  });
+
+  it("複数質問 (全 single) は各 digit → 最後に Review digit 1", () => {
+    const steps = buildKeySequence(
+      [q3, q3],
+      [
+        { kind: "options", indexes: [0] },
+        { kind: "options", indexes: [1] },
+      ]
+    );
+    expect(digitsOf(steps)).toEqual(["1", "2", "1"]);
+  });
+
+  it("multi + single 混在: multi は Right でタブ送り", () => {
+    const steps = buildKeySequence(
+      [q3multi, q3],
+      [
+        { kind: "options", indexes: [1] },
+        { kind: "options", indexes: [2] },
+      ]
+    );
+    expect(digitsOf(steps)).toEqual(["2", "<Right>", "3", "1"]);
+  });
+
+  it("回答数が一致しなければ null", () => {
+    expect(buildKeySequence([q3], [])).toBeNull();
+  });
+
+  it("multiSelect で 0 個選択は null", () => {
+    expect(
+      buildKeySequence([q3multi], [{ kind: "options", indexes: [] }])
+    ).toBeNull();
+  });
+
+  it("digit が 9 を超える選択肢は null (ターミナル誘導)", () => {
+    const big: AuqQuestion = {
+      question: "q",
+      multiSelect: false,
+      options: Array.from({ length: 12 }, (_, i) => ({ label: `o${i}` })),
+    };
+    expect(
+      buildKeySequence([big], [{ kind: "options", indexes: [10] }])
+    ).toBeNull();
+    // 選択肢 9 個だと free text が 10 番になるので free は不可
+    const nine: AuqQuestion = {
+      question: "q",
+      multiSelect: false,
+      options: Array.from({ length: 9 }, (_, i) => ({ label: `o${i}` })),
+    };
+    expect(buildKeySequence([nine], [{ kind: "free", text: "x" }])).toBeNull();
+    // ただし 9 個でも option 選択自体は可能
+    expect(
+      buildKeySequence([nine], [{ kind: "options", indexes: [8] }])
+    ).not.toBeNull();
+  });
+
+  it("single-select で複数 index は null", () => {
+    expect(
+      buildKeySequence([q3], [{ kind: "options", indexes: [0, 1] }])
+    ).toBeNull();
+  });
+});

--- a/packages/web/src/lib/ask-user-question-state.ts
+++ b/packages/web/src/lib/ask-user-question-state.ts
@@ -1,0 +1,181 @@
+/**
+ * ask-user-question-state - AskUserQuestion の JSONL ベース状態抽出と
+ * tmux キー送出列の構築 (純粋関数)。
+ *
+ * 設計原則 (チャット UI v3): 質問・選択肢・回答状態はすべて JSONL の
+ * tool_use / tool_result から得る。tmux 画面のパースは行わない。
+ * 「回答待ち」= tool_use に対応する tool_result が未出現 (status: "running")。
+ *
+ * キー操作列は 2026-06-10 の実機スパイクで確定した挙動に基づく:
+ *  - 単問 single-select: digit 一発で即 submit (Enter 不要・Review 無し)
+ *  - multiSelect: digit = トグル。submit は Right → Review 画面 → digit 1
+ *  - 複数質問: single 回答 (digit) で自動的に次タブへ。全問回答後は必ず
+ *    Review 画面が出るので digit 1 (Submit answers) が必要
+ *  - Review 画面が出る条件 = 質問が複数 or multiSelect を含む
+ *  - 自由入力 "Type something." = options.length+1 にフォーカス (digit) →
+ *    literal 一括送信 → Enter で確定
+ *  - Escape は一発で全体 decline
+ */
+
+import type { JsonlParsedEvent, ToolCallEvent } from "./jsonl-event-parser";
+
+export interface AuqOption {
+  label: string;
+  description?: string;
+}
+
+export interface AuqQuestion {
+  question: string;
+  header?: string;
+  multiSelect: boolean;
+  options: AuqOption[];
+}
+
+/** 回答待ちの AskUserQuestion (アクティブカードの描画対象) */
+export interface ActiveAuq {
+  toolUseId: string;
+  questions: AuqQuestion[];
+}
+
+/** ユーザーが UI 上で選んだ回答 (キー送出列の入力) */
+export type AuqAnswer =
+  | { kind: "options"; indexes: number[] } // 0-based。single なら 1 要素
+  | { kind: "free"; text: string };
+
+/** キー送出ステップ。UI 層が順番に dispatch する */
+export type AuqKeyStep =
+  | { kind: "digit"; value: string } // session:key (1-9)
+  | { kind: "key"; value: "Right" | "Enter" } // session:key
+  | { kind: "literal"; value: string } // session:send-literal
+  | { kind: "wait"; ms: number };
+
+/** input.questions を型ガードしつつ正規化する。形が想定外なら null */
+export function parseAuqInput(
+  input: Record<string, unknown>
+): AuqQuestion[] | null {
+  const qs = input.questions;
+  if (!Array.isArray(qs) || qs.length === 0) return null;
+  const out: AuqQuestion[] = [];
+  for (const q of qs) {
+    if (!q || typeof q !== "object") return null;
+    const rec = q as Record<string, unknown>;
+    if (typeof rec.question !== "string") return null;
+    const optsRaw = rec.options;
+    if (!Array.isArray(optsRaw)) return null;
+    const options: AuqOption[] = [];
+    for (const o of optsRaw) {
+      if (!o || typeof o !== "object") return null;
+      const oRec = o as Record<string, unknown>;
+      if (typeof oRec.label !== "string") return null;
+      options.push({
+        label: oRec.label,
+        description:
+          typeof oRec.description === "string" ? oRec.description : undefined,
+      });
+    }
+    out.push({
+      question: rec.question,
+      header: typeof rec.header === "string" ? rec.header : undefined,
+      multiSelect: rec.multiSelect === true,
+      options,
+    });
+  }
+  return out;
+}
+
+/**
+ * events 内に「at (epoch ms) 以降に解決された AskUserQuestion」があるか。
+ *
+ * 対話版 claude は AUQ の tool_use を「回答/拒否が確定した瞬間」に
+ * tool_result とまとめて JSONL へ書く (= 質問表示中は JSONL に何も出ない)。
+ * そのため回答待ちカードの表示開始は PreToolUse hook (session:auq) が担い、
+ * この関数は「カードを閉じてよいか」(解決イベントが書かれたか) の判定に使う。
+ *
+ * timestamp は tool_use レコードの書き込み時刻 = 回答確定時刻なので、
+ * hook 受信時刻 at より必ず後になる (同一ホストなのでクロックずれは数 ms)。
+ * 5 秒のマージンは「直前の別 AUQ の解決」を誤検知しない範囲の安全幅。
+ */
+export function hasResolvedAuqSince(
+  events: JsonlParsedEvent[],
+  at: number
+): boolean {
+  for (let i = events.length - 1; i >= 0; i--) {
+    const ev = events[i];
+    if (ev.kind !== "tool-call") continue;
+    if (ev.tool !== "AskUserQuestion") continue;
+    if (ev.isSidechain === true) continue;
+    const tc = ev as ToolCallEvent;
+    if (tc.status !== "done") continue;
+    if (tc.timestamp !== undefined && tc.timestamp >= at - 5000) return true;
+    // これより古いイベントしか無いので打ち切り
+    return false;
+  }
+  return false;
+}
+
+/** Review 画面 (Submit answers 確認) が出るか。実機検証に基づく条件 */
+export function needsReview(questions: AuqQuestion[]): boolean {
+  return questions.length > 1 || questions.some(q => q.multiSelect);
+}
+
+/** 自由入力 "Type something." の TUI 上の番号 (1-based) */
+export function freeTextDigit(q: AuqQuestion): number {
+  return q.options.length + 1;
+}
+
+/**
+ * 回答列からキー送出ステップ列を構築する。
+ * answers は questions と同じ長さ・同じ順序であること。
+ *
+ * 制約: TUI の digit ジャンプは 1〜9 のみ。選択肢が 9 個を超えるケースや
+ * freeTextDigit が 10 以上になるケースは null を返す (UI 側でターミナル
+ * 誘導にフォールバックする)。
+ */
+export function buildKeySequence(
+  questions: AuqQuestion[],
+  answers: AuqAnswer[]
+): AuqKeyStep[] | null {
+  if (questions.length !== answers.length) return null;
+  const steps: AuqKeyStep[] = [];
+  for (let i = 0; i < questions.length; i++) {
+    const q = questions[i];
+    const a = answers[i];
+    if (a.kind === "free") {
+      const digit = freeTextDigit(q);
+      if (digit > 9) return null;
+      // digit でフォーカス → テキスト一括 literal → Enter で確定
+      // (確定は single 回答と同じセマンティクスで自動的に次タブへ進む)
+      steps.push({ kind: "digit", value: String(digit) });
+      steps.push({ kind: "wait", ms: 300 });
+      steps.push({ kind: "literal", value: a.text });
+      steps.push({ kind: "wait", ms: 200 });
+      steps.push({ kind: "key", value: "Enter" });
+      steps.push({ kind: "wait", ms: 300 });
+    } else if (q.multiSelect) {
+      if (a.indexes.length === 0) return null;
+      for (const idx of a.indexes) {
+        if (idx + 1 > 9) return null;
+        steps.push({ kind: "digit", value: String(idx + 1) });
+        steps.push({ kind: "wait", ms: 150 });
+      }
+      // multiSelect はトグルだけでは次に進まないので Right でタブ送り
+      // (最後の質問なら Review 画面へ進む)
+      steps.push({ kind: "key", value: "Right" });
+      steps.push({ kind: "wait", ms: 300 });
+    } else {
+      if (a.indexes.length !== 1) return null;
+      const idx = a.indexes[0];
+      if (idx + 1 > 9) return null;
+      // single-select は digit 一発で回答確定 + 自動タブ送り
+      // (単問の場合はこれだけで即 submit される)
+      steps.push({ kind: "digit", value: String(idx + 1) });
+      steps.push({ kind: "wait", ms: 300 });
+    }
+  }
+  if (needsReview(questions)) {
+    // Review 画面 (1. Submit answers / 2. Cancel) を digit 1 で確定
+    steps.push({ kind: "wait", ms: 200 });
+    steps.push({ kind: "digit", value: "1" });
+  }
+  return steps;
+}

--- a/packages/web/src/lib/ask-user-question-state.ts
+++ b/packages/web/src/lib/ask-user-question-state.ts
@@ -154,6 +154,9 @@ export function buildKeySequence(
     } else if (q.multiSelect) {
       if (a.indexes.length === 0) return null;
       for (const idx of a.indexes) {
+        // 範囲外 index (負数含む) は SpecialKey 型外の digit ("0" 等) を
+        // 生成し得るため明示的に拒否する
+        if (idx < 0 || idx >= q.options.length) return null;
         if (idx + 1 > 9) return null;
         steps.push({ kind: "digit", value: String(idx + 1) });
         steps.push({ kind: "wait", ms: 150 });
@@ -165,6 +168,7 @@ export function buildKeySequence(
     } else {
       if (a.indexes.length !== 1) return null;
       const idx = a.indexes[0];
+      if (idx < 0 || idx >= q.options.length) return null;
       if (idx + 1 > 9) return null;
       // single-select は digit 一発で回答確定 + 自動タブ送り
       // (単問の場合はこれだけで即 submit される)

--- a/packages/web/src/lib/jsonl-event-parser.test.ts
+++ b/packages/web/src/lib/jsonl-event-parser.test.ts
@@ -1,0 +1,458 @@
+import { describe, expect, it } from "vitest";
+import {
+  type JsonlParsedEvent,
+  mergeJsonlLine,
+  parseJsonlEvents,
+} from "./jsonl-event-parser";
+
+function jsonl(...objs: unknown[]): string[] {
+  return objs.map(o => JSON.stringify(o));
+}
+
+describe("parseJsonlEvents", () => {
+  it("user テキストメッセージを抽出する", () => {
+    const events = parseJsonlEvents(
+      jsonl({
+        type: "user",
+        uuid: "u1",
+        message: { role: "user", content: "こんにちは" },
+      })
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("user-input");
+    expect(events[0].id).toBe("u1:u");
+    if (events[0].kind === "user-input") {
+      expect(events[0].text).toBe("こんにちは");
+    }
+  });
+
+  it("local-command-caveat は除外する", () => {
+    const events = parseJsonlEvents(
+      jsonl({
+        type: "user",
+        uuid: "u1",
+        message: {
+          role: "user",
+          content: "<local-command-caveat>...</local-command-caveat>",
+        },
+      })
+    );
+    expect(events).toHaveLength(0);
+  });
+
+  it("slash command を抽出する", () => {
+    const events = parseJsonlEvents(
+      jsonl({
+        type: "user",
+        uuid: "u1",
+        message: {
+          role: "user",
+          content:
+            "<command-name>/clear</command-name>\n<command-message>clear</command-message>",
+        },
+      })
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("slash-command");
+    if (events[0].kind === "slash-command") {
+      expect(events[0].name).toBe("/clear");
+    }
+  });
+
+  it("assistant の text/thinking/tool_use を抽出する", () => {
+    const events = parseJsonlEvents(
+      jsonl({
+        type: "assistant",
+        uuid: "a1",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "考え中..." },
+            { type: "text", text: "答え" },
+            {
+              type: "tool_use",
+              id: "tool_abc",
+              name: "Bash",
+              input: { command: "ls -la", description: "List" },
+            },
+          ],
+        },
+      })
+    );
+    expect(events.map(e => e.kind)).toEqual([
+      "thinking",
+      "assistant-text",
+      "tool-call",
+    ]);
+    const toolCall = events.find(e => e.kind === "tool-call");
+    if (toolCall?.kind === "tool-call") {
+      expect(toolCall.tool).toBe("Bash");
+      expect(toolCall.input.command).toBe("ls -la");
+      expect(toolCall.status).toBe("running");
+      expect(toolCall.toolUseId).toBe("tool_abc");
+    }
+  });
+
+  it("tool_result を対応する tool_use にマージする", () => {
+    const events = parseJsonlEvents(
+      jsonl(
+        {
+          type: "assistant",
+          uuid: "a1",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "tool_xyz",
+                name: "Read",
+                input: { file_path: "/tmp/foo.txt" },
+              },
+            ],
+          },
+        },
+        {
+          type: "user",
+          uuid: "u2",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "tool_xyz",
+                content: "file contents here",
+              },
+            ],
+          },
+        }
+      )
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("tool-call");
+    if (events[0].kind === "tool-call") {
+      expect(events[0].status).toBe("done");
+      expect(events[0].result).toBe("file contents here");
+    }
+  });
+
+  it("内部 type (file-history-snapshot / attachment / system) は無視する", () => {
+    const events = parseJsonlEvents(
+      jsonl(
+        { type: "file-history-snapshot", messageId: "x" },
+        { type: "attachment", attachment: { type: "hook_success" } },
+        { type: "system" },
+        { type: "last-prompt" },
+        {
+          type: "user",
+          uuid: "u",
+          message: { role: "user", content: "実コンテンツ" },
+        }
+      )
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("user-input");
+  });
+
+  it("壊れた JSON 行はスキップする (後続は処理続行)", () => {
+    const events = parseJsonlEvents([
+      "not-json",
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        message: { role: "user", content: "ok" },
+      }),
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("user-input");
+  });
+});
+
+describe("mergeJsonlLine (差分パース)", () => {
+  it("1 行ずつ追加して累積結果が parseJsonlEvents と一致する", () => {
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        message: { role: "user", content: "ひとこと" },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "返事" }],
+        },
+      }),
+    ];
+    const expected = parseJsonlEvents(lines);
+
+    const toolMap = new Map<
+      string,
+      Extract<JsonlParsedEvent, { kind: "tool-call" }>
+    >();
+    let events: JsonlParsedEvent[] = [];
+    for (const l of lines) events = mergeJsonlLine(events, toolMap, l);
+    expect(events).toEqual(expected);
+  });
+
+  it("行追加で events 参照が更新される (React 再描画用)", () => {
+    const toolMap = new Map<
+      string,
+      Extract<JsonlParsedEvent, { kind: "tool-call" }>
+    >();
+    const initial: JsonlParsedEvent[] = [];
+    const after = mergeJsonlLine(
+      initial,
+      toolMap,
+      JSON.stringify({
+        type: "user",
+        uuid: "u1",
+        message: { role: "user", content: "x" },
+      })
+    );
+    expect(after).not.toBe(initial);
+    expect(after).toHaveLength(1);
+  });
+
+  it("無視される行 (内部 type) は同じ events 参照を返す", () => {
+    const toolMap = new Map<
+      string,
+      Extract<JsonlParsedEvent, { kind: "tool-call" }>
+    >();
+    const events: JsonlParsedEvent[] = [];
+    const after = mergeJsonlLine(
+      events,
+      toolMap,
+      JSON.stringify({ type: "file-history-snapshot" })
+    );
+    expect(after).toBe(events);
+  });
+
+  it("後から届いた tool_result が既存 tool-call にマージされる", () => {
+    const toolMap = new Map<
+      string,
+      Extract<JsonlParsedEvent, { kind: "tool-call" }>
+    >();
+    let events: JsonlParsedEvent[] = [];
+    events = mergeJsonlLine(
+      events,
+      toolMap,
+      JSON.stringify({
+        type: "assistant",
+        uuid: "a1",
+        message: {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: "tu",
+              name: "Read",
+              input: { file_path: "/x" },
+            },
+          ],
+        },
+      })
+    );
+    expect(events[0].kind).toBe("tool-call");
+    if (events[0].kind === "tool-call") {
+      expect(events[0].status).toBe("running");
+    }
+    events = mergeJsonlLine(
+      events,
+      toolMap,
+      JSON.stringify({
+        type: "user",
+        uuid: "u2",
+        message: {
+          role: "user",
+          content: [
+            { type: "tool_result", tool_use_id: "tu", content: "本文" },
+          ],
+        },
+      })
+    );
+    expect(events[0].kind).toBe("tool-call");
+    if (events[0].kind === "tool-call") {
+      expect(events[0].status).toBe("done");
+      expect(events[0].result).toBe("本文");
+    }
+  });
+});
+
+describe("チャット UI v3 拡張", () => {
+  it("isCompactSummary レコードは compact-marker になり本文は表示されない", () => {
+    // /compact は JSONL ファイルを切り替えず、巨大な要約 user レコードを
+    // 同一ファイルに挿入する。user-input として描画すると巨大バブルになる
+    const events = parseJsonlEvents(
+      jsonl({
+        type: "user",
+        uuid: "c1",
+        isCompactSummary: true,
+        message: {
+          role: "user",
+          content: "巨大な要約テキスト...".repeat(100),
+        },
+      })
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("compact-marker");
+  });
+
+  it("local-command-stdout も除外する", () => {
+    const events = parseJsonlEvents(
+      jsonl({
+        type: "user",
+        uuid: "u1",
+        message: {
+          role: "user",
+          content: "<local-command-stdout>出力...</local-command-stdout>",
+        },
+      })
+    );
+    expect(events).toHaveLength(0);
+  });
+
+  it("tool_result の toolUseResult / is_error を tool-call にマージする", () => {
+    const events = parseJsonlEvents(
+      jsonl(
+        {
+          type: "assistant",
+          uuid: "a1",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "auq1",
+                name: "AskUserQuestion",
+                input: {
+                  questions: [
+                    {
+                      question: "どっち？",
+                      header: "選択",
+                      multiSelect: false,
+                      options: [{ label: "A" }, { label: "B" }],
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: "user",
+          uuid: "u2",
+          toolUseResult: {
+            questions: [{ question: "どっち？" }],
+            answers: { "どっち？": "A" },
+          },
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "auq1",
+                content: 'User has answered your questions: "どっち？"="A"',
+              },
+            ],
+          },
+        }
+      )
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("tool-call");
+    if (events[0].kind === "tool-call") {
+      expect(events[0].status).toBe("done");
+      expect(events[0].isError).toBeUndefined();
+      expect(events[0].structuredResult).toEqual({
+        questions: [{ question: "どっち？" }],
+        answers: { "どっち？": "A" },
+      });
+    }
+  });
+
+  it("Esc 拒否 (is_error: true) は isError として届く", () => {
+    const events = parseJsonlEvents(
+      jsonl(
+        {
+          type: "assistant",
+          uuid: "a1",
+          message: {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_use",
+                id: "auq2",
+                name: "AskUserQuestion",
+                input: { questions: [] },
+              },
+            ],
+          },
+        },
+        {
+          type: "user",
+          uuid: "u2",
+          toolUseResult: "User rejected tool use",
+          message: {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                tool_use_id: "auq2",
+                is_error: true,
+                content: "The user doesn't want to proceed with this tool use.",
+              },
+            ],
+          },
+        }
+      )
+    );
+    expect(events[0].kind).toBe("tool-call");
+    if (events[0].kind === "tool-call") {
+      expect(events[0].isError).toBe(true);
+      expect(events[0].structuredResult).toBe("User rejected tool use");
+    }
+  });
+
+  it("isSidechain が全イベント種別に伝播する", () => {
+    const events = parseJsonlEvents(
+      jsonl(
+        {
+          type: "user",
+          uuid: "u1",
+          isSidechain: true,
+          message: { role: "user", content: "subagent への指示" },
+        },
+        {
+          type: "assistant",
+          uuid: "a1",
+          isSidechain: true,
+          message: {
+            role: "assistant",
+            content: [
+              { type: "thinking", thinking: "..." },
+              { type: "text", text: "subagent の返答" },
+              { type: "tool_use", id: "t1", name: "Read", input: {} },
+            ],
+          },
+        }
+      )
+    );
+    expect(events).toHaveLength(4);
+    for (const e of events) {
+      expect(e.isSidechain).toBe(true);
+    }
+  });
+
+  it("isSidechain でない行には isSidechain が付かない", () => {
+    const events = parseJsonlEvents(
+      jsonl({
+        type: "user",
+        uuid: "u1",
+        isSidechain: false,
+        message: { role: "user", content: "メイン会話" },
+      })
+    );
+    expect(events[0].isSidechain).toBeUndefined();
+  });
+});

--- a/packages/web/src/lib/jsonl-event-parser.ts
+++ b/packages/web/src/lib/jsonl-event-parser.ts
@@ -1,0 +1,287 @@
+/**
+ * Claude Code の JSONL 履歴ファイルを構造化イベントに変換する。
+ *
+ * 入力: ~/.claude/projects/<encoded-cwd>/<uuid>.jsonl の 1 行 = 1 JSON。
+ * 出力: SplitChatPane が描画する `JsonlParsedEvent` 配列。
+ *
+ * 含まれる情報量は tmux 画面パースとは段違いで、tool_use の input 引数全文・
+ * thinking ブロック本文・tool_result の完全な出力までを保持する。
+ * **会話内容の情報源はこの JSONL のみ** (チャット UI v3 の設計原則)。
+ * AskUserQuestion も tool_use の input.questions / tool_result の
+ * toolUseResult から構築し、tmux 画面パースは一切行わない。
+ *
+ * 抑制する type:
+ *   - file-history-snapshot / attachment / system / last-prompt: 内部メタ。表示しない
+ *   - user content "<local-command-caveat>...": Claude Code 内部メタ。表示しない
+ *   - isCompactSummary: /compact の要約 (巨大テキスト)。compact-marker に変換して
+ *     本文は表示しない (/compact は JSONL ファイルを切り替えず同一ファイルに
+ *     要約 user レコードを挿入する)
+ */
+
+/**
+ * 全 event 共通の任意プロパティ。
+ *  - `timestamp`: epoch ms (パース失敗時 undefined)
+ *  - `isSidechain`: subagent の対話に true。連続する true は SplitChatPane 側で
+ *    1 ブロックに集約される。
+ */
+interface CommonEventFields {
+  timestamp?: number;
+  isSidechain?: boolean;
+}
+
+export type JsonlParsedEvent =
+  | ({ id: string; kind: "user-input"; text: string } & CommonEventFields)
+  | ({
+      id: string;
+      kind: "slash-command";
+      name: string;
+      args?: string;
+    } & CommonEventFields)
+  | ({ id: string; kind: "assistant-text"; text: string } & CommonEventFields)
+  | ({ id: string; kind: "thinking"; text: string } & CommonEventFields)
+  | ({
+      id: string;
+      kind: "compact-marker";
+    } & CommonEventFields)
+  | ({
+      id: string;
+      kind: "tool-call";
+      tool: string;
+      input: Record<string, unknown>;
+      result?: string;
+      /**
+       * tool_result と同一レコードの `toolUseResult` フィールド (構造化 JSON)。
+       * AskUserQuestion では { questions, answers } が入り、回答テキストの
+       * 正規表現パースより信頼できる第一情報源になる。
+       */
+      structuredResult?: unknown;
+      /** tool_result の is_error (AskUserQuestion の Esc 拒否などで true) */
+      isError?: boolean;
+      status: "running" | "done";
+      toolUseId: string;
+    } & CommonEventFields);
+
+export type ToolCallEvent = Extract<JsonlParsedEvent, { kind: "tool-call" }>;
+
+interface RawJsonlMessage {
+  uuid?: string;
+  type?: string;
+  timestamp?: string;
+  isSidechain?: boolean;
+  /** /compact が同一ファイルに挿入する要約レコードのフラグ */
+  isCompactSummary?: boolean;
+  /** tool_result レコードに併記される構造化結果 (レコードレベル) */
+  toolUseResult?: unknown;
+  message?: {
+    role?: string;
+    content?:
+      | string
+      | Array<{
+          type?: string;
+          text?: string;
+          thinking?: string;
+          id?: string;
+          name?: string;
+          input?: Record<string, unknown>;
+          tool_use_id?: string;
+          content?: unknown;
+          is_error?: boolean;
+        }>;
+  };
+}
+
+const SLASH_CMD_RE = /^<command-name>([^<]+)<\/command-name>/;
+const SLASH_ARGS_RE = /<command-args>([^<]*)<\/command-args>/;
+
+function safeJsonStringify(v: unknown): string {
+  try {
+    return typeof v === "string" ? v : JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+}
+
+/**
+ * 1 JSONL 行を解釈して、events に追加・既存 tool_use にマージする。
+ * 状態 (toolCallByUseId) を呼び出し側に持たせることで差分パースが可能。
+ *
+ * - tool_use → events に新規 tool-call を push、toolCallByUseId に登録
+ * - tool_result → toolCallByUseId から該当を引き、結果をマージ (events は新インスタンスに置換)
+ * - その他 → events に push のみ
+ *
+ * イベント追加・更新は **新しい events 配列を返す** (React の参照不変性を保つため)。
+ * 行が無視される場合は同じ events 参照を返す。
+ */
+export function mergeJsonlLine(
+  events: JsonlParsedEvent[],
+  toolCallByUseId: Map<string, ToolCallEvent>,
+  raw: string
+): JsonlParsedEvent[] {
+  if (!raw) return events;
+  let obj: RawJsonlMessage | null;
+  try {
+    obj = JSON.parse(raw) as RawJsonlMessage;
+  } catch {
+    return events;
+  }
+  if (!obj || typeof obj !== "object") return events;
+  const uuid = obj.uuid ?? `${events.length}`;
+  // timestamp は ISO 文字列。パース失敗時は undefined のままで OK
+  const tsParsed =
+    typeof obj.timestamp === "string" ? Date.parse(obj.timestamp) : NaN;
+  const ts = Number.isFinite(tsParsed) ? tsParsed : undefined;
+  // sidechain (subagent) フラグは true のときだけ持たせる
+  const sc = obj.isSidechain === true ? true : undefined;
+  let next = events;
+  const pushIfNew = (ev: JsonlParsedEvent) => {
+    if (next === events) next = events.slice();
+    next.push(ev);
+  };
+
+  if (obj.type === "user" && obj.message?.role === "user") {
+    // /compact の要約レコード。本文は数十 KB の巨大テキストなので
+    // user-input として描画せず、コンパクト実行マーカーに変換する
+    if (obj.isCompactSummary === true) {
+      pushIfNew({
+        id: `${uuid}:compact`,
+        kind: "compact-marker",
+        timestamp: ts,
+        isSidechain: sc,
+      });
+      return next;
+    }
+    const content = obj.message.content;
+    if (typeof content === "string") {
+      // Claude CLI が記録する内部メタ。caveat は `/clear` 等の注意書き、
+      // stdout は `/compact` 等のローカル出力 (ANSI 込みでノイジー)。
+      if (
+        content.startsWith("<local-command-caveat>") ||
+        content.startsWith("<local-command-stdout>")
+      )
+        return events;
+      const cmdMatch = content.match(SLASH_CMD_RE);
+      if (cmdMatch) {
+        const argsMatch = content.match(SLASH_ARGS_RE);
+        pushIfNew({
+          id: `${uuid}:slash`,
+          kind: "slash-command",
+          name: cmdMatch[1],
+          args: argsMatch?.[1] || undefined,
+          timestamp: ts,
+          isSidechain: sc,
+        });
+        return next;
+      }
+      pushIfNew({
+        id: `${uuid}:u`,
+        kind: "user-input",
+        text: content,
+        timestamp: ts,
+        isSidechain: sc,
+      });
+    } else if (Array.isArray(content)) {
+      // toolUseResult はレコードレベルに 1 つだけ載る。レコード内に
+      // tool_result block が複数あるケース (通常は無い) では対応が曖昧に
+      // なるため、1 block のときだけ適用する
+      const toolResultBlocks = content.filter(
+        b => b.type === "tool_result" && typeof b.tool_use_id === "string"
+      );
+      const structuredResult =
+        toolResultBlocks.length === 1 ? obj.toolUseResult : undefined;
+      let idx = 0;
+      for (const block of content) {
+        if (block.type === "text" && typeof block.text === "string") {
+          pushIfNew({
+            id: `${uuid}:u:${idx}`,
+            kind: "user-input",
+            text: block.text,
+            timestamp: ts,
+            isSidechain: sc,
+          });
+        } else if (
+          block.type === "tool_result" &&
+          typeof block.tool_use_id === "string"
+        ) {
+          const target = toolCallByUseId.get(block.tool_use_id);
+          if (target) {
+            // 既存 tool-call を結果付きの新インスタンスに置換する。
+            // events 配列内も新インスタンスに差し替えて React の比較が確実に効くようにする。
+            const updated: ToolCallEvent = {
+              ...target,
+              result: safeJsonStringify(block.content),
+              structuredResult,
+              isError: block.is_error === true ? true : undefined,
+              status: "done" as const,
+            };
+            toolCallByUseId.set(block.tool_use_id, updated);
+            if (next === events) next = events.slice();
+            const at = next.indexOf(target);
+            if (at >= 0) next[at] = updated;
+          }
+        }
+        idx++;
+      }
+    }
+  } else if (obj.type === "assistant" && obj.message?.role === "assistant") {
+    const content = obj.message.content;
+    if (Array.isArray(content)) {
+      let idx = 0;
+      for (const block of content) {
+        if (block.type === "text" && typeof block.text === "string") {
+          pushIfNew({
+            id: `${uuid}:a:${idx}`,
+            kind: "assistant-text",
+            text: block.text,
+            timestamp: ts,
+            isSidechain: sc,
+          });
+        } else if (
+          block.type === "thinking" &&
+          typeof block.thinking === "string"
+        ) {
+          pushIfNew({
+            id: `${uuid}:th:${idx}`,
+            kind: "thinking",
+            text: block.thinking,
+            timestamp: ts,
+            isSidechain: sc,
+          });
+        } else if (
+          block.type === "tool_use" &&
+          typeof block.id === "string" &&
+          typeof block.name === "string"
+        ) {
+          const e: ToolCallEvent = {
+            id: block.id,
+            kind: "tool-call",
+            tool: block.name,
+            input: block.input ?? {},
+            status: "running",
+            toolUseId: block.id,
+            timestamp: ts,
+            isSidechain: sc,
+          };
+          pushIfNew(e);
+          toolCallByUseId.set(block.id, e);
+        }
+        idx++;
+      }
+    }
+  }
+  // file-history-snapshot, attachment, system, last-prompt は無視
+
+  return next;
+}
+
+/**
+ * 複数行をまとめてパースする (snapshot 用)。
+ * 内部状態を持たないので毎回新規 Map を作る。
+ */
+export function parseJsonlEvents(lines: string[]): JsonlParsedEvent[] {
+  const toolCallByUseId = new Map<string, ToolCallEvent>();
+  let events: JsonlParsedEvent[] = [];
+  for (const raw of lines) {
+    events = mergeJsonlLine(events, toolCallByUseId, raw);
+  }
+  return events;
+}

--- a/packages/web/src/lib/jsonl-event-parser.ts
+++ b/packages/web/src/lib/jsonl-event-parser.ts
@@ -95,7 +95,11 @@ const SLASH_ARGS_RE = /<command-args>([^<]*)<\/command-args>/;
 
 function safeJsonStringify(v: unknown): string {
   try {
-    return typeof v === "string" ? v : JSON.stringify(v);
+    if (typeof v === "string") return v;
+    // JSON.stringify(undefined) は undefined を返し string 型と実値がズレる
+    // ため、文字列化を保証する
+    const s = JSON.stringify(v);
+    return s ?? String(v);
   } catch {
     return String(v);
   }

--- a/packages/web/src/lib/reconcile-escape.test.ts
+++ b/packages/web/src/lib/reconcile-escape.test.ts
@@ -1,0 +1,103 @@
+/**
+ * reconcileEscape の単体テスト。Esc 押下時の 4 分岐を網羅する。
+ */
+
+import { describe, expect, it } from "vitest";
+import { type EscapeContext, reconcileEscape } from "./reconcile-escape";
+
+const base: EscapeContext = {
+  inputValue: "",
+  slashOpen: false,
+  lastSubmitted: "",
+};
+
+describe("reconcileEscape", () => {
+  describe("分岐 1: スラッシュ補完が開いているとき", () => {
+    it("最優先で補完を閉じる (他状態に依存しない)", () => {
+      expect(
+        reconcileEscape({ ...base, slashOpen: true, inputValue: "/foo" })
+      ).toEqual({ kind: "close-slash" });
+    });
+
+    it("入力欄が空でも lastSubmitted があっても close-slash 優先", () => {
+      expect(
+        reconcileEscape({
+          slashOpen: true,
+          inputValue: "",
+          lastSubmitted: "prev",
+        })
+      ).toEqual({ kind: "close-slash" });
+    });
+  });
+
+  describe("分岐 2: 入力欄に文字があるとき", () => {
+    it("clear-input を返し tmux 送信はしない", () => {
+      expect(reconcileEscape({ ...base, inputValue: "draft" })).toEqual({
+        kind: "clear-input",
+      });
+    });
+
+    it("lastSubmitted が残っていても 入力中なら clear-input が優先", () => {
+      // 「直前送信後にユーザが新しいテキストを打ち始めた」状態。
+      // Esc は新しい入力を消すだけにとどめ、Claude 側へは送らない。
+      expect(
+        reconcileEscape({
+          inputValue: "new draft",
+          slashOpen: false,
+          lastSubmitted: "old prompt",
+        })
+      ).toEqual({ kind: "clear-input" });
+    });
+
+    it("空白だけでも length > 0 なら clear-input 扱い", () => {
+      expect(reconcileEscape({ ...base, inputValue: " " })).toEqual({
+        kind: "clear-input",
+      });
+    });
+  });
+
+  describe("分岐 3: 入力欄空 + 直前送信あり", () => {
+    it("interrupt + restore + removePendingText を返す", () => {
+      expect(reconcileEscape({ ...base, lastSubmitted: "中止テスト" })).toEqual(
+        {
+          kind: "interrupt",
+          restore: "中止テスト",
+          removePendingText: "中止テスト",
+        }
+      );
+    });
+  });
+
+  describe("分岐 4: 入力欄空 + 直前送信なし", () => {
+    it("純粋な interrupt (restore=null, removePendingText=null)", () => {
+      expect(reconcileEscape(base)).toEqual({
+        kind: "interrupt",
+        restore: null,
+        removePendingText: null,
+      });
+    });
+  });
+
+  describe("分岐の優先順位", () => {
+    it("優先度: close-slash > clear-input > interrupt", () => {
+      // 全条件揃った状態でも close-slash が勝つ
+      expect(
+        reconcileEscape({
+          slashOpen: true,
+          inputValue: "draft",
+          lastSubmitted: "prev",
+        })
+      ).toEqual({ kind: "close-slash" });
+    });
+
+    it("close-slash 不発時に clear-input が勝つ", () => {
+      expect(
+        reconcileEscape({
+          slashOpen: false,
+          inputValue: "draft",
+          lastSubmitted: "prev",
+        })
+      ).toEqual({ kind: "clear-input" });
+    });
+  });
+});

--- a/packages/web/src/lib/reconcile-escape.ts
+++ b/packages/web/src/lib/reconcile-escape.ts
@@ -1,0 +1,49 @@
+/**
+ * SplitChatPane の Esc キー押下挙動を Claude Code 本体と合わせるための
+ * 純粋関数。state の書き換えや tmux 送信は呼び出し側が action を見て実行する。
+ *
+ * 4 分岐:
+ *   1. スラッシュ補完オープン中    → 補完を閉じる
+ *   2. 入力欄に文字あり            → 入力欄をクリア
+ *   3. 入力欄空 + 直前送信あり     → tmux に Escape を送る + 入力欄に直前
+ *                                    送信テキストを復元 + 該当 pending を除去
+ *   4. 入力欄空 + 直前送信なし     → tmux に Escape を送る (純粋な中断)
+ *
+ * 1 と 2 では tmux に Escape を送らない。Ark の textarea は Claude の
+ * 入力欄のミラーであり、入力中の文字はまだ Claude に届いていないため。
+ */
+
+export interface EscapeContext {
+  /** 現在 textarea に入っているテキスト */
+  inputValue: string;
+  /** スラッシュ補完が開いているか (true なら最優先で閉じる) */
+  slashOpen: boolean;
+  /** 直近に送信したテキスト ("" = なし) */
+  lastSubmitted: string;
+}
+
+export type EscapeAction =
+  | { kind: "close-slash" }
+  | { kind: "clear-input" }
+  | {
+      kind: "interrupt";
+      restore: string | null;
+      removePendingText: string | null;
+    };
+
+export function reconcileEscape(ctx: EscapeContext): EscapeAction {
+  if (ctx.slashOpen) {
+    return { kind: "close-slash" };
+  }
+  if (ctx.inputValue.length > 0) {
+    return { kind: "clear-input" };
+  }
+  if (ctx.lastSubmitted.length > 0) {
+    return {
+      kind: "interrupt",
+      restore: ctx.lastSubmitted,
+      removePendingText: ctx.lastSubmitted,
+    };
+  }
+  return { kind: "interrupt", restore: null, removePendingText: null };
+}

--- a/packages/web/src/lib/reconcile-pending.test.ts
+++ b/packages/web/src/lib/reconcile-pending.test.ts
@@ -1,0 +1,204 @@
+/**
+ * reconcilePending の単体テスト。
+ *
+ * 純粋関数なので時刻 (now) を引数で渡せる。
+ * helper を使い pending / event は経過秒数 (ago, ms) で記述する:
+ *   pending("a", "hello", 100)        → 100ms 前に送信した "hello" pending
+ *   userInput("hello", 50)            → 50ms 前にタイムスタンプを持つ user-input event
+ */
+
+import { describe, expect, it } from "vitest";
+import type { JsonlParsedEvent } from "./jsonl-event-parser";
+import { type PendingMessage, reconcilePending } from "./reconcile-pending";
+
+const NOW = 1_700_000_000_000;
+
+function pending(id: string, text: string, ago: number): PendingMessage {
+  return { id, text, sentAt: NOW - ago };
+}
+
+function userInput(text: string, ago: number, id = "e"): JsonlParsedEvent {
+  return { id, kind: "user-input", text, timestamp: NOW - ago };
+}
+
+function assistant(text: string, ago: number, id = "e"): JsonlParsedEvent {
+  return { id, kind: "assistant-text", text, timestamp: NOW - ago };
+}
+
+describe("reconcilePending", () => {
+  describe("基本動作", () => {
+    it("空 pending は同じ参照を返す (再レンダ抑止)", () => {
+      const empty: PendingMessage[] = [];
+      expect(reconcilePending(empty, [], NOW)).toBe(empty);
+    });
+
+    it("マッチ無しなら同じ参照を返す", () => {
+      const p = [pending("a", "hello", 100)];
+      expect(reconcilePending(p, [], NOW)).toBe(p);
+    });
+
+    it("正規化テキスト完全一致で pending を除去", () => {
+      const p = [pending("a", "hello", 100)];
+      const evs = [userInput("hello", 50)];
+      expect(reconcilePending(p, evs, NOW)).toEqual([]);
+    });
+
+    it("user-input 以外のイベントは無視する", () => {
+      const p = [pending("a", "hello", 100)];
+      const evs = [assistant("hello", 50)];
+      expect(reconcilePending(p, evs, NOW)).toEqual(p);
+    });
+  });
+
+  describe("テキスト正規化", () => {
+    it("前後の空白・改行は無視して一致判定", () => {
+      const p = [pending("a", "hello", 100)];
+      const evs = [userInput("  hello  \n", 50)];
+      expect(reconcilePending(p, evs, NOW)).toEqual([]);
+    });
+
+    it("連続する空白は 1 つにまとめて比較", () => {
+      const p = [pending("a", "hello   world", 100)];
+      const evs = [userInput("hello world", 50)];
+      expect(reconcilePending(p, evs, NOW)).toEqual([]);
+    });
+
+    it("改行を空白として正規化して比較", () => {
+      const p = [pending("a", "line1\nline2", 100)];
+      const evs = [userInput("line1 line2", 50)];
+      expect(reconcilePending(p, evs, NOW)).toEqual([]);
+    });
+
+    it("Unicode 分解形 (NFD) と合成形 (NFC) を同一視する", () => {
+      // U+30D1 (NFC) ⇔ U+30CF + U+309A (NFD) のどちらも「パ」を表す
+      const nfcText = "パ";
+      const nfdText = "パ";
+      expect(nfcText.normalize("NFD")).toBe(nfdText);
+      const p = [pending("a", nfcText, 100)];
+      const evs = [userInput(nfdText, 50)];
+      expect(reconcilePending(p, evs, NOW)).toEqual([]);
+    });
+  });
+
+  describe("時刻窓 (clock skew)", () => {
+    it("event timestamp が sentAt - 1000ms より前なら一致対象外", () => {
+      // p.sentAt = NOW - 100, threshold = sentAt - 1000 = NOW - 1100
+      // event timestamp = NOW - 2000 < NOW - 1100 → 不一致
+      const p = [pending("a", "hello", 100)];
+      const evs = [userInput("hello", 2000)];
+      expect(reconcilePending(p, evs, NOW)).toEqual(p);
+    });
+
+    it("clock skew 1秒以内の event は許容して一致させる", () => {
+      // p.sentAt = NOW - 100, threshold = NOW - 1100
+      // event timestamp = NOW - 500 > NOW - 1100 → 一致
+      const p = [pending("a", "hello", 100)];
+      const evs = [userInput("hello", 500)];
+      expect(reconcilePending(p, evs, NOW)).toEqual([]);
+    });
+
+    it("sentAt より新しい event (queue 経由) も一致する", () => {
+      const p = [pending("a", "hello", 5_000)]; // 5秒前送信
+      const evs = [userInput("hello", 100)]; // 100ms 前に JSONL 反映
+      expect(reconcilePending(p, evs, NOW)).toEqual([]);
+    });
+  });
+
+  describe("1 対 1 マッチング (重複消費の防止)", () => {
+    it("同一テキストの pending 2 件と event 1 件 → 1 件だけ除去", () => {
+      const p1 = pending("a", "hello", 200); // より古い
+      const p2 = pending("b", "hello", 100);
+      const evs = [userInput("hello", 50)];
+      const result = reconcilePending([p1, p2], evs, NOW);
+      expect(result.length).toBe(1);
+      // FIFO: 古い p1 (sentAt = NOW-200) が先に消費されるので b が残る
+      expect(result[0].id).toBe("b");
+    });
+
+    it("同一テキストの event 2 件と pending 2 件 → 両方除去", () => {
+      const p1 = pending("a", "hello", 200);
+      const p2 = pending("b", "hello", 100);
+      const evs = [userInput("hello", 80, "e1"), userInput("hello", 30, "e2")];
+      const result = reconcilePending([p1, p2], evs, NOW);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("タイムアウト", () => {
+    it("10 分を超えた pending は match 不要で除去", () => {
+      const p = [pending("a", "hello", 11 * 60_000)];
+      expect(reconcilePending(p, [], NOW)).toEqual([]);
+    });
+
+    it("10 分以内の pending は match 無しなら残す", () => {
+      const p = [pending("a", "hello", 9 * 60_000)];
+      expect(reconcilePending(p, [], NOW)).toEqual(p);
+    });
+  });
+
+  describe("FIFO フォールバック", () => {
+    it("5秒以上経過 + 未マッチ + 未消費 event → FIFO で割り当て除去", () => {
+      const p = [pending("a", "hello", 6_000)];
+      const evs = [userInput("totally different text", 3_000)];
+      expect(reconcilePending(p, evs, NOW)).toEqual([]);
+    });
+
+    it("5秒未満の pending は FIFO 発動しない", () => {
+      const p = [pending("a", "hello", 3_000)];
+      const evs = [userInput("totally different text", 2_000)];
+      expect(reconcilePending(p, evs, NOW)).toEqual(p);
+    });
+
+    it("FIFO は古い pending から順に消費する", () => {
+      const p1 = pending("a", "first", 10_000); // 10秒前 → FIFO対象
+      const p2 = pending("b", "second", 8_000); // 8秒前 → FIFO対象
+      const evs = [userInput("noise", 5_000)]; // 1件だけ
+      const result = reconcilePending([p1, p2], evs, NOW);
+      expect(result.length).toBe(1);
+      expect(result[0].id).toBe("b"); // 古い p1 が消費されて b が残る
+    });
+
+    it("1st pass で消費済みの event は 2nd pass でも再利用されない", () => {
+      // p1 は exact 一致で event[0] を消費。p2 は FIFO 対象だが event は全部消費済み
+      const p1 = pending("a", "exact", 6_000);
+      const p2 = pending("b", "fallback", 6_000);
+      const evs = [userInput("exact", 3_000)]; // 1件しかない
+      const result = reconcilePending([p1, p2], evs, NOW);
+      expect(result.length).toBe(1);
+      expect(result[0].id).toBe("b"); // FIFO は消費する event がないので残す
+    });
+
+    it("clock skew より古い event は FIFO 対象にも入らない", () => {
+      const p = [pending("a", "hello", 6_000)]; // sentAt = NOW-6000, threshold = NOW-7000
+      const evs = [userInput("noise", 8_000)]; // NOW-8000 < threshold
+      expect(reconcilePending(p, evs, NOW)).toEqual(p);
+    });
+  });
+
+  describe("混合シナリオ", () => {
+    it("exact + FIFO + 残留 が同時にある状態を整合的に処理する", () => {
+      const p1 = pending("a", "exact", 6_000); // exact 一致で消費
+      const p2 = pending("b", "fallback", 6_000); // FIFO 対象、event 余りで消費
+      const p3 = pending("c", "fresh", 1_000); // 5秒未満なので FIFO 対象外、event 完全一致無し
+      const evs = [
+        userInput("exact", 4_000, "e1"),
+        userInput("noise-different", 3_000, "e2"),
+      ];
+      const result = reconcilePending([p1, p2, p3], evs, NOW);
+      expect(result.map(p => p.id)).toEqual(["c"]);
+    });
+
+    it("queue 経由で複数の同文 pending が時間差で消化されるケース", () => {
+      // 3 件まとめて submit、Claude が 1 件ずつ消化して JSONL に書き込んだ状況
+      const p1 = pending("a", "same", 6_000);
+      const p2 = pending("b", "same", 5_500);
+      const p3 = pending("c", "same", 5_000);
+      const evs = [
+        userInput("same", 4_000, "e1"),
+        userInput("same", 3_000, "e2"),
+        userInput("same", 2_000, "e3"),
+      ];
+      expect(reconcilePending([p1, p2, p3], evs, NOW)).toEqual([]);
+    });
+  });
+});

--- a/packages/web/src/lib/reconcile-pending.ts
+++ b/packages/web/src/lib/reconcile-pending.ts
@@ -1,0 +1,95 @@
+/**
+ * SplitChatPane の pending bubble (Claude 処理待ち表示) を JSONL の
+ * user-input イベントと突き合わせて整理する純粋関数。
+ *
+ * 単純な text === text 比較だと、Claude Code が queue 経由で処理した際に
+ * 末尾改行・空白の付与や Unicode 正規化形の差異で取りこぼすため、
+ *  1. NFC + 空白圧縮 + trim で正規化して 1 対 1 マッチング
+ *  2. 5 秒以上経過しても未マッチなら FIFO で時系列消費
+ *  3. 10 分超は無条件除去
+ * の 3 段構えで残留を防ぐ。
+ *
+ * React に依存しない純粋関数として切り出してあるので、本ファイルは
+ * `reconcile-pending.test.ts` で単体テストする。
+ */
+
+import type { JsonlParsedEvent } from "./jsonl-event-parser";
+
+export interface PendingMessage {
+  id: string;
+  text: string;
+  /** 送信時刻 (Date.now() ベース、ms) */
+  sentAt: number;
+}
+
+/** 10 分超は無条件で除去 (queue から消えた / そもそも届かなかったケースの保険) */
+const STALE_PENDING_MS = 10 * 60_000;
+/** JSONL timestamp と sentAt の clock skew 許容 */
+const CLOCK_SKEW_MS = 1_000;
+/** これ以上経過した未マッチ pending は FIFO フォールバックの対象にする */
+const FIFO_FALLBACK_DELAY_MS = 5_000;
+
+const normalize = (s: string): string =>
+  s.trim().normalize("NFC").replace(/\s+/g, " ");
+
+export function reconcilePending(
+  pending: PendingMessage[],
+  events: JsonlParsedEvent[],
+  now: number
+): PendingMessage[] {
+  if (pending.length === 0) return pending;
+
+  // sentAt が古い順に並べた pending と、timestamp 昇順の user-input イベント
+  const sortedPending = [...pending].sort((a, b) => a.sentAt - b.sentAt);
+  const candidateEvents = events
+    .filter(
+      (e): e is Extract<JsonlParsedEvent, { kind: "user-input" }> =>
+        e.kind === "user-input"
+    )
+    .map(e => ({
+      text: normalize(e.text),
+      timestamp: e.timestamp ?? 0,
+    }))
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  const removed = new Set<string>();
+  const consumed = new Set<number>();
+
+  // 1st pass: 正規化テキストが完全一致するペアを優先で消費
+  for (const p of sortedPending) {
+    if (now - p.sentAt > STALE_PENDING_MS) {
+      removed.add(p.id);
+      continue;
+    }
+    const np = normalize(p.text);
+    for (let i = 0; i < candidateEvents.length; i++) {
+      if (consumed.has(i)) continue;
+      const ev = candidateEvents[i];
+      if (ev.timestamp < p.sentAt - CLOCK_SKEW_MS) continue;
+      if (ev.text === np) {
+        removed.add(p.id);
+        consumed.add(i);
+        break;
+      }
+    }
+  }
+
+  // 2nd pass (FIFO フォールバック): 5 秒以上経過しても未マッチの pending を、
+  // 未消費の user-input イベントに古い順で割り当てる。テキストが微妙に違っても
+  // Claude Code の queue 内で順序は保たれるという仮定。
+  for (const p of sortedPending) {
+    if (removed.has(p.id)) continue;
+    if (now - p.sentAt < FIFO_FALLBACK_DELAY_MS) continue;
+    for (let i = 0; i < candidateEvents.length; i++) {
+      if (consumed.has(i)) continue;
+      const ev = candidateEvents[i];
+      if (ev.timestamp < p.sentAt - CLOCK_SKEW_MS) continue;
+      removed.add(p.id);
+      consumed.add(i);
+      break;
+    }
+  }
+
+  if (removed.size === 0) return pending;
+  return pending.filter(p => !removed.has(p.id));
+}

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import type { ManagedSession, Worktree } from "@ark/shared";
+import type { ManagedSession, SpecialKey, Worktree } from "@ark/shared";
 import { AlertCircle, Copy, Loader2, Terminal } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -22,6 +22,7 @@ import { RepoGridView } from "@/components/RepoGridView";
 import { RepoSelectDialog } from "@/components/RepoSelectDialog";
 import { SessionSidebar } from "@/components/SessionSidebar";
 import { SidebarMainLayout } from "@/components/SidebarMainLayout";
+import { SplitViewPane } from "@/components/SplitViewPane";
 import { TerminalPane } from "@/components/TerminalPane";
 import { UpdateBanner } from "@/components/UpdateBanner";
 import { Button } from "@/components/ui/button";
@@ -163,6 +164,13 @@ export default function Dashboard() {
     typeof window !== "undefined" &&
     window.location.hostname !== "localhost" &&
     window.location.hostname !== "127.0.0.1";
+
+  // チャットビュー (JSONL ベース + on-demand ターミナル) のオプトイン。
+  // `?view=chat` で有効化する (安定後にデフォルト反転して `?view=classic` を
+  // 逃げ道にする予定)。
+  const isChatView =
+    typeof window !== "undefined" &&
+    new URLSearchParams(window.location.search).get("view") === "chat";
 
   const activeBrowserSession = Array.from(browserSessions.values())[0] ?? null;
 
@@ -728,35 +736,47 @@ export default function Dashboard() {
                     const repo = findRepoForSession(session, repoList);
                     return repo ? getBaseName(repo) : undefined;
                   })();
+                  const paneProps = {
+                    session,
+                    worktree: wt,
+                    repoName: rn,
+                    tabs: getTabsForSession(session.id),
+                    activeTabIndex: getActiveTabForSession(session.id),
+                    onTabSelect: (idx: number) =>
+                      handleTabSelect(session.id, idx),
+                    onTabClose: (idx: number) =>
+                      handleTabClose(session.id, idx),
+                    onSendMessage: (msg: string) =>
+                      sendMessage(session.id, msg),
+                    onSendKey: (key: SpecialKey) => sendKey(session.id, key),
+                    onDeleteSession: () => handleDeleteSession(session.id, wt),
+                    onUploadFile: (data: {
+                      base64Data: string;
+                      mimeType: string;
+                      originalFilename?: string;
+                    }) => uploadFile({ sessionId: session.id, ...data }),
+                    onCopyBuffer: copyBuffer
+                      ? () => copyBuffer(session.id)
+                      : undefined,
+                    messageShortcuts,
+                    onCreateShortcut: createShortcut,
+                    onUpdateShortcut: updateShortcut,
+                    onDeleteShortcut: deleteShortcut,
+                  };
                   return (
                     <div
                       key={session.id}
                       className={isActive ? "h-full flex flex-col" : "hidden"}
                     >
-                      <TerminalPane
-                        session={session}
-                        worktree={wt}
-                        repoName={rn}
-                        tabs={getTabsForSession(session.id)}
-                        activeTabIndex={getActiveTabForSession(session.id)}
-                        onTabSelect={idx => handleTabSelect(session.id, idx)}
-                        onTabClose={idx => handleTabClose(session.id, idx)}
-                        onSendMessage={msg => sendMessage(session.id, msg)}
-                        onSendKey={key => sendKey(session.id, key)}
-                        onDeleteSession={() =>
-                          handleDeleteSession(session.id, wt)
-                        }
-                        onUploadFile={data =>
-                          uploadFile({ sessionId: session.id, ...data })
-                        }
-                        onCopyBuffer={
-                          copyBuffer ? () => copyBuffer(session.id) : undefined
-                        }
-                        messageShortcuts={messageShortcuts}
-                        onCreateShortcut={createShortcut}
-                        onUpdateShortcut={updateShortcut}
-                        onDeleteShortcut={deleteShortcut}
-                      />
+                      {isChatView ? (
+                        <SplitViewPane
+                          socket={socket}
+                          isActive={isActive}
+                          {...paneProps}
+                        />
+                      ) : (
+                        <TerminalPane {...paneProps} />
+                      )}
                     </div>
                   );
                 })}

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -165,12 +165,11 @@ export default function Dashboard() {
     window.location.hostname !== "localhost" &&
     window.location.hostname !== "127.0.0.1";
 
-  // チャットビュー (JSONL ベース + on-demand ターミナル) のオプトイン。
-  // `?view=chat` で有効化する (安定後にデフォルト反転して `?view=classic` を
-  // 逃げ道にする予定)。
+  // チャットビュー (JSONL ベース + on-demand ターミナル) がデフォルト。
+  // 旧来の TerminalPane 単独表示に戻したい場合は `?view=classic` を指定する。
   const isChatView =
-    typeof window !== "undefined" &&
-    new URLSearchParams(window.location.search).get("view") === "chat";
+    typeof window === "undefined" ||
+    new URLSearchParams(window.location.search).get("view") !== "classic";
 
   const activeBrowserSession = Array.from(browserSessions.values())[0] ?? null;
 

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -772,6 +772,7 @@ export default function Dashboard() {
                         <SplitViewPane
                           socket={socket}
                           isActive={isActive}
+                          bridgeStatus={sessionStatuses.get(session.id)}
                           {...paneProps}
                         />
                       ) : (

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -110,6 +110,7 @@ export default function Dashboard() {
     beaconSetProfile,
     sessionPreviews,
     sessionActivityTexts,
+    sessionAwaitingTexts,
     gridSnapshots,
     subscribeGrid,
     unsubscribeGrid,
@@ -772,6 +773,7 @@ export default function Dashboard() {
                           socket={socket}
                           isActive={isActive}
                           bridgeStatus={sessionStatuses.get(session.id)}
+                          awaitingText={sessionAwaitingTexts.get(session.id)}
                           {...paneProps}
                         />
                       ) : (

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     include: [
       "packages/server/src/**/*.test.ts",
       "packages/shared/src/**/*.test.ts",
+      "packages/web/src/**/*.test.ts",
     ],
     environment: "node",
   },


### PR DESCRIPTION
## 概要

セッションのデフォルト UI を ttyd ターミナル転送から **JSONL tail ベースのチャットビュー**へ置き換える。旧来表示は `?view=classic` で利用可能。

## 設計原則: 情報源の分離

会話内容は JSONL transcript のみを情報源とし、tmux 画面テキストの内容パースは行わない。

| 情報 | 情報源 |
|---|---|
| 会話内容 (履歴・増分) | JSONL transcript の tail (JsonlTailManager) |
| 回答待ち AskUserQuestion | セッション起動時に `--settings` 注入する PreToolUse hook → `/api/internal/auq-event` → `session:auq` |
| busy / AWAITING | 既存 `session:previews` の bridgeStatus (existence チェックのみ) |

### 実装上の要点

- 対話版 claude は AUQ の tool_use を回答確定の瞬間に tool_result とまとめて JSONL へ書く (質問表示中は出ない)。回答待ちのリアルタイム検出は hook が情報源
- AUQ TUI のキー操作列: 単問 single = digit 一発即確定 / multiSelect = digit トグル → Right → Review digit 1 / 自由入力 = digit(options.length+1) → literal → Enter
- /compact はファイルを切り替えず isCompactSummary レコードを同一ファイルに挿入 (パーサで marker 化)
- プロファイル未指定セッションは `unset CLAUDE_CONFIG_DIR` 前置で起動 (env 継承による config dir 取り違えを防ぐ)

## 主な変更

- **JsonlTailManager**: fs.watch + 1s polling の push 型 pub/sub。dir/file 後発出現の自己回復、subscribeWithSnapshot による snapshot と増分の隙間ゼロ保証
- **claude-projects.ts**: encodeProjectDir (全非英数→'-')、pickLatestJsonl (cwd 検証つき、既知不一致にはフォールバックしない)
- **SplitChatPane / SplitViewPane**: チャット全幅 + 🖥 トグルで ttyd on-demand。pending reconcile (Esc 4 分岐)、slash 補完、画像添付、sidechain 折りたたみ、/compact マーカー
- **AskUserQuestionCard**: hook 由来の構造化データでカード表示、tmux キー送出で回答 (multiSelect / 複数質問 / 自由入力対応)、解決は JSONL の tool_result 出現で検知
- **AwaitingPad**: hook 未注入セッション向けフォールバック。確認 UI の生テキストミラー + キーパッド + 自由入力
- **auq-hook-bridge**: PreToolUse hook 注入 (token は DB 永続化、timingSafeEqual 検証、settings 0600)
- **復元時プロファイル検出**: tmux session env → pane プロセス environ (/proc) の 2 段フォールバック

## 検証

- テスト 293 件パス / pnpm check クリーン
- 実 claude での E2E (履歴表示・増分反映・送信・AUQ single/multi/自由入力/Escape・hook フロー・リロード再送) と Playwright での実ブラウザ表示を確認

## 残課題 (別 PR)

- Phase B: モバイル (MobileSessionView) のチャット化
