### PR TITLE
feat(web): 会話エリアのクリックで入力欄にフォーカス

### DIFF
--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -674,6 +674,9 @@ export function SplitChatPane({
   // 連続する subagent イベントを折りたたみグループへ
   const groupedEvents = useMemo(() => groupSidechain(events), [events]);
 
+  // 入力欄。会話エリアのクリックでここにフォーカスを移す
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
   // ===== スクロール追従 + 上端で過去読み込み =====
   const jsonlScrollRef = useRef<HTMLDivElement>(null);
   const [isNearBottom, setIsNearBottom] = useState(true);
@@ -710,6 +713,24 @@ export function SplitChatPane({
     if (!el) return;
     el.scrollTop = el.scrollHeight;
     setIsNearBottom(true);
+  }, []);
+
+  // 会話エリアのクリックで入力欄にフォーカスする。ただし
+  //  - テキスト選択中 (ドラッグでコピー等) はフォーカスを奪わない
+  //  - ボタン / リンク / 入力など操作要素のクリックは本来の挙動を優先する
+  // (AskUserQuestion の選択肢ボタン、ファイルリンク、「最新へ」ボタン等)
+  const handleConversationClick = useCallback((e: React.MouseEvent) => {
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed) return;
+    const target = e.target as HTMLElement | null;
+    if (
+      target?.closest(
+        "button, a, input, textarea, select, [role='button'], [contenteditable='true']"
+      )
+    ) {
+      return;
+    }
+    inputRef.current?.focus();
   }, []);
 
   useEffect(() => {
@@ -967,8 +988,11 @@ export function SplitChatPane({
           relative ラッパーで囲み「下へジャンプ」ボタンをスクロール領域に
           重ねて配置する。スクロール領域自体は absolute inset-0 で内側を埋める。 */}
       <div className="flex-1 min-h-0 relative">
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: クリックで入力欄にフォーカスを移すだけの補助操作。会話ログ自体は非対話要素のまま */}
+        {/* biome-ignore lint/a11y/useKeyWithClickEvents: キーボード利用者は Tab で入力欄 (textarea) に直接到達できるため、キーハンドラは不要 */}
         <div
           ref={jsonlScrollRef}
+          onClick={handleConversationClick}
           className="absolute inset-0 overflow-y-auto py-2"
         >
           {events.length === 0 &&
@@ -1091,6 +1115,7 @@ export function SplitChatPane({
           </>
         )}
         <textarea
+          ref={inputRef}
           value={inputValue}
           onChange={e => setInputValue(e.target.value)}
           onKeyDown={handleKeyDown}

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -722,10 +722,15 @@ export function SplitChatPane({
   const handleConversationClick = useCallback((e: React.MouseEvent) => {
     const selection = window.getSelection();
     if (selection && !selection.isCollapsed) return;
-    const target = e.target as HTMLElement | null;
+    // e.target は Node 型保証がない (closest 非存在で例外になり得る) ため
+    // Element であることを実行時に確認してから扱う
+    const target = e.target;
+    if (!(target instanceof Element)) return;
+    // 操作要素・フォーカス可能要素のクリックは本来の挙動を優先する。
+    // contenteditable は属性値 ("" / true / plaintext-only) を問わず拾う
     if (
-      target?.closest(
-        "button, a, input, textarea, select, [role='button'], [contenteditable='true']"
+      target.closest(
+        "button, a, input, textarea, select, [role='button'], [role='link'], [tabindex], [contenteditable]"
       )
     ) {
       return;


### PR DESCRIPTION
## 変更

チャットビューの会話ログのどこをクリックしても入力欄 (textarea) にフォーカスが移るようにする。

本来の挙動を優先してフォーカスを横取りしないケース:
- テキスト選択中 (メッセージのドラッグ選択・コピー)
- ボタン / リンク / 入力 / フォーカス可能要素のクリック (AskUserQuestion 選択肢、ファイルリンク、「最新へ」ボタン、slash 候補等)

## 実装

- `SplitChatPane` の会話スクロール領域に `onClick` を追加し、`inputRef` に `focus()`
- `e.target` は `instanceof Element` を確認してから `closest()` で操作要素を除外
- 除外セレクタ: `button, a, input, textarea, select, [role=button], [role=link], [tabindex], [contenteditable]`
- 非対話要素への onClick のため a11y 警告は biome-ignore で意図を明記 (キーボード利用者は Tab で textarea に到達できる)

## 検証

- codex P5 ([P2]x2 を反映済み)
- pnpm check / build クリーン
- Playwright: 空白クリック → textarea にフォーカス ✓ / テキスト選択中クリック → フォーカスを奪わない ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * チャット画面で会話ログエリアをクリックすると、自動で入力欄にフォーカスされるようになりました。テキスト選択中やボタン操作時は既定の挙動が優先されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->