### PR TITLE
docs(build-deploy): pm2 start/--update-env 時の env 汚染への注意を追記

### DIFF
--- a/.claude/skills/build-deploy/SKILL.md
+++ b/.claude/skills/build-deploy/SKILL.md
@@ -39,3 +39,63 @@ pm2 restart claude-code-ark
 
 - `pkill -f ttyd` を省略するとttydのポート(7680〜)が競合し、ターミナルが表示されなくなる
 - 3つのコマンドは必ず上記の順番で実行すること
+
+## pm2 の env 汚染に注意 (pm2 start / --update-env 時)
+
+pm2 は **start 時（および `--update-env` 付き restart 時）の呼び出し元シェルの
+環境変数をアプリ env として永続保存し、以後の restart で使い回す**。
+
+このスキルは Claude Code セッション内の Bash から実行されるため、呼び出し元には
+セッション由来の `CLAUDE_CONFIG_DIR`（プロファイル）/ `CLAUDECODE` /
+`CLAUDE_CODE_ENTRYPOINT` のほか、セッションが持つあらゆる環境変数（秘密情報を
+含み得る）が含まれている。これが保存されると、本番 Ark → Ark が fork する
+tmux サーバー → 既定プロファイルのセッション、と伝播し、**プロファイル未指定の
+セッションが意図しない config dir を使う事故**になる。
+
+- 通常の再起動は上記手順どおり素の `pm2 restart`（保存 env を変更しない）でよい
+- **初回の `pm2 start`、`pm2 delete` 後の start、`--update-env` 付き restart は、
+  特定変数の除外（denylist）ではなく `env -i` の allowlist 方式で実行する**。
+  アプリ設定は `.env.production`（`--node-args="--env-file=..."` 経由）に
+  集約されているため、シェル env は HOME / PATH / LANG だけで足りる。
+  - 信頼境界の整理: HOME / PATH は「このマシンの実行環境の解決」(mise shims の
+    node / pm2 / ~/.pm2) に、LANG は **Ark 配下の ttyd / tmux の UTF-8 処理**
+    (落とすと日本語が文字化けする) に必要なため呼び出し元から引き継ぐ。
+    この 3 つは秘密情報でも config dir 伝播事故の原因でもない。事故の原因と
+    なる `CLAUDE_*` 系を含む**他の全変数は `env -i` が確実に落とす**
+
+```bash
+cd /home/admin/dev/github.com/ignission/claude-code-manager
+env -i HOME="$HOME" PATH="$PATH" LANG="${LANG:-en_US.UTF-8}" pm2 start packages/server/dist/cli.js \
+  --name claude-code-ark \
+  --node-args="--env-file=.env.production" \
+  -- --remote
+```
+
+- 保存 env が汚染されているかは次で確認する。
+  「クリーン」と表示されれば未汚染、JSON が出れば汚染済み、
+  「プロセスなし」なら名前か pm2 の状態を疑う（無出力での見落としを防ぐ）:
+
+```bash
+pm2 jlist | jq -e '[.[] | select(.name=="claude-code-ark")] | first // error("プロセスなし")
+  | .pm2_env.env | {CLAUDE_CONFIG_DIR, CLAUDECODE, CLAUDE_CODE_ENTRYPOINT}
+  | with_entries(select(.value != null))
+  | if . == {} then "クリーン" else . end'
+```
+
+- 汚染時の浄化: `pm2 restart --update-env` は env の**マージ更新**であり、
+  保存済みキーの削除を保証しない（オーファン変数が残る:
+  [pm2#3486](https://github.com/Unitech/pm2/issues/3486)）。
+  確実な浄化は **delete → allowlist 方式のフレッシュ start**:
+
+```bash
+cd /home/admin/dev/github.com/ignission/claude-code-manager
+pm2 delete claude-code-ark
+env -i HOME="$HOME" PATH="$PATH" LANG="${LANG:-en_US.UTF-8}" pm2 start packages/server/dist/cli.js \
+  --name claude-code-ark \
+  --node-args="--env-file=.env.production" \
+  -- --remote
+pm2 save
+```
+
+  実行後、上記の汚染確認コマンドで「クリーン」になったことを必ず検証する
+  （`pm2 save` は delete で dump から消えた登録を保存し直すために必要）


### PR DESCRIPTION
## 変更

build-deploy スキルに pm2 の env 汚染防止手順を追記する。

pm2 は start 時 (および `--update-env` 付き restart 時) の呼び出し元シェルの環境変数をアプリ env として永続保存し、以後の restart で使い回す。Claude Code セッション内から `pm2 start` すると、セッション由来の `CLAUDE_CONFIG_DIR` 等が保存され、Ark → tmux サーバー → 既定プロファイルのセッションへ伝播し、意図しない config dir を使う事故になる。

- 高リスク操作 (初回 start / delete 後 start) は `env -i HOME PATH` の **allowlist 方式**で実行する完全なコマンド例を明記 (denylist では他のセッション由来 env や秘密情報の保存リスクが残るため)
- 汚染確認コマンド (`jq -e`、クリーン / 汚染 / プロセスなしの 3 状態を明示、実走検証済み)
- 浄化手順は `pm2 delete` → フレッシュ `pm2 start` → `pm2 save` (`--update-env` はマージ更新で保存済みキーの削除を保証しないため: [pm2#3486](https://github.com/Unitech/pm2/issues/3486))

## 関連

- 実行系の恒久対策 (既定セッションの `unset CLAUDE_CONFIG_DIR` 前置) は #205 に含まれる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * pm2 による環境変数の意図しない引き継ぎ（セッション由来の特殊変数が次回プロセスへ伝播する可能性）について注意喚起を追加しました。
  * 初回起動／再起動時にクリーンな環境で起動する具体手順（allowlist 起動）と、汚染の検出および確実な浄化手順（削除→クリーン起動→保存）の手順・コマンド例を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->