### PR TITLE
fix(web): worktree を repoPath ごとに保持しリロードで消えないようにする

### DIFF
--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -623,6 +623,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         typeof c.id === "string" &&
         c.id.length > 0 &&
         typeof c.path === "string" &&
+        c.path.length > 0 &&
         typeof c.branch === "string" &&
         typeof c.commit === "string" &&
         typeof c.isMain === "boolean" &&
@@ -632,8 +633,11 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
 
     socket.on("worktree:list", ({ repoPath: listRepoPath, worktrees: wts }) => {
       if (!isAllowedWorktreeRepo(listRepoPath) || !Array.isArray(wts)) return;
-      const valid = wts.filter(isValidWorktree);
-      setWorktreesByRepo(prev => setRepoWorktrees(prev, listRepoPath, valid));
+      // worktree:list は repo の authoritative snapshot。不正 item を filter で
+      // 黙って落とすと部分リストが「正」として保存され、schema drift / 壊れた
+      // payload で worktree が静かに消える。1件でも不正なら list 全体を拒否する。
+      if (!wts.every(isValidWorktree)) return;
+      setWorktreesByRepo(prev => setRepoWorktrees(prev, listRepoPath, wts));
     });
 
     socket.on("worktree:created", ({ repoPath: eventRepoPath, worktree }) => {

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -29,9 +29,18 @@ import type {
   UsageReport,
   Worktree,
 } from "@ark/shared";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { io, type Socket } from "socket.io-client";
 import { toast } from "sonner";
+import {
+  addWorktree,
+  clearRepo,
+  flattenWorktrees,
+  pruneToRepos,
+  removeWorktree,
+  setRepoWorktrees,
+  type WorktreesByRepo,
+} from "./worktreesByRepo";
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
@@ -253,6 +262,11 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   const [repoList, setRepoList] = useState<string[]>(
     options.initialRepoList ?? []
   );
+  // worktree:* イベント受信時に最新の repoList で許可判定するための ref。
+  // 登録外/削除済み repo への遅延 worktree:list や不正 payload で bucket が
+  // 復活するのを防ぐ（毎レンダー同期。socket ハンドラは登録時クロージャから参照）。
+  const repoListRef = useRef(repoList);
+  repoListRef.current = repoList;
   const [repoPath, setRepoPath] = useState<string | null>(
     options.initialRepoPath ?? null
   );
@@ -270,7 +284,18 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
    */
   const confirmedRepoPathRef = useRef<string | null>(null);
 
-  const [worktrees, setWorktrees] = useState<Worktree[]>([]);
+  // worktree は repoPath ごとに bucket 分けして保持する。
+  // 単一配列で上書き保持していた旧実装は「現在選択中の1リポジトリ」分しか
+  // worktree を持てず、リロード時に選択中以外のリポジトリの worktree が
+  // サイドバーから丸ごと消えていた（複数 repo をまたいで同時に保持できなかった）。
+  const [worktreesByRepo, setWorktreesByRepo] = useState<WorktreesByRepo>(
+    () => new Map()
+  );
+  // 消費側（サイドバー等）へは全 repo を平坦化した配列で公開する（既存 API 互換）。
+  const worktrees = useMemo(
+    () => flattenWorktrees(worktreesByRepo, repoList),
+    [worktreesByRepo, repoList]
+  );
   const [deletedWorktreeId, setDeletedWorktreeId] = useState<string | null>(
     null
   );
@@ -410,6 +435,21 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     }
   }, [repoList]);
 
+  // repoList の全リポジトリの worktree を取得する。
+  // サーバーは repo:select 応答時に選択中repoの worktree:list しか返さないため、
+  // これが無いと選択中以外のリポジトリの worktree がサイドバーに出ない
+  // （リロードで「別リポジトリが丸ごと消える」原因）。接続時/repoList変化時に
+  // 全repo分を明示的にリクエストし、不要になったrepoのbucketは掃除する。
+  useEffect(() => {
+    if (!isConnected) return;
+    const socket = socketRef.current;
+    if (!socket) return;
+    setWorktreesByRepo(prev => pruneToRepos(prev, repoList));
+    for (const repo of repoList) {
+      socket.emit("worktree:list", repo);
+    }
+  }, [isConnected, repoList]);
+
   // Initialize socket connection（enabled=falseの間は接続しない）
   const enabled = options.enabled ?? true;
   useEffect(() => {
@@ -526,8 +566,8 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       if (errorRepoPath === confirmedRepoPathRef.current) {
         setError(errMsg);
         // server側がrepo:set後にworktree取得で失敗するケース（listWorktrees throw 等）。
-        // worktreesは前repoのstaleデータが残るため、確認済みrepoには有効データがない事を表すため空にする。
-        setWorktrees([]);
+        // 当該repoのbucketだけを破棄する（他repoのworktreeは保持したまま）。
+        setWorktreesByRepo(prev => clearRepo(prev, errorRepoPath));
         return;
       }
       setError(errMsg);
@@ -557,32 +597,61 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       }
     });
 
