### PR TITLE
fix: worktree削除時のブランチ後始末と作成・削除失敗時の復旧を改善 (#213)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1749,6 +1749,10 @@ export async function startServer(
           worktree = await createWorktree(repoPath, branchName, baseBranch);
           io.emit("worktree:created", { repoPath, worktree });
         } catch (error) {
+          // UI 通知だけでなくサーバーログにも残して調査可能にする (Issue #213 ③)
+          console.error(
+            `[Worktree] 作成に失敗しました (repo=${repoPath}, branch=${branchName}, base=${baseBranch ?? "HEAD"}): ${getErrorMessage(error)}`
+          );
           socket.emit("worktree:error", getErrorMessage(error));
           return;
         }
@@ -1789,7 +1793,13 @@ export async function startServer(
           .toString("base64")
           .replace(/[/+=]/g, "");
 
-        await deleteWorktree(repoPath, worktreePath);
+        const result = await deleteWorktree(repoPath, worktreePath);
+        if (result.branchKeptReason) {
+          // ブランチが残った場合は調査の起点になるようハンドラー側でも記録する
+          console.log(
+            `[Worktree] ${result.branchKeptReason} (repo=${repoPath})`
+          );
+        }
 
         // 削除成功を通知
         io.emit("worktree:deleted", {
@@ -1800,6 +1810,10 @@ export async function startServer(
         const worktrees = await listWorktrees(repoPath);
         io.emit("worktree:list", { repoPath, worktrees });
       } catch (error) {
+        // UI 通知だけでなくサーバーログにも残して調査可能にする (Issue #213 ③)
+        console.error(
+          `[Worktree] 削除に失敗しました (repo=${repoPath}, path=${worktreePath}): ${getErrorMessage(error)}`
+        );
         socket.emit("worktree:error", getErrorMessage(error));
       }
     });

--- a/packages/server/src/lib/git.test.ts
+++ b/packages/server/src/lib/git.test.ts
@@ -1,0 +1,523 @@
+/**
+ * git.ts createWorktree / deleteWorktree のテスト (Issue #213)
+ *
+ * exec / fs をモックして、git コマンドの呼び出し内容と
+ * ブランチ後始末・残骸ディレクトリ後始末のロジックを検証する。
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// child_process.exec をモック化（git.ts は promisify(exec) 経由で利用する）
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+}));
+
+// fs をモック化（existsSync / promises.rm のみ使用）
+vi.mock("node:fs", () => {
+  const fsMock = {
+    existsSync: vi.fn(),
+    promises: {
+      rm: vi.fn(),
+    },
+  };
+  return { default: fsMock };
+});
+
+import { exec } from "node:child_process";
+import fs from "node:fs";
+import { createWorktree, deleteWorktree } from "./git.js";
+
+const mockedExec = vi.mocked(exec);
+
+const REPO = "/repo";
+const WT = "/repo-doc";
+
+/** exec に対する応答ルール（match した最初のルールが応答する） */
+interface ExecRule {
+  match: RegExp;
+  respond: (cmd: string) => { stdout: string } | Error;
+}
+
+let execRules: ExecRule[] = [];
+let execCalls: string[] = [];
+
+/**
+ * git worktree list --porcelain 形式の出力を組み立てる
+ */
+function porcelain(
+  entries: Array<{ path: string; branch?: string; detached?: boolean }>
+): string {
+  return `${entries
+    .map(e =>
+      [
+        `worktree ${e.path}`,
+        "HEAD abc1234567890",
+        e.detached ? "detached" : `branch refs/heads/${e.branch}`,
+        "",
+      ].join("\n")
+    )
+    .join("\n")}\n`;
+}
+
+/** exec の失敗を exit code 付きで模倣する（promisify(exec) は error.code に exit code を載せる） */
+function execError(message: string, code = 1): Error {
+  const err = new Error(message) as Error & { code: number };
+  err.code = code;
+  return err;
+}
+
+/** ブランチ後始末系のコマンド（merge-base / branch 操作）が呼ばれたか */
+function branchCleanupAttempted(): boolean {
+  return execCalls.some(
+    c => c.includes("merge-base") || c.startsWith("git branch")
+  );
+}
+
+/** getGitRoot / isGitRepository / worktree list の基本ルール */
+function baseRules(
+  listResponse: () => string = () =>
+    porcelain([
+      { path: REPO, branch: "main" },
+      { path: WT, branch: "doc" },
+    ])
+): ExecRule[] {
+  return [
+    {
+      match: /rev-parse --show-toplevel/,
+      respond: () => ({ stdout: `${REPO}\n` }),
+    },
+    {
+      match: /rev-parse --is-inside-work-tree/,
+      respond: () => ({ stdout: "true\n" }),
+    },
+    {
+      match: /worktree list --porcelain/,
+      respond: () => ({ stdout: listResponse() }),
+    },
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  execRules = [];
+  execCalls = [];
+
+  // console 出力を抑制しつつ呼び出しを検証可能にする
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+
+  // exec: ルールにマッチした応答を promisify 互換のコールバックで返す
+  mockedExec.mockImplementation(((
+    cmd: string,
+    opts: unknown,
+    callback?: (
+      err: Error | null,
+      result?: { stdout: string; stderr: string }
+    ) => void
+  ) => {
+    const cb = (typeof opts === "function" ? opts : callback) as (
+      err: Error | null,
+      result?: { stdout: string; stderr: string }
+    ) => void;
+    execCalls.push(cmd);
+    const rule = execRules.find(r => r.match.test(cmd));
+    if (!rule) {
+      cb(new Error(`unexpected command: ${cmd}`));
+      return;
+    }
+    const res = rule.respond(cmd);
+    if (res instanceof Error) {
+      cb(res);
+    } else {
+      cb(null, { stdout: res.stdout, stderr: "" });
+    }
+  }) as never);
+
+  // fs デフォルト: パスは存在し、rm は成功する
+  vi.mocked(fs.existsSync).mockReturnValue(true);
+  vi.mocked(fs.promises.rm).mockResolvedValue(undefined);
+});
+
+describe("createWorktree", () => {
+  it("同名ブランチに固有コミットがなければ削除してから新規ブランチで作成する", async () => {
+    let targetExists = false;
+    vi.mocked(fs.existsSync).mockImplementation(p =>
+      p === WT ? targetExists : true
+    );
+    execRules = [
+      ...baseRules(() =>
+        targetExists
+          ? porcelain([
+              { path: REPO, branch: "main" },
+              { path: WT, branch: "doc" },
+            ])
+          : porcelain([{ path: REPO, branch: "main" }])
+      ),
+      { match: /show-ref --verify/, respond: () => ({ stdout: "" }) },
+      { match: /merge-base --is-ancestor/, respond: () => ({ stdout: "" }) },
+      { match: /^git branch -D /, respond: () => ({ stdout: "" }) },
+      {
+        match: /worktree add/,
+        respond: () => {
+          targetExists = true;
+          return { stdout: "" };
+        },
+      },
+    ];
+
+    const worktree = await createWorktree(REPO, "doc", "main");
+
+    expect(worktree.path).toBe(WT);
+    // 到達可能性は baseRef (main) に対して明示的に検証される
+    expect(execCalls).toContain('git merge-base --is-ancestor "doc" "main"');
+    expect(execCalls).toContain('git branch -D "doc"');
+    const addCall = execCalls.find(c => c.includes("worktree add"));
+    expect(addCall).toContain('-b "doc"');
+  });
+
+  it("固有コミットを持つ同名ブランチには -b なしで attach する", async () => {
+    let targetExists = false;
+    vi.mocked(fs.existsSync).mockImplementation(p =>
+      p === WT ? targetExists : true
+    );
+    execRules = [
+      ...baseRules(() =>
+        targetExists
+          ? porcelain([
+              { path: REPO, branch: "main" },
+              { path: WT, branch: "doc" },
+            ])
+          : porcelain([{ path: REPO, branch: "main" }])
+      ),
+      { match: /show-ref --verify/, respond: () => ({ stdout: "" }) },
+      {
+        match: /merge-base --is-ancestor/,
+        respond: () => execError("not an ancestor", 1),
+      },
+      { match: /branch -r --contains/, respond: () => ({ stdout: "" }) },
+      {
+        match: /worktree add/,
+        respond: () => {
+          targetExists = true;
+          return { stdout: "" };
+        },
+      },
+    ];
+
+    const worktree = await createWorktree(REPO, "doc");
+
+    expect(worktree.path).toBe(WT);
+    const addCall = execCalls.find(c => c.includes("worktree add"));
+    expect(addCall).toBeDefined();
+    expect(addCall).not.toContain("-b");
+    expect(addCall).toContain(`"${WT}" "doc"`);
+    // 到達可能性を証明できないブランチは削除されない
+    expect(execCalls.some(c => c.startsWith("git branch -D"))).toBe(false);
+  });
+
+  it("同名ブランチが別worktreeでチェックアウト済みなら使用中エラーを投げる", async () => {
+    vi.mocked(fs.existsSync).mockImplementation(p => p !== WT);
+    execRules = [
+      ...baseRules(() =>
+        porcelain([
+          { path: REPO, branch: "main" },
+          { path: "/repo-doc-old", branch: "doc" },
+        ])
+      ),
+      { match: /show-ref --verify/, respond: () => ({ stdout: "" }) },
+    ];
+
+    await expect(createWorktree(REPO, "doc")).rejects.toThrow(/使用中/);
+    expect(execCalls.some(c => c.includes("worktree add"))).toBe(false);
+  });
+
+  it("ブランチが存在しなければ従来どおり -b で新規作成する", async () => {
+    let targetExists = false;
+    vi.mocked(fs.existsSync).mockImplementation(p =>
+      p === WT ? targetExists : true
+    );
+    execRules = [
+      ...baseRules(() =>
+        targetExists
+          ? porcelain([
+              { path: REPO, branch: "main" },
+              { path: WT, branch: "doc" },
+            ])
+          : porcelain([{ path: REPO, branch: "main" }])
+      ),
+      {
+        // show-ref は「存在しない」場合 exit 1
+        match: /show-ref --verify/,
+        respond: () => execError("branch not found", 1),
+      },
+      {
+        match: /worktree add/,
+        respond: () => {
+          targetExists = true;
+          return { stdout: "" };
+        },
+      },
+    ];
+
+    const worktree = await createWorktree(REPO, "doc");
+
+    expect(worktree.path).toBe(WT);
+    const addCall = execCalls.find(c => c.includes("worktree add"));
+    expect(addCall).toContain('-b "doc"');
+    // ブランチ後始末は試行されない
+    expect(branchCleanupAttempted()).toBe(false);
+  });
+
+  it("ブランチ存在確認が exit 1 以外で失敗した場合は握りつぶさず伝播する", async () => {
+    vi.mocked(fs.existsSync).mockImplementation(p => p !== WT);
+    execRules = [
+      ...baseRules(() => porcelain([{ path: REPO, branch: "main" }])),
+      {
+        match: /show-ref --verify/,
+        respond: () => execError("fatal: not a git repository", 128),
+      },
+    ];
+
+    await expect(createWorktree(REPO, "doc")).rejects.toThrow(
+      /not a git repository/
+    );
+    expect(execCalls.some(c => c.includes("worktree add"))).toBe(false);
+  });
+
+  it("作成先ディレクトリが既に存在する場合は案内付きのエラーを投げる", async () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    execRules = baseRules();
+
+    await expect(createWorktree(REPO, "doc")).rejects.toThrow(/既に存在/);
+  });
+
+  it("worktree add が失敗した場合は console.error に記録する", async () => {
+    vi.mocked(fs.existsSync).mockImplementation(p => p !== WT);
+    execRules = [
+      ...baseRules(() => porcelain([{ path: REPO, branch: "main" }])),
+      {
+        match: /show-ref --verify/,
+        respond: () => execError("branch not found", 1),
+      },
+      {
+        match: /worktree add/,
+        respond: () => new Error("fatal: could not create work tree dir"),
+      },
+    ];
+
+    await expect(createWorktree(REPO, "doc")).rejects.toThrow(
+      /could not create work tree dir/
+    );
+    expect(console.error).toHaveBeenCalled();
+  });
+});
+
+describe("deleteWorktree", () => {
+  it("HEAD から到達可能なブランチは worktree 削除後に削除する", async () => {
+    execRules = [
+      ...baseRules(),
+      { match: /worktree remove/, respond: () => ({ stdout: "" }) },
+      { match: /merge-base --is-ancestor/, respond: () => ({ stdout: "" }) },
+      { match: /^git branch -D /, respond: () => ({ stdout: "" }) },
+    ];
+
+    const result = await deleteWorktree(REPO, WT);
+
+    expect(result.branchCleanup).toBe("deleted");
+    // 到達可能性は HEAD に対して明示的に検証される
+    expect(execCalls).toContain('git merge-base --is-ancestor "doc" "HEAD"');
+    expect(execCalls).toContain('git branch -D "doc"');
+  });
+
+  it("HEAD 未マージでもリモートに取り込み済みなら削除する", async () => {
+    execRules = [
+      ...baseRules(),
+      { match: /worktree remove/, respond: () => ({ stdout: "" }) },
+      {
+        match: /merge-base --is-ancestor/,
+        respond: () => execError("not an ancestor", 1),
+      },
+      {
+        match: /branch -r --contains/,
+        respond: () => ({ stdout: "  origin/main\n" }),
+      },
+      { match: /^git branch -D /, respond: () => ({ stdout: "" }) },
+    ];
+
+    const result = await deleteWorktree(REPO, WT);
+
+    expect(result.branchCleanup).toBe("deleted");
+    expect(execCalls).toContain('git branch -D "doc"');
+  });
+
+  it("固有コミットを持つ可能性のあるブランチは保持して理由を返す", async () => {
+    execRules = [
+      ...baseRules(),
+      { match: /worktree remove/, respond: () => ({ stdout: "" }) },
+      {
+        match: /merge-base --is-ancestor/,
+        respond: () => execError("not an ancestor", 1),
+      },
+      { match: /branch -r --contains/, respond: () => ({ stdout: "" }) },
+    ];
+
+    const result = await deleteWorktree(REPO, WT);
+
+    expect(result.branchCleanup).toBe("kept");
+    expect(result.branchKeptReason).toBeTruthy();
+    expect(execCalls.some(c => c.startsWith("git branch -D"))).toBe(false);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("到達可能なのに branch -D が失敗した場合は削除失敗として保持する", async () => {
+    execRules = [
+      ...baseRules(),
+      { match: /worktree remove/, respond: () => ({ stdout: "" }) },
+      { match: /merge-base --is-ancestor/, respond: () => ({ stdout: "" }) },
+      {
+        match: /^git branch -D /,
+        respond: () => execError("error: Cannot delete branch 'doc'", 1),
+      },
+    ];
+
+    const result = await deleteWorktree(REPO, WT);
+
+    expect(result.branchCleanup).toBe("kept");
+    expect(result.branchKeptReason).toMatch(/削除に失敗/);
+    // 削除失敗を「未マージ」と誤分類してリモート確認へ進まない
+    expect(execCalls.some(c => c.includes("branch -r --contains"))).toBe(false);
+  });
+
+  it("到達可能性判定が exit 1 以外で失敗した場合は異常として保持する", async () => {
+    execRules = [
+      ...baseRules(),
+      { match: /worktree remove/, respond: () => ({ stdout: "" }) },
+      {
+        match: /merge-base --is-ancestor/,
+        respond: () => execError("fatal: bad revision", 128),
+      },
+    ];
+
+    const result = await deleteWorktree(REPO, WT);
+
+    expect(result.branchCleanup).toBe("kept");
+    expect(result.branchKeptReason).toMatch(/判定に失敗/);
+    // リポジトリ異常時はそれ以上ブランチ操作を重ねない
+    expect(execCalls.some(c => c.includes("branch -r --contains"))).toBe(false);
+    expect(execCalls.some(c => c.startsWith("git branch -D"))).toBe(false);
+  });
+
+  it("不正な形式のブランチ名は後始末をスキップして理由を返す", async () => {
+    execRules = [
+      ...baseRules(() =>
+        porcelain([
+          { path: REPO, branch: "main" },
+          { path: WT, branch: "doc;evil" },
+        ])
+      ),
+      { match: /worktree remove/, respond: () => ({ stdout: "" }) },
+    ];
+
+    const result = await deleteWorktree(REPO, WT);
+
+    expect(result.branchCleanup).toBe("kept");
+    expect(result.branchKeptReason).toBeTruthy();
+    // 不正なブランチ名は shell に渡さない（コマンドインジェクション対策）
+    expect(branchCleanupAttempted()).toBe(false);
+  });
+
+  it("detached の worktree はブランチ削除をスキップする", async () => {
+    execRules = [
+      ...baseRules(() =>
+        porcelain([
+          { path: REPO, branch: "main" },
+          { path: WT, detached: true },
+        ])
+      ),
+      { match: /worktree remove/, respond: () => ({ stdout: "" }) },
+    ];
+
+    const result = await deleteWorktree(REPO, WT);
+
+    expect(result.branchCleanup).toBe("skipped");
+    expect(branchCleanupAttempted()).toBe(false);
+  });
+
+  it("worktree remove 失敗時は残骸ディレクトリ削除と prune で後始末する", async () => {
+    let wtExists = true;
+    vi.mocked(fs.existsSync).mockImplementation(p =>
+      p === WT ? wtExists : true
+    );
+    vi.mocked(fs.promises.rm).mockImplementation(async () => {
+      wtExists = false;
+    });
+    execRules = [
+      ...baseRules(),
+      {
+        match: /worktree remove/,
+        respond: () =>
+          new Error("fatal: failed to delete '/repo-doc': Directory not empty"),
+      },
+      { match: /worktree prune/, respond: () => ({ stdout: "" }) },
+      { match: /merge-base --is-ancestor/, respond: () => ({ stdout: "" }) },
+      { match: /^git branch -D /, respond: () => ({ stdout: "" }) },
+    ];
+
+    const result = await deleteWorktree(REPO, WT);
+
+    expect(fs.promises.rm).toHaveBeenCalledWith(WT, {
+      recursive: true,
+      force: true,
+    });
+    expect(execCalls.some(c => c.includes("worktree prune"))).toBe(true);
+    expect(console.error).toHaveBeenCalled();
+    expect(result.branchCleanup).toBe("deleted");
+  });
+
+  it("Directory not empty 以外の worktree remove 失敗は後始末せず即エラーにする", async () => {
+    execRules = [
+      ...baseRules(),
+      {
+        match: /worktree remove/,
+        respond: () =>
+          execError("fatal: cannot remove a locked working tree", 128),
+      },
+    ];
+
+    await expect(deleteWorktree(REPO, WT)).rejects.toThrow(
+      /locked working tree/
+    );
+    // git が明示的に拒否したケースでは残骸扱いの rm -rf をしない
+    expect(fs.promises.rm).not.toHaveBeenCalled();
+    expect(execCalls.some(c => c.includes("worktree prune"))).toBe(false);
+  });
+
+  it("後始末にも失敗した場合は元のエラーを投げてブランチ削除は行わない", async () => {
+    vi.mocked(fs.promises.rm).mockRejectedValue(new Error("EACCES"));
+    execRules = [
+      ...baseRules(),
+      {
+        match: /worktree remove/,
+        respond: () =>
+          new Error("fatal: failed to delete '/repo-doc': Directory not empty"),
+      },
+      { match: /worktree prune/, respond: () => ({ stdout: "" }) },
+    ];
+
+    await expect(deleteWorktree(REPO, WT)).rejects.toThrow(
+      /Directory not empty/
+    );
+    // 後始末（rm）は試行されるが、失敗したらブランチ削除には進まない
+    expect(fs.promises.rm).toHaveBeenCalled();
+    expect(branchCleanupAttempted()).toBe(false);
+  });
+
+  it("メインworktreeは削除できない", async () => {
+    execRules = baseRules();
+
+    await expect(deleteWorktree(REPO, REPO)).rejects.toThrow(
+      /Cannot delete the main worktree/
+    );
+  });
+});

--- a/packages/server/src/lib/git.ts
+++ b/packages/server/src/lib/git.ts
@@ -10,6 +10,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
 import type { RepoInfo, Worktree } from "@ark/shared";
+import { getErrorMessage } from "./errors.js";
 
 const execAsync = promisify(exec);
 
@@ -325,6 +326,121 @@ export async function listWorktrees(repoPath: string): Promise<Worktree[]> {
   return worktrees.filter(w => w.isBare || fs.existsSync(w.path));
 }
 
+/**
+ * ローカルブランチが存在するか確認する
+ *
+ * `git show-ref --verify --quiet` は「存在しない」場合に exit 1 を返す。
+ * それ以外の失敗（リポジトリ異常等）は「存在しない」と区別して伝播する。
+ */
+async function branchExists(gitRoot: string, branch: string): Promise<boolean> {
+  // shell へ渡す前に必ず検証する（呼び出し元に依存しない防御境界）
+  const safeBranch = validateBranchName(branch);
+  try {
+    await execAsync(
+      `git show-ref --verify --quiet "refs/heads/${safeBranch}"`,
+      { cwd: gitRoot }
+    );
+    return true;
+  } catch (error) {
+    if ((error as { code?: number | string }).code === 1) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/**
+ * ローカルブランチを安全に後始末する (Issue #213 ①)
+ *
+ * - baseRef から到達可能（固有コミットなし）なら削除しても情報は失われない → 削除
+ * - いずれかのリモートブランチから到達可能なら remote-tracking ref から復元できる → 削除
+ * - それ以外（固有コミットを持つ可能性あり）は削除せず理由を返す
+ *
+ * 到達可能性は `git merge-base --is-ancestor` で明示的に検証する
+ * （`git branch -d` の成否に頼ると HEAD/upstream の状態に暗黙依存するため）。
+ */
+async function cleanupLocalBranch(
+  gitRoot: string,
+  branch: string,
+  baseRef = "HEAD"
+): Promise<{ deleted: boolean; keptReason?: string }> {
+  // 呼び出し元によらず、shell へ渡す前に必ず検証する（多重防御）
+  const safeBranch = validateBranchName(branch);
+  const safeBaseRef = baseRef === "HEAD" ? "HEAD" : validateBranchName(baseRef);
+
+  const keep = (reason: string) => {
+    console.warn(`[Git] ${reason}`);
+    return { deleted: false, keptReason: reason };
+  };
+
+  // 1) baseRef からの到達可能性を判定する。`merge-base --is-ancestor` は
+  //    「ancestor ではない」場合のみ exit 1 を返すため、それ以外の失敗は
+  //    リポジトリ異常として区別し、以降のブランチ操作を重ねない
+  let reachableFromBase = false;
+  try {
+    await execAsync(
+      `git merge-base --is-ancestor "${safeBranch}" "${safeBaseRef}"`,
+      { cwd: gitRoot }
+    );
+    reachableFromBase = true;
+  } catch (error) {
+    if ((error as { code?: number | string }).code !== 1) {
+      return keep(
+        `ブランチ '${safeBranch}' の到達可能性の判定に失敗しました: ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  if (reachableFromBase) {
+    // 固有コミットなし → 削除しても情報は失われない
+    try {
+      await execAsync(`git branch -D "${safeBranch}"`, { cwd: gitRoot });
+      console.log(
+        `[Git] ${safeBaseRef} に取り込み済みのブランチ '${safeBranch}' を削除しました`
+      );
+      return { deleted: true };
+    } catch (error) {
+      // 削除失敗は「未マージ」と誤分類せず、失敗として明示する
+      return keep(
+        `ブランチ '${safeBranch}' の削除に失敗しました: ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  // 2) いずれかのリモートブランチから到達可能なら remote-tracking ref から復元できる → 削除
+  //    確認の失敗と削除の失敗は理由を分けて記録する
+  let remoteContains = false;
+  try {
+    const { stdout } = await execAsync(
+      `git branch -r --contains "${safeBranch}"`,
+      { cwd: gitRoot }
+    );
+    remoteContains = stdout.trim().length > 0;
+  } catch (error) {
+    return keep(
+      `ブランチ '${safeBranch}' のリモート取り込み状況の確認に失敗しました: ${getErrorMessage(error)}`
+    );
+  }
+
+  if (remoteContains) {
+    try {
+      await execAsync(`git branch -D "${safeBranch}"`, { cwd: gitRoot });
+      console.log(
+        `[Git] リモート取り込み済みブランチ '${safeBranch}' を削除しました`
+      );
+      return { deleted: true };
+    } catch (error) {
+      return keep(
+        `ブランチ '${safeBranch}' の削除に失敗しました: ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  return keep(
+    `ブランチ '${safeBranch}' は未マージのコミットを持つ可能性があるため削除しませんでした（不要な場合は git branch -D ${safeBranch} で削除してください）`
+  );
+}
+
 // Create a new worktree
 export async function createWorktree(
   repoPath: string,
@@ -347,18 +463,58 @@ export async function createWorktree(
 
   // Check if path already exists
   if (fs.existsSync(worktreePath)) {
-    throw new Error(`Directory already exists: ${worktreePath}`);
+    throw new Error(
+      `作成先ディレクトリが既に存在します: ${worktreePath}（前回の worktree 削除の残骸の可能性があります。不要であれば削除してから再試行してください）`
+    );
   }
 
-  // Create the worktree with a new branch
   const baseRef = baseBranch ? validateBranchName(baseBranch) : "HEAD";
 
-  await execAsync(
-    `git worktree add -b "${safeBranch}" "${worktreePath}" ${baseRef}`,
-    {
-      cwd: gitRoot,
+  // 同名ブランチが既に存在する場合の扱い (Issue #213 ②)
+  // - 別 worktree で使用中 → 明確なエラー
+  // - baseRef/リモートに取り込み済み（固有コミットなし）→ 削除して新規作成（残骸ブランチからの再作成を防ぐ）
+  // - 固有コミットを持つ可能性あり → 既存ブランチに attach して作業を引き継ぐ
+  let attachExisting = false;
+  if (await branchExists(gitRoot, safeBranch)) {
+    const worktrees = await listWorktrees(gitRoot);
+    const inUse = worktrees.find(w => w.branch === safeBranch);
+    if (inUse) {
+      throw new Error(
+        `ブランチ '${safeBranch}' は既に別の worktree で使用中です: ${inUse.path}`
+      );
     }
-  );
+
+    const cleanup = await cleanupLocalBranch(gitRoot, safeBranch, baseRef);
+    if (!cleanup.deleted) {
+      attachExisting = true;
+      console.log(
+        `[Git] 既存ブランチ '${safeBranch}' を再利用して worktree を作成します${
+          baseBranch ? `（baseBranch '${baseBranch}' は使用されません）` : ""
+        }`
+      );
+    }
+  }
+
+  try {
+    if (attachExisting) {
+      await execAsync(`git worktree add "${worktreePath}" "${safeBranch}"`, {
+        cwd: gitRoot,
+      });
+    } else {
+      // Create the worktree with a new branch
+      await execAsync(
+        `git worktree add -b "${safeBranch}" "${worktreePath}" ${baseRef}`,
+        {
+          cwd: gitRoot,
+        }
+      );
+    }
+  } catch (error) {
+    console.error(
+      `[Git] worktree の作成に失敗しました (branch=${safeBranch}, path=${worktreePath}): ${getErrorMessage(error)}`
+    );
+    throw error;
+  }
 
   // Get the created worktree info
   const worktrees = await listWorktrees(gitRoot);
@@ -371,11 +527,26 @@ export async function createWorktree(
   return created;
 }
 
+/** deleteWorktree の結果（ブランチ後始末の内訳） */
+export interface DeleteWorktreeResult {
+  /**
+   * ローカルブランチ後始末の結果
+   * - deleted: ブランチを削除した
+   * - kept: ブランチを保持した（理由は branchKeptReason）
+   * - skipped: 後始末対象なし（detached 等）
+   */
+  branchCleanup: "deleted" | "kept" | "skipped";
+  /** 後始末対象のブランチ名（skipped の場合は undefined） */
+  branch?: string;
+  /** ブランチを保持した理由（kept の場合のみ） */
+  branchKeptReason?: string;
+}
+
 // Delete a worktree
 export async function deleteWorktree(
   repoPath: string,
   worktreePath: string
-): Promise<void> {
+): Promise<DeleteWorktreeResult> {
   const safePath = validatePath(repoPath);
   const safeWorktreePath = validatePath(worktreePath);
 
@@ -395,18 +566,63 @@ export async function deleteWorktree(
   }
 
   // Remove the worktree
-  await execAsync(`git worktree remove "${safeWorktreePath}" --force`, {
-    cwd: gitRoot,
-  });
-
-  // Also delete the branch if it was created for this worktree
   try {
-    await execAsync(`git branch -D "${worktree.branch}"`, {
+    await execAsync(`git worktree remove "${safeWorktreePath}" --force`, {
       cwd: gitRoot,
     });
-  } catch {
-    // Branch might be used elsewhere, ignore error
+  } catch (error) {
+    console.error(
+      `[Git] worktree の削除に失敗しました (${safeWorktreePath}): ${getErrorMessage(error)}`
+    );
+    // 後始末 (Issue #213 ④) は「Directory not empty」（削除途中の残骸）に限定する。
+    // locked worktree や権限問題等、git が明示的に拒否したケースまで rm -rf しない
+    if (!/directory not empty/i.test(getErrorMessage(error))) {
+      throw error;
+    }
+    // 残骸ディレクトリを削除し、stale な管理情報を prune で整理する
+    // （残骸が残ると、次回作成時に「作成先ディレクトリが既に存在します」で詰まる）
+    try {
+      if (fs.existsSync(safeWorktreePath)) {
+        await fs.promises.rm(safeWorktreePath, {
+          recursive: true,
+          force: true,
+        });
+      }
+      await execAsync("git worktree prune", { cwd: gitRoot });
+    } catch (cleanupError) {
+      console.error(
+        `[Git] worktree の後始末に失敗しました (${safeWorktreePath}): ${getErrorMessage(cleanupError)}`
+      );
+      throw error;
+    }
+    if (fs.existsSync(safeWorktreePath)) {
+      throw error;
+    }
+    console.log(`[Git] worktree の残骸を後始末しました (${safeWorktreePath})`);
   }
+
+  // ローカルブランチの後始末 (Issue #213 ①)。detached 等は対象外
+  const branch = worktree.branch;
+  if (!branch || branch === "(detached)" || branch === "unknown") {
+    return { branchCleanup: "skipped" };
+  }
+
+  // ブランチ名の検証だけを限定的に catch する。worktree 自体は削除済みなので
+  // 名前不正は保持扱いに留め、それ以外の未知の例外は握りつぶさず伝播させる
+  try {
+    validateBranchName(branch);
+  } catch {
+    const reason = `ブランチ名 '${branch}' が不正なため後始末をスキップしました`;
+    console.warn(`[Git] ${reason}`);
+    return { branch, branchCleanup: "kept", branchKeptReason: reason };
+  }
+
+  const cleanup = await cleanupLocalBranch(gitRoot, branch);
+  return {
+    branch,
+    branchCleanup: cleanup.deleted ? "deleted" : "kept",
+    branchKeptReason: cleanup.keptReason,
+  };
 }
 
 // Get list of branches


### PR DESCRIPTION
## 概要

Closes #213

worktree 削除でローカルブランチが残り、同名ブランチの再作成が「a branch named 'x' already exists」で失敗し続ける問題への対応です。Issue 記載の4点を実装しました。

## 変更内容

### ① worktree 削除時のローカルブランチ後始末（安全化）

従来の無条件 `git branch -D`（エラー黙殺）をやめ、`git merge-base --is-ancestor` で到達可能性を明示的に検証してから削除します。

- HEAD から到達可能（固有コミットなし）→ 削除
- HEAD 未マージでもリモートブランチに取り込み済み → 削除（remote-tracking ref から復元可能）
- それ以外（固有コミットを持つ可能性あり）→ **保持**し、理由をサーバーログと戻り値 `DeleteWorktreeResult.branchCleanup`（`deleted` / `kept` / `skipped`）で返す

### ② createWorktree の同名ブランチ既存時の改善

- 別 worktree でチェックアウト済み → 「使用中」の明確なエラー（従来は git の生エラー）
- baseRef に取り込み済み（固有コミットなし）→ 残骸ブランチを削除して新規作成（**今回の障害ケースはこれで自己回復**）
- 固有コミットを持つ可能性あり → `-b` なしで attach して作業を引き継ぐ

### ③ 作成・削除失敗のサーバーログ記録

`worktree:create` / `worktree:delete` ハンドラーと git.ts 内部で `console.error` に記録し、UI 通知のみで調査困難だった問題を解消。

### ④ 削除失敗「Directory not empty」時の後始末

`git worktree remove --force` が **Directory not empty で失敗した場合に限り**、残骸ディレクトリの再帰削除 + `git worktree prune` で後始末し、次回作成時の「ディレクトリが既に存在」を防ぎます。locked worktree 等 git が明示的に拒否したケースは残骸扱いにせず即エラーにします。

## セキュリティ

ブランチ名は shell へ渡す前に必ず `validateBranchName` を通す多重防御構成（`branchExists` / `cleanupLocalBranch` 内でも検証）。不正な形式のブランチ名は後始末をスキップして理由を返します。

## テスト

- `git.test.ts` を新規追加（exec / fs モックで 18 ケース）: 到達可能性判定・リモート取り込み判定・attach 再利用・使用中エラー・残骸後始末・後始末失敗時の元エラー伝播・不正ブランチ名スキップ・exit code 区別など
- `pnpm check`（biome + tsc）/ サーバー全テスト 256 件 PASS

## 挙動変更の注意点

squash マージ後のブランチはコミットがリモートから到達不能なため「保持」判定になります（従来は無条件削除）。その場合も同名での worktree 再作成は attach で成功するため、Issue の障害パターンは発生しません。保持時はサーバーログに `git branch -D <name>` の案内を出します。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Worktree の作成・削除時の失敗がより分かりやすくなり、状況確認に役立つ情報が記録されるようになりました。
  * 削除後にブランチが残るケースで、条件に応じて自動的に整理するか、残す理由を保持するようになりました。
  * 作成先が既に存在する場合や、使用中のブランチがある場合のエラー表示が改善されました。
  * Worktree 削除時の失敗処理が強化され、途中で残った不要な状態の後始末がより安定しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->