### PR TITLE
feat(web): AskUserQuestion 履歴カード内の URL をクリック可能に

### DIFF
--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -42,6 +42,7 @@ import {
   parseAuqInput,
 } from "@/lib/ask-user-question-state";
 import type { JsonlParsedEvent } from "@/lib/jsonl-event-parser";
+import { splitTextWithUrls } from "@/lib/linkify";
 import { reconcileEscape } from "@/lib/reconcile-escape";
 import { reconcilePending } from "@/lib/reconcile-pending";
 
@@ -170,6 +171,30 @@ function CompactMarkerCard() {
   );
 }
 
+/**
+ * プレーンテキスト中の URL をクリック可能なリンクにして描画する。
+ * リンク方針は assistant markdown と揃える (http/https のみ・新規タブ・noopener)。
+ */
+function Linkify({ text }: { text: string }) {
+  return splitTextWithUrls(text).map((seg, i) =>
+    seg.type === "url" ? (
+      <a
+        // biome-ignore lint/suspicious/noArrayIndexKey: セグメント列は text から純粋導出され順序不変
+        key={i}
+        href={seg.value}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-600 dark:text-blue-400 underline break-all"
+      >
+        {seg.value}
+      </a>
+    ) : (
+      // biome-ignore lint/suspicious/noArrayIndexKey: 同上
+      <span key={i}>{seg.value}</span>
+    )
+  );
+}
+
 function AskUserQuestionResultCard({
   input,
   result,
@@ -237,11 +262,15 @@ function AskUserQuestionResultCard({
             >
               <span className="text-muted-foreground shrink-0">·</span>
               <div className="min-w-0 flex-1">
-                <span className="text-foreground">{q.question}</span>
+                <span className="text-foreground">
+                  <Linkify text={q.question} />
+                </span>
                 {answer && (
                   <>
                     <span className="text-muted-foreground"> → </span>
-                    <span className="font-medium text-primary">{answer}</span>
+                    <span className="font-medium text-primary">
+                      <Linkify text={answer} />
+                    </span>
                   </>
                 )}
               </div>

--- a/packages/web/src/lib/linkify.test.ts
+++ b/packages/web/src/lib/linkify.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { splitTextWithUrls } from "./linkify";
+
+describe("splitTextWithUrls", () => {
+  it("URL を含まないテキストは 1 つの text セグメント", () => {
+    expect(splitTextWithUrls("ただのテキスト")).toEqual([
+      { type: "text", value: "ただのテキスト" },
+    ]);
+  });
+
+  it("空文字は空配列", () => {
+    expect(splitTextWithUrls("")).toEqual([]);
+  });
+
+  it("前後にテキストのある URL を分解する", () => {
+    expect(splitTextWithUrls("詳細は https://example.com を参照")).toEqual([
+      { type: "text", value: "詳細は " },
+      { type: "url", value: "https://example.com" },
+      { type: "text", value: " を参照" },
+    ]);
+  });
+
+  it("文末の句読点は URL に含めない", () => {
+    expect(splitTextWithUrls("see https://example.com.")).toEqual([
+      { type: "text", value: "see " },
+      { type: "url", value: "https://example.com" },
+      { type: "text", value: "." },
+    ]);
+  });
+
+  it("括弧で囲まれた URL の閉じ括弧は URL に含めない", () => {
+    expect(splitTextWithUrls("(https://example.com)")).toEqual([
+      { type: "text", value: "(" },
+      { type: "url", value: "https://example.com" },
+      { type: "text", value: ")" },
+    ]);
+  });
+
+  it("URL 内に対応する括弧があれば閉じ括弧を保持する", () => {
+    expect(
+      splitTextWithUrls("https://ja.wikipedia.org/wiki/Foo_(bar)")
+    ).toEqual([
+      { type: "url", value: "https://ja.wikipedia.org/wiki/Foo_(bar)" },
+    ]);
+  });
+
+  it("複数の URL を分解する", () => {
+    expect(splitTextWithUrls("a https://x.com b http://y.org c")).toEqual([
+      { type: "text", value: "a " },
+      { type: "url", value: "https://x.com" },
+      { type: "text", value: " b " },
+      { type: "url", value: "http://y.org" },
+      { type: "text", value: " c" },
+    ]);
+  });
+
+  it("http も対象", () => {
+    expect(splitTextWithUrls("http://localhost:4001/foo")).toEqual([
+      { type: "url", value: "http://localhost:4001/foo" },
+    ]);
+  });
+
+  it("ftp 等の非 http スキームはリンクにしない", () => {
+    expect(splitTextWithUrls("ftp://example.com/file")).toEqual([
+      { type: "text", value: "ftp://example.com/file" },
+    ]);
+  });
+
+  it("ホスト部の無い壊れた URL はリンク化しない", () => {
+    expect(splitTextWithUrls("http://. と http:// は無効")).toEqual([
+      { type: "text", value: "http://. と http:// は無効" },
+    ]);
+  });
+
+  it("localhost はホストにドットが無くてもリンク化する", () => {
+    expect(splitTextWithUrls("http://localhost:4001/x")).toEqual([
+      { type: "url", value: "http://localhost:4001/x" },
+    ]);
+  });
+
+  it("クエリ・フラグメント付き URL をそのまま拾う", () => {
+    expect(
+      splitTextWithUrls("https://example.com/a?b=1&c=2#frag のように")
+    ).toEqual([
+      { type: "url", value: "https://example.com/a?b=1&c=2#frag" },
+      { type: "text", value: " のように" },
+    ]);
+  });
+});

--- a/packages/web/src/lib/linkify.ts
+++ b/packages/web/src/lib/linkify.ts
@@ -1,0 +1,95 @@
+/**
+ * プレーンテキスト中の URL を検出して断片に分解する純粋ロジック。
+ *
+ * AskUserQuestion の質問文・回答など、Markdown レンダリングを通さない
+ * プレーンテキスト表示で URL をクリッカブルにするために使う。
+ * 描画 (React) 側は `Linkify` コンポーネント (SplitChatPane) が担う。
+ */
+
+/** http(s) URL を検出する */
+const URL_RE = /https?:\/\/[^\s<>"'`]+/g;
+
+/**
+ * URL の末尾に付きがちな句読点・閉じ括弧を切り離す。
+ * 例: "(see https://example.com)." → URL は "https://example.com"
+ * 閉じ括弧は、URL 内に対応する開き括弧がある場合のみ残す
+ * (Wikipedia 等の `..._(disambiguation)` を壊さない)。
+ */
+function trimTrailingPunctuation(url: string): {
+  url: string;
+  trailing: string;
+} {
+  let end = url.length;
+  while (end > 0) {
+    const ch = url[end - 1];
+    if (")]".includes(ch)) {
+      const open = ch === ")" ? "(" : "[";
+      const slice = url.slice(0, end);
+      const opens = slice.split(open).length - 1;
+      const closes = slice.split(ch).length - 1;
+      if (opens >= closes) break;
+      end--;
+    } else if (".,;:!?".includes(ch)) {
+      end--;
+    } else {
+      break;
+    }
+  }
+  return { url: url.slice(0, end), trailing: url.slice(end) };
+}
+
+export type LinkSegment =
+  | { type: "text"; value: string }
+  | { type: "url"; value: string };
+
+/**
+ * 正規化後の文字列がリンク化に値する http(s) URL か検証する。
+ * `http://` や `http://.` のようにホスト部が無い壊れた文字列を弾く。
+ */
+function isLinkableHttpUrl(url: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return false;
+  }
+  // ホスト名にドットを含む or localhost のみ許可 (http://. や http://, を弾く)
+  return parsed.hostname.includes(".") || parsed.hostname === "localhost";
+}
+
+/**
+ * テキストを「テキスト断片」と「URL 断片」の列に分解する。
+ * 連続するテキストはまとめる。URL 末尾の句読点はテキスト側へ送る。
+ */
+export function splitTextWithUrls(text: string): LinkSegment[] {
+  const segments: LinkSegment[] = [];
+  let lastIndex = 0;
+  const pushText = (value: string) => {
+    if (!value) return;
+    const last = segments[segments.length - 1];
+    if (last && last.type === "text") last.value += value;
+    else segments.push({ type: "text", value });
+  };
+
+  URL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = URL_RE.exec(text);
+  while (m !== null) {
+    pushText(text.slice(lastIndex, m.index));
+    const { url, trailing } = trimTrailingPunctuation(m[0]);
+    // 正規化後にリンク化可能な URL か検証し、壊れた文字列 (http://. 等) は
+    // text セグメントへ戻す (壊れた href を作らない)
+    if (isLinkableHttpUrl(url)) {
+      segments.push({ type: "url", value: url });
+      if (trailing) pushText(trailing);
+    } else {
+      pushText(m[0]);
+    }
+    lastIndex = m.index + m[0].length;
+    m = URL_RE.exec(text);
+  }
+  pushText(text.slice(lastIndex));
+  return segments;
+}


### PR DESCRIPTION
## 変更

会話履歴の AskUserQuestion 回答カード (AskUserQuestionResultCard) で、質問文・回答テキスト中の http(s) URL をクリック可能なリンクにする。これまでは plain text で、URL が含まれていてもクリックできなかった。

## 実装

- `linkify.ts`: テキストを text/url 断片に分解する純粋関数 `splitTextWithUrls`
  - URL 末尾の句読点・非対応の閉じ括弧を切り離す (Wikipedia 等の `..._(bar)` は保持)
  - 正規化後に `new URL()` で検証し、ホスト部の無い壊れた文字列 (`http://.` 等) は text へ戻す
- `SplitChatPane` の `Linkify` コンポーネント: http/https のみ・新規タブ・`rel=noopener noreferrer` (assistant markdown のリンク方針に合わせる)
- 質問文と回答の plain span を `Linkify` に置換

## 検証

- linkify 単体テスト 12 件 (前後テキスト付き URL / 文末句読点 / 括弧 / 複数 URL / 非対応スキーム / 壊れた URL / localhost など)
- pnpm check / build クリーン
- AUQ 履歴カードのリグレッション無しを実ブラウザ (検証サーバー) で確認
- codex P5 ([P2]x2 を反映: `new URL()` 検証で壊れた href の生成を防止)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* チャット内の質問および回答に含まれるHTTP/HTTPS URLを自動的にクリック可能なリンクに変換しました
* リンクは新規タブで安全に開きます

## テスト

* URL検出と変換機能の包括的なテストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->