-    /**
-     * worktree系イベントの受け入れ判定。
-     * ユーザーの最新意図 (pendingRepoPathRef) を最優先で使用し、未設定時は確認済み (repoPathRef) で判定する。
-     * pendingベースで判定する理由: 直前のselectRepo(B)後にA向け遅延応答が届いた場合、
-     * refはまだAだが意図はBなので、Aのlistを誤って適用しないようにする。
-     */
-    const eventTargetRepoPath = (): string | null =>
-      pendingRepoPathRef.current ?? repoPathRef.current;
-
     // Worktree events
+    // 各イベントは payload の repoPath で bucket を特定して更新する。
+    // repoPath ごとに分離保持するため、別 repo の遅延応答が届いても
+    // その repo の bucket だけが更新され、他 repo を破壊しない
+    // （旧実装の eventTargetRepoPath による stale-drop は不要になった）。
+    //
+    // worktree イベントを受理してよい repo か判定する allowlist。
+    // 登録外/削除済み repo への遅延 worktree:list や不正な payload で、サイドバーに
+    // 想定外の path が復活するのを防ぐ。runtime では非 string も来うる前提で type guard。
+    // 空 path も弾く（repoList に含まれないため）。選択直後は confirmedRepoPathRef が
+    // 同期更新済み（repo:set 参照）なので、repoList state 反映前の worktree:list も取りこぼさない。
+    const isAllowedWorktreeRepo = (path: unknown): path is string =>
+      typeof path === "string" &&
+      (repoListRef.current.includes(path) ||
+        path === confirmedRepoPathRef.current);
+
+    // payload 健全性チェック。イベントは型付き（ServerToClientEvents）だが、
+    // socket 境界では実行時に壊れた payload が届きうるため、helper へ渡す前に
+    // Worktree の全必須フィールドの型・非空性を検証して例外終了や不正 state 流入を防ぐ。
+    const isValidWorktree = (w: unknown): w is Worktree => {
+      if (typeof w !== "object" || w === null) return false;
+      const c = w as Record<string, unknown>;
+      return (
+        typeof c.id === "string" &&
+        c.id.length > 0 &&
+        typeof c.path === "string" &&
+        typeof c.branch === "string" &&
+        typeof c.commit === "string" &&
+        typeof c.isMain === "boolean" &&
+        typeof c.isBare === "boolean"
+      );
+    };
+
     socket.on("worktree:list", ({ repoPath: listRepoPath, worktrees: wts }) => {
-      const target = eventTargetRepoPath();
-      if (target !== null && listRepoPath !== target) return;
-      setWorktrees(wts);
+      if (!isAllowedWorktreeRepo(listRepoPath) || !Array.isArray(wts)) return;
+      const valid = wts.filter(isValidWorktree);
+      setWorktreesByRepo(prev => setRepoWorktrees(prev, listRepoPath, valid));
     });
 
     socket.on("worktree:created", ({ repoPath: eventRepoPath, worktree }) => {
-      const target = eventTargetRepoPath();
-      if (target !== null && eventRepoPath !== target) return;
-      setWorktrees(prev => [...prev, worktree]);
+      if (!isAllowedWorktreeRepo(eventRepoPath) || !isValidWorktree(worktree)) {
+        return;
+      }
+      setWorktreesByRepo(prev => addWorktree(prev, eventRepoPath, worktree));
     });
 
     socket.on("worktree:deleted", ({ repoPath: eventRepoPath, worktreeId }) => {
-      const target = eventTargetRepoPath();
-      if (target !== null && eventRepoPath !== target) return;
-      setWorktrees(prev => prev.filter(w => w.id !== worktreeId));
+      if (typeof worktreeId !== "string" || worktreeId.length === 0) return;
+      // 信頼できない repo 由来のイベントで bucket / グローバル UI state を動かさない。
+      // bucket 削除と deletedWorktreeId（該当ペインのクローズ等）はどちらも
+      // allowlist repo のイベントに限定する（3 ハンドラで一貫した受理条件）。
+      if (!isAllowedWorktreeRepo(eventRepoPath)) return;
+      setWorktreesByRepo(prev =>
+        removeWorktree(prev, eventRepoPath, worktreeId)
+      );
       setDeletedWorktreeId(worktreeId);
     });
 
