### PR TITLE
feat(session): 全セッションを UI から再起動できるようにする

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3296,18 +3296,24 @@ export async function startServer(
       }
     );
 
+    // 再起動は profile 機能に依存しない汎用操作 (restartSession 内の
+    // profile 再解決は、profile 未対応環境では env 無しに解決されるだけ)
+    // のため、multiProfileSupported では gate しない
     socket.on("session:restart-with-profile", async ({ sessionId }) => {
-      if (!capabilities.multiProfileSupported) {
-        emitUnsupported();
-        return;
-      }
       try {
         // restartSession 自身が orchestrator.emit("session:stopped") と
         // session:created を発行し、forwardedEvents 経由で全接続クライアントに
         // 旧IDの停止と新IDの作成が届く。ここで重ねて io.emit("session:updated")
         // を流すと、別タブが session:stopped を取りこぼした幻シナリオで旧IDが
         // 残ったまま新IDが追加される懸念があるため、追加 emit はしない。
-        await sessionOrchestrator.restartSession(sessionId);
+        const restarted = await sessionOrchestrator.restartSession(sessionId);
+        // 旧ID→新IDの対応を全クライアントへ通知する (別タブの選択追従用。
+        // sessions 一覧の更新は上記 stopped/created が担うため、受信側は
+        // このイベントで一覧に session を追加してはならない)
+        io.emit("session:restarted", {
+          oldSessionId: sessionId,
+          session: restarted,
+        });
       } catch (e) {
         socket.emit("session:error", {
           sessionId,

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1580,6 +1580,7 @@ export async function startServer(
     // （自動復元で発行されるsession:restoredイベントを転送するため）
     const forwardedEvents = [
       "session:created",
+      "session:restarted",
       "session:restored",
       "session:stopped",
       "session:updated",
@@ -3301,19 +3302,13 @@ export async function startServer(
     // のため、multiProfileSupported では gate しない
     socket.on("session:restart-with-profile", async ({ sessionId }) => {
       try {
-        // restartSession 自身が orchestrator.emit("session:stopped") と
-        // session:created を発行し、forwardedEvents 経由で全接続クライアントに
-        // 旧IDの停止と新IDの作成が届く。ここで重ねて io.emit("session:updated")
-        // を流すと、別タブが session:stopped を取りこぼした幻シナリオで旧IDが
-        // 残ったまま新IDが追加される懸念があるため、追加 emit はしない。
-        const restarted = await sessionOrchestrator.restartSession(sessionId);
-        // 旧ID→新IDの対応を全クライアントへ通知する (別タブの選択追従用。
-        // sessions 一覧の更新は上記 stopped/created が担うため、受信側は
-        // このイベントで一覧に session を追加してはならない)
-        io.emit("session:restarted", {
-          oldSessionId: sessionId,
-          session: restarted,
-        });
+        // restartSession 自身が orchestrator 経由で
+        // session:created → session:restarted → session:stopped を発行し、
+        // forwardedEvents で全接続クライアントに届く (順序は選択追従の要件。
+        // session-orchestrator.ts 参照)。ここで重ねて emit すると、別タブが
+        // session:stopped を取りこぼした幻シナリオで旧IDが残ったまま新IDが
+        // 追加される懸念があるため、追加 emit はしない。
+        await sessionOrchestrator.restartSession(sessionId);
       } catch (e) {
         socket.emit("session:error", {
           sessionId,

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -472,5 +472,49 @@ describe("SessionOrchestrator - プロファイル切替", () => {
         orchestrator.restartSession("does-not-exist")
       ).rejects.toThrow(/Session not found/);
     });
+
+    it("created → restarted → stopped の順で emit する (受信側の選択追従がイベント順序に依存するため)", async () => {
+      const oldSession = makeTmuxSession({ id: "sess-id-1" });
+      mockedTmux.getSession.mockReturnValue(oldSession);
+      mockedDb.getSessionByWorktreePath.mockReturnValue({
+        id: "sess-id-1",
+        worktreeId: "wt-1",
+        worktreePath: "/path/to/work",
+        repoPath: "/repo",
+        status: "active",
+        createdAt: "2026-04-25T00:00:00Z",
+        updatedAt: "2026-04-25T00:00:00Z",
+      } as never);
+      mockedTmux.createSession.mockResolvedValue(
+        makeTmuxSession({ id: "sess-id-2", tmuxSessionName: "ark-sess2" })
+      );
+      mockedTmux.getSessionByWorktree.mockReturnValue(undefined);
+      mockedTtyd.startInstance.mockResolvedValue({
+        sessionId: "sess-id-2",
+        port: 7682,
+        tmuxSessionName: "ark-sess2",
+        basePath: "/ttyd/sess-id-2",
+      } as never);
+
+      const order: string[] = [];
+      orchestrator.on("session:created", () => order.push("created"));
+      orchestrator.on("session:restarted", () => order.push("restarted"));
+      orchestrator.on("session:stopped", () => order.push("stopped"));
+      let restartedPayload: unknown;
+      orchestrator.on("session:restarted", payload => {
+        restartedPayload = payload;
+      });
+
+      await orchestrator.restartSession("sess-id-1");
+
+      // stopped を先に流すと、受信側で「選択中セッション消失」フォールバックが
+      // session:restarted より先に走り、選択追従 (prev === oldSessionId) が
+      // 失敗するため、この順序を仕様として固定する
+      expect(order).toEqual(["created", "restarted", "stopped"]);
+      expect(restartedPayload).toMatchObject({
+        oldSessionId: "sess-id-1",
+        session: { id: "sess-id-2" },
+      });
+    });
   });
 });

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -516,5 +516,51 @@ describe("SessionOrchestrator - プロファイル切替", () => {
         session: { id: "sess-id-2" },
       });
     });
+
+    it("同一セッションの並行再起動は直列化され、同じ新セッションを返す", async () => {
+      const oldSession = makeTmuxSession({ id: "sess-id-1" });
+      mockedTmux.getSession.mockReturnValue(oldSession);
+      mockedDb.getSessionByWorktreePath.mockReturnValue({
+        id: "sess-id-1",
+        worktreeId: "wt-1",
+        worktreePath: "/path/to/work",
+        repoPath: "/repo",
+        status: "active",
+        createdAt: "2026-04-25T00:00:00Z",
+        updatedAt: "2026-04-25T00:00:00Z",
+      } as never);
+      // 並行実行が直列化されない場合は2つの新セッションが作られてしまう
+      mockedTmux.createSession
+        .mockResolvedValueOnce(
+          makeTmuxSession({ id: "sess-id-2", tmuxSessionName: "ark-sess2" })
+        )
+        .mockResolvedValueOnce(
+          makeTmuxSession({ id: "sess-id-3", tmuxSessionName: "ark-sess3" })
+        );
+      mockedTmux.getSessionByWorktree.mockReturnValue(undefined);
+      mockedTtyd.startInstance
+        .mockResolvedValueOnce({
+          sessionId: "sess-id-2",
+          port: 7682,
+          tmuxSessionName: "ark-sess2",
+          basePath: "/ttyd/sess-id-2",
+        } as never)
+        .mockResolvedValueOnce({
+          sessionId: "sess-id-3",
+          port: 7683,
+          tmuxSessionName: "ark-sess3",
+          basePath: "/ttyd/sess-id-3",
+        } as never);
+
+      const [r1, r2] = await Promise.all([
+        orchestrator.restartSession("sess-id-1"),
+        orchestrator.restartSession("sess-id-1"),
+      ]);
+
+      // 2つ目の呼び出しは進行中の再起動に相乗りし、新セッションは1つだけ
+      expect(mockedTmux.createSession).toHaveBeenCalledTimes(1);
+      expect(r1.id).toBe("sess-id-2");
+      expect(r2.id).toBe("sess-id-2");
+    });
   });
 });

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -558,9 +558,11 @@ export class SessionOrchestrator extends EventEmitter {
     ttydManager.stopInstance(sessionId);
     tmuxManager.killSession(sessionId);
 
-    // 6. クライアント通知
-    this.emit("session:stopped", sessionId);
-
+    // 6. クライアント通知。順序が重要:
+    //    created(新) → restarted(旧→新の対応) → stopped(旧)。
+    //    stopped を先に流すと、受信側で「選択中セッションの消失」による
+    //    フォールバック選択が session:restarted の到着より先に走り、
+    //    選択追従 (prev === oldSessionId) が失敗するため
     const managed: ManagedSession = {
       id: newTmux.id,
       worktreeId,
@@ -574,6 +576,11 @@ export class SessionOrchestrator extends EventEmitter {
       profileId: snapshot?.id ?? null,
     };
     this.emit("session:created", managed);
+    this.emit("session:restarted", {
+      oldSessionId: sessionId,
+      session: managed,
+    });
+    this.emit("session:stopped", sessionId);
     return managed;
   }
 

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -482,7 +482,25 @@ export class SessionOrchestrator extends EventEmitter {
    * @throws sessionId に対応する tmux セッションが見つからない場合
    * @throws 新セッション起動失敗 (旧セッションは無傷)
    */
+  /**
+   * 同一セッションへの並行 restartSession を直列化する in-flight guard。
+   * ガード無しだと複数タブからの同時再起動が両方とも旧セッションを基に
+   * 新セッションを作成し、重複 tmux/ttyd と DB 不整合が発生する。
+   * 進行中の再起動があればその Promise に相乗りする (冪等)
+   */
+  private restartsInFlight = new Map<string, Promise<ManagedSession>>();
+
   async restartSession(sessionId: string): Promise<ManagedSession> {
+    const inFlight = this.restartsInFlight.get(sessionId);
+    if (inFlight) return inFlight;
+    const promise = this.doRestartSession(sessionId).finally(() => {
+      this.restartsInFlight.delete(sessionId);
+    });
+    this.restartsInFlight.set(sessionId, promise);
+    return promise;
+  }
+
+  private async doRestartSession(sessionId: string): Promise<ManagedSession> {
     const oldTmux = tmuxManager.getSession(sessionId);
     if (!oldTmux) {
       throw new Error(`Session not found: ${sessionId}`);

--- a/packages/server/src/lib/tmux-manager.test.ts
+++ b/packages/server/src/lib/tmux-manager.test.ts
@@ -139,6 +139,44 @@ describe("TmuxManager.createSession - options互換", () => {
     expect(session.tmuxSessionName).toBe("ark-testid01");
   });
 
+  it("createSession の tmux 呼び出しすべてに timeout が付与される", async () => {
+    // spawnSync は同期呼び出しでハングするとイベントループごと停止するため、
+    // JS 側のタイムアウトでは救えない。timeout オプションで子プロセスを
+    // kill させ、error → throw → restartSession の finally が in-flight を
+    // 解放する経路を成立させる (CodeRabbit PR#221 指摘対応)
+    await manager.createSession("/path/to/worktree");
+
+    const tmuxCalls = mockedSpawnSync.mock.calls.filter(
+      ([, args]) =>
+        Array.isArray(args) &&
+        ["new-session", "set-option", "send-keys"].includes(String(args[0]))
+    );
+    expect(tmuxCalls.length).toBeGreaterThanOrEqual(3);
+    for (const call of tmuxCalls) {
+      const opts = call[2] as { timeout?: number } | undefined;
+      expect(opts?.timeout).toBeGreaterThan(0);
+    }
+  });
+
+  it("createSession 失敗時のクリーンアップ kill-session にも timeout が付与される", async () => {
+    // new-session 成功 → set-option 失敗、でクリーンアップ経路に入れる
+    mockedSpawnSync.mockImplementation((_cmd, args) => {
+      if (Array.isArray(args) && args[0] === "set-option") {
+        return { ...successResult, status: 1 } as never;
+      }
+      return successResult as never;
+    });
+
+    await expect(manager.createSession("/path/to/worktree")).rejects.toThrow();
+
+    const killCall = mockedSpawnSync.mock.calls.find(
+      ([, args]) => Array.isArray(args) && args[0] === "kill-session"
+    );
+    expect(killCall).toBeDefined();
+    const opts = killCall?.[2] as { timeout?: number } | undefined;
+    expect(opts?.timeout).toBeGreaterThan(0);
+  });
+
   it("options.envで -e KEY=VALUE が追加される", async () => {
     await manager.createSession("/path/to/worktree", {
       env: { FOO: "bar", BAZ: "qux" },

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -18,6 +18,15 @@ import { resolveClaudePath, resolveTmuxPath } from "./system.js";
 const TMUX_BINARY_PATH = resolveTmuxPath() ?? "tmux";
 
 /**
+ * セッション作成/破棄系の tmux コマンドの打ち切り時間 (ms)。
+ * spawnSync は同期呼び出しでハングするとイベントループごと停止し、
+ * JS 側のタイムアウト (Promise.race 等) では救えない。timeout で子プロセスを
+ * kill させ error → throw に変換することで、restartSession の in-flight guard
+ * が finally で確実に解放される (通常の tmux コマンドは数十 ms で完了する)
+ */
+const TMUX_CMD_TIMEOUT_MS = 10_000;
+
+/**
  * POSIX shell の single-quote 文字列にエスケープする。
  * 'foo bar' のように wrap し、入力中の `'` は `'\''` (single quote を抜けて
  * リテラル single quote を入れ再度入る) に置き換える。
@@ -165,7 +174,7 @@ export class TmuxManager extends EventEmitter {
       spawnSync(
         TMUX_BINARY_PATH,
         ["set-option", "-s", "copy-command", "pbcopy"],
-        { stdio: "pipe" }
+        { stdio: "pipe", timeout: TMUX_CMD_TIMEOUT_MS }
       );
     } catch {
       // tmuxサーバーが起動していない場合は設定不要
@@ -210,7 +219,7 @@ export class TmuxManager extends EventEmitter {
             const killResult = spawnSync(
               TMUX_BINARY_PATH,
               ["kill-session", "-t", name],
-              { stdio: "pipe" }
+              { stdio: "pipe", timeout: TMUX_CMD_TIMEOUT_MS }
             );
             if (killResult.status === 0) {
               console.log(
@@ -243,7 +252,7 @@ export class TmuxManager extends EventEmitter {
             spawnSync(
               TMUX_BINARY_PATH,
               ["set-option", "-t", name, "mouse", "on"],
-              { stdio: "pipe" }
+              { stdio: "pipe", timeout: TMUX_CMD_TIMEOUT_MS }
             );
           } catch {
             // セッションが利用不可の場合は無視
@@ -363,7 +372,7 @@ export class TmuxManager extends EventEmitter {
           "NODE_ENV=",
           ...extraEnvArgs,
         ],
-        { stdio: "pipe" }
+        { stdio: "pipe", timeout: TMUX_CMD_TIMEOUT_MS }
       );
       if (newSessionResult.error) throw newSessionResult.error;
       if (newSessionResult.status !== 0)
@@ -376,7 +385,7 @@ export class TmuxManager extends EventEmitter {
       const setOptionResult = spawnSync(
         TMUX_BINARY_PATH,
         ["set-option", "-t", tmuxSessionName, "mouse", "on"],
-        { stdio: "pipe" }
+        { stdio: "pipe", timeout: TMUX_CMD_TIMEOUT_MS }
       );
       if (setOptionResult.error) throw setOptionResult.error;
       if (setOptionResult.status !== 0)
@@ -389,7 +398,7 @@ export class TmuxManager extends EventEmitter {
       const sendKeysResult = spawnSync(
         TMUX_BINARY_PATH,
         ["send-keys", "-t", tmuxSessionName, claudeCmd, "Enter"],
-        { stdio: "pipe" }
+        { stdio: "pipe", timeout: TMUX_CMD_TIMEOUT_MS }
       );
       if (sendKeysResult.error) throw sendKeysResult.error;
       if (sendKeysResult.status !== 0)
@@ -401,6 +410,7 @@ export class TmuxManager extends EventEmitter {
       if (tmuxCreated) {
         spawnSync(TMUX_BINARY_PATH, ["kill-session", "-t", tmuxSessionName], {
           stdio: "pipe",
+          timeout: TMUX_CMD_TIMEOUT_MS,
         });
       }
       throw new Error(`Failed to create tmux session: ${error}`);
@@ -551,7 +561,7 @@ export class TmuxManager extends EventEmitter {
     const result = spawnSync(
       TMUX_BINARY_PATH,
       ["kill-session", "-t", session.tmuxSessionName],
-      { stdio: "pipe" }
+      { stdio: "pipe", timeout: TMUX_CMD_TIMEOUT_MS }
     );
     if (result.status === 0) {
       console.log(`[TmuxManager] Killed session: ${session.tmuxSessionName}`);

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -371,6 +371,16 @@ export interface ServerToClientEvents {
   "session:created": (session: ManagedSession) => void;
   "session:updated": (session: ManagedSession) => void;
   "session:stopped": (sessionId: string) => void;
+  /**
+   * セッション再起動の完了通知 (旧ID → 新セッションの対応)。
+   * sessions 一覧の更新は session:stopped / session:created が担うため、
+   * このイベントは「選択中セッションの新IDへの追従」のヒント専用。
+   * 一覧へ session を追加してはならない (旧ID残留の幻セッション防止)
+   */
+  "session:restarted": (data: {
+    oldSessionId: string;
+    session: ManagedSession;
+  }) => void;
   "session:error": (data: { sessionId: string; error: string }) => void;
 
   /**

--- a/packages/web/src/components/MobileLayout.tsx
+++ b/packages/web/src/components/MobileLayout.tsx
@@ -66,6 +66,8 @@ interface MobileLayoutProps {
   onStartSession: (worktree: Worktree) => void;
   /** セッション削除（停止 + メイン以外のWorktree削除） */
   onDeleteSession: (sessionId: string, worktree: Worktree | undefined) => void;
+  /** セッション再起動（tmux kill → 新セッション作成。会話履歴は失われる） */
+  onRestartSession?: (sessionId: string) => void;
   onDeleteWorktree: (worktree: Worktree) => void;
   onSendMessage: (sessionId: string, message: string) => void;
   onSendKey: (sessionId: string, key: SpecialKey) => void;
@@ -142,6 +144,7 @@ export function MobileLayout({
   repoPath: _repoPath,
   onStartSession,
   onDeleteSession,
+  onRestartSession,
   onDeleteWorktree,
   onSendMessage,
   onSendKey,
@@ -359,6 +362,9 @@ export function MobileLayout({
               onSendKey={key => onSendKey(sessionId, key)}
               onDeleteSession={() =>
                 onDeleteSession(sessionId, getWorktreeForSession(session))
+              }
+              onRestartSession={
+                onRestartSession ? () => onRestartSession(sessionId) : undefined
               }
               onUploadFile={
                 onUploadFile

--- a/packages/web/src/components/MobileSessionView.tsx
+++ b/packages/web/src/components/MobileSessionView.tsx
@@ -19,6 +19,7 @@ import {
   ImageIcon,
   MoreVertical,
   RefreshCw,
+  RotateCw,
   Send,
   Trash2,
   X,
@@ -72,6 +73,11 @@ interface MobileSessionViewProps {
   onSendKey: (key: SpecialKey) => void;
   /** セッション削除（停止 + メイン以外のWorktree削除） */
   onDeleteSession: () => void;
+  /**
+   * セッション再起動（tmux kill → 新セッション作成。会話履歴は失われる）。
+   * 未指定ならメニュー項目を表示しない
+   */
+  onRestartSession?: () => void;
   onUploadFile?: (data: {
     base64Data: string;
     mimeType: string;
@@ -99,6 +105,7 @@ export function MobileSessionView({
   onSendMessage,
   onSendKey,
   onDeleteSession,
+  onRestartSession,
   onUploadFile,
   onCopyBuffer,
   tabs,
@@ -119,6 +126,7 @@ export function MobileSessionView({
   const [isSending, setIsSending] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showRestartDialog, setShowRestartDialog] = useState(false);
   const [showShortcutManager, setShowShortcutManager] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -383,6 +391,12 @@ export function MobileSessionView({
                 <RefreshCw className="w-4 h-4 mr-2" />
                 Reload Terminal
               </DropdownMenuItem>
+              {onRestartSession && (
+                <DropdownMenuItem onClick={() => setShowRestartDialog(true)}>
+                  <RotateCw className="w-4 h-4 mr-2" />
+                  セッションを再起動
+                </DropdownMenuItem>
+              )}
               <DropdownMenuSeparator />
               {slashCommands.map(({ label, cmd }) => (
                 <DropdownMenuItem
@@ -681,6 +695,32 @@ export function MobileSessionView({
               }}
             >
               削除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* 再起動確認ダイアログ */}
+      <AlertDialog open={showRestartDialog} onOpenChange={setShowRestartDialog}>
+        <AlertDialogContent className="bg-card border-border w-[calc(100%-2rem)] max-w-md mx-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle>セッションを再起動しますか？</AlertDialogTitle>
+            <AlertDialogDescription>
+              このセッションを再起動するとClaude会話履歴・実行中コマンド・ターミナル内容がすべて失われます。続行しますか？
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col gap-2 sm:flex-row">
+            <AlertDialogCancel className="h-12 md:h-10">
+              キャンセル
+            </AlertDialogCancel>
+            <AlertDialogAction
+              className="h-12 md:h-10"
+              onClick={() => {
+                onRestartSession?.();
+                setShowRestartDialog(false);
+              }}
+            >
+              再起動
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -3,7 +3,7 @@ import type {
   ManagedSession,
   Worktree,
 } from "@ark/shared";
-import { MessageSquare, Pencil, Trash2 } from "lucide-react";
+import { MessageSquare, Pencil, RotateCw, Trash2 } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import {
   AlertDialog,
@@ -42,6 +42,12 @@ interface SessionCardProps {
   onClick: () => void;
   /** セッション削除（停止 + メイン以外のWorktree削除） */
   onDelete: () => void;
+  /**
+   * セッション再起動（tmux kill → 新セッション作成。会話履歴は失われる）。
+   * 確認ダイアログは親 (SessionSidebar) が持つため、ここではトリガーのみ。
+   * 未指定なら再起動メニューを表示しない
+   */
+  onRestart?: () => void;
   onStart?: () => void;
   /**
    * ステータスドットと worktree名 (branch) の間に挿入するバッジ等のスロット。
@@ -71,6 +77,7 @@ export function SessionCard({
   gridStatus,
   onClick,
   onDelete,
+  onRestart,
   onStart,
   profileBadgeSlot,
   customDisplayName,
@@ -315,6 +322,12 @@ export function SessionCard({
             </ContextMenuItem>
           )}
           <ContextMenuSeparator />
+          {onRestart && (
+            <ContextMenuItem onSelect={onRestart}>
+              <RotateCw className="w-4 h-4 mr-2" />
+              セッションを再起動
+            </ContextMenuItem>
+          )}
           <ContextMenuItem
             className="text-destructive focus:text-destructive"
             onSelect={() => setShowDeleteDialog(true)}

--- a/packages/web/src/components/SessionSidebar.tsx
+++ b/packages/web/src/components/SessionSidebar.tsx
@@ -593,6 +593,11 @@ export function SessionSidebar({
                             session &&
                             onDeleteSession(session.id, wt ?? undefined)
                           }
+                          onRestart={
+                            session && onRestartSession
+                              ? () => setRestartTargetSessionId(session.id)
+                              : undefined
+                          }
                           onStart={() => (wt ? onStartSession(wt) : undefined)}
                           profileBadgeSlot={renderProfileBadgeSlot(
                             session,
@@ -660,7 +665,7 @@ export function SessionSidebar({
         </AlertDialogContent>
       </AlertDialog>
 
-      {/* セッション再起動 確認ダイアログ (staleProfile対応) */}
+      {/* セッション再起動 確認ダイアログ (コンテキストメニュー / staleProfile 警告の両方から開く) */}
       <AlertDialog
         open={restartTargetSessionId !== null}
         onOpenChange={open => {

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -604,6 +604,7 @@ export default function Dashboard() {
           repoPath={repoPath}
           onStartSession={handleStartSession}
           onDeleteSession={handleDeleteSession}
+          onRestartSession={handleRestartSession}
           onDeleteWorktree={handleDeleteWorktree}
           onSendMessage={sendMessage}
           onSendKey={sendKey}

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -352,47 +352,22 @@ export default function Dashboard() {
     }
   }, [tunnelJustStarted, clearTunnelJustStarted]);
 
-  // restart進行中の対象worktreePath。
-  // 再起動するとサーバ側で sessionId が変わるため、新IDで session:created
-  // が届くまで selectedSessionId を「同じ worktreePath を持つ新セッション」
-  // に自動migrateするための一時記録。
-  const restartingWorktreePathRef = useRef<string | null>(null);
-  // 直近選択中だった ManagedSession のスナップショット。
-  // 別タブで再起動が起きた場合 (initiating tab以外) でも、
-  // selectedSessionId が消えたタイミングで worktreePath を取り出して
-  // restartingWorktreePathRef に保存し、新セッションへ追従できるようにする。
-  const lastSelectedSessionRef = useRef<ManagedSession | null>(null);
-
-  // selectedSessionId に対応する ManagedSession を毎回スナップショット
-  useEffect(() => {
-    if (selectedSessionId && selectedSessionId !== "browser") {
-      const s = sessions.get(selectedSessionId);
-      if (s) lastSelectedSessionRef.current = s;
-    } else {
-      lastSelectedSessionRef.current = null;
-    }
-  }, [selectedSessionId, sessions]);
-
   const handleRestartSession = useCallback(
     (sessionId: string) => {
-      // 再起動対象が選択中ならworktreePathを覚えておき、
-      // 新セッション到着時に selectedSessionId を新IDへ追従させる
-      if (selectedSessionId === sessionId) {
-        const target = sessions.get(sessionId);
-        if (target) {
-          restartingWorktreePathRef.current = target.worktreePath;
-        }
-      }
       restartSessionWithProfile(sessionId);
     },
-    [selectedSessionId, sessions, restartSessionWithProfile]
+    [restartSessionWithProfile]
   );
 
-  // 再起動完了通知 (旧ID→新ID) による選択追従。別タブ発の再起動でも
-  // 選択中セッションを新IDへ確実に移す (サーバーが io.emit で全クライアント
-  // に配るため、initiating tab 以外もこの経路で追従できる)。
+  // 再起動完了通知 (旧ID→新ID) による選択追従。
+  // サーバーは created(新) → restarted(旧→新) → stopped(旧) の順で emit する
+  // ため、選択中セッションが sessions Map から消える前にこのハンドラで新IDへ
+  // 付け替わる (= 消失フォールバックとの競合が起きない)。initiating tab /
+  // 別タブの区別なくこの1経路で追従が完結するので、worktreePath ベースの
+  // migration ヒューリスティックは持たない (pending 残留の温床だったため廃止)。
   // sessions 一覧の更新は session:stopped / session:created が担うので、
-  // ここでは selectedSessionId の付け替えだけを行う
+  // ここでは selectedSessionId の付け替えだけを行う。
+  // 選択が "browser" 等の別対象に移っていた場合は付け替えない (prev 不一致)
   useEffect(() => {
     if (!socket) return;
     const handler = (data: {
@@ -409,11 +384,8 @@ export default function Dashboard() {
     };
   }, [socket]);
 
-  // ユーザー操作によるセッション選択。restart pending 中にユーザーが
-  // 別セッションを手動で選んだ場合、新セッション到着時に元の worktree
-  // へ自動移動させない (= migration を破棄する)。
+  // ユーザー操作によるセッション選択
   const handleSelectSession = useCallback((id: string | null) => {
-    restartingWorktreePathRef.current = null;
     setSelectedSessionId(id);
   }, []);
 
@@ -421,49 +393,6 @@ export default function Dashboard() {
   useEffect(() => {
     // ブラウザ選択中はリセットしない
     if (selectedSessionId === "browser") return;
-
-    // 別タブで再起動が起きた場合のフォールバック:
-    // 選択中セッションが今回の sessions Map から消えた瞬間に、
-    // 直前 snapshot から worktreePath を取り出して restart pending として扱う。
-    // (initiating tab は handleRestartSession で先に値を入れているため上書きしない)
-    //
-    // 別タブ発の再起動の一次経路は session:restarted イベントによる追従。
-    // このヒューリスティックは同イベントを取りこぼした場合の保険で、
-    // restart 由来かどうかの推定は「直前snapshot で staleProfile=true だった」
-    // ことを条件にする。stale でないセッションが消えるのは通常停止
-    // (別タブからのstop等) の可能性があり、migration を発動させると
-    // 停止済みセッションを選択したまま固まるため、保険は stale に限定する。
-    if (
-      !restartingWorktreePathRef.current &&
-      selectedSessionId &&
-      !sessions.has(selectedSessionId) &&
-      lastSelectedSessionRef.current?.id === selectedSessionId &&
-      lastSelectedSessionRef.current?.staleProfile === true
-    ) {
-      restartingWorktreePathRef.current =
-        lastSelectedSessionRef.current.worktreePath;
-    }
-
-    // 再起動進行中: 新セッションが届いていれば selectedSessionId を新IDへ移す
-    if (restartingWorktreePathRef.current) {
-      const replacement = Array.from(sessions.values()).find(
-        s => s.worktreePath === restartingWorktreePathRef.current
-      );
-      if (replacement) {
-        if (replacement.id !== selectedSessionId) {
-          setSelectedSessionId(replacement.id);
-        }
-        // session:restarted の追従が先に効いて選択済みでも pending は解消する。
-        // 残すと以後の通常停止でフォールバック選択が抑制され続け、
-        // 停止済みセッションを選択したまま固まる
-        restartingWorktreePathRef.current = null;
-        return;
-      }
-      // まだ届いていない: 通常のフォールバックを抑制して新session到着を待つ
-      if (selectedSessionId && !sessions.has(selectedSessionId)) {
-        return;
-      }
-    }
 
     // グリッドビュー表示中は自動選択を抑制 (ユーザーがセルクリックで明示的に選ぶ)
     if (!selectedSessionId && sessions.size > 0 && !gridRepoPath) {

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -449,8 +449,13 @@ export default function Dashboard() {
       const replacement = Array.from(sessions.values()).find(
         s => s.worktreePath === restartingWorktreePathRef.current
       );
-      if (replacement && replacement.id !== selectedSessionId) {
-        setSelectedSessionId(replacement.id);
+      if (replacement) {
+        if (replacement.id !== selectedSessionId) {
+          setSelectedSessionId(replacement.id);
+        }
+        // session:restarted の追従が先に効いて選択済みでも pending は解消する。
+        // 残すと以後の通常停止でフォールバック選択が抑制され続け、
+        // 停止済みセッションを選択したまま固まる
         restartingWorktreePathRef.current = null;
         return;
       }

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -388,6 +388,27 @@ export default function Dashboard() {
     [selectedSessionId, sessions, restartSessionWithProfile]
   );
 
+  // 再起動完了通知 (旧ID→新ID) による選択追従。別タブ発の再起動でも
+  // 選択中セッションを新IDへ確実に移す (サーバーが io.emit で全クライアント
+  // に配るため、initiating tab 以外もこの経路で追従できる)。
+  // sessions 一覧の更新は session:stopped / session:created が担うので、
+  // ここでは selectedSessionId の付け替えだけを行う
+  useEffect(() => {
+    if (!socket) return;
+    const handler = (data: {
+      oldSessionId: string;
+      session: ManagedSession;
+    }) => {
+      setSelectedSessionId(prev =>
+        prev === data.oldSessionId ? data.session.id : prev
+      );
+    };
+    socket.on("session:restarted", handler);
+    return () => {
+      socket.off("session:restarted", handler);
+    };
+  }, [socket]);
+
   // ユーザー操作によるセッション選択。restart pending 中にユーザーが
   // 別セッションを手動で選んだ場合、新セッション到着時に元の worktree
   // へ自動移動させない (= migration を破棄する)。
@@ -406,10 +427,12 @@ export default function Dashboard() {
     // 直前 snapshot から worktreePath を取り出して restart pending として扱う。
     // (initiating tab は handleRestartSession で先に値を入れているため上書きしない)
     //
+    // 別タブ発の再起動の一次経路は session:restarted イベントによる追従。
+    // このヒューリスティックは同イベントを取りこぼした場合の保険で、
     // restart 由来かどうかの推定は「直前snapshot で staleProfile=true だった」
-    // ことを条件にする。restart は staleProfile セッションに対してのみ実行され
-    // るため、stale でないセッションが消えるのは通常停止 (別タブからのstop等)
-    // とみなして migration を発動させない。
+    // ことを条件にする。stale でないセッションが消えるのは通常停止
+    // (別タブからのstop等) の可能性があり、migration を発動させると
+    // 停止済みセッションを選択したまま固まるため、保険は stale に限定する。
     if (
       !restartingWorktreePathRef.current &&
       selectedSessionId &&


### PR DESCRIPTION
## 概要

セッション再起動 UI がプロファイル切替の staleProfile 警告時にしか表示されず、メイン worktree のセッション等を UI から再起動する手段がなかった問題を解消する。

## 変更内容

- **PC**: SessionCard の右クリックメニューに「セッションを再起動」を追加（確認ダイアログは SessionSidebar の既存ダイアログを共用）
- **モバイル**: MobileSessionView のヘッダーメニューに「セッションを再起動」を追加（削除と同型の確認ダイアログを新設）
- **サーバー**: `session:restart-with-profile` の multiProfileSupported gate を除去（再起動は profile 機能に依存しない汎用操作のため。macOS でも動作するようになる）
- **選択追従の堅牢化**: 再起動イベントを `created(新) → restarted(旧→新) → stopped(旧)` の順に固定し、新設の `session:restarted` イベントによる旧ID→新ID の選択追従に一本化。従来の worktreePath ベースの migration ヒューリスティック（pending 残留の温床）を撤去
- **並行再起動の直列化**: 複数タブからの同時再起動で重複セッションが作られないよう in-flight guard を追加

## テスト

- orchestrator の emit 順序・`session:restarted` payload・並行再起動の直列化をテストで固定（vitest 367件 全通過）
- `pnpm check`（biome + tsc -b）/ `pnpm build` 通過
- Codex レビュー3巡（capability gate、イベント順序レース、ref 残留、並行再起動の指摘に対応）→ LGTM、P5 ゲート GATE_PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - セッションを再起動できる操作を、デスクトップおよびモバイルのメニューに追加しました。
  - 再起動前に確認ダイアログを表示します。
  - 再起動完了時に、選択中のセッションを新しいセッションへ自動引き継ぎします。

- **バグ修正**
  - 同一セッションの同時再起動による重複作成や不整合を防止しました。
  - 再起動完了イベントに基づく画面追従を改善しました。
  - tmuxコマンドのハングを抑止するタイムアウトを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->