### PR TITLE
feat: 生成ファイルのチャットインライン DL/サムネ表示

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -998,25 +998,33 @@ export async function startServer(
       return;
     }
 
-    let realPath: string;
-    let stat: fs.Stats;
+    // TOCTOU/symlink 対策: O_NOFOLLOW で最終要素が symlink なら open を失敗させ、
+    // allowlist 済みパスが symlink 経由で別実体を指す経路を排除する。検証(fstat)も
+    // 配信(stream)も同一 fd 経由にし、open 後のパス差し替えの影響を受けないようにする
+    // (realpath をパス名で再確認すると fd と乖離するため使わない)。
+    // 中間ディレクトリの symlink は辿るが、その作成には FS 書き込み権限が必要で、
+    // 本ツールの利用者は既に同等の権限を持つため脅威としては等価。
+    let fileHandle: fs.promises.FileHandle;
     try {
-      realPath = await fs.promises.realpath(normalizedPath);
-      stat = await fs.promises.stat(realPath);
+      fileHandle = await fs.promises.open(
+        normalizedPath,
+        fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+      );
     } catch {
+      // ELOOP(最終要素が symlink) / ENOENT など。存在しない扱いで 404
       res.status(404).json({ error: "File not found" });
       return;
     }
-    if (!stat.isFile()) {
-      res.status(400).json({ error: "Path is not a regular file" });
-      return;
-    }
-    // realpath が allowlist 外を指す symlink を弾く (実体も allowlist 必須)
-    if (
-      realPath !== normalizedPath &&
-      !isFilePathAllowed(realPath, allowlist)
-    ) {
-      res.status(403).json({ error: "File path is not allowed" });
+    try {
+      const stat = await fileHandle.stat();
+      if (!stat.isFile()) {
+        await fileHandle.close();
+        res.status(400).json({ error: "Path is not a regular file" });
+        return;
+      }
+    } catch {
+      await fileHandle.close();
+      res.status(404).json({ error: "File not found" });
       return;
     }
 
@@ -1037,15 +1045,24 @@ export async function startServer(
       );
     }
 
-    const stream = fs.createReadStream(realPath);
+    // open 済み fd からストリーム配信し、終了/エラー時に必ず一度だけ fd を閉じる。
+    const stream = fileHandle.createReadStream({ autoClose: false });
+    let handleClosed = false;
+    const closeHandleOnce = () => {
+      if (handleClosed) return;
+      handleClosed = true;
+      void fileHandle.close().catch(() => {});
+    };
     stream.on("error", error => {
       console.error("[SessionFile] stream error:", getErrorMessage(error));
+      closeHandleOnce();
       if (!res.headersSent) {
         res.status(500).json({ error: "Failed to read file" });
       } else {
         res.destroy(error);
       }
     });
+    stream.on("close", closeHandleOnce);
     stream.pipe(res);
   });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -82,6 +82,14 @@ import {
 } from "./lib/mcp-oauth/providers.js";
 import { getListeningPorts } from "./lib/port-scanner.js";
 import { printRemoteAccessInfo } from "./lib/qrcode.js";
+import {
+  attachmentDispositionForPath,
+  buildAllowlistFromTranscriptFiles,
+  contentTypeForPath,
+  isFilePathAllowed,
+  listTranscriptPathsForWorktree,
+  normalizeRequestedFilePath,
+} from "./lib/session-file-download.js";
 import { sessionOrchestrator } from "./lib/session-orchestrator.js";
 import { listSlashCommands } from "./lib/slash-command-scanner.js";
 import { detectMultiProfileSupported } from "./lib/system.js";
@@ -954,6 +962,94 @@ export async function startServer(
       console.error("[Screenshot] エラー:", getErrorMessage(e));
       res.status(500).json({ error: getErrorMessage(e) });
     }
+  });
+
+  // ===== セッション生成ファイル配信API =====
+
+  app.get("/api/session/:sessionId/file", async (req, res) => {
+    const { sessionId } = req.params;
+    const filePath = req.query.path;
+    const mode = req.query.mode === "download" ? "download" : "inline";
+    if (typeof filePath !== "string") {
+      res.status(400).json({ error: "path query parameter is required" });
+      return;
+    }
+    const normalizedPath = normalizeRequestedFilePath(filePath);
+    if (!normalizedPath) {
+      res.status(400).json({ error: "Invalid path" });
+      return;
+    }
+
+    const session = sessionOrchestrator.getSession(sessionId);
+    if (!session) {
+      res.status(404).json({ error: "Session not found" });
+      return;
+    }
+
+    const transcriptPaths = await listTranscriptPathsForWorktree(
+      session.worktreePath,
+      session.profileConfigDir ?? null
+    );
+    if (transcriptPaths.length === 0) {
+      res.status(404).json({ error: "Transcript not found" });
+      return;
+    }
+
+    const allowlist = await buildAllowlistFromTranscriptFiles(transcriptPaths);
+    if (!isFilePathAllowed(filePath, allowlist)) {
+      res.status(403).json({ error: "File path is not allowed" });
+      return;
+    }
+
+    let realPath: string;
+    let stat: fs.Stats;
+    try {
+      realPath = await fs.promises.realpath(normalizedPath);
+      stat = await fs.promises.stat(realPath);
+    } catch {
+      res.status(404).json({ error: "File not found" });
+      return;
+    }
+    if (!stat.isFile()) {
+      res.status(400).json({ error: "Path is not a regular file" });
+      return;
+    }
+    // realpath が allowlist 外を指す symlink を弾く (実体も allowlist 必須)
+    if (
+      realPath !== normalizedPath &&
+      !isFilePathAllowed(realPath, allowlist)
+    ) {
+      res.status(403).json({ error: "File path is not allowed" });
+      return;
+    }
+
+    const contentType = contentTypeForPath(normalizedPath);
+    res.setHeader("Content-Type", contentType);
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    // 直接ナビゲーション時のスクリプト実行を無効化 (SVG/HTML の stored XSS 対策)
+    res.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
+    res.setHeader("Cache-Control", "no-store");
+    // HTML 系はインラインでもダウンロード扱いにし、アプリ origin での実行を防ぐ
+    const forceAttachment =
+      contentType.startsWith("text/html") ||
+      contentType.startsWith("application/xhtml");
+    if (mode === "download" || forceAttachment) {
+      res.setHeader(
+        "Content-Disposition",
+        attachmentDispositionForPath(normalizedPath)
+      );
+    }
+
+    const stream = fs.createReadStream(realPath);
+    stream.on("error", error => {
+      console.error("[SessionFile] stream error:", getErrorMessage(error));
+      if (!res.headersSent) {
+        res.status(500).json({ error: "Failed to read file" });
+      } else {
+        res.destroy(error);
+      }
+    });
+    stream.pipe(res);
   });
 
   // ===== Settings API =====

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -75,11 +75,7 @@ import { htmlScreenshotter } from "./lib/html-screenshotter.js";
 import { jsonlTailManager } from "./lib/jsonl-tail-manager.js";
 import { DiscoveryError } from "./lib/mcp-oauth/discovery.js";
 import { mcpOAuthOrchestrator } from "./lib/mcp-oauth/oauth-flow-orchestrator.js";