@@ -1087,6 +1156,8 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     (path: string) => {
       // コールバック通知はuseEffectで行う（StrictMode二重実行対策）
       setRepoList(prev => prev.filter(p => p !== path));
+      // 除外したリポジトリの worktree bucket も破棄する（他repoは保持）
+      setWorktreesByRepo(prev => clearRepo(prev, path));
 
       // 削除したリポジトリが選択中の場合はクリア
       if (repoPath === path) {
@@ -1095,7 +1166,6 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         pendingRepoPathRef.current = null;
         confirmedRepoPathRef.current = null;
         setRepoPath(null);
-        setWorktrees([]);
       }
     },
     [repoPath]

--- a/packages/web/src/hooks/worktreesByRepo.test.ts
+++ b/packages/web/src/hooks/worktreesByRepo.test.ts
@@ -1,0 +1,197 @@
+import type { Worktree } from "@ark/shared";
+import { describe, expect, it } from "vitest";
+import {
+  addWorktree,
+  clearRepo,
+  flattenWorktrees,
+  pruneToRepos,
+  removeWorktree,
+  setRepoWorktrees,
+  type WorktreesByRepo,
+} from "./worktreesByRepo";
+
+function wt(id: string, path: string): Worktree {
+  return {
+    id,
+    path,
+    branch: id,
+    commit: "abc123",
+    isMain: false,
+    isBare: false,
+  };
+}
+
+const REPO_A = "/work/a";
+const REPO_B = "/work/b";
+
+describe("worktreesByRepo", () => {
+  describe("setRepoWorktrees", () => {
+    it("repo ごとに worktree リストを保持し、他 repo を破壊しない", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [wt("a1", "/work/a/wt1")]);
+      state = setRepoWorktrees(state, REPO_B, [wt("b1", "/work/b/wt1")]);
+
+      expect(state.get(REPO_A)).toHaveLength(1);
+      expect(state.get(REPO_B)).toHaveLength(1);
+      // 別 repo を上書きしない（これが「丸ごと消える」バグの修正点）
+      expect(flattenWorktrees(state)).toHaveLength(2);
+    });
+
+    it("同じ repo を再受信したら丸ごと差し替える", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [wt("a1", "/work/a/wt1")]);
+      state = setRepoWorktrees(state, REPO_A, [
+        wt("a2", "/work/a/wt2"),
+        wt("a3", "/work/a/wt3"),
+      ]);
+      expect(state.get(REPO_A)?.map(w => w.id)).toEqual(["a2", "a3"]);
+    });
+
+    it("元の Map を変更しない（イミュータブル）", () => {
+      const prev: WorktreesByRepo = new Map();
+      const next = setRepoWorktrees(prev, REPO_A, [wt("a1", "/work/a/wt1")]);
+      expect(prev.size).toBe(0);
+      expect(next).not.toBe(prev);
+    });
+
+    it("入力配列・要素をコピーして保持する（呼び出し元の mutation が波及しない）", () => {
+      const input = [wt("a1", "/work/a/wt1")];
+      const state = setRepoWorktrees(new Map(), REPO_A, input);
+      // 配列の後続 push は波及しない
+      input.push(wt("a2", "/work/a/wt2"));
+      expect(state.get(REPO_A)).toHaveLength(1);
+      expect(state.get(REPO_A)).not.toBe(input);
+      // 要素オブジェクトの後続 mutation も波及しない（浅いコピー）
+      input[0].branch = "mutated";
+      expect(state.get(REPO_A)?.[0]?.branch).toBe("a1");
+    });
+  });
+
+  describe("addWorktree", () => {
+    it("該当 repo に1件追加する", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [wt("a1", "/work/a/wt1")]);
+      state = addWorktree(state, REPO_A, wt("a2", "/work/a/wt2"));
+      expect(state.get(REPO_A)?.map(w => w.id)).toEqual(["a1", "a2"]);
+    });
+
+    it("未知の repo でも bucket を新規作成する", () => {
+      const state = addWorktree(new Map(), REPO_B, wt("b1", "/work/b/wt1"));
+      expect(state.get(REPO_B)?.map(w => w.id)).toEqual(["b1"]);
+    });
+
+    it("重複 id は追加しない（再接続時の二重 created 対策）", () => {
+      let state: WorktreesByRepo = new Map();
+      state = addWorktree(state, REPO_A, wt("a1", "/work/a/wt1"));
+      const before = state;
+      state = addWorktree(state, REPO_A, wt("a1", "/work/a/wt1"));
+      expect(state.get(REPO_A)).toHaveLength(1);
+      expect(state).toBe(before); // 変化なしなら同一参照
+    });
+  });
+
+  describe("removeWorktree", () => {
+    it("該当 repo から id 一致を削除する", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [
+        wt("a1", "/work/a/wt1"),
+        wt("a2", "/work/a/wt2"),
+      ]);
+      state = removeWorktree(state, REPO_A, "a1");
+      expect(state.get(REPO_A)?.map(w => w.id)).toEqual(["a2"]);
+    });
+
+    it("存在しない id なら状態を変えない", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [wt("a1", "/work/a/wt1")]);
+      const before = state;
+      state = removeWorktree(state, REPO_A, "zzz");
+      expect(state).toBe(before);
+    });
+
+    it("未知の repo なら状態を変えない", () => {
+      const before: WorktreesByRepo = new Map();
+      const after = removeWorktree(before, REPO_B, "a1");
+      expect(after).toBe(before);
+    });
+  });
+
+  describe("clearRepo", () => {
+    it("repo の bucket ごと破棄する", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [wt("a1", "/work/a/wt1")]);
+      state = setRepoWorktrees(state, REPO_B, [wt("b1", "/work/b/wt1")]);
+      state = clearRepo(state, REPO_A);
+      expect(state.has(REPO_A)).toBe(false);
+      expect(state.has(REPO_B)).toBe(true);
+    });
+
+    it("未知の repo なら状態を変えない", () => {
+      const before: WorktreesByRepo = new Map();
+      expect(clearRepo(before, REPO_A)).toBe(before);
+    });
+  });
+
+  describe("pruneToRepos", () => {
+    it("repoList に無い repo の bucket を掃除する", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [wt("a1", "/work/a/wt1")]);
+      state = setRepoWorktrees(state, REPO_B, [wt("b1", "/work/b/wt1")]);
+      state = pruneToRepos(state, [REPO_A]);
+      expect(state.has(REPO_A)).toBe(true);
+      expect(state.has(REPO_B)).toBe(false);
+    });
+
+    it("掃除対象が無ければ同一参照を返す", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [wt("a1", "/work/a/wt1")]);
+      expect(pruneToRepos(state, [REPO_A])).toBe(state);
+    });
+  });
+
+  describe("flattenWorktrees", () => {
+    it("全 repo の worktree を1配列に平坦化する", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [
+        wt("a1", "/work/a/wt1"),
+        wt("a2", "/work/a/wt2"),
+      ]);
+      state = setRepoWorktrees(state, REPO_B, [wt("b1", "/work/b/wt1")]);
+      expect(
+        flattenWorktrees(state)
+          .map(w => w.id)
+          .sort()
+      ).toEqual(["a1", "a2", "b1"]);
+    });
+
+    it("空なら空配列", () => {
+      expect(flattenWorktrees(new Map())).toEqual([]);
+    });
+
+    it("repoOrder を渡すとその順で flatten する（到着順非依存）", () => {
+      // 挿入順は B → A だが、repoOrder で A → B を指定する
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_B, [wt("b1", "/work/b/wt1")]);
+      state = setRepoWorktrees(state, REPO_A, [
+        wt("a1", "/work/a/wt1"),
+        wt("a2", "/work/a/wt2"),
+      ]);
+      expect(flattenWorktrees(state, [REPO_A, REPO_B]).map(w => w.id)).toEqual([
+        "a1",
+        "a2",
+        "b1",
+      ]);
+    });
+
+    it("repoOrder に無い bucket は末尾に挿入順で付ける（取りこぼし防止）", () => {
+      let state: WorktreesByRepo = new Map();
+      state = setRepoWorktrees(state, REPO_A, [wt("a1", "/work/a/wt1")]);
+      state = setRepoWorktrees(state, REPO_B, [wt("b1", "/work/b/wt1")]);
+      // repoOrder に REPO_A のみ → REPO_B は末尾に残る
+      expect(flattenWorktrees(state, [REPO_A]).map(w => w.id)).toEqual([
+        "a1",
+        "b1",
+      ]);
+    });
+  });
+});

