### PR TITLE
fix(usage): /usage TUI をフォールド下まで取得できるよう pane を拡大

### DIFF
--- a/packages/server/src/lib/usage-collector.test.ts
+++ b/packages/server/src/lib/usage-collector.test.ts
@@ -103,6 +103,38 @@ const NEW_UI_USAGE_OUTPUT = `    Status   Config   Usage   Stats
    other devices or claude.ai
 `;
 
+/**
+ * 新UI フルスクリーン版 (claude 2.1.183 で確認)。
+ * 上部に「Settings」タブが増え、Session 統計ブロック + 折り返しで縦に伸びた。
+ * 「Current week (Sonnet only)」は 0% used を表示しつつ Resets 行が無く、
+ * 直後に「What's contributing to your limits usage?」が続く。
+ * pane を十分高くキャプチャできれば session/weekly all/sonnet の 3 区画が揃う。
+ */
+const NEW_UI_FULLSCREEN_OUTPUT = `   Settings  Status   Config   Usage   Stats
+
+   Session
+
+   Total cost:            $0.0000
+   Total duration (API):  0s
+   Total duration (wall): 5s
+   Total code changes:    0 lines added, 0 lines removed
+   Usage:                 0 input, 0 output, 0 cache read, 0 cache write
+
+   Current session
+   █████████████████████                              42% used
+   Resets 9:20pm (Asia/Tokyo)
+
+   Current week (all models)
+   ███████████                                        22% used
+   Resets Jun 23, 3am (Asia/Tokyo)
+
+   Current week (Sonnet only)
+                                                      0% used
+
+   What's contributing to your limits usage?
+   Approximate, based on local sessions on this machine — does not include other devices or claude.ai
+`;
+
 const ANSI_USAGE_OUTPUT = `\x1b[2J\x1b[H\x1b[1m   Current session\x1b[0m
    \x1b[36m██\x1b[0m                                                 4% used
    Resets 8:20pm (Asia/Tokyo)
@@ -176,6 +208,18 @@ describe("parseUsage", () => {
     expect(parsed?.weeklyAllPercent).toBe(12);
     expect(parsed?.weeklySonnetPercent).toBeNull();
     expect(parsed?.weeklySonnetResets).toBeNull();
+  });
+
+  it("新UI フルスクリーン版 (2.1.183) の 3 区画をパース成功", () => {
+    const parsed = parseUsage(NEW_UI_FULLSCREEN_OUTPUT);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.sessionPercent).toBe(42);
+    expect(parsed?.weeklyAllPercent).toBe(22);
+    expect(parsed?.weeklySonnetPercent).toBe(0);
+    expect(parsed?.sessionResets).toBe("9:20pm (Asia/Tokyo)");
+    expect(parsed?.weeklyAllResets).toBe("Jun 23, 3am (Asia/Tokyo)");
+    // Sonnet 0% は Resets 行が無いので空文字
+    expect(parsed?.weeklySonnetResets).toBe("");
   });
 
   it("Team プラン (Sonnet 0% で Resets行欠落) も Sonnet resets を空文字でパース成功", () => {
@@ -288,6 +332,10 @@ Current week (Sonnet only)
 
   it("新UI ('What's contributing' アンカー + % used 2つ + Resets 2つ) → true", () => {
     expect(hasUsageResult(NEW_UI_USAGE_OUTPUT)).toBe(true);
+  });
+
+  it("新UI フルスクリーン版 (2.1.183 / Sonnet 表示あり % used 3つ) → true", () => {
+    expect(hasUsageResult(NEW_UI_FULLSCREEN_OUTPUT)).toBe(true);
   });
 
   it("旧UI で Sonnet 見出しは描画されたが Sonnet 行が未描画 → false (mid-render race防止)", () => {
@@ -534,6 +582,68 @@ describe("UsageCollector.collectOne", () => {
       args => args[3] === "1" && args.includes("Enter")
     );
     expect(trustAccepts).toHaveLength(1);
+  });
+
+  it("capture 前に pane を大きくリサイズして /usage TUI 全文を収める", async () => {
+    // /usage はフルスクリーン TUI で pane 高さより下の行を capture-pane で
+    // 取得できない。デフォルト pane だと Sonnet 区画がフォールド下に隠れ
+    // パース失敗するため、collector が window を大きく固定することを検証する。
+    const sessionPattern = "ark-usage-profA-1000";
+    const calls: string[][] = [];
+    const outputs = [
+      "", // 起動中
+      "❯ for shortcuts", // ready
+      NEW_UI_FULLSCREEN_OUTPUT, // /usage 結果
+    ];
+    let captureCount = 0;
+    const tmuxExec = (
+      args: string[]
+    ): { status: number; stdout: string; stderr: string } => {
+      calls.push(args);
+      const subcmd = args[0];
+      if (subcmd === "capture-pane") {
+        const stdout = outputs[Math.min(captureCount, outputs.length - 1)];
+        captureCount += 1;
+        return { status: 0, stdout, stderr: "" };
+      }
+      return { status: 0, stdout: "", stderr: "" };
+    };
+
+    const collector = new UsageCollector({
+      tmuxExec,
+      now: () => nowValue,
+      sleep: async () => {
+        nowValue += 200;
+      },
+    });
+
+    const entry = await collector.collectOne(profileA);
+    expect(entry.status).toBe("ok");
+    expect(entry.parsed?.weeklySonnetPercent).toBe(0);
+
+    // window-size manual + resize-window が new-session 直後に発行されること
+    const newSessionIdx = calls.findIndex(c => c[0] === "new-session");
+    const resizeIdx = calls.findIndex(c => c[0] === "resize-window");
+    const captureIdx = calls.findIndex(c => c[0] === "capture-pane");
+    expect(newSessionIdx).toBeGreaterThanOrEqual(0);
+    expect(resizeIdx).toBeGreaterThan(newSessionIdx);
+    expect(resizeIdx).toBeLessThan(captureIdx);
+
+    const manualOpt = calls.find(
+      c =>
+        c[0] === "set-option" &&
+        c.includes("window-size") &&
+        c.includes("manual")
+    );
+    expect(manualOpt).toBeDefined();
+    expect(manualOpt).toContain(sessionPattern);
+
+    const resize = calls[resizeIdx];
+    expect(resize).toContain(sessionPattern);
+    // 高さ(-y)が /usage 全文を収める十分な大きさであること
+    const yIdx = resize.indexOf("-y");
+    expect(yIdx).toBeGreaterThanOrEqual(0);
+    expect(Number(resize[yIdx + 1])).toBeGreaterThanOrEqual(50);
   });
 
   it("new-session失敗時は error", async () => {

--- a/packages/server/src/lib/usage-collector.ts
+++ b/packages/server/src/lib/usage-collector.ts
@@ -54,6 +54,24 @@ const TRUST_DIALOG_ANCHORS = ["trust this folder", "Quick safety check"];
 /** capture-paneの取得行数（/usage画面 + ヘッダ余裕分） */
 const CAPTURE_LINES = 300;
 
+/**
+ * /usage TUI 全文を 1 画面に収めるための強制 pane サイズ。
+ *
+ * `/usage` はフルスクリーン TUI で、pane の高さより下の行はレンダリングされず
+ * `capture-pane` で取得できない（フォールド下は `↓` インジケータになるだけで
+ * scrollback にも積まれない）。claude 2.1.183 で `/usage` 出力が縦に伸び
+ * （上部に `Settings` タブ追加 + Session 統計ブロック + 狭い pane での折り返し）、
+ * detached セッションのデフォルト pane（約 80x24）では
+ * 「Current week (Sonnet only)」の数値がフォールド下に隠れ、capture-pane が
+ * `% used` を 2 個しか拾えず `hasUsageResult` が永久に成立しない事象が発生した。
+ * pane を大きく固定し、全区画を 1 画面に収めてからキャプチャする。
+ *
+ * 既定の `window-size latest` だと `resize-window` / `new-session -x/-y` が
+ * クライアントサイズ追従で無効化されるため、`window-size manual` 併用が必須。
+ */
+const USAGE_PANE_WIDTH = 120;
+const USAGE_PANE_HEIGHT = 200;
+
 /** ポーリング間隔（ミリ秒） */
 const POLL_INTERVAL_MS = 200;
 
@@ -395,6 +413,28 @@ export class UsageCollector extends EventEmitter {
           errorMessage: `tmux new-session failed (status: ${newSession.status}, stderr: ${newSession.stderr.trim()})`,
         };
       }
+
+      // pane を大きく固定して /usage TUI 全文を 1 画面に収める
+      // （フォールド下のキャプチャ漏れ防止）。claude 起動前にリサイズして
+      // 最初から大きいサイズで描画させる。`window-size manual` にしないと
+      // resize-window が既定の `latest` に上書きされて効かない。
+      // best-effort: 失敗しても後続のタイムアウト検出に委ねる。
+      this.deps.tmuxExec([
+        "set-option",
+        "-t",
+        sessionName,
+        "window-size",
+        "manual",
+      ]);
+      this.deps.tmuxExec([
+        "resize-window",
+        "-t",
+        sessionName,
+        "-x",
+        String(USAGE_PANE_WIDTH),
+        "-y",
+        String(USAGE_PANE_HEIGHT),
+      ]);
 
       // シェル起動後に claude を送信。CLAUDE_LAUNCH_COMMAND は起動時に
       // 解決した絶対パスを使うので、PATH に claude が無い pm2/systemd 環境


### PR DESCRIPTION
## 概要

プロファイルの使用量取得（`/usage`）が「パースに失敗しました」となる不具合を修正します。

## 原因

`/usage` はフルスクリーン TUI で、pane の高さより下の行はレンダリングされず `capture-pane` で取得できません（フォールド下は `↓` インジケータになるだけで scrollback にも積まれない）。

claude 2.1.183 で `/usage` 出力が縦に伸び（上部に `Settings` タブ追加 + Session 統計ブロック + 狭い pane での折り返し）、detached セッションのデフォルト pane（約 80x24）では「Current week (Sonnet only)」の数値がフォールド下に隠れます。その結果 `capture-pane` が `% used` を 2 個しか拾えず、`hasUsageResult`（Sonnet 見出しがある場合は `% used` 3 個を要求）が成立せず、タイムアウト／パース失敗となっていました。

## 修正

`UsageCollector.collectOne()` で `new-session` 直後・claude 起動前に `window-size manual` + `resize-window` を発行し、pane を 120x200 に固定します。これで `/usage` 全文が 1 画面に収まり、確実にキャプチャできます。

- 既定の `window-size latest` だと `resize-window` / `new-session -x/-y` がクライアントサイズ追従で無効化されるため、`window-size manual` 併用が必須
- リサイズ失敗は best-effort（後続のタイムアウト検出に委ねる）

## 検証

- 新フォーマット（2.1.183 フルスクリーン版）の `parseUsage` / `hasUsageResult` 回帰テスト、および collector がリサイズを発行することのテストを追加（usage-collector 全 34 件パス）
- server パッケージ型チェック通過（`tsc --noEmit` exit 0）
- 実機: リサイズ前 pane=69x23 で `% used` 2 個 → リサイズ後 120x200 で session / weekly all / Sonnet の 3 区画すべて取得を確認
- ローカル本番（pm2）へデプロイ済みで動作確認可能


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * フルスクリーンUIでの使用状況の表示と解析の信頼性を向上

* **Tests**
  * 新UI対応のテストを拡張
  * ウィンドウサイズ調整処理の動作検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->