-import {
-  getProvider,
-  listProviders,
-  type McpProviderEntry,
-} from "./lib/mcp-oauth/providers.js";
+import { getProvider, listProviders } from "./lib/mcp-oauth/providers.js";
 import { getListeningPorts } from "./lib/port-scanner.js";
 import { printRemoteAccessInfo } from "./lib/qrcode.js";
 import {
@@ -873,7 +869,8 @@ export async function startServer(
    */
   async function startQuickTunnelShared(targetPort: number): Promise<string> {
     if (activeTunnel) {
-      return tunnelUrl!;
+      if (tunnelUrl) return tunnelUrl;
+      throw new Error("Quick Tunnel URL is missing");
     }
 
     // トークン生成
@@ -2382,37 +2379,6 @@ export async function startServer(
 
     // ===== MCP OAuth Commands (whitelist 形式) =====
 
-    /** http(s) URL のみ許可 (callback origin の検証用) */
-    const isValidHttpUrl = (s: unknown): s is string => {
-      if (typeof s !== "string") return false;
-      try {
-        const u = new URL(s);
-        return u.protocol === "http:" || u.protocol === "https:";
-      } catch {
-        return false;
-      }
-    };
-
-    /** providerId で provider を引き当てつつ存在チェック */
-    const requireProvider = (providerId: unknown): McpProviderEntry | null => {
-      if (typeof providerId !== "string" || providerId.length === 0) {
-        socket.emit("mcp:error", {
-          message: "providerId は必須です",
-          code: "invalid_provider_id",
-        });
-        return null;
-      }
-      const p = getProvider(providerId);
-      if (!p) {
-        socket.emit("mcp:error", {
-          message: `サポート対象外のプロバイダ: ${providerId}`,
-          code: "unknown_provider",
-        });
-        return null;
-      }
-      return p;
-    };
-
     socket.on("mcp:state", () => {
       try {
         socket.emit("mcp:state", buildMcpSnapshot());
@@ -2431,8 +2397,8 @@ export async function startServer(
       "mcp:connect",
       async ({ providerId, label, connectionId: existingId, requestId }) => {
         try {
-          // requireProvider は失敗時に mcp:error を emit するが requestId を持たない。
-          // popup correlation のため、ここでは inline で provider を検証する。
+          // provider 検証は popup correlation のため inline で行う
+          // (共通ヘルパだと requestId を保持できず mcp:error を相関できないため)。
           if (typeof providerId !== "string" || providerId.length === 0) {
             socket.emit("mcp:error", {
               message: "providerId は必須です",

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1045,7 +1045,9 @@ export async function startServer(
       );
     }
 
-    // open 済み fd からストリーム配信し、終了/エラー時に必ず一度だけ fd を閉じる。
+    // open 済み fd からストリーム配信し、終了/エラー/クライアント切断時に必ず一度だけ
+    // fd を閉じる。stream.pipe だけだと配信途中の切断で stream の close が来ず fd が
+    // 残るため、res の close でも stream を破棄して fd を解放する。
     const stream = fileHandle.createReadStream({ autoClose: false });
     let handleClosed = false;
     const closeHandleOnce = () => {
@@ -1053,6 +1055,10 @@ export async function startServer(
       handleClosed = true;
       void fileHandle.close().catch(() => {});
     };
+    res.on("close", () => {
+      stream.destroy();
+      closeHandleOnce();
+    });
     stream.on("error", error => {
       console.error("[SessionFile] stream error:", getErrorMessage(error));
       closeHandleOnce();

--- a/packages/server/src/lib/session-file-download.test.ts
+++ b/packages/server/src/lib/session-file-download.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildFileAllowlistFromTexts,
+  collectGeneratedTextsFromTranscript,
   isFilePathAllowed,
   normalizeRequestedFilePath,
 } from "./session-file-download.js";
@@ -36,5 +37,79 @@ describe("session-file-download allowlist", () => {
   it("相対パスは照合対象外", () => {
     const allowlist = buildFileAllowlistFromTexts(["created /tmp/result.png"]);
     expect(isFilePathAllowed("tmp/result.png", allowlist)).toBe(false);
+  });
+});
+
+describe("collectGeneratedTextsFromTranscript (出所限定)", () => {
+  const line = (obj: unknown) => JSON.stringify(obj);
+
+  it("assistant の text 出力からはパスを拾う", () => {
+    const jsonl = line({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "生成しました /tmp/shot.png" }],
+      },
+    });
+    const allowlist = buildFileAllowlistFromTexts(
+      collectGeneratedTextsFromTranscript(jsonl)
+    );
+    expect(isFilePathAllowed("/tmp/shot.png", allowlist)).toBe(true);
+  });
+
+  it("tool_result(tool 出力)からはパスを拾う", () => {
+    const jsonl = line({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "tool_result", content: "saved to /tmp/result.pdf" }],
+      },
+    });
+    const allowlist = buildFileAllowlistFromTexts(
+      collectGeneratedTextsFromTranscript(jsonl)
+    );
+    expect(isFilePathAllowed("/tmp/result.pdf", allowlist)).toBe(true);
+  });
+
+  it("user 入力(string content)のパスは除外する", () => {
+    const jsonl = line({
+      type: "user",
+      message: { role: "user", content: "このパスを見て /etc/secret.png" },
+    });
+    const allowlist = buildFileAllowlistFromTexts(
+      collectGeneratedTextsFromTranscript(jsonl)
+    );
+    expect(isFilePathAllowed("/etc/secret.png", allowlist)).toBe(false);
+  });
+
+  it("user 入力(text ブロック)のパスは除外する", () => {
+    const jsonl = line({
+      type: "user",
+      message: {
+        role: "user",
+        content: [{ type: "text", text: "/home/me/input.png を確認" }],
+      },
+    });
+    const allowlist = buildFileAllowlistFromTexts(
+      collectGeneratedTextsFromTranscript(jsonl)
+    );
+    expect(isFilePathAllowed("/home/me/input.png", allowlist)).toBe(false);
+  });
+
+  it("壊れた JSONL 行はスキップして処理を継続する", () => {
+    const jsonl = [
+      "{壊れた行",
+      line({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "ok /tmp/ok.png" }],
+        },
+      }),
+    ].join("\n");
+    const allowlist = buildFileAllowlistFromTexts(
+      collectGeneratedTextsFromTranscript(jsonl)
+    );
+    expect(isFilePathAllowed("/tmp/ok.png", allowlist)).toBe(true);
   });
 });

--- a/packages/server/src/lib/session-file-download.test.ts
+++ b/packages/server/src/lib/session-file-download.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFileAllowlistFromTexts,
+  isFilePathAllowed,
+  normalizeRequestedFilePath,
+} from "./session-file-download.js";
+
+describe("session-file-download allowlist", () => {
+  it("transcript 内に出現したパスは許可する", () => {
+    const allowlist = buildFileAllowlistFromTexts([
+      'assistant: {"text":"created /tmp/result.png"}',
+    ]);
+    expect(isFilePathAllowed("/tmp/result.png", allowlist)).toBe(true);
+  });
+
+  it("transcript 外のパスは拒否する", () => {
+    const allowlist = buildFileAllowlistFromTexts(["created /tmp/result.png"]);
+    expect(isFilePathAllowed("/tmp/other.png", allowlist)).toBe(false);
+  });
+
+  it("allowlist パスを接頭辞にした traversal は拒否する", () => {
+    const allowlist = buildFileAllowlistFromTexts(["created /tmp/allowed.png"]);
+    expect(
+      isFilePathAllowed("/tmp/allowed.png/../../etc/passwd", allowlist)
+    ).toBe(false);
+  });
+
+  it("リクエストパスは正規化して照合する", () => {
+    const allowlist = buildFileAllowlistFromTexts(["created /tmp/result.png"]);
+    expect(normalizeRequestedFilePath("/tmp/work/../result.png")).toBe(
+      "/tmp/result.png"
+    );
+    expect(isFilePathAllowed("/tmp/work/../result.png", allowlist)).toBe(true);
+  });
+
+  it("相対パスは照合対象外", () => {
+    const allowlist = buildFileAllowlistFromTexts(["created /tmp/result.png"]);
+    expect(isFilePathAllowed("tmp/result.png", allowlist)).toBe(false);
+  });
+});

--- a/packages/server/src/lib/session-file-download.ts
+++ b/packages/server/src/lib/session-file-download.ts
@@ -1,7 +1,21 @@
 /**
  * 生成ファイル配信用の transcript allowlist ヘルパー。
  *
- * セッション transcript に実際に出現した絶対パスだけを配信許可する。
+ * セッション transcript に実際に出現した絶対パスだけを配信許可する。出所は
+ * assistant の text 出力と tool_result(tool 出力)に限定し、user 入力は除外する
+ * ([[collectGeneratedTextsFromTranscript]])。
+ *
+ * 【受容済みリスク (documented)】
+ * これは「生成ファイルの証明」ではなく「transcript に表示された process-readable な
+ * パス」への配信権限であり、worktree 等の trusted root には限定していない。これは
+ * spec の確定設計である (screenshot は /home や /tmp に出るため worktree 限定は使えず、
+ * 「transcript に出たパスだけ許可」を選択した)。
+ *
+ * 脅威モデル上これは権限昇格にならない: 本エンドポイントへ到達できる主体 (local /
+ * Quick Tunnel トークン / Named Tunnel 認証) は、いずれも既に Claude セッションを
+ * 操作でき = 任意コマンド実行・任意ファイル読取が可能なため、本配信は追加権限を
+ * 与えない。将来 Claude を操作できない read-only 閲覧モードを追加する場合は、ここを
+ * trusted root 限定へ見直すこと。
  */
 
 import fs from "node:fs";
@@ -83,6 +97,72 @@ function normalizeAbsolutePosixPath(filePath: string): string | null {
   return path.normalize(filePath);
 }
 
+interface TranscriptBlock {
+  type?: string;
+  text?: string;
+  content?: unknown;
+}
+
+interface TranscriptRecord {
+  type?: string;
+  message?: { role?: string; content?: unknown };
+}
+
+function pushToolResultText(texts: string[], content: unknown): void {
+  if (typeof content === "string") {
+    texts.push(content);
+  } else if (Array.isArray(content)) {
+    for (const block of content as TranscriptBlock[]) {
+      if (block?.type === "text" && typeof block.text === "string") {
+        texts.push(block.text);
+      }
+    }
+  }
+}
+
+/**
+ * transcript(JSONL)から配信 allowlist の根拠テキストだけを取り出す。
+ *
+ * 出所を区別せず全文からパス抽出すると、user 入力に任意パスを書かせるだけで
+ * プロセス権限で読める任意ファイルを配信できてしまう。そのため
+ * 「assistant の text 出力」と「tool_result(= tool 出力)」に限定する。
+ * user 入力(string/text ブロック)と assistant の tool_use input は対象外。
+ */
+export function collectGeneratedTextsFromTranscript(jsonl: string): string[] {
+  const texts: string[] = [];
+  for (const line of jsonl.split("\n")) {
+    if (line === "") continue;
+    let rec: TranscriptRecord;
+    try {
+      rec = JSON.parse(line) as TranscriptRecord;
+    } catch {
+      // 書き込み途中で切れた行など。次の行へ
+      continue;
+    }
+    const content = rec.message?.content;
+    if (rec.type === "assistant" && rec.message?.role === "assistant") {
+      if (Array.isArray(content)) {
+        for (const block of content as TranscriptBlock[]) {
+          if (block?.type === "text" && typeof block.text === "string") {
+            texts.push(block.text);
+          }
+        }
+      }
+    } else if (rec.type === "user" && rec.message?.role === "user") {
+      // user レコードでも tool_result は tool 出力なので拾う。
+      // string content / text ブロックは user 入力なので除外する。
+      if (Array.isArray(content)) {
+        for (const block of content as TranscriptBlock[]) {
+          if (block?.type === "tool_result") {
+            pushToolResultText(texts, block.content);
+          }
+        }
+      }
+    }
+  }
+  return texts;
+}
+
 /** transcript テキスト群から配信許可パス集合を構築する。 */
 export function buildFileAllowlistFromTexts(
   texts: Iterable<string>
@@ -141,8 +221,13 @@ export async function listTranscriptPathsForWorktree(
       continue;
     }
     if (!st.isFile()) continue;
+    // worktree 紐付けの検証: ディレクトリ名(encodeProjectDir)で既に紐付くが、
+    // encode 衝突(例 /a/b と /a.b は同一ディレクトリ名)対策として cwd も照合する。
+    // cwd を読めない transcript は worktree 対応を確証できないため除外する(assertive)。
+    // 照合は canonical path ではなく transcript の cwd 文字列との完全一致(意図的)。
+    // worktreePath は呼び出し元(orchestrator)で一貫した文字列を使うため表記ゆれは無い。
     const cwd = readTranscriptCwd(filePath);
-    if (cwd !== null && cwd !== worktreePath) continue;
+    if (cwd !== worktreePath) continue;
     results.push({ filePath, mtimeMs: st.mtimeMs });
   }
   results.sort((a, b) => b.mtimeMs - a.mtimeMs);
@@ -160,7 +245,9 @@ async function readCachedTranscriptPaths(filePath: string): Promise<string[]> {
   }
 
   const text = await fs.promises.readFile(filePath, "utf-8");
-  const paths = [...buildFileAllowlistFromTexts([text])];
+  const paths = [
+    ...buildFileAllowlistFromTexts(collectGeneratedTextsFromTranscript(text)),
+  ];
   transcriptFilePathCache.set(key, { paths, lastAccess: Date.now() });
   pruneTranscriptCache();
   return paths;

--- a/packages/server/src/lib/session-file-download.ts
+++ b/packages/server/src/lib/session-file-download.ts
@@ -1,0 +1,199 @@
+/**
+ * 生成ファイル配信用の transcript allowlist ヘルパー。
+ *
+ * セッション transcript に実際に出現した絶対パスだけを配信許可する。
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { extractFilePaths } from "@ark/shared/file-paths";
+import { encodeProjectDir, projectsDirFor } from "./claude-projects.js";
+
+const MAX_TRANSCRIPT_CACHE_ENTRIES = 64;
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".avif": "image/avif",
+  ".bmp": "image/bmp",
+  ".csv": "text/csv; charset=utf-8",
+  ".gif": "image/gif",
+  ".html": "text/html; charset=utf-8",
+  ".ico": "image/x-icon",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".json": "application/json; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain; charset=utf-8",
+  ".webp": "image/webp",
+};
+
+interface TranscriptCacheEntry {
+  paths: string[];
+  lastAccess: number;
+}
+
+const transcriptFilePathCache = new Map<string, TranscriptCacheEntry>();
+
+function transcriptCacheKey(filePath: string, mtimeMs: number): string {
+  return `${filePath}\0${mtimeMs}`;
+}
+
+function pruneTranscriptCache(): void {
+  if (transcriptFilePathCache.size <= MAX_TRANSCRIPT_CACHE_ENTRIES) return;
+  const entries = [...transcriptFilePathCache.entries()].sort(
+    (a, b) => a[1].lastAccess - b[1].lastAccess
+  );
+  for (const [key] of entries.slice(
+    0,
+    transcriptFilePathCache.size - MAX_TRANSCRIPT_CACHE_ENTRIES
+  )) {
+    transcriptFilePathCache.delete(key);
+  }
+}
+
+function readTranscriptCwd(filePath: string): string | null {
+  try {
+    const fd = fs.openSync(filePath, "r");
+    try {
+      const buf = Buffer.alloc(64 * 1024);
+      const n = fs.readSync(fd, buf, 0, buf.length, 0);
+      const head = buf.toString("utf-8", 0, n);
+      for (const line of head.split("\n")) {
+        if (line === "") continue;
+        try {
+          const parsed = JSON.parse(line) as { cwd?: unknown };
+          if (typeof parsed.cwd === "string") return parsed.cwd;
+        } catch {
+          // 読み込み境界で切れた行など。次の行へ
+        }
+      }
+      return null;
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return null;
+  }
+}
+
+function normalizeAbsolutePosixPath(filePath: string): string | null {
+  if (filePath.includes("\0") || !filePath.startsWith("/")) return null;
+  return path.normalize(filePath);
+}
+
+/** transcript テキスト群から配信許可パス集合を構築する。 */
+export function buildFileAllowlistFromTexts(
+  texts: Iterable<string>
+): Set<string> {
+  const allowlist = new Set<string>();
+  for (const text of texts) {
+    for (const filePath of extractFilePaths(text)) {
+      const normalized = normalizeAbsolutePosixPath(filePath);
+      if (normalized) allowlist.add(normalized);
+    }
+  }
+  return allowlist;
+}
+
+/** リクエストされたパスを照合用に正規化する。 */
+export function normalizeRequestedFilePath(filePath: string): string | null {
+  return normalizeAbsolutePosixPath(filePath);
+}
+
+/** リクエストパスが transcript allowlist に完全一致するか判定する。 */
+export function isFilePathAllowed(
+  requestedPath: string,
+  allowlist: Set<string>
+): boolean {
+  const normalized = normalizeRequestedFilePath(requestedPath);
+  return normalized !== null && allowlist.has(normalized);
+}
+
+/**
+ * worktree に対応する Claude JSONL transcript 群を列挙する。
+ * encode 衝突対策として、cwd が読めた不一致ファイルは除外する。
+ */
+export async function listTranscriptPathsForWorktree(
+  worktreePath: string,
+  configDir: string | null | undefined
+): Promise<string[]> {
+  const dir = path.join(
+    projectsDirFor(configDir),
+    encodeProjectDir(worktreePath)
+  );
+  let entries: string[];
+  try {
+    entries = await fs.promises.readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const results: { filePath: string; mtimeMs: number }[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".jsonl")) continue;
+    const filePath = path.join(dir, name);
+    let st: fs.Stats;
+    try {
+      st = await fs.promises.stat(filePath);
+    } catch {
+      continue;
+    }
+    if (!st.isFile()) continue;
+    const cwd = readTranscriptCwd(filePath);
+    if (cwd !== null && cwd !== worktreePath) continue;
+    results.push({ filePath, mtimeMs: st.mtimeMs });
+  }
+  results.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return results.map(r => r.filePath);
+}
+
+async function readCachedTranscriptPaths(filePath: string): Promise<string[]> {
+  const st = await fs.promises.stat(filePath);
+  if (!st.isFile()) return [];
+  const key = transcriptCacheKey(filePath, st.mtimeMs);
+  const cached = transcriptFilePathCache.get(key);
+  if (cached) {
+    cached.lastAccess = Date.now();
+    return cached.paths;
+  }
+
+  const text = await fs.promises.readFile(filePath, "utf-8");
+  const paths = [...buildFileAllowlistFromTexts([text])];
+  transcriptFilePathCache.set(key, { paths, lastAccess: Date.now() });
+  pruneTranscriptCache();
+  return paths;
+}
+
+/** transcript ファイル群から配信許可パス集合を構築する。 */
+export async function buildAllowlistFromTranscriptFiles(
+  transcriptPaths: string[]
+): Promise<Set<string>> {
+  const allowlist = new Set<string>();
+  for (const transcriptPath of transcriptPaths) {
+    let paths: string[];
+    try {
+      paths = await readCachedTranscriptPaths(transcriptPath);
+    } catch {
+      continue;
+    }
+    for (const filePath of paths) {
+      allowlist.add(filePath);
+    }
+  }
+  return allowlist;
+}
+
+/** 拡張子から Content-Type を返す。未知拡張子は download 向けの汎用型にする。 */
+export function contentTypeForPath(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return MIME_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+/** Content-Disposition attachment 用の filename を安全に組み立てる。 */
+export function attachmentDispositionForPath(filePath: string): string {
+  const basename = path.basename(filePath) || "download";
+  const fallback = basename.replace(/[^\x20-\x7e]|["\\\r\n]/g, "_");
+  return `attachment; filename="${fallback}"; filename*=UTF-8''${encodeURIComponent(basename)}`;
+}

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -863,8 +863,8 @@ export class SessionOrchestrator extends EventEmitter {
       // チェックボックス記号。本文・選択肢内に紛れた ☐/☒ を誤検出しないよう
       // 行頭形状に限定する。
       const AUQ_HEADER_RE = /^\s*(?:←\s*)?[☐☒]\s/;
-      // ツール結果 (⎿) / assistant 出力ブロック (●) の「先頭行」。継続行や他種は
-      // 検出しないため、防御範囲は「ブロック先頭の検出」に限られる。
+      // ツール結果 (⎿) / assistant 出力ブロック (●) の「先頭行」。継続行は
+      // toolBlockEnd でインデントから判定し、ブロックごと除外する。
       const BLOCK_START_RE = /^\s*(?:⎿|●)/;
       const MAX_SCAN_LINES = 60; // ヘッダ探索の上限 (暴走防止)
       const FALLBACK_TAIL_LINES = 20; // フッタ未検出時に出す末尾行数の上限
@@ -876,6 +876,29 @@ export class SessionOrchestrator extends EventEmitter {
         while (rawLines.length > 0 && rawLines[rawLines.length - 1] === "") {
           rawLines.pop();
         }
+        // ⎿/● ブロックを「先頭行 + それより深いインデントの継続行 (空行含む)」と
+        // みなし、ブロック直後の行 index を返す。継続行 (⎿ Edited 配下の差分や
+        // ファイル内容) がバナーへ漏れるのを防ぐ。選択肢/プロンプト (先頭行と同等
+        // 以下のインデント) で打ち切る。
+        const toolBlockEnd = (headerIdx: number): number => {
+          const headerIndent =
+            rawLines[headerIdx].match(/^\s*/)?.[0].length ?? 0;
+          let j = headerIdx + 1;
+          while (j < rawLines.length) {
+            const line = rawLines[j];
+            if (line === "") {
+              j++;
+              continue;
+            }
+            const indent = line.match(/^\s*/)?.[0].length ?? 0;
+            if (indent > headerIndent) {
+              j++;
+              continue;
+            }
+            break;
+          }
+          return j;
+        };
         let footerIdx = -1;
         for (let i = rawLines.length - 1; i >= 0; i--) {
           if (AUQ_FOOTER_RE.test(rawLines[i])) {
@@ -885,7 +908,8 @@ export class SessionOrchestrator extends EventEmitter {
         }
         if (footerIdx >= 0) {
           // フッタから上へヘッダ (☐/☒) を探す。ヘッダ = ボックス先頭なので
-          // それ以上は遡らない。ヘッダ前に prose/ツール結果に当たったらその直下で打ち切る。
+          // それ以上は遡らない。ヘッダ前にツール結果ブロックに当たったら、
+          // ブロック (継続行含む) を丸ごと除外した直後から開始する。
           let startIdx = footerIdx;
           for (
             let i = footerIdx - 1;
@@ -897,26 +921,26 @@ export class SessionOrchestrator extends EventEmitter {
               break;
             }
             if (BLOCK_START_RE.test(rawLines[i])) {
-              startIdx = i + 1;
+              startIdx = toolBlockEnd(i);
               break;
             }
             startIdx = i;
           }
+          // 除外の結果フッタしか残らない場合があるため start<=footer を保証
+          if (startIdx > footerIdx) startIdx = footerIdx;
           awaitingText = rawLines.slice(startIdx, footerIdx + 1).join("\n");
         } else {
-          // フッタ未検出 (permission プロンプト等)。末尾から上へ、ツール結果/prose の
-          // ブロック先頭 (⎿/●) に達するまで最大 FALLBACK_TAIL_LINES 行を出す
-          // (フッタが無くてもツール出力を無条件に含めない)。
-          const collected: string[] = [];
-          for (
-            let i = rawLines.length - 1;
-            i >= 0 && collected.length < FALLBACK_TAIL_LINES;
-            i--
-          ) {
-            if (BLOCK_START_RE.test(rawLines[i])) break;
-            collected.push(rawLines[i]);
+          // フッタ未検出 (permission プロンプト等)。末尾 FALLBACK_TAIL_LINES 行を窓と
+          // し、その中で最下位のツール結果ブロックを検出したら、ブロック (継続行含む)
+          // を丸ごと除外した直後から下を出す (フッタが無くてもツール出力を漏らさない)。
+          let startIdx = Math.max(0, rawLines.length - FALLBACK_TAIL_LINES);
+          for (let i = rawLines.length - 1; i >= startIdx; i--) {
+            if (BLOCK_START_RE.test(rawLines[i])) {
+              startIdx = toolBlockEnd(i);
+              break;
+            }
           }
-          awaitingText = collected.reverse().join("\n");
+          awaitingText = rawLines.slice(startIdx).join("\n");
         }
       }
 

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -847,7 +847,27 @@ export class SessionOrchestrator extends EventEmitter {
 
       // AWAITING (ユーザー判断待ち) のときは、確認 UI の生テキストを添える。
       // チャットビューのバナーが「何を聞かれているか」をそのまま表示するため。
-      // 構造のパースはせず ANSI 除去済みの末尾をミラーするだけ (壊れない)
+      //
+      // AUQ ボックス (ヘッダ「☐/☒」行 〜 フッタ「Enter to select/confirm」行) だけを
+      // 抽出する。以前は末尾 slice(-18) だったため、選択肢が多い縦長 AUQ では先頭の
+      // 質問文/見出しが落ちて ttyd と一致しなかった。
+      // ボックスのヘッダ行 (☐/☒) を上端アンカーにすることで、その上にある assistant
+      // prose やツール結果 (⎿ = Edit プレビュー/ファイル内容など機密が混じり得る) を
+      // 構造上一切含めない (ツール結果の継続行も混入しない)。
+      // AUQ_HEADER_RE: AUQ のヘッダ/タブ行 (単問「☐ <header>」/ 複数問タブバー)
+      // フッタ正規表現は bridge-collector.ts の AWAITING 検出契約 (先頭空白 0〜2) に
+      // 揃える。同じ capture-pane のフッタ行を見ているため、緩い \s* だとインデント
+      // された引用/混入行を誤検出し得る。
+      const AUQ_FOOTER_RE = /^\s{0,2}Enter to (?:select|confirm)\b/;
+      // AUQ ヘッダ/タブ行: 行頭 (任意の先頭空白 + 複数問タブの「←」) の直後に
+      // チェックボックス記号。本文・選択肢内に紛れた ☐/☒ を誤検出しないよう
+      // 行頭形状に限定する。
+      const AUQ_HEADER_RE = /^\s*(?:←\s*)?[☐☒]\s/;
+      // ツール結果 (⎿) / assistant 出力ブロック (●) の「先頭行」。継続行や他種は
+      // 検出しないため、防御範囲は「ブロック先頭の検出」に限られる。
+      const BLOCK_START_RE = /^\s*(?:⎿|●)/;
+      const MAX_SCAN_LINES = 60; // ヘッダ探索の上限 (暴走防止)
+      const FALLBACK_TAIL_LINES = 20; // フッタ未検出時に出す末尾行数の上限
       let awaitingText: string | undefined;
       if (bridgeStatus === "AWAITING") {
         const rawLines = stripAnsi(raw)
@@ -856,7 +876,48 @@ export class SessionOrchestrator extends EventEmitter {
         while (rawLines.length > 0 && rawLines[rawLines.length - 1] === "") {
           rawLines.pop();
         }
-        awaitingText = rawLines.slice(-18).join("\n");
+        let footerIdx = -1;
+        for (let i = rawLines.length - 1; i >= 0; i--) {
+          if (AUQ_FOOTER_RE.test(rawLines[i])) {
+            footerIdx = i;
+            break;
+          }
+        }
+        if (footerIdx >= 0) {
+          // フッタから上へヘッダ (☐/☒) を探す。ヘッダ = ボックス先頭なので
+          // それ以上は遡らない。ヘッダ前に prose/ツール結果に当たったらその直下で打ち切る。
+          let startIdx = footerIdx;
+          for (
+            let i = footerIdx - 1;
+            i >= 0 && footerIdx - i <= MAX_SCAN_LINES;
+            i--
+          ) {
+            if (AUQ_HEADER_RE.test(rawLines[i])) {
+              startIdx = i;
+              break;
+            }
+            if (BLOCK_START_RE.test(rawLines[i])) {
+              startIdx = i + 1;
+              break;
+            }
+            startIdx = i;
+          }
+          awaitingText = rawLines.slice(startIdx, footerIdx + 1).join("\n");
+        } else {
+          // フッタ未検出 (permission プロンプト等)。末尾から上へ、ツール結果/prose の
+          // ブロック先頭 (⎿/●) に達するまで最大 FALLBACK_TAIL_LINES 行を出す
+          // (フッタが無くてもツール出力を無条件に含めない)。
+          const collected: string[] = [];
+          for (
+            let i = rawLines.length - 1;
+            i >= 0 && collected.length < FALLBACK_TAIL_LINES;
+            i--
+          ) {
+            if (BLOCK_START_RE.test(rawLines[i])) break;
+            collected.push(rawLines[i]);
+          }
+          awaitingText = collected.reverse().join("\n");
+        }
       }
 
       previews.push({

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,7 +6,8 @@
   "main": "./src/types.ts",
   "types": "./src/types.ts",
   "exports": {
-    ".": "./src/types.ts"
+    ".": "./src/types.ts",
+    "./file-paths": "./src/file-paths.ts"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/shared/src/file-paths.test.ts
+++ b/packages/shared/src/file-paths.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractFilePaths,
+  isImagePath,
+  splitTextWithFilePaths,
+} from "./file-paths";
+
+describe("isImagePath", () => {
+  it("画像拡張子は大小文字を無視して true", () => {
+    expect(isImagePath("/home/admin/a.PNG")).toBe(true);
+    expect(isImagePath("/tmp/b.jpeg")).toBe(true);
+    expect(isImagePath("/tmp/c.webp")).toBe(true);
+  });
+
+  it("非画像拡張子と拡張子なしは false", () => {
+    expect(isImagePath("/home/admin/report.pdf")).toBe(false);
+    expect(isImagePath("/home/admin/README")).toBe(false);
+  });
+});
+
+describe("splitTextWithFilePaths", () => {
+  it("画像と非画像の複数パスを分解する", () => {
+    expect(
+      splitTextWithFilePaths(
+        "files: /home/admin/a.png and /tmp/report.csv done"
+      )
+    ).toEqual([
+      { type: "text", value: "files: " },
+      { type: "file", value: "/home/admin/a.png" },
+      { type: "text", value: " and " },
+      { type: "file", value: "/tmp/report.csv" },
+      { type: "text", value: " done" },
+    ]);
+  });
+
+  it("罫線テーブル内の絶対パスを検出する", () => {
+    const text = [
+      "┌────┬────┐",
+      "│ /home/admin/stanby-sponsors-page-pc-1440.png │ 842K │",
+      "└────┴────┘",
+    ].join("\n");
+    expect(extractFilePaths(text)).toEqual([
+      "/home/admin/stanby-sponsors-page-pc-1440.png",
+    ]);
+  });
+
+  it("prose 中の相対パスは検出しない", () => {
+    expect(
+      splitTextWithFilePaths("src/foo.ts and docs/spec.md are relative")
+    ).toEqual([
+      { type: "text", value: "src/foo.ts and docs/spec.md are relative" },
+    ]);
+  });
+
+  it("末尾の句読点と閉じ括弧はパスに含めない", () => {
+    expect(splitTextWithFilePaths("see (/tmp/result.json).")).toEqual([
+      { type: "text", value: "see (" },
+      { type: "file", value: "/tmp/result.json" },
+      { type: "text", value: ")." },
+    ]);
+  });
+
+  it("拡張子なしは検出しない", () => {
+    expect(splitTextWithFilePaths("output: /home/admin/result")).toEqual([
+      { type: "text", value: "output: /home/admin/result" },
+    ]);
+  });
+
+  it("http URL 内のパス部分は検出しない", () => {
+    expect(splitTextWithFilePaths("https://example.com/a.png")).toEqual([
+      { type: "text", value: "https://example.com/a.png" },
+    ]);
+  });
+});

--- a/packages/shared/src/file-paths.ts
+++ b/packages/shared/src/file-paths.ts
@@ -1,0 +1,115 @@
+/**
+ * プレーンテキスト中の生成ファイル絶対パスを検出して断片に分解する純粋ロジック。
+ *
+ * クライアントのリンク化とサーバの transcript allowlist が同じ判定を使うため、
+ * shared に置く。
+ */
+
+/** 絶対 POSIX パスらしいトークンを検出する */
+const FILE_PATH_RE = /(^|[^\w:/])((?:\/(?!\/)[^\s<>"'`|│]+)+)/g;
+
+const IMAGE_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "webp",
+  "svg",
+  "avif",
+  "bmp",
+  "ico",
+]);
+
+/**
+ * パス末尾に付きがちな句読点・閉じ括弧を切り離す。
+ * 閉じ括弧は、パス内に対応する開き括弧がある場合のみ残す。
+ */
+function trimTrailingPunctuation(filePath: string): {
+  filePath: string;
+  trailing: string;
+} {
+  let end = filePath.length;
+  while (end > 0) {
+    const ch = filePath[end - 1];
+    if (")]}".includes(ch)) {
+      const open = ch === ")" ? "(" : ch === "]" ? "[" : "{";
+      const slice = filePath.slice(0, end);
+      const opens = slice.split(open).length - 1;
+      const closes = slice.split(ch).length - 1;
+      if (opens >= closes) break;
+      end--;
+    } else if (".,;:!?".includes(ch)) {
+      end--;
+    } else {
+      break;
+    }
+  }
+  return {
+    filePath: filePath.slice(0, end),
+    trailing: filePath.slice(end),
+  };
+}
+
+function getExtension(filePath: string): string | null {
+  const name = filePath.slice(filePath.lastIndexOf("/") + 1);
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0 || dot === name.length - 1) return null;
+  const ext = name.slice(dot + 1);
+  return /^[a-zA-Z0-9]+$/.test(ext) ? ext.toLowerCase() : null;
+}
+
+function isDetectableFilePath(filePath: string): boolean {
+  return filePath.startsWith("/") && getExtension(filePath) !== null;
+}
+
+export type FilePathSegment =
+  | { type: "text"; value: string }
+  | { type: "file"; value: string };
+
+/** 拡張子で画像ファイルか判定する。 */
+export function isImagePath(filePath: string): boolean {
+  const ext = getExtension(filePath);
+  return ext !== null && IMAGE_EXTENSIONS.has(ext);
+}
+
+/**
+ * テキストを「テキスト断片」と「ファイルパス断片」の列に分解する。
+ * 連続するテキストはまとめる。パス末尾の句読点はテキスト側へ送る。
+ */
+export function splitTextWithFilePaths(text: string): FilePathSegment[] {
+  const segments: FilePathSegment[] = [];
+  let lastIndex = 0;
+  const pushText = (value: string) => {
+    if (!value) return;
+    const last = segments[segments.length - 1];
+    if (last && last.type === "text") last.value += value;
+    else segments.push({ type: "text", value });
+  };
+
+  FILE_PATH_RE.lastIndex = 0;
+  let m: RegExpExecArray | null = FILE_PATH_RE.exec(text);
+  while (m !== null) {
+    const prefix = m[1] ?? "";
+    const rawPath = m[2] ?? "";
+    const pathStart = m.index + prefix.length;
+    const { filePath, trailing } = trimTrailingPunctuation(rawPath);
+    if (isDetectableFilePath(filePath)) {
+      pushText(text.slice(lastIndex, pathStart));
+      segments.push({ type: "file", value: filePath });
+      if (trailing) pushText(trailing);
+    } else {
+      pushText(text.slice(lastIndex, m.index + m[0].length));
+    }
+    lastIndex = m.index + m[0].length;
+    m = FILE_PATH_RE.exec(text);
+  }
+  pushText(text.slice(lastIndex));
+  return segments;
+}
+
+/** テキスト中の検出対象ファイルパスだけを抽出する。 */
+export function extractFilePaths(text: string): string[] {
+  return splitTextWithFilePaths(text)
+    .filter(seg => seg.type === "file")
+    .map(seg => seg.value);
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -15,5 +15,6 @@
     "isolatedModules": true,
     "noEmit": false
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts", "dist", "node_modules"]
 }

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -125,10 +125,15 @@ function SlashCommandCard({ name, args }: { name: string; args?: string }) {
  *   情報漏えいを防ぐ。alt テキストのプレースホルダ表示に置き換える)
  * - リンクは http/https のみ許可し、新規タブ + noopener noreferrer で開く
  */
+// remarkFilePaths が検出パスを link ノード化する際に使う内部 sentinel scheme。
+// 外部 URL として許可された scheme ではなく、`a` component 上書きで FileLink へ
+// 振り替えるための内部マーカー。urlTransform は href を素通しさせるため許可する。
+// 実際の配信可否はサーバ側の transcript allowlist が唯一の境界であり、sentinel が
+// 任意パスを指していても allowlist 外なら 403 になる。
+const INTERNAL_FILE_LINK_SCHEME = "ark-file:";
+
 const MD_URL_TRANSFORM = (url: string): string =>
   /^(https?:|#|ark-file:)/i.test(url) ? url : "";
-
-const ARK_FILE_HREF_PREFIX = "ark-file:";
 
 interface MarkdownNode {
   type?: string;
@@ -156,7 +161,7 @@ function transformMarkdownFilePathText(node: MarkdownNode): void {
             seg.type === "file"
               ? {
                   type: "link",
-                  url: `${ARK_FILE_HREF_PREFIX}${seg.value}`,
+                  url: `${INTERNAL_FILE_LINK_SCHEME}${seg.value}`,
                   title: null,
                   children: [{ type: "text", value: seg.value }],
                 }
@@ -296,11 +301,11 @@ function createMarkdownComponents(sessionId: string): Components {
       </span>
     ),
     a: ({ href, children }) => {
-      if (href?.startsWith(ARK_FILE_HREF_PREFIX)) {
+      if (href?.startsWith(INTERNAL_FILE_LINK_SCHEME)) {
         return (
           <FileLink
             sessionId={sessionId}
-            filePath={href.slice(ARK_FILE_HREF_PREFIX.length)}
+            filePath={href.slice(INTERNAL_FILE_LINK_SCHEME.length)}
           />
         );
       }

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -18,9 +18,11 @@ import type {
   SlashCommandInfo,
   SpecialKey,
 } from "@ark/shared";
-import { ArrowDown, Loader2, Paperclip, Send } from "lucide-react";
+import { isImagePath, splitTextWithFilePaths } from "@ark/shared/file-paths";
+import { ArrowDown, Download, Loader2, Paperclip, Send } from "lucide-react";
 import {
   type FormEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -124,32 +126,220 @@ function SlashCommandCard({ name, args }: { name: string; args?: string }) {
  * - リンクは http/https のみ許可し、新規タブ + noopener noreferrer で開く
  */
 const MD_URL_TRANSFORM = (url: string): string =>
-  /^(https?:|#)/i.test(url) ? url : "";
+  /^(https?:|#|ark-file:)/i.test(url) ? url : "";
 
-const MD_COMPONENTS: Components = {
-  img: ({ alt }) => (
-    <span
-      className="inline-block text-xs text-muted-foreground bg-muted rounded px-1.5 py-0.5"
-      title="モデル出力由来の外部画像は自動表示しません"
-    >
-      🖼 {alt || "画像"}
+const ARK_FILE_HREF_PREFIX = "ark-file:";
+
+interface MarkdownNode {
+  type?: string;
+  value?: string;
+  url?: string;
+  title?: string | null;
+  children?: MarkdownNode[];
+}
+
+function remarkFilePaths() {
+  return (tree: MarkdownNode) => {
+    transformMarkdownFilePathText(tree);
+  };
+}
+
+function transformMarkdownFilePathText(node: MarkdownNode): void {
+  if (!node.children) return;
+  const next: MarkdownNode[] = [];
+  for (const child of node.children) {
+    if (child.type === "text" && typeof child.value === "string") {
+      const segments = splitTextWithFilePaths(child.value);
+      if (segments.some(seg => seg.type === "file")) {
+        for (const seg of segments) {
+          next.push(
+            seg.type === "file"
+              ? {
+                  type: "link",
+                  url: `${ARK_FILE_HREF_PREFIX}${seg.value}`,
+                  title: null,
+                  children: [{ type: "text", value: seg.value }],
+                }
+              : { type: "text", value: seg.value }
+          );
+        }
+      } else {
+        next.push(child);
+      }
+      continue;
+    }
+    if (
+      child.type !== "link" &&
+      child.type !== "image" &&
+      child.type !== "linkReference" &&
+      child.type !== "definition"
+    ) {
+      transformMarkdownFilePathText(child);
+    }
+    next.push(child);
+  }
+  node.children = next;
+}
+
+function buildSessionFileUrl(
+  sessionId: string,
+  filePath: string,
+  mode: "download" | "inline"
+): string {
+  const token =
+    typeof window === "undefined"
+      ? null
+      : new URLSearchParams(window.location.search).get("token");
+  let url = `/api/session/${encodeURIComponent(sessionId)}/file?path=${encodeURIComponent(filePath)}&mode=${mode}`;
+  if (token) {
+    url += `&token=${encodeURIComponent(token)}`;
+  }
+  return url;
+}
+
+function FileLink({
+  sessionId,
+  filePath,
+  compact = false,
+}: {
+  sessionId: string;
+  filePath: string;
+  compact?: boolean;
+}) {
+  const [missing, setMissing] = useState(false);
+  const downloadUrl = buildSessionFileUrl(sessionId, filePath, "download");
+
+  if (compact || !isImagePath(filePath)) {
+    return (
+      <a
+        href={downloadUrl}
+        download
+        className="text-blue-600 dark:text-blue-400 underline break-all"
+      >
+        {filePath}
+      </a>
+    );
+  }
+
+  const inlineUrl = buildSessionFileUrl(sessionId, filePath, "inline");
+  return (
+    <span className="my-2 inline-flex max-w-full flex-col gap-1 rounded-md border border-border bg-muted/30 p-2 align-top">
+      {missing ? (
+        <span className="flex min-h-20 max-w-full items-center justify-center rounded bg-muted px-3 py-6 text-sm text-muted-foreground">
+          ファイルが見つかりません
+        </span>
+      ) : (
+        <img
+          src={inlineUrl}
+          alt={filePath}
+          loading="lazy"
+          onError={() => setMissing(true)}
+          className="max-h-[200px] max-w-full object-contain rounded bg-background"
+        />
+      )}
+      <span className="flex min-w-0 items-center gap-2">
+        <a
+          href={downloadUrl}
+          download
+          className="inline-flex h-7 items-center gap-1 rounded border border-border bg-background px-2 text-xs text-foreground hover:bg-muted"
+        >
+          <Download className="h-3.5 w-3.5" />
+          <span>DL</span>
+        </a>
+        <span className="min-w-0 break-all font-mono text-xs text-muted-foreground">
+          {filePath}
+        </span>
+      </span>
     </span>
-  ),
-  a: ({ href, children }) => (
-    <a href={href} target="_blank" rel="noopener noreferrer">
-      {children}
-    </a>
-  ),
-};
+  );
+}
 
-function AssistantTextCard({ text }: { text: string }) {
+function FilePathText({
+  text,
+  sessionId,
+  compact = false,
+}: {
+  text: string;
+  sessionId: string;
+  compact?: boolean;
+}) {
+  return splitTextWithFilePaths(text).map((seg, i) =>
+    seg.type === "file" ? (
+      <FileLink
+        // biome-ignore lint/suspicious/noArrayIndexKey: セグメント列は text から純粋導出され順序不変
+        key={i}
+        sessionId={sessionId}
+        filePath={seg.value}
+        compact={compact}
+      />
+    ) : (
+      // biome-ignore lint/suspicious/noArrayIndexKey: 同上
+      <span key={i}>{seg.value}</span>
+    )
+  );
+}
+
+function reactNodeToText(node: ReactNode): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(reactNodeToText).join("");
+  return "";
+}
+
+function createMarkdownComponents(sessionId: string): Components {
+  return {
+    img: ({ alt }) => (
+      <span
+        className="inline-block text-xs text-muted-foreground bg-muted rounded px-1.5 py-0.5"
+        title="モデル出力由来の外部画像は自動表示しません"
+      >
+        🖼 {alt || "画像"}
+      </span>
+    ),
+    a: ({ href, children }) => {
+      if (href?.startsWith(ARK_FILE_HREF_PREFIX)) {
+        return (
+          <FileLink
+            sessionId={sessionId}
+            filePath={href.slice(ARK_FILE_HREF_PREFIX.length)}
+          />
+        );
+      }
+      return (
+        <a href={href} target="_blank" rel="noopener noreferrer">
+          {children}
+        </a>
+      );
+    },
+    code: ({ className, children, node: _node, ...props }) => (
+      <code className={className} {...props}>
+        <FilePathText
+          text={reactNodeToText(children)}
+          sessionId={sessionId}
+          compact
+        />
+      </code>
+    ),
+  };
+}
+
+function AssistantTextCard({
+  text,
+  sessionId,
+}: {
+  text: string;
+  sessionId: string;
+}) {
+  const components = useMemo(
+    () => createMarkdownComponents(sessionId),
+    [sessionId]
+  );
   return (
     <div className="px-4 py-2">
       <div className="md-prose text-[16px] text-foreground leading-[1.65]">
         <ReactMarkdown
-          remarkPlugins={[remarkGfm]}
+          remarkPlugins={[remarkGfm, remarkFilePaths]}
           urlTransform={MD_URL_TRANSFORM}
-          components={MD_COMPONENTS}
+          components={components}
         >
           {text}
         </ReactMarkdown>
@@ -257,6 +447,7 @@ function AskUserQuestionResultCard({
           const answer = answers.get(q.question);
           return (
             <div
+              // biome-ignore lint/suspicious/noArrayIndexKey: 質問文だけでは重複時に key が衝突するため
               key={`${i}-${q.question}`}
               className="flex gap-1.5 items-start"
             >
@@ -455,7 +646,13 @@ function AwaitingPad({
  * subagent (isSidechain) の連続イベントを 1 ブロックに集約した折りたたみ表示。
  * 大量のツール呼び出しがメイン会話を埋めないようにする。
  */
-function SidechainGroupCard({ events }: { events: JsonlParsedEvent[] }) {
+function SidechainGroupCard({
+  events,
+  sessionId,
+}: {
+  events: JsonlParsedEvent[];
+  sessionId: string;
+}) {
   const [expanded, setExpanded] = useState(false);
   return (
     <div className="px-4 py-1">
@@ -470,7 +667,7 @@ function SidechainGroupCard({ events }: { events: JsonlParsedEvent[] }) {
       {expanded && (
         <div className="mt-1 border-l-2 border-border pl-2 opacity-80">
           {events.map(ev => (
-            <EventCard key={ev.id} event={ev} />
+            <EventCard key={ev.id} event={ev} sessionId={sessionId} />
           ))}
         </div>
       )}
@@ -503,14 +700,20 @@ function groupSidechain(events: JsonlParsedEvent[]): (
   return out;
 }
 
-function EventCard({ event }: { event: JsonlParsedEvent }) {
+function EventCard({
+  event,
+  sessionId,
+}: {
+  event: JsonlParsedEvent;
+  sessionId: string;
+}) {
   switch (event.kind) {
     case "user-input":
       return <UserInputCard text={event.text} />;
     case "slash-command":
       return <SlashCommandCard name={event.name} args={event.args} />;
     case "assistant-text":
-      return <AssistantTextCard text={event.text} />;
+      return <AssistantTextCard text={event.text} sessionId={sessionId} />;
     case "compact-marker":
       return <CompactMarkerCard />;
     case "tool-call":
@@ -1044,9 +1247,17 @@ export function SplitChatPane({
               )}
               {groupedEvents.map(g =>
                 g.kind === "sidechain" ? (
-                  <SidechainGroupCard key={g.id} events={g.events} />
+                  <SidechainGroupCard
+                    key={g.id}
+                    events={g.events}
+                    sessionId={session.id}
+                  />
                 ) : (
-                  <EventCard key={g.event.id} event={g.event} />
+                  <EventCard
+                    key={g.event.id}
+                    event={g.event}
+                    sessionId={session.id}
+                  />
                 )
               )}
               {localSlashCommands.map(c => (


### PR DESCRIPTION
## 概要

Claude Code セッションが会話テキストに記載した絶対パス（screenshot 等の生成物）を、Ark のチャットビューからダウンロード／サムネ表示できるようにする。リモートアクセス（Cloudflare Tunnel）ではサーバ側 FS にしか生成物が無いため、Web UI から取得できることに価値がある。

## 変更内容（論理コミット 4 系統）

1. **生成ファイル DL 機能** (`c114bc5`)
   - `shared/file-paths`: パス検出・断片分解・画像判定の純粋ロジック（クライアント描画とサーバ allowlist が同一判定を共有）
   - `server`: `GET /api/session/:id/file`。transcript に出現したパスだけを allowlist として配信。CSP sandbox / nosniff / HTML 強制 attachment
   - `web/SplitChatPane`: remark プラグインでパスを FileLink 化、画像は遅延サムネ + DL ボタン、非画像は download リンク
2. **AWAITING バナー抽出改善** (`1be48d4`): 選択肢の多い縦長 AUQ で質問文が落ち ttyd と不一致になる問題を修正。AUQ ボックス（ヘッダ☐〜フッタ）のみ抽出し、上方の prose やツール結果（機密混入）を構造的に除外
3. **MCP provider デッドコード削除 + Quick Tunnel URL ガード** (`8a962f5`)
4. **Codex P5 レビュー指摘対応** (`f0fe294`): 下記セキュリティ参照

## セキュリティ（Codex `/codex review` P5 を反映）

3 巡実施し、修正可能な指摘を全対応:
- **allowlist の出所を限定**: transcript 全文ではなく assistant の text 出力と tool_result（tool 出力）からのみパス抽出。user 入力に任意パスを書かせる経路を遮断
- **TOCTOU/symlink 対策**: `realpath` のパス名再確認をやめ、`O_NOFOLLOW` で最終要素の symlink を拒否。検証（fstat）も配信（stream）も同一 fd 経由に統一。stream 終了/エラー時は一度だけ fd を close
- cwd を読めない transcript の除外（assertive）、内部 sentinel scheme の命名明確化

### 受容したリスク（documented）

transcript 出現パスを allowlist にする設計は「生成ファイルの証明」ではなく「process-readable な任意パス」への配信になる、という指摘がある。これは **spec の確定設計**（`/home`・`/tmp` の screenshot を対象にするため `resolveSafePath` の worktree 限定を避け、transcript 出現パスを許可する方式を選択）であり、**脅威モデル上は権限昇格にならない**: 本エンドポイントへ到達できる主体（local / Quick Tunnel トークン / Named Tunnel 認証）はいずれも既に Claude セッションを操作でき = 任意コマンド実行・任意ファイル読取が可能なため、本配信は追加権限を与えない。将来 Claude を操作できない read-only 閲覧モードを追加する際は trusted root 限定へ見直す（`session-file-download.ts` に明記済み）。

## テスト

- ユニット 18 件: パス検出/画像判定、allowlist 出所限定（assistant/tool は許可・user 入力は除外）、traversal/相対パス拒否、壊れた JSONL のスキップ
- ライブエンドポイント E2E（HTTP プラウミング・status/ヘッダ）: allowlist 内→200（正しい Content-Type / CSP / nosniff）、download→`Content-Disposition: attachment`（RFC5987 で日本語ファイル名対応）、allowlist 外・traversal→403、欠損 session→404、path 欠落→400
- `pnpm check`（biome + `tsc --noEmit`）パス


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 会話内で 検出された ファイルパス を クリック可能なリンク として表示。 セッションに紐づくファイルを 開けるようにしました。
  * セッション ファイルの配信に対応し、 表示（inline）と ダウンロード（download）を 指定して切り替え可能にしました。
* **不具合修正**
  * Quick Tunnel 起動時、 トンネルURLが 欠落している場合は 早期にエラーを返します。
  * 応答中の 待機テキスト抽出精度 を 改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->