--- a/packages/web/src/hooks/worktreesByRepo.ts
+++ b/packages/web/src/hooks/worktreesByRepo.ts
@@ -1,0 +1,130 @@
+/**
+ * worktreesByRepo - repoPath ごとに worktree リストを保持するイミュータブルな状態ヘルパー
+ *
+ * 背景: サイドバーは複数リポジトリを repoList でグルーピングして表示するが、
+ * 旧実装は `worktrees: Worktree[]` を単一 state で保持し、worktree:list 受信のたびに
+ * 丸ごと上書きしていた。このため worktree を取得できるのは「現在選択中の1リポジトリ」
+ * だけで、リロード時に選択中以外のリポジトリの worktree がサイドバーから丸ごと消えていた。
+ *
+ * 本ヘルパーは worktree を repoPath ごとの bucket に分けて保持することで、複数リポジトリの
+ * worktree を同時に保持できるようにする。useSocket から純粋ロジックを切り出してテスト可能にする。
+ *
+ * 前提: repoPath / worktree.id の非空・正当性は呼び出し側（useSocket の socket ハンドラ）で
+ * allowlist 検証済みであること。本ヘルパーは検証済み入力を受け取る純粋な state 変換に徹する。
+ */
+
+import type { Worktree } from "@ark/shared";
+
+// React state として扱うため、helper は常に新しい Map を返す（参照が変わるので再描画される）。
+// 深い不変性まで型で強制するため ReadonlyMap + readonly 配列で公開し、
+// 呼び出し側が state.get(repo)?.push(...) のような直接変異をできないようにする。
+export type WorktreesByRepo = ReadonlyMap<string, readonly Worktree[]>;
+
+/** repo の worktree リストを丸ごと差し替える（worktree:list 受信時） */
+export function setRepoWorktrees(
+  prev: WorktreesByRepo,
+  repoPath: string,
+  worktrees: Worktree[]
+): WorktreesByRepo {
+  const next = new Map(prev);
+  // 受け取った配列・要素をそのまま保持すると、呼び出し元や payload 側の後続 mutation
+  // （worktrees.push(...) や worktrees[0].branch = ... 等）が setter を通さず state に
+  // 波及する。配列と各要素を浅くコピーして helper の immutable 契約を守る。
+  next.set(
+    repoPath,
+    worktrees.map(w => ({ ...w }))
+  );
+  return next;
+}
+
+/** repo に worktree を1件追加（worktree:created）。重複 id は無視する */
+export function addWorktree(
+  prev: WorktreesByRepo,
+  repoPath: string,
+  worktree: Worktree
+): WorktreesByRepo {
+  const cur = prev.get(repoPath) ?? [];
+  if (cur.some(w => w.id === worktree.id)) return prev;
+  const next = new Map(prev);
+  // 追加要素も浅くコピーして、呼び出し元の後続 mutation が state に波及しないようにする。
+  next.set(repoPath, [...cur, { ...worktree }]);
+  return next;
+}
+
+/** worktree を1件削除（worktree:deleted）。変化が無ければ同一参照を返す */
+export function removeWorktree(
+  prev: WorktreesByRepo,
+  repoPath: string,
+  worktreeId: string
+): WorktreesByRepo {
+  const cur = prev.get(repoPath);
+  if (!cur) return prev;
+  const filtered = cur.filter(w => w.id !== worktreeId);
+  if (filtered.length === cur.length) return prev;
+  const next = new Map(prev);
+  next.set(repoPath, filtered);
+  return next;
+}
+
+/** repo の bucket ごと破棄する（removeRepo / repo:error）。変化が無ければ同一参照を返す */
+export function clearRepo(
+  prev: WorktreesByRepo,
+  repoPath: string
+): WorktreesByRepo {
+  if (!prev.has(repoPath)) return prev;
+  const next = new Map(prev);
+  next.delete(repoPath);
+  return next;
+}
+
+/**
+ * repoList に含まれない repo の bucket を掃除する（メモリ衛生）。
+ * 変化が無ければ同一参照を返す。
+ */
+export function pruneToRepos(
+  prev: WorktreesByRepo,
+  repos: string[]
+): WorktreesByRepo {
+  const allowed = new Set(repos);
+  let changed = false;
+  for (const repoPath of prev.keys()) {
+    if (!allowed.has(repoPath)) {
+      changed = true;
+      break;
+    }
+  }
+  if (!changed) return prev;
+  const next = new Map<string, readonly Worktree[]>();
+  for (const [repoPath, worktrees] of prev) {
+    if (allowed.has(repoPath)) next.set(repoPath, worktrees);
+  }
+  return next;
+}
+
+/**
+ * 全 repo の worktree を1配列に平坦化する（消費側へ公開する配列）。
+ *
+ * repoOrder を渡すと、その順で flatten する。Map の挿入順は worktree:list 応答の
+ * 到着順に左右されるため、repoList 順を渡すことで公開配列の順序を安定させる
+ * （リロードごとにサイドバーの並びが揺れるのを防ぐ）。repoOrder に無い bucket は
+ * 取りこぼし防止のため挿入順で末尾に付ける。
+ */
+export function flattenWorktrees(
+  byRepo: WorktreesByRepo,
+  repoOrder?: string[]
+): Worktree[] {
+  if (!repoOrder) return Array.from(byRepo.values()).flat();
+  const result: Worktree[] = [];
+  const seen = new Set<string>();
+  for (const repoPath of repoOrder) {
+    const wts = byRepo.get(repoPath);
+    if (wts) {
+      result.push(...wts);
+      seen.add(repoPath);
+    }
+  }
+  for (const [repoPath, wts] of byRepo) {
+    if (!seen.has(repoPath)) result.push(...wts);
+  }
+  return result;
+}


