### PR TITLE
図解ハーネス B-2: graph コンテナ（2次元配置・edge 描画・ドラッグ移動） (#224)

### DIFF
--- a/docs/diagrams/sample.diagram.html
+++ b/docs/diagrams/sample.diagram.html
@@ -3,11 +3,11 @@
 <meta charset="utf-8"><title>サンプル</title>
 <style>
   body { font-family: system-ui, sans-serif; background:#1a1b26; color:#c0caf5; padding:1.5rem; }
-  .entity { border:1px solid #2c2f42; border-radius:4px; margin-bottom:1rem; max-width:22rem; }
+  .graph { min-height:420px; }
+  .entity { width:22rem; border:1px solid #2c2f42; border-radius:4px; }
   .entity h3 { margin:0; padding:.6rem .9rem; border-bottom:1px solid #2c2f42; font-size:.9rem; }
   .entity ul { list-style:none; margin:0; padding:.4rem 0; }
   .entity li { padding:.25rem .9rem; font-family:ui-monospace,monospace; font-size:.8rem; }
-  .rel { color:#7aa2f7; font-size:.8rem; }
 </style>
 </head>
 <body>
@@ -20,6 +20,10 @@
       "id": "order",
       "label": "Order",
       "kind": "entity",
+      "ext": {
+        "x": 40,
+        "y": 50
+      },
       "fields": [
         {
           "id": "order_id",
@@ -39,6 +43,10 @@
       "id": "user",
       "label": "User",
       "kind": "entity",
+      "ext": {
+        "x": 360,
+        "y": 180
+      },
       "fields": [
         {
           "id": "user_id",
@@ -63,22 +71,23 @@
 }
 </script>
 
-<div class="entity" data-model-id="order">
-  <h3>Order</h3>
-  <ul>
-    <li data-model-id="order_id">id</li>
-    <li data-model-id="order_user_id">user_id</li>
-    <li data-model-id="order_status">status</li>
-  </ul>
+<div class="graph" data-ark-container="graph">
+  <div class="entity" data-model-id="order">
+    <h3>Order</h3>
+    <ul>
+      <li data-model-id="order_id">id</li>
+      <li data-model-id="order_user_id">user_id</li>
+      <li data-model-id="order_status">status</li>
+    </ul>
+  </div>
+  <div class="entity" data-model-id="user">
+    <h3>User</h3>
+    <ul>
+      <li data-model-id="user_id">id</li>
+      <li data-model-id="user_email">email</li>
+    </ul>
+  </div>
 </div>
-<div class="entity" data-model-id="user">
-  <h3>User</h3>
-  <ul>
-    <li data-model-id="user_id">id</li>
-    <li data-model-id="user_email">email</li>
-  </ul>
-</div>
-<p class="rel" data-model-id="e_order_user">Order — belongs to → User</p>
 
 
 

--- a/docs/superpowers/plans/2026-07-21-issue-224.md
+++ b/docs/superpowers/plans/2026-07-21-issue-224.md
@@ -1,0 +1,405 @@
+# issue-224: graph コンテナ（2次元配置・edge 描画・ドラッグ移動） Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 既存 list 編集を維持したまま、`node.ext.x/y` に基づく2次元ノード配置、SVG edge 描画、ドラッグによる座標更新を図解ハーネスへ追加する。
+
+**Issue:** 224 (GitHub Issue 紐付けあり)
+
+**Architecture:** Ark が `packages/server/src/lib/diagram-harness.ts:37-592` から srcDoc へ注入するハーネスに、`data-ark-container="graph"` を opt-in 契約とする graph 投影を追加し、モデルの `node.ext.x/y` を CSS 座標へ反映して edge を一時 SVG overlay で描く。更新は既存の MessageChannel と `diagram:submit`（`packages/shared/src/types.ts:642-660`、`packages/server/src/index.ts:2207-2342`、`packages/web/src/components/DiagramPane.tsx:146-223`）を再利用するため Socket.IO イベント追加、`useSocket.ts` の購読追加、SQLite スキーマ変更はなく、純粋な位置変更は既存の `describeModelDiff` が `ext` を無視する性質を明示的にテストして tmux へ送らない。SessionOrchestrator の start / stop / restart / restore と ttyd ライフサイクルには触れず、PC の `SplitViewPane` 内 `DiagramPane` を受入対象とし、現行で diagram を描画しない `MobileLayout` / `MobileSessionView` は変更しない一方、ドラッグ実装自体は Pointer Events を使って将来のタッチ対応を妨げない。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Express / Socket.IO / better-sqlite3 / tmux / ttyd
+
+---
+
+## 前提と変更境界
+
+- 設計の正は `docs/superpowers/specs/2026-07-20-html-diagram-harness-design.md:36-64,80-95,150-168,241-248`。図ファイルを正とし、編集能力は Ark 注入ハーネスが保証し、iframe から散文を受け取らない。
+- graph 投影の DOM 契約は `<div data-ark-container="graph">` とする。その配下で `data-model-id` が `model.nodes[].id` と一致する要素だけを graph node とみなし、field / edge / group の `data-model-id` は node と誤認しない。
+- node の初期位置は有限数の `node.ext.x` / `node.ext.y` が両方ある場合だけ採用する。不正値・欠損値の node は graph 配置と edge 描画から安全に除外し、暗黙の自動レイアウトは行わない。
+- edge は `model.edges` から読み、同じ graph コンテナ内で `from` / `to` の両 node が解決できたものだけを描く。edge の張り替え、カーディナリティ編集、自動レイアウト、undo/redo、イベントストーミング固有 kind は実装しない。
+- SVG overlay、drag handle、graph 用 class / CSS custom property はハーネスの一時 UI であり、`buildSubmissionHtml()` が生成する保存 HTML には残さない。座標の永続化先はモデルの `ext` だけとする。
+- 新規 Socket.IO イベントは作らない。したがって `packages/shared/src/types.ts`、`packages/server/src/index.ts`、`packages/web/src/hooks/useSocket.ts` は変更しない。イベント追加が必要になる設計変更はこの plan の範囲外であり、採用する場合は3ファイルを同時更新する必要がある。
+- SQLite は変更しない。`packages/server/src/lib/database.ts:179-281` の起動時 migration、`SessionOrchestrator` の復元（`packages/server/src/lib/session-orchestrator.ts:274-330`）、tmux/ttyd の start / stop / restart / restore は現状維持する。図の座標は `docs/diagrams/*.diagram.html` に保存される。
+- web 側にはコンポーネントテスト基盤がないため、`diagram-harness.ts` の文字列注入契約は vitest、実ブラウザ上の geometry / Pointer Events / MessageChannel / list 共存は Playwright で検証する。
+- 各実装タスクは Red → Green → Refactor の順で進める。server 相対 import は `.js` 拡張子を使い、コミット対象は明示したファイルだけを stage する。
+
+---
+
+## Task 1: graph ハーネスのブラウザ受入テストを Red にする
+
+**Files:**
+
+- Create: `e2e/diagram-harness.spec.ts`
+- Reference: `packages/server/src/lib/diagram-harness.ts:100-574`
+- Reference: `packages/server/src/lib/diagram-model.ts:15-45`
+
+- [ ] **Step 1: 生成物の最小 graph + list 共存 fixture を作る（2-5分）**
+
+  `injectHarness()` を直接 import し、`page.setContent()` へ渡す helper を作る。fixture は `order` と `user` の2 node、`belongs to` edge、各 node 内の `<ul><li data-model-id>`、graph container の `data-ark-container="graph"` を含める。
+
+  ```ts
+  import { expect, test } from "@playwright/test";
+  import { injectHarness } from "../packages/server/src/lib/diagram-harness";
+
+  const model = {
+    version: 1,
+    nodes: [
+      {
+        id: "order",
+        label: "Order",
+        fields: [
+          { id: "order_id", label: "id" },
+          { id: "order_status", label: "status" },
+        ],
+        ext: { x: 40, y: 50 },
+      },
+      {
+        id: "user",
+        label: "User",
+        fields: [{ id: "user_id", label: "id" }],
+        ext: { x: 360, y: 180 },
+      },
+    ],
+    edges: [
+      { id: "e_order_user", from: "order", to: "user", label: "belongs to" },
+    ],
+    groups: [],
+  };
+  ```
+
+  HTML 側では graph container に `position` や node の `left/top` を書かない。`ext` が唯一の座標源であることをテストで固定する。
+
+- [ ] **Step 2: 2次元配置と SVG edge の失敗テストを書く（2-5分）**
+
+  次を assertion にする。
+
+  - `order` / `user` の bounding box が `ext.x/y` に対応して別位置にある。
+  - graph container 内に `.ark-harness-edge-layer` が1つある。
+  - `[data-ark-edge-id="e_order_user"]` の線と label `belongs to` がある。
+  - line の始終点が両 node の外周上にあり、単なるテキスト `Order — belongs to → User` は fixture に存在しない。
+
+- [ ] **Step 3: ドラッグ・送信モデル・list 回帰の失敗テストを書く（2-5分）**
+
+  `order` node に追加される `.ark-harness-graph-handle` を `page.mouse` で `(80, 60)` 移動し、次を検証する。
+
+  - node の bounding box と edge の from 側 endpoint が同じ delta で更新される。
+  - MessageChannel を渡して「変更を送る」を押すと、`ark:diagram-submit` の `model.nodes[order].ext` が `{ x: 120, y: 110 }` になる。
+  - 送信 `html` に `.ark-harness-edge-layer`、`.ark-harness-graph-handle`、`--ark-harness-graph-x/y` が含まれない。
+  - `order` 内の field は従来どおり `contenteditable` になり、既存の行 drag handle で `status, id` へ並べ替えると送信モデルの fields 順も変わる。
+
+- [ ] **Step 4: Red を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: FAIL。最初の graph assertion が `.ark-harness-edge-layer` または `.ark-harness-graph-handle` を見つけられず失敗する。既存 list fixture の初期化自体は成功する。
+
+---
+
+## Task 2: ext 座標で node を配置し SVG edge を描画する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:37-93`（graph / SVG / handle CSS）
+- Modify: `packages/server/src/lib/diagram-harness.ts:112-210`（graph state と model lookup）
+- Modify: `packages/server/src/lib/diagram-harness.ts:373-407`（list と graph の共存初期化）
+- Modify: `packages/server/src/lib/diagram-harness.ts:550-560`（graph 初期化）
+- Modify: `packages/server/src/lib/diagram-harness.test.ts:7-34`
+
+- [ ] **Step 1: 注入文字列の vitest を Red にする（2-5分）**
+
+  `injectHarness(page(...))` の結果が次の契約を含むテストを追加する。
+
+  ```ts
+  expect(out).toContain('[data-ark-container="graph"]');
+  expect(out).toContain("ark-harness-edge-layer");
+  expect(out).toContain("ark-harness-graph-handle");
+  expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  ```
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: FAIL。graph selector / class がまだ HARNESS_JS / HARNESS_STYLE に存在しない。
+
+- [ ] **Step 2: graph node の解決と座標適用を実装する（2-5分）**
+
+  HARNESS_JS に次の責務を持つ helper を追加する。
+
+  ```js
+  function finiteNumber(v) {
+    return typeof v === "number" && Number.isFinite(v);
+  }
+
+  function graphPosition(node) {
+    if (!node || !isRecordObject(node.ext)) return null;
+    if (!finiteNumber(node.ext.x) || !finiteNumber(node.ext.y)) return null;
+    return { x: node.ext.x, y: node.ext.y };
+  }
+  ```
+
+  `wireGraph(container)` は container 内の `[data-model-id]` を列挙し、`getNode(state.model, id)` が返り、かつ最も近い `[data-ark-container="graph"]` が当該 container である要素だけを node として Map 化する。node へ `ark-harness-graph-node` class と `--ark-harness-graph-x: <x>px` / `--ark-harness-graph-y: <y>px` を設定し、CSS class 側で `position:absolute; left:var(...); top:var(...); z-index:1` を適用する。
+
+- [ ] **Step 3: edge geometry と SVG overlay を実装する（2-5分）**
+
+  container ごとに `svg.ark-harness-edge-layer[data-ark-harness-ui="1"]` を1つだけ追加する。各 edge は次の式で node 中心間ベクトルと矩形半径を使い、中心ではなく node 外周を結ぶ。
+
+  ```js
+  var dx = toCx - fromCx;
+  var dy = toCy - fromCy;
+  var length = Math.sqrt(dx * dx + dy * dy) || 1;
+  var ux = dx / length;
+  var uy = dy / length;
+  var fromRadius = Math.min(
+    Math.abs(ux) > 0 ? fromRect.width / 2 / Math.abs(ux) : Infinity,
+    Math.abs(uy) > 0 ? fromRect.height / 2 / Math.abs(uy) : Infinity
+  );
+  ```
+
+  `from + unit * radius` と `to - unit * radius` を `<line data-ark-edge-id>` の endpoint にし、`marker-end` で矢印を描く。label は線の中点へ `<text>` で描き、空 label の edge は text を作らない。自己 edge は node の右辺から上辺へ戻る cubic `<path>` として描く。同一 graph 内に両端がない edge、有限座標を持たない node は描画せず、例外を投げない。
+
+- [ ] **Step 4: resize 時の edge 再描画を追加する（2-5分）**
+
+  `requestAnimationFrame` で多重呼び出しを1 frame にまとめる `scheduleGraphRender()` を作り、初期化直後、`ResizeObserver` による container / node サイズ変更、`window.resize` で edge を再計算する。observer がない環境でも初期描画は行う。
+
+- [ ] **Step 5: Green と list 初期化の非回帰を確認する（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: PASS。既存3テストと graph 契約テストがすべて成功する。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "2次元配置と edge"`
+
+  Expected: PASS。node が2次元配置され、edge と label が表示される。
+
+- [ ] **Step 6: Refactor（2-5分）**
+
+  graph ごとの mutable state を `{ container, nodesById, svg, resizeObserver, scheduled }` にまとめ、DOM query と model lookup の重複を除く。`initEditing()` の既存 list binding（`diagram-harness.ts:373-405`）は処理順を変えず、その前後に graph 初期化を追加するだけにする。
+
+---
+
+## Task 3: Pointer Events で node を動かし ext と edge を同期する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:112-116`（drag state）
+- Modify: `packages/server/src/lib/diagram-harness.ts`（Task 2 で追加した graph helper 群）
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: drag handle を追加する（2-5分）**
+
+  graph node ごとに `button.ark-harness-graph-handle[data-ark-harness-ui="1"]` を追加し、`aria-label` を `${node.label} をドラッグして移動` とする。handle に `touch-action:none`、node に drag 中だけ `ark-harness-graph-dragging` class を付け、field の contenteditable と list の HTML Drag and Drop を奪わない。
+
+- [ ] **Step 2: pointerdown / move / up を実装する（2-5分）**
+
+  `pointerdown` で pointer capture、開始時の `clientX/clientY` と `ext.x/y` を保存する。`pointermove` では次のように整数座標へ更新し、負値だけ0へ clamp する。
+
+  ```js
+  var x = Math.max(0, Math.round(start.x + event.clientX - start.clientX));
+  var y = Math.max(0, Math.round(start.y + event.clientY - start.clientY));
+  if (!isRecordObject(node.ext)) node.ext = {};
+  node.ext.x = x;
+  node.ext.y = y;
+  el.style.setProperty("--ark-harness-graph-x", x + "px");
+  el.style.setProperty("--ark-harness-graph-y", y + "px");
+  scheduleGraphRender(graph);
+  ```
+
+  `pointerup` / `pointercancel` では capture と drag class を解除する。位置は model と DOM の両方へ move 中に反映するが、ファイル保存と会話還流は従来どおり「変更を送る」まで行わない。
+
+- [ ] **Step 3: edge が drag に追従する Green を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "ドラッグ"`
+
+  Expected: PASS。`order` は `(40,50)` から `(120,110)` へ移り、edge endpoint も更新され、送信 model の `order.ext` が `{ x: 120, y: 110 }` になる。
+
+- [ ] **Step 4: 異常入力の browser test を追加する（2-5分）**
+
+  `ext.x = "40"`、`ext.y = null`、参照先が graph 外の edge を含む fixture を追加する。ページが例外で停止せず、有効 node / edge だけが描画され、不正座標 node に drag handle が付かないことを確認する。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "不正座標"`
+
+  Expected: PASS。page error 0件、無効 edge 0本、有効 edge のみ1本。
+
+- [ ] **Step 5: Refactor（2-5分）**
+
+  pointer listener の共通終了処理を `finishGraphDrag()` にまとめ、drag state は同時に1 pointer だけを保持する。DOM の node id ではなく解決済み model node object を保持し、move ごとの全 model scan を避ける。
+
+---
+
+## Task 4: 保存 HTML を清掃し list と graph の共存を Green にする
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:409-440`（`buildSubmissionHtml`）
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: cleanup assertion を Red にする（2-5分）**
+
+  Task 1 の送信テストへ次を追加する。
+
+  ```ts
+  expect(submission.html).not.toContain("ark-harness-edge-layer");
+  expect(submission.html).not.toContain("ark-harness-graph-handle");
+  expect(submission.html).not.toContain("--ark-harness-graph-x");
+  expect(submission.html).not.toContain("--ark-harness-graph-y");
+  expect(submission.html).toContain('data-ark-container="graph"');
+  ```
+
+  Expected: Task 2/3 の実装直後は custom property が clone に残るため FAIL。
+
+- [ ] **Step 2: graph の一時属性だけを削除する（2-5分）**
+
+  `buildSubmissionHtml()` で `data-ark-harness-ui` を削除した後、graph node clone から `--ark-harness-graph-x` / `--ark-harness-graph-y` だけを `style.removeProperty()` し、空になった `style` 属性を削除する。生成物が元から持つ `style` の他 property と `data-ark-container="graph"` は保持する。既存の `ark-harness-` class 除去（`diagram-harness.ts:427-437`）をそのまま最終 cleanup として使う。
+
+- [ ] **Step 3: list inline edit と並べ替えの回帰を確認する（2-5分）**
+
+  Playwright で `order_status` の contenteditable を `state` に変え、既存の行 handle（`aria-label="ドラッグして並べ替え"`）を使って `state/id` の順へ動かす。送信 model が label と fields 順を反映し、graph node の `ext` を保持することを確認する。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: PASS。graph 描画、node drag、送信 cleanup、list inline edit / reorder、不正座標の全テストが成功する。
+
+- [ ] **Step 4: harness の unit regression を再実行する（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts src/lib/diagram-file.test.ts src/lib/diagram-reader.test.ts`
+
+  Expected: PASS。二重注入防止、CSP 注入、モデル block の置換、配信時 harness 注入が壊れていない。
+
+- [ ] **Step 5: 実装単位をコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts e2e/diagram-harness.spec.ts
+  git commit -m "feat(diagram): graph コンテナの配置とドラッグを追加"
+  ```
+
+---
+
+## Task 5: ext の保存・非還流契約と sample 図を固定する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-model.test.ts:31-43`
+- Modify: `packages/server/src/lib/diagram-diff.test.ts:242-257`
+- Modify: `packages/server/src/lib/diagram-file.test.ts:134-195`
+- Modify: `docs/diagrams/sample.diagram.html:4-81`
+- Reference only: `packages/server/src/lib/diagram-model.ts:55-57,111-117`
+- Reference only: `packages/server/src/lib/diagram-diff.ts:104-166`
+- Reference only: `packages/server/src/index.ts:2278-2342`
+
+- [ ] **Step 1: ext 座標の parse / file round-trip regression test を追加する（2-5分）**
+
+  `parseDiagramModel()` が `{ ext: { x: 40, y: 50, color: "blue" } }` を欠落させず返すこと、`replaceModelBlock()` → `extractModel()` の往復後も同じ ext が残ることを検証する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts src/lib/diagram-file.test.ts`
+
+  Expected: PASS。既存の `asExt()` と model block 置換が graph 固有情報をそのまま保持する。production model parser の変更は不要。
+
+- [ ] **Step 2: 位置変更を意味差分へ含めない regression test を追加する（2-5分）**
+
+  ```ts
+  it("node.ext の座標変更は意味差分に含めない", () => {
+    const before = model([{ ...order, ext: { x: 40, y: 50 } }]);
+    const after = model([{ ...order, ext: { x: 120, y: 110 } }]);
+    expect(describeModelDiff(before, after)).toEqual([]);
+  });
+  ```
+
+  加えて座標変更と field 改名を同時に行った場合、返る文が field 改名の1行だけであることを確認する。これにより `index.ts:2319-2342` は pure movement ではファイルだけを書き、`SessionOrchestrator.sendMessage()` を呼ばず `sent: []` を返す。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-diff.test.ts`
+
+  Expected: PASS。production diff 変更なしで、`ext` 非還流の契約が明示される。
+
+- [ ] **Step 3: sample を graph + list 共存図へ更新する（2-5分）**
+
+  `docs/diagrams/sample.diagram.html` の `order` / `user` に次の ext を追加する。
+
+  ```json
+  { "x": 40, "y": 50 }
+  { "x": 360, "y": 180 }
+  ```
+
+  両 entity を高さ `420px` 以上の `<div class="graph" data-ark-container="graph">` で包み、entity の幅だけ生成 CSS で定める。現在の text edge `<p class="rel" ...>`（`sample.diagram.html:81`）は削除し、edge 表示は model の `edges` からハーネスが生成する SVG のみにする。entity 内の `<ul>` と field の `data-model-id` は残し、同じ図で graph node drag と list 行編集を受入確認できる fixture にする。
+
+- [ ] **Step 4: sample の配信契約を確認する（2-5分）**
+
+  `diagram-reader.test.ts` の fixture または新しい test case で、graph HTML を `readDiagram()` に通した結果が model ext、Ark CSP、ハーネス marker を含むことを検証する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts src/lib/diagram-diff.test.ts src/lib/diagram-file.test.ts src/lib/diagram-reader.test.ts`
+
+  Expected: PASS。座標は model に保存され、edge SVG は保存 file ではなく配信時 harness が生成する。
+
+- [ ] **Step 5: fixture / semantic contract をコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-diff.test.ts packages/server/src/lib/diagram-file.test.ts packages/server/src/lib/diagram-reader.test.ts docs/diagrams/sample.diagram.html
+  git commit -m "test(diagram): graph 座標の保存と非還流を固定"
+  ```
+
+---
+
+## Task 6: 全回帰と実機受け入れを完了する
+
+**Files:**
+
+- Verify only: `packages/shared/src/types.ts:386-389,630-660`
+- Verify only: `packages/server/src/index.ts:1074-1098,2127-2346`
+- Verify only: `packages/web/src/hooks/useSocket.ts:45,252-253,1615-1721`
+- Verify only: `packages/web/src/components/DiagramPane.tsx:121-223`
+- Verify only: `packages/web/src/components/SplitViewPane.tsx:252-279`
+- Verify only: `packages/web/src/components/MobileLayout.tsx:1-31`
+- Verify only: `packages/web/src/components/MobileSessionView.tsx:521-588`
+- Verify only: `packages/server/src/lib/session-orchestrator.ts:274-330,885-928,1245-1252`
+- Verify only: `packages/server/src/lib/tmux-manager.ts:488-520,601-620`
+- Verify only: `packages/server/src/lib/ttyd-manager.ts:175-203,315-351`
+- Verify only: `packages/server/src/lib/database.ts:179-281,352-355`
+
+- [ ] **Step 1: Socket.IO / DB / lifecycle の非変更を diff で確認する（2-5分）**
+
+  `git diff -- packages/shared/src/types.ts packages/server/src/index.ts packages/web/src/hooks/useSocket.ts packages/server/src/lib/database.ts packages/server/src/lib/session-orchestrator.ts packages/server/src/lib/tmux-manager.ts packages/server/src/lib/ttyd-manager.ts` を実行する。
+
+  Expected: 出力なし。graph は既存 `diagram:submit` と既存 `SessionOrchestrator.sendMessage()` だけを利用し、新規 event、DB migration、tmux/ttyd lifecycle 変更を含まない。
+
+- [ ] **Step 2: 型チェックを実行する（2-5分）**
+
+  Run: `pnpm exec tsc -b`
+
+  Expected: exit 0、標準出力・標準エラーともに無出力。
+
+- [ ] **Step 3: 全 vitest を実行する（2-5分）**
+
+  Run: `pnpm exec vitest run`
+
+  Expected: exit 0、全 test file / test が PASS。
+
+- [ ] **Step 4: graph Playwright と既存 e2e を実行する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: graph の配置、edge、drag、cleanup、list 共存、不正入力 test がすべて PASS。
+
+  Run: `pnpm test:e2e`
+
+  Expected: localhost:4001 の Ark に対する既存 desktop / mobile test を含め全実行が PASS（API key 必須と明記された test は環境変数未設定時のみ SKIP）。
+
+- [ ] **Step 5: desktop 実機で受入条件を確認する（各2-5分）**
+
+  1. 稼働中 session で `docs/diagrams/sample.diagram.html` を `board_open` し、PC の右 `DiagramPane` に Order / User が2次元配置され `belongs to` edge が線と矢印で表示されることを確認する。
+  2. Order を drag し、edge が pointer move 中に追従することを確認する。「変更を送る」後に file の `order.ext.x/y` が移動後の整数座標へ変わり、会話には位置変更メッセージが送られないことを確認する。
+  3. Order の field を inline edit し、行順を drag で変更して再送する。file の DOM / model が一致し、会話へは field の意味差分だけが届くことを確認する。
+  4. 図 tab の閉開、`diagram:updated` による再読込、右 pane 幅変更後も node 座標と edge endpoint が正しく再投影されることを確認する。
+  5. 同じ図の graph 外に通常 list を一時的な受入 fixture として置いた場合も、graph node drag と list 行 drag の handle が混同されず両方動くことを確認する。受入 fixture はテストで表現済みのため、確認後に追加ファイルを残さない。
+
+- [ ] **Step 6: mobile 対応範囲を確認する（2-5分）**
+
+  現行の `MobileSessionView.tsx:563-588` は file / html viewer のみを描画し diagram を描画しないため、この Issue では `MobileLayout` / `MobileSessionView` を変更しない。既存 mobile e2e が PASS することを回帰条件とし、graph の mobile 閲覧・編集 UI 追加は行わない。
+
+- [ ] **Step 7: formatting と最終差分を確認する（2-5分）**
+
+  Run: `pnpm exec biome check packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-diff.test.ts packages/server/src/lib/diagram-file.test.ts packages/server/src/lib/diagram-reader.test.ts e2e/diagram-harness.spec.ts`
+
+  Expected: exit 0、format / lint error なし。
+
+  Run: `git diff --check`
+
+  Expected: 出力なし。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -256,6 +256,64 @@ test("node ドラッグと list 編集を送信 model と clean HTML に反映�
   expect(html).toContain('data-ark-container="graph"');
 });
 
+test("モデル直接編集後の node ドラッグを送信 model に反映する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  await connectSubmissionPort(page);
+
+  const editedModel = {
+    ...model,
+    nodes: model.nodes.map(node =>
+      node.id === "order" ? { ...node, label: "Edited Order" } : node
+    ),
+  };
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  await page.locator(".ark-harness-textarea").fill(JSON.stringify(editedModel));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+
+  const order = page.locator('section[data-model-id="order"]');
+  const handleBox = await requiredBoundingBox(
+    order.locator(".ark-harness-graph-handle")
+  );
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2 + 80,
+    handleBox.y + handleBox.height / 2 + 60
+  );
+  await page.mouse.up();
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+  );
+  expect(submission).toMatchObject({
+    type: "ark:diagram-submit",
+    model: {
+      nodes: [
+        { id: "order", label: "Edited Order", ext: { x: 120, y: 110 } },
+        { id: "user" },
+      ],
+    },
+  });
+});
+
 test("不正座標と graph 外参照を安全に除外する", async ({ page }) => {
   const errors: string[] = [];
   page.on("pageerror", error => errors.push(error.message));

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1,0 +1,281 @@
+import { expect, type Locator, type Page, test } from "@playwright/test";
+import { injectHarness } from "../packages/server/src/lib/diagram-harness";
+
+const model = {
+  version: 1,
+  nodes: [
+    {
+      id: "order",
+      label: "Order",
+      fields: [
+        { id: "order_id", label: "id" },
+        { id: "order_status", label: "status" },
+      ],
+      ext: { x: 40, y: 50 },
+    },
+    {
+      id: "user",
+      label: "User",
+      fields: [{ id: "user_id", label: "id" }],
+      ext: { x: 360, y: 180 },
+    },
+  ],
+  edges: [
+    { id: "e_order_user", from: "order", to: "user", label: "belongs to" },
+  ],
+  groups: [],
+};
+
+function diagramHtml(diagramModel: unknown = model): string {
+  return injectHarness(`<!doctype html>
+<html>
+  <head>
+    <style>
+      body { margin: 0; }
+      .graph { width: 720px; height: 480px; background: #f8fafc; }
+      .entity { box-sizing: border-box; width: 220px; padding: 12px; border: 1px solid #64748b; background: white; }
+    </style>
+  </head>
+  <body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
+    <div class="graph" data-ark-container="graph">
+      <section class="entity" data-model-id="order">
+        <h2 data-model-id="order">Order</h2>
+        <ul>
+          <li data-model-id="order_id">id</li>
+          <li data-model-id="order_status">status</li>
+        </ul>
+      </section>
+      <section class="entity" data-model-id="user">
+        <h2 data-model-id="user">User</h2>
+        <ul><li data-model-id="user_id">id</li></ul>
+      </section>
+    </div>
+  </body>
+</html>`);
+}
+
+function invalidCoordinateHtml(): string {
+  const invalidModel = {
+    version: 1,
+    nodes: [
+      { id: "valid_a", label: "Valid A", ext: { x: 40, y: 50 } },
+      { id: "valid_b", label: "Valid B", ext: { x: 360, y: 180 } },
+      { id: "string_x", label: "String X", ext: { x: "40", y: 80 } },
+      { id: "null_y", label: "Null Y", ext: { x: 80, y: null } },
+      { id: "outside", label: "Outside", ext: { x: 10, y: 10 } },
+    ],
+    edges: [
+      { id: "valid_edge", from: "valid_a", to: "valid_b" },
+      { id: "invalid_coordinate_edge", from: "valid_a", to: "string_x" },
+      { id: "outside_edge", from: "valid_a", to: "outside" },
+    ],
+    groups: [],
+  };
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .graph { width: 720px; height: 480px; }
+    .node { width: 160px; height: 80px; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(invalidModel)}</script>
+    <div class="graph" data-ark-container="graph">
+      <section class="node" data-model-id="valid_a">Valid A</section>
+      <section class="node" data-model-id="valid_b">Valid B</section>
+      <section class="node" data-model-id="string_x">String X</section>
+      <section class="node" data-model-id="null_y">Null Y</section>
+    </div>
+    <section data-model-id="outside">Outside</section>
+  </body></html>`);
+}
+
+async function openDiagram(page: Page, diagramModel: unknown = model) {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
+  await page.setContent(diagramHtml(diagramModel));
+  return errors;
+}
+
+async function connectSubmissionPort(page: Page) {
+  await page.evaluate(() => {
+    const browserWindow = window as typeof window & {
+      arkHarnessSubmission?: unknown;
+    };
+    const channel = new MessageChannel();
+    channel.port1.onmessage = event => {
+      browserWindow.arkHarnessSubmission = event.data;
+    };
+    window.postMessage({ type: "ark:test-connect" }, "*", [channel.port2]);
+  });
+  await expect(
+    page.getByRole("button", { name: "変更を親フレームへ送信する" })
+  ).toBeEnabled();
+}
+
+async function readEdge(page: Page) {
+  return page.locator('[data-ark-edge-id="e_order_user"]').evaluate(line => {
+    const svg = line.ownerSVGElement;
+    if (!svg) throw new Error("edge SVG がありません");
+    const svgRect = svg.getBoundingClientRect();
+    return {
+      x1: svgRect.x + Number(line.getAttribute("x1")),
+      y1: svgRect.y + Number(line.getAttribute("y1")),
+      x2: svgRect.x + Number(line.getAttribute("x2")),
+      y2: svgRect.y + Number(line.getAttribute("y2")),
+    };
+  });
+}
+
+async function requiredBoundingBox(locator: Locator) {
+  const box = await locator.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) throw new Error("要素の bounding box がありません");
+  return box;
+}
+
+test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ page }) => {
+  await openDiagram(page);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const order = graph.locator('section[data-model-id="order"]');
+  const user = graph.locator('section[data-model-id="user"]');
+  await expect(graph.locator(".ark-harness-edge-layer")).toHaveCount(1);
+  const [graphBox, orderBox, userBox] = await Promise.all([
+    requiredBoundingBox(graph),
+    requiredBoundingBox(order),
+    requiredBoundingBox(user),
+  ]);
+  expect(orderBox.x - graphBox.x).toBeCloseTo(40, 0);
+  expect(orderBox.y - graphBox.y).toBeCloseTo(50, 0);
+  expect(userBox.x - graphBox.x).toBeCloseTo(360, 0);
+  expect(userBox.y - graphBox.y).toBeCloseTo(180, 0);
+
+  const edge = graph.locator('[data-ark-edge-id="e_order_user"]');
+  await expect(edge).toHaveCount(1);
+  await expect(graph.locator("text", { hasText: "belongs to" })).toHaveCount(1);
+  await expect(
+    page.getByText("Order — belongs to → User", { exact: true })
+  ).toHaveCount(0);
+
+  const line = await readEdge(page);
+  const pointIsOnPerimeter = (x: number, y: number, box: typeof orderBox) => {
+    const inX = x >= box.x - 1 && x <= box.x + box.width + 1;
+    const inY = y >= box.y - 1 && y <= box.y + box.height + 1;
+    const sideDistance = Math.min(
+      Math.abs(x - box.x),
+      Math.abs(x - (box.x + box.width)),
+      Math.abs(y - box.y),
+      Math.abs(y - (box.y + box.height))
+    );
+    return inX && inY && sideDistance <= 1;
+  };
+  expect(pointIsOnPerimeter(line.x1, line.y1, orderBox)).toBe(true);
+  expect(pointIsOnPerimeter(line.x2, line.y2, userBox)).toBe(true);
+});
+
+test("node ドラッグと list 編集を送信 model と clean HTML に反映する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  await connectSubmissionPort(page);
+
+  const order = page.locator('section[data-model-id="order"]');
+  const handle = order.locator(".ark-harness-graph-handle");
+  const beforeBox = await requiredBoundingBox(order);
+  const beforeEdge = await readEdge(page);
+  const handleBox = await requiredBoundingBox(handle);
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2 + 80,
+    handleBox.y + handleBox.height / 2 + 60
+  );
+  await page.mouse.up();
+
+  await expect
+    .poll(async () => (await order.boundingBox())?.x)
+    .toBeCloseTo(beforeBox.x + 80, 0);
+  const afterBox = await requiredBoundingBox(order);
+  const afterEdge = await readEdge(page);
+  expect(afterBox.y).toBeCloseTo(beforeBox.y + 60, 0);
+  expect(afterEdge.x1 - beforeEdge.x1).toBeCloseTo(80, 0);
+  expect(afterEdge.y1).not.toBeCloseTo(beforeEdge.y1, 0);
+  expect(afterEdge.x1).toBeCloseTo(afterBox.x + afterBox.width, 0);
+  expect(afterEdge.y1).toBeGreaterThanOrEqual(afterBox.y);
+  expect(afterEdge.y1).toBeLessThanOrEqual(afterBox.y + afterBox.height);
+
+  const status = page.locator('li[data-model-id="order_status"]');
+  await expect(status.locator(".ark-harness-text")).toHaveAttribute(
+    "contenteditable",
+    "true"
+  );
+  await status.locator(".ark-harness-text").fill("state");
+  await status
+    .getByRole("button", { name: "ドラッグして並べ替え" })
+    .dragTo(page.locator('li[data-model-id="order_id"]'), {
+      targetPosition: { x: 10, y: 1 },
+    });
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+  );
+  expect(submission).toMatchObject({
+    type: "ark:diagram-submit",
+    model: {
+      nodes: [
+        {
+          id: "order",
+          ext: { x: 120, y: 110 },
+          fields: [
+            { id: "order_status", label: "state" },
+            { id: "order_id", label: "id" },
+          ],
+        },
+        { id: "user" },
+      ],
+    },
+  });
+  const html = (submission as { html: string }).html;
+  expect(html).not.toContain("ark-harness-edge-layer");
+  expect(html).not.toContain("ark-harness-graph-handle");
+  expect(html).not.toContain("--ark-harness-graph-x");
+  expect(html).not.toContain("--ark-harness-graph-y");
+  expect(html).toContain('data-ark-container="graph"');
+});
+
+test("不正座標と graph 外参照を安全に除外する", async ({ page }) => {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
+  await page.setContent(invalidCoordinateHtml());
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  await expect(graph.locator('[data-ark-edge-id="valid_edge"]')).toHaveCount(1);
+  await expect(
+    graph.locator('[data-ark-edge-id="invalid_coordinate_edge"]')
+  ).toHaveCount(0);
+  await expect(graph.locator('[data-ark-edge-id="outside_edge"]')).toHaveCount(
+    0
+  );
+  await expect(graph.locator("[data-ark-edge-id]")).toHaveCount(1);
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
+  await expect(
+    graph.locator('[data-model-id="string_x"] .ark-harness-graph-handle')
+  ).toHaveCount(0);
+  await expect(
+    graph.locator('[data-model-id="null_y"] .ark-harness-graph-handle')
+  ).toHaveCount(0);
+  expect(errors).toEqual([]);
+});

--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -256,6 +256,31 @@ describe("describeModelDiff（境界ケース）", () => {
     expect(describeModelDiff(model([before]), model([after]))).toEqual([]);
   });
 
+  it("node.ext の座標変更は意味差分に含めない", () => {
+    const before = model([{ ...order, ext: { x: 40, y: 50 } }]);
+    const after = model([{ ...order, ext: { x: 120, y: 110 } }]);
+
+    expect(describeModelDiff(before, after)).toEqual([]);
+  });
+
+  it("node.ext の座標変更と field 改名では改名だけを述べる", () => {
+    const before = model([{ ...order, ext: { x: 40, y: 50 } }]);
+    const after = model([
+      {
+        ...order,
+        fields: [
+          { id: "f_id", label: "id" },
+          { id: "f_status", label: "state" },
+        ],
+        ext: { x: 120, y: 110 },
+      },
+    ]);
+
+    expect(describeModelDiff(before, after)).toEqual([
+      "Order の status を state に変更",
+    ]);
+  });
+
   it("label の「」はエスケープせずそのまま埋め込むが、改行は無害化で落ちる", () => {
     const after = model([
       {

--- a/packages/server/src/lib/diagram-file.test.ts
+++ b/packages/server/src/lib/diagram-file.test.ts
@@ -194,6 +194,36 @@ describe("replaceModelBlock", () => {
     if (extracted.ok) expect(extracted.model.nodes[0]?.label).toBe("A2");
   });
 
+  it("モデルブロックの往復で node.ext の graph 座標を保持する", () => {
+    const html = page(
+      `<script type="application/json" id="ark-diagram-model">${MODEL}</script><div>図</div>`
+    );
+    const nextModel: DiagramModel = {
+      ...MODEL_OBJ,
+      nodes: [
+        {
+          id: "a",
+          label: "A",
+          ext: { x: 40, y: 50, color: "blue" },
+        },
+      ],
+    };
+
+    const replaced = replaceModelBlock(html, nextModel);
+    expect(replaced.ok).toBe(true);
+    if (!replaced.ok) return;
+
+    const extracted = extractModel(replaced.html);
+    expect(extracted.ok).toBe(true);
+    if (extracted.ok) {
+      expect(extracted.model.nodes[0]?.ext).toEqual({
+        x: 40,
+        y: 50,
+        color: "blue",
+      });
+    }
+  });
+
   it("属性の順序が逆でも差し替えられる", () => {
     const html = page(
       `<script id="ark-diagram-model" type="application/json">${MODEL}</script>`

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -31,4 +31,17 @@ describe("injectHarness", () => {
       1
     );
   });
+
+  it("graph 編集 UI の契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain('[data-ark-container="graph"]');
+    expect(out).toContain("ark-harness-edge-layer");
+    expect(out).toContain("ark-harness-graph-handle");
+    expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  });
 });

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -89,6 +89,27 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   font-size: 11.5px; cursor: pointer;
 }
 .ark-harness-add-row:hover { border-color: #38bdf8; color: #38bdf8; }
+[data-ark-container="graph"] { position: relative; }
+.ark-harness-graph-node {
+  position: absolute; left: var(--ark-harness-graph-x); top: var(--ark-harness-graph-y); z-index: 1;
+}
+.ark-harness-edge-layer {
+  position: absolute; inset: 0; z-index: 0; width: 100%; height: 100%;
+  overflow: visible; pointer-events: none;
+}
+.ark-harness-edge-layer line, .ark-harness-edge-layer path {
+  fill: none; stroke: #64748b; stroke-width: 1.5;
+}
+.ark-harness-edge-layer text {
+  fill: #475569; font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
+  font-size: 12px; text-anchor: middle; dominant-baseline: central;
+}
+.ark-harness-graph-handle {
+  position: absolute; top: .25rem; right: .25rem; z-index: 2;
+  border: 1px solid rgba(100,116,139,.45); border-radius: 4px; background: rgba(255,255,255,.9);
+  color: #64748b; cursor: grab; line-height: 1; padding: .25rem; touch-action: none;
+}
+.ark-harness-graph-dragging { z-index: 2; }
 body { padding-bottom: 3.4rem !important; }
 </style>`;
 
@@ -112,6 +133,9 @@ const HARNESS_JS = `(function () {
   var state = { model: null };
   var submitPort = null;
   var dragSrcLi = null;
+  var graphDrag = null;
+  var graphs = [];
+  var graphSequence = 0;
   var statusEl = null;
   var sendBtn = null;
 
@@ -151,6 +175,228 @@ const HARNESS_JS = `(function () {
       if (nodes[i].id === id) return nodes[i];
     }
     return null;
+  }
+
+  function finiteNumber(v) {
+    return typeof v === "number" && Number.isFinite(v);
+  }
+
+  function graphPosition(node) {
+    if (!node || !isRecordObject(node.ext)) return null;
+    if (!finiteNumber(node.ext.x) || !finiteNumber(node.ext.y)) return null;
+    return { x: node.ext.x, y: node.ext.y };
+  }
+
+  function svgElement(name) {
+    return document.createElementNS("http://www.w3.org/2000/svg", name);
+  }
+
+  function appendGraphMarker(svg, markerId) {
+    var defs = svgElement("defs");
+    var marker = svgElement("marker");
+    marker.setAttribute("id", markerId);
+    marker.setAttribute("viewBox", "0 0 10 10");
+    marker.setAttribute("refX", "9");
+    marker.setAttribute("refY", "5");
+    marker.setAttribute("markerWidth", "7");
+    marker.setAttribute("markerHeight", "7");
+    marker.setAttribute("orient", "auto-start-reverse");
+    var arrow = svgElement("path");
+    arrow.setAttribute("d", "M 0 0 L 10 5 L 0 10 z");
+    arrow.setAttribute("fill", "#64748b");
+    arrow.setAttribute("stroke", "none");
+    marker.appendChild(arrow);
+    defs.appendChild(marker);
+    svg.appendChild(defs);
+  }
+
+  function appendGraphLabel(svg, label, x, y) {
+    if (typeof label !== "string" || label.length === 0) return;
+    var text = svgElement("text");
+    text.setAttribute("x", String(x));
+    text.setAttribute("y", String(y));
+    text.textContent = label;
+    svg.appendChild(text);
+  }
+
+  function renderGraph(graph) {
+    graph.scheduled = false;
+    while (graph.svg.firstChild) graph.svg.removeChild(graph.svg.firstChild);
+    appendGraphMarker(graph.svg, graph.markerId);
+
+    var svgRect = graph.svg.getBoundingClientRect();
+    var edges = state.model && state.model.edges ? state.model.edges : [];
+    edges.forEach(function (edge) {
+      var fromEl = graph.nodesById.get(edge.from);
+      var toEl = graph.nodesById.get(edge.to);
+      if (!fromEl || !toEl) return;
+
+      var fromRect = fromEl.getBoundingClientRect();
+      var toRect = toEl.getBoundingClientRect();
+      var fromCx = fromRect.left + fromRect.width / 2 - svgRect.left;
+      var fromCy = fromRect.top + fromRect.height / 2 - svgRect.top;
+      var toCx = toRect.left + toRect.width / 2 - svgRect.left;
+      var toCy = toRect.top + toRect.height / 2 - svgRect.top;
+
+      if (edge.from === edge.to) {
+        var loop = svgElement("path");
+        var startX = fromRect.right - svgRect.left;
+        var startY = fromCy;
+        var endX = fromCx;
+        var endY = fromRect.top - svgRect.top;
+        var loopSize = Math.max(36, Math.min(fromRect.width, fromRect.height) / 2);
+        loop.setAttribute("data-ark-edge-id", edge.id);
+        loop.setAttribute(
+          "d",
+          "M " + startX + " " + startY + " C " +
+            (startX + loopSize) + " " + startY + ", " +
+            fromCx + " " + (endY - loopSize) + ", " + endX + " " + endY
+        );
+        loop.setAttribute("marker-end", "url(#" + graph.markerId + ")");
+        graph.svg.appendChild(loop);
+        appendGraphLabel(graph.svg, edge.label, startX + loopSize * 0.7, endY - loopSize * 0.45);
+        return;
+      }
+
+      var dx = toCx - fromCx;
+      var dy = toCy - fromCy;
+      var length = Math.sqrt(dx * dx + dy * dy) || 1;
+      var ux = dx / length;
+      var uy = dy / length;
+      var fromRadius = Math.min(
+        Math.abs(ux) > 0 ? fromRect.width / 2 / Math.abs(ux) : Infinity,
+        Math.abs(uy) > 0 ? fromRect.height / 2 / Math.abs(uy) : Infinity
+      );
+      var toRadius = Math.min(
+        Math.abs(ux) > 0 ? toRect.width / 2 / Math.abs(ux) : Infinity,
+        Math.abs(uy) > 0 ? toRect.height / 2 / Math.abs(uy) : Infinity
+      );
+      var x1 = fromCx + ux * fromRadius;
+      var y1 = fromCy + uy * fromRadius;
+      var x2 = toCx - ux * toRadius;
+      var y2 = toCy - uy * toRadius;
+      var line = svgElement("line");
+      line.setAttribute("data-ark-edge-id", edge.id);
+      line.setAttribute("x1", String(x1));
+      line.setAttribute("y1", String(y1));
+      line.setAttribute("x2", String(x2));
+      line.setAttribute("y2", String(y2));
+      line.setAttribute("marker-end", "url(#" + graph.markerId + ")");
+      graph.svg.appendChild(line);
+      appendGraphLabel(graph.svg, edge.label, (x1 + x2) / 2, (y1 + y2) / 2);
+    });
+  }
+
+  function scheduleGraphRender(graph) {
+    if (graph.scheduled) return;
+    graph.scheduled = true;
+    window.requestAnimationFrame(function () { renderGraph(graph); });
+  }
+
+  function finishGraphDrag(event) {
+    if (!graphDrag) return;
+    if (event && event.pointerId !== graphDrag.pointerId) return;
+    var drag = graphDrag;
+    graphDrag = null;
+    drag.el.classList.remove("ark-harness-graph-dragging");
+    if (drag.handle.hasPointerCapture(drag.pointerId)) {
+      drag.handle.releasePointerCapture(drag.pointerId);
+    }
+  }
+
+  function attachGraphHandle(graph, el, node) {
+    var handle = createButton(
+      "\\u283F",
+      "ark-harness-graph-handle",
+      (node.label || node.id) + " をドラッグして移動"
+    );
+    handle.addEventListener("pointerdown", function (event) {
+      if (graphDrag) return;
+      var position = graphPosition(node);
+      if (!position) return;
+      event.preventDefault();
+      handle.setPointerCapture(event.pointerId);
+      el.classList.add("ark-harness-graph-dragging");
+      graphDrag = {
+        pointerId: event.pointerId,
+        handle: handle,
+        graph: graph,
+        el: el,
+        node: node,
+        start: {
+          clientX: event.clientX,
+          clientY: event.clientY,
+          x: position.x,
+          y: position.y
+        }
+      };
+    });
+    handle.addEventListener("pointermove", function (event) {
+      if (!graphDrag || event.pointerId !== graphDrag.pointerId) return;
+      var drag = graphDrag;
+      var x = Math.max(0, Math.round(drag.start.x + event.clientX - drag.start.clientX));
+      var y = Math.max(0, Math.round(drag.start.y + event.clientY - drag.start.clientY));
+      if (!isRecordObject(drag.node.ext)) drag.node.ext = {};
+      drag.node.ext.x = x;
+      drag.node.ext.y = y;
+      drag.el.style.setProperty("--ark-harness-graph-x", x + "px");
+      drag.el.style.setProperty("--ark-harness-graph-y", y + "px");
+      scheduleGraphRender(drag.graph);
+    });
+    handle.addEventListener("pointerup", finishGraphDrag);
+    handle.addEventListener("pointercancel", finishGraphDrag);
+    el.appendChild(handle);
+  }
+
+  function wireGraph(container) {
+    var nodesById = new Map();
+    var modelNodesById = new Map();
+    var candidates = container.querySelectorAll("[data-model-id]");
+    candidates.forEach(function (el) {
+      if (el.closest('[data-ark-container="graph"]') !== container) return;
+      var id = el.getAttribute("data-model-id");
+      if (!id || nodesById.has(id)) return;
+      var node = getNode(state.model, id);
+      var position = graphPosition(node);
+      if (!position) return;
+      nodesById.set(id, el);
+      modelNodesById.set(id, node);
+      el.classList.add("ark-harness-graph-node");
+      el.style.setProperty("--ark-harness-graph-x", position.x + "px");
+      el.style.setProperty("--ark-harness-graph-y", position.y + "px");
+    });
+
+    var svg = svgElement("svg");
+    svg.classList.add("ark-harness-edge-layer");
+    markUi(svg);
+    container.appendChild(svg);
+    graphSequence += 1;
+    var graph = {
+      container: container,
+      nodesById: nodesById,
+      svg: svg,
+      resizeObserver: null,
+      scheduled: false,
+      markerId: "ark-harness-arrow-" + graphSequence
+    };
+    nodesById.forEach(function (el, id) {
+      attachGraphHandle(graph, el, modelNodesById.get(id));
+    });
+    if (typeof ResizeObserver !== "undefined") {
+      graph.resizeObserver = new ResizeObserver(function () { scheduleGraphRender(graph); });
+      graph.resizeObserver.observe(container);
+      nodesById.forEach(function (el) { graph.resizeObserver.observe(el); });
+    }
+    scheduleGraphRender(graph);
+    return graph;
+  }
+
+  function initGraphs() {
+    var containers = document.querySelectorAll('[data-ark-container="graph"]');
+    containers.forEach(function (container) { graphs.push(wireGraph(container)); });
+    window.addEventListener("resize", function () {
+      graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+    });
   }
 
   function findEntry(model, id) {
@@ -412,6 +658,11 @@ const HARNESS_JS = `(function () {
     clone.querySelectorAll("[data-ark-harness-ui]").forEach(function (el) {
       if (el.parentNode) el.parentNode.removeChild(el);
     });
+    clone.querySelectorAll(".ark-harness-graph-node").forEach(function (el) {
+      el.style.removeProperty("--ark-harness-graph-x");
+      el.style.removeProperty("--ark-harness-graph-y");
+      if (el.style.length === 0) el.removeAttribute("style");
+    });
     clone.querySelectorAll("[data-ark-harness-wrap]").forEach(function (span) {
       var parent = span.parentNode;
       if (!parent) return;
@@ -554,6 +805,7 @@ const HARNESS_JS = `(function () {
       state.model = model;
       buildToolbar();
       initEditing();
+      initGraphs();
     } catch (e) {
       console.error("[ark-harness] 初期化に失敗しました", e);
     }

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -312,7 +312,10 @@ const HARNESS_JS = `(function () {
     );
     handle.addEventListener("pointerdown", function (event) {
       if (graphDrag) return;
-      var position = graphPosition(node);
+      var id = el.getAttribute("data-model-id");
+      if (!id) return;
+      var currentNode = getNode(state.model, id);
+      var position = graphPosition(currentNode);
       if (!position) return;
       event.preventDefault();
       handle.setPointerCapture(event.pointerId);
@@ -322,7 +325,7 @@ const HARNESS_JS = `(function () {
         handle: handle,
         graph: graph,
         el: el,
-        node: node,
+        node: currentNode,
         start: {
           clientX: event.clientX,
           clientY: event.clientY,

--- a/packages/server/src/lib/diagram-model.test.ts
+++ b/packages/server/src/lib/diagram-model.test.ts
@@ -31,14 +31,24 @@ describe("parseDiagramModel", () => {
   it("図種固有の情報は ext に保持する", () => {
     const json = JSON.stringify({
       version: 1,
-      nodes: [{ id: "n1", label: "N", ext: { cardinality: "1..N" } }],
+      nodes: [
+        {
+          id: "n1",
+          label: "N",
+          ext: { x: 40, y: 50, color: "blue" },
+        },
+      ],
     });
 
     const result = parseDiagramModel(json);
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.model.nodes[0]?.ext).toEqual({ cardinality: "1..N" });
+      expect(result.model.nodes[0]?.ext).toEqual({
+        x: 40,
+        y: 50,
+        color: "blue",
+      });
     }
   });
 

--- a/packages/server/src/lib/diagram-reader.test.ts
+++ b/packages/server/src/lib/diagram-reader.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DIAGRAM_CSP } from "./diagram-file.js";
+import { DIAGRAM_HARNESS_MARKER } from "./diagram-harness.js";
 import { readDiagram } from "./diagram-reader.js";
 
 let wt: string;
@@ -31,11 +32,11 @@ afterEach(() => {
   fs.rmSync(outsideDir, { recursive: true, force: true });
 });
 
-function write(name: string, body: string) {
+function write(name: string, body: string, model = MODEL) {
   fs.writeFileSync(
     path.join(dir, name),
     `<!doctype html><html><head></head><body>` +
-      `<script type="application/json" id="ark-diagram-model">${MODEL}</script>` +
+      `<script type="application/json" id="ark-diagram-model">${model}</script>` +
       body +
       `</body></html>`
   );
@@ -51,6 +52,36 @@ describe("readDiagram", () => {
     if (result.ok) {
       expect(result.model.title).toBe("購買フロー");
       expect(result.html).toContain(DIAGRAM_CSP);
+    }
+  });
+
+  it("graph の ext と配信時 harness を返す", async () => {
+    const graphModel = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: "order", label: "Order", ext: { x: 40, y: 50 } },
+        { id: "user", label: "User", ext: { x: 360, y: 180 } },
+      ],
+      edges: [
+        { id: "e_order_user", from: "order", to: "user", label: "belongs to" },
+      ],
+      groups: [],
+    });
+    write(
+      "graph.diagram.html",
+      '<div data-ark-container="graph"><div data-model-id="order">Order</div><div data-model-id="user">User</div></div>',
+      graphModel
+    );
+
+    const result = await readDiagram(wt, "graph.diagram.html");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.nodes[0]?.ext).toEqual({ x: 40, y: 50 });
+      expect(result.model.nodes[1]?.ext).toEqual({ x: 360, y: 180 });
+      expect(result.html).toContain(DIAGRAM_CSP);
+      expect(result.html).toContain(DIAGRAM_HARNESS_MARKER);
+      expect(result.html).toContain('data-ark-container="graph"');
     }
   });
 


### PR DESCRIPTION
## 概要

図解ハーネス B-2。編集ハーネスに **graph コンテナ**を追加し、これまで list（縦積み）1 種だった図に「ノードを2次元に置いて関係を線で結ぶ」表現を加える。汎用ドメインモデリングとイベントストーミングの共通土台となる。

Closes #224

## 変更点

- **2次元配置**: `data-ark-container="graph"` を opt-in 契約とし、その配下の `data-model-id` ノードを `node.ext.x/y` の座標で絶対配置する（有限数の x/y が両方揃うノードのみ。不正・欠損座標は安全に除外）
- **edge を線で描画**: `model.edges` から SVG の `<line>`（自己 edge は cubic `<path>`）+ 矢印 marker を生成。両端がグラフ内で解決できる edge のみ描画。label は線の中点へ
- **ドラッグ移動**: Pointer Events でノードを動かすと `node.ext.x/y`（整数・≥0 clamp）と DOM を同期。`ResizeObserver` / `window.resize` で edge を再描画（rAF debounce）
- **list と共存**: 既存の list（インライン編集・行の並べ替え）は `data-ark-container` 無しの既定として不変。graph node のドラッグ handle と list の行 handle は混同しない
- **保存 HTML の清掃**: SVG・ドラッグ handle・graph 用 CSS 変数・`ark-harness-` class は `buildSubmissionHtml()` で要素ごと除去。座標の永続先はモデルの `ext` のみ（HTML 投影には残さない）

## 設計上の要点

- **還流しない位置変更**: ドラッグの座標変更は「意味の変化」ではないので会話へ還流しない。`describeModelDiff` が `ext` を無視する性質を明示的にテストで固定（純粋な移動はファイル保存のみ、`sent: []`）
- **既存経路の再利用**: 新規 Socket.IO イベント・DB スキーマ変更なし。既存の `diagram:submit` / MessageChannel / `SessionOrchestrator.sendMessage()` をそのまま使う
- **スコープ外**: edge の張り替え・カーディナリティ編集、自動レイアウト（elkjs）、イベントストーミングの `kind` 語彙・swimlane、モバイル UI は後続単位

## テスト

- `tsc -b`: pass（無出力）
- `vitest run`: 36 ファイル / 514 テスト pass
- `playwright test e2e/diagram-harness.spec.ts`: graph 3 テスト pass（2次元配置+edge / ドラッグ+list編集+clean HTML / 不正座標の安全除外）
- `biome check`: 変更 7 ファイル clean
- 実装は TDD（Red→Green→Refactor）。全挙動に vitest 文字列契約 + Playwright geometry テスト

## レビュー体制

codex が plan 立案・TDD 実装、Claude が P2（plan）/ P5（実装）レビューを担当（flow-x 役割逆転。実装者 ≠ レビュアー）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ダイアグラムに2次元グラフ表示を追加しました。
  - ノード間の関係をエッジ（矢印）として表示できるようになりました。
  - ノードをドラッグして配置を変更できるようになりました。
  - グラフ表示と従来のリスト編集を併用できます。
- **改善**
  - ノードの位置や追加属性を保存・復元できるようになりました。
  - 位置変更のみでは不要な差分として送信されないよう改善しました。
  - 不正な座標や無効な関係がある場合も安全に表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->