### PR DESCRIPTION
## 概要

ブラウザをリロードすると、サイドパネルから**選択中以外のリポジトリの worktree が丸ごと消える**バグを修正する。

## 原因

`useSocket` は worktree を単一配列 state (`worktrees: Worktree[]`) で保持し、`worktree:list` を受信するたびに丸ごと上書きしていた。サーバーは `repo:select` 応答時に**選択中リポジトリの worktree:list しか返さない**ため、保持できるのは常に1リポジトリ分のみ。リロード直後は選択中リポジトリの worktree しか取得されず、それ以外のリポジトリの worktree がサイドバーから消えていた。

## 修正

- **`worktreesByRepo.ts`（新規）**: worktree を `repoPath` ごとの bucket に分けて保持する純粋ロジック（`setRepoWorktrees` / `addWorktree` / `removeWorktree` / `clearRepo` / `pruneToRepos` / `flattenWorktrees`）。`ReadonlyMap<string, readonly Worktree[]>` で公開し、要素まで浅くコピーしてイミュータビリティを保証。
- **`useSocket`**: 内部状態を `Map<repoPath, Worktree[]>` 化し、消費側へは `repoList` 順で平坦化した配列で公開（既存 API 互換）。**接続時 / repoList 変化時に全リポジトリ分の `worktree:list` を取得する effect** を追加（これが本修正の核）。不要になったリポジトリの bucket は掃除する。
- **受信境界の堅牢化**: `worktree:list/created/deleted` は payload の `repoPath` を repoList 許可リスト（+選択直後の confirmedRepoPath）で検証し、登録外/削除済みリポジトリへの遅延応答や不正 payload で bucket が復活するのを防ぐ。Worktree の全必須フィールドを実行時検証。別リポジトリの遅延応答が他リポジトリを破壊しなくなったため、旧 `eventTargetRepoPath` による stale-drop を撤去。

## テスト

- `worktreesByRepo.test.ts`: 純粋ロジック 18 ケース（repoごと保持 / イミュータビリティ / 入力コピー / 重複除外 / repoOrder 順序）
- biome / tsc クリーン

## レビュー状況（要確認）

push 前 Codex レビュー（P5 相当）を6ラウンド実施。実バグ関連の指摘（受信時 allowlist 検証・削除通知の発火条件・payload バリデーション）は対応済み。ただし以降のラウンドで Codex が**矛盾する [P1] を出し続ける非収束状態**（例: 削除通知の発火条件をラウンド間で逆方向に要求）になったため、ユーザー判断で打ち切り。残る指摘は自前の型付き Socket.IO イベントに対する追加防御要求（payload エンベロープ自体の object 検証、path-repoPath 整合性検証等）で、優先度は P2 相当と判断している。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * Worktree の表示更新を repo ごとに分離し、別 repo の更新で表示が崩れにくくなりました。
  * 遅延イベントや不正なデータが届いても、対象の repo のみを更新・破棄するようになりました。
  * リポジトリの切り替えや削除時に、不要な worktree 表示が残りにくくなりました。
* **テスト**
  * repo 単位の更新、追加・削除、一覧の整形（順序を含む）を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->