### PR TITLE
図解ハーネス: kind スタイリング（node.kind を投影 data-kind へ同期・色/アイコン区別） (#226)

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -33,7 +33,7 @@ description: 図解を求められたときに .diagram.html を生成する規�
 }
 </script>
 
-<div data-model-id="order" class="entity">…投影…</div>
+<div data-model-id="order" data-kind="entity" class="entity">…投影…</div>
 </body>
 </html>
 ```
@@ -45,27 +45,80 @@ description: 図解を求められたときに .diagram.html を生成する規�
 - **id はファイル内で一意にする。** 重複するとサーバーが拒否する
 - **edge の `from` と `to` は実在する node の id を指す。** 存在しない id を指すと 422 で拒否される
 - **投影の各要素に `data-model-id` を付ける。** 編集ハーネスがモデルと対応づけるため
-- **外部リソースを参照しない。** CSS も画像も自前で書き、画像は data URI として埋め込む（外部通信は遮断される）
+- **node の投影 root の `data-kind` は model の `node.kind` と同じ値にする。** Ark ハーネスも初期表示とモデル直接編集の反映時に同期する
+- **kind ごとの CSS は `[data-kind="..."]` で指定する。** class は layout や tone など見た目の補助に使う
+- **外部リソースを参照しない。** Unicode、inline SVG、data URI は使えるが、外部 URL の画像・stylesheet・font・icon library・外部 `<use href>` は使わない（外部通信は遮断される）
 - **`<meta http-equiv="Content-Security-Policy">` を自分で書かない。** Ark が注入する
 
 ## 語彙: kind
 
-node の `kind` フィールドで図の要素型を指定する。サーバーは `kind` の値を解釈せず、投影側（HTML/CSS）と skill の取り決めに従う。
+node の `kind` フィールドで図の要素型を指定する。サーバーは `kind` の値を解釈せず、投影側（HTML/CSS）と skill の取り決めに従う。値は lowercase kebab-case を推奨するが、server enum ではなく未知の値もそのまま保持される。
 
 - `kind: "entity"` — エンティティ（ER図など）
 - `kind: "step"` — プロセスステップ（フローチャートなど）
 - `kind: "state"` — ステートマシンの状態
-- その他の値でも可。投影側で CSS セレクタ `[kind="..."]` で見た目を分け替える
+- その他の値でも可。未知 kind には共通 `.node` style を fallback として適用する
 
 例：
 
 ```html
-<div data-model-id="order" class="entity">…</div>
+<div data-model-id="order" data-kind="entity" class="node entity">
+  <span class="kind-icon" aria-hidden="true"></span>
+  <span>Order</span>
+</div>
 ```
 
 ```css
-[kind="entity"] { border-radius: 4px; }
-[kind="state"] { border-radius: 50%; }
+.node { border: 1px solid #565f89; background: #1e202b; }
+[data-kind="entity"] { border-radius: 4px; }
+[data-kind="state"] { border-radius: 50%; }
+```
+
+### Event storming の例
+
+`command` / `event` / `aggregate` / `policy` は event storming で使える推奨語彙の例であり、server が制限する enum ではない。色だけに依存せず、Unicode icon と可視 label を併用する。
+
+```html
+<div class="node" data-model-id="place-order" data-kind="command">
+  <span class="kind-icon" aria-hidden="true"></span><span>Place order</span>
+</div>
+<div class="node" data-model-id="order-placed" data-kind="event">
+  <span class="kind-icon" aria-hidden="true"></span><span>Order placed</span>
+</div>
+<div class="node" data-model-id="order" data-kind="aggregate">
+  <span class="kind-icon" aria-hidden="true"></span><span>Order</span>
+</div>
+<div class="node" data-model-id="payment-policy" data-kind="policy">
+  <span class="kind-icon" aria-hidden="true"></span><span>Payment policy</span>
+</div>
+```
+
+```css
+.node {
+  --kind-color: #565f89;
+  --kind-bg: #1e202b;
+  border: 1px solid var(--kind-color);
+  background: var(--kind-bg);
+}
+[data-kind="command"] { --kind-color: #7aa2f7; --kind-bg: #1f2a44; }
+[data-kind="event"] { --kind-color: #9ece6a; --kind-bg: #203222; }
+[data-kind="aggregate"] { --kind-color: #e0af68; --kind-bg: #332b1f; }
+[data-kind="policy"] { --kind-color: #bb9af7; --kind-bg: #302640; }
+[data-kind="command"] .kind-icon::before { content: "▶"; }
+[data-kind="event"] .kind-icon::before { content: "⚡"; }
+[data-kind="aggregate"] .kind-icon::before { content: "◆"; }
+[data-kind="policy"] .kind-icon::before { content: "◇"; }
+```
+
+### Infrastructure の例
+
+`service` / `db` / `queue` / `lb` も推奨語彙の例として使える。Unicode の代わりに inline SVG や data URI を使ってもよいが、`<img src="https://...">`、外部 stylesheet、icon font / icon library、外部ファイルを指す `<use href>` は禁止する。
+
+```css
+[data-kind="service"] .kind-icon::before { content: "▣"; }
+[data-kind="db"] .kind-icon::before { content: "◉"; }
+[data-kind="queue"] .kind-icon::before { content: "≋"; }
+[data-kind="lb"] .kind-icon::before { content: "⇄"; }
 ```
 
 ## 表現

--- a/docs/diagrams/diagram-harness.diagram.html
+++ b/docs/diagrams/diagram-harness.diagram.html
@@ -30,9 +30,9 @@
   .node .ds .m { font-family:var(--mono); }
 
   /* kind ごとの見え方 */
-  [kind="step"]   { border-left:2px solid var(--tone,var(--line)); }
-  [kind="entity"] { border-radius:4px; }
-  [kind="asset"]  { border-style:dashed; }
+  [data-kind="step"]   { border-left:2px solid var(--tone,var(--line)); }
+  [data-kind="entity"] { border-radius:4px; }
+  [data-kind="asset"]  { border-style:dashed; }
 
   .t-blue{--tone:var(--blue)} .t-green{--tone:var(--green)}
   .t-amber{--tone:var(--amber)} .t-violet{--tone:var(--violet)} .t-red{--tone:var(--red)}
@@ -115,7 +115,7 @@
 <h2 data-model-id="g_flow">いま動いている経路</h2>
 <ol class="flow">
   <li>
-    <div class="node t-blue" kind="step" data-model-id="claude">
+    <div class="node t-blue" data-kind="step" data-model-id="claude">
       <div class="nm">Claude</div>
       <div class="ds">
         <span data-model-id="claude_write"><span class="m">docs/diagrams/*.diagram.html</span> を Write/Edit で書く</span><br>
@@ -124,7 +124,7 @@
     </div>
   </li>
   <li>
-    <div class="node t-green" kind="step" data-model-id="file">
+    <div class="node t-green" data-kind="step" data-model-id="file">
       <div class="nm">図ファイル</div>
       <div class="ds">
         <span data-model-id="file_model">モデル(JSON) と 投影(HTML) を1ファイルに埋め込む</span><br>
@@ -133,7 +133,7 @@
     </div>
   </li>
   <li>
-    <div class="node t-amber" kind="step" data-model-id="server">
+    <div class="node t-amber" data-kind="step" data-model-id="server">
       <div class="nm">Ark server</div>
       <div class="ds">
         <span data-model-id="server_path">worktree 配下へ封じ込め + symlink 実体検証</span><br>
@@ -143,7 +143,7 @@
     </div>
   </li>
   <li>
-    <div class="node t-violet" kind="step" data-model-id="pane">
+    <div class="node t-violet" data-kind="step" data-model-id="pane">
       <div class="nm">右ペイン（いまあなたが見ている場所）</div>
       <div class="ds">
         <span data-model-id="pane_iframe">sandbox iframe / 不透明オリジン</span><br>
@@ -159,19 +159,19 @@
 
 <h2 data-model-id="g_keep">引き継いだ資産</h2>
 <ul class="assets">
-  <li class="node" kind="asset" data-model-id="keep_mcp">
+  <li class="node" data-kind="asset" data-model-id="keep_mcp">
     <div class="nm">BoardMcpServer</div>
     <div class="ds"><span class="num" data-model-id="keep_mcp_n">245行</span> — HTTP / registry / 認証</div>
   </li>
-  <li class="node" kind="asset" data-model-id="keep_token">
+  <li class="node" data-kind="asset" data-model-id="keep_token">
     <div class="nm">board token ライフサイクル</div>
     <div class="ds"><span class="num" data-model-id="keep_token_n">77行</span> — 再起動をまたいで復帰する</div>
   </li>
-  <li class="node" kind="asset" data-model-id="keep_wt">
+  <li class="node" data-kind="asset" data-model-id="keep_wt">
     <div class="nm">managed-worktree</div>
     <div class="ds"><span class="num" data-model-id="keep_wt_n">155行</span> — 失敗要因を型で区別する</div>
   </li>
-  <li class="node" kind="asset" data-model-id="keep_html">
+  <li class="node" data-kind="asset" data-model-id="keep_html">
     <div class="nm">HtmlViewerPane 系</div>
     <div class="ds"><span class="num" data-model-id="keep_html_n">359行</span> — srcDoc 描画の土台になった</div>
   </li>
@@ -179,19 +179,19 @@
 
 <h2 data-model-id="g_drop">撤去した資産</h2>
 <ul class="assets">
-  <li class="node" kind="asset" data-model-id="drop_canvas">
+  <li class="node" data-kind="asset" data-model-id="drop_canvas">
     <div class="nm drop">CanvasPane (Excalidraw)</div>
     <div class="ds"><span class="num" data-model-id="drop_canvas_n">551行</span> — 撤去済み</div>
   </li>
-  <li class="node" kind="asset" data-model-id="drop_codec">
+  <li class="node" data-kind="asset" data-model-id="drop_codec">
     <div class="nm drop">board-element-codec</div>
     <div class="ds"><span class="num" data-model-id="drop_codec_n">282行</span> — 撤去済み</div>
   </li>
-  <li class="node" kind="asset" data-model-id="drop_canvas_ev">
+  <li class="node" data-kind="asset" data-model-id="drop_canvas_ev">
     <div class="nm drop">canvas:* と canvas_boards</div>
     <div class="ds"><span class="num" data-model-id="drop_canvas_ev_n">337行</span> — 撤去済み</div>
   </li>
-  <li class="node" kind="asset" data-model-id="drop_diff">
+  <li class="node" data-kind="asset" data-model-id="drop_diff">
     <div class="nm drop">canvas-diff-utils</div>
     <div class="ds"><span class="num" data-model-id="drop_diff_n">167行</span> — コードは捨てたが、解いていた問題は B-0b でサーバー側に戻る</div>
   </li>

--- a/docs/diagrams/sample.diagram.html
+++ b/docs/diagrams/sample.diagram.html
@@ -4,7 +4,16 @@
 <style>
   body { font-family: system-ui, sans-serif; background:#1a1b26; color:#c0caf5; padding:1.5rem; }
   .graph { min-height:420px; }
-  .entity { width:22rem; border:1px solid #2c2f42; border-radius:4px; }
+  .entity {
+    --kind-color:#565f89; --kind-bg:#1e202b;
+    width:22rem; border:1px solid #2c2f42; border-left:4px solid var(--kind-color);
+    border-radius:4px; background:var(--kind-bg);
+  }
+  [data-kind="aggregate"] { --kind-color:#e0af68; --kind-bg:#332b1f; }
+  [data-kind="entity"] { --kind-color:#7aa2f7; --kind-bg:#1f2a44; }
+  [data-kind="aggregate"] .kind-icon::before { content:"◆"; }
+  [data-kind="entity"] .kind-icon::before { content:"●"; }
+  .kind-icon { display:inline-block; width:1.25em; color:var(--kind-color); }
   .entity h3 { margin:0; padding:.6rem .9rem; border-bottom:1px solid #2c2f42; font-size:.9rem; }
   .entity ul { list-style:none; margin:0; padding:.4rem 0; }
   .entity li { padding:.25rem .9rem; font-family:ui-monospace,monospace; font-size:.8rem; }
@@ -19,7 +28,7 @@
     {
       "id": "order",
       "label": "Order",
-      "kind": "entity",
+      "kind": "aggregate",
       "ext": {
         "x": 40,
         "y": 50
@@ -72,16 +81,16 @@
 </script>
 
 <div class="graph" data-ark-container="graph">
-  <div class="entity" data-model-id="order">
-    <h3>Order</h3>
+  <div class="entity" data-model-id="order" data-kind="aggregate">
+    <h3><span class="kind-icon" aria-hidden="true"></span>Order</h3>
     <ul>
       <li data-model-id="order_id">id</li>
       <li data-model-id="order_user_id">user_id</li>
       <li data-model-id="order_status">status</li>
     </ul>
   </div>
-  <div class="entity" data-model-id="user">
-    <h3>User</h3>
+  <div class="entity" data-model-id="user" data-kind="entity">
+    <h3><span class="kind-icon" aria-hidden="true"></span>User</h3>
     <ul>
       <li data-model-id="user_id">id</li>
       <li data-model-id="user_email">email</li>

--- a/docs/superpowers/plans/2026-07-21-issue-226.md
+++ b/docs/superpowers/plans/2026-07-21-issue-226.md
@@ -1,0 +1,300 @@
+# issue-226: kind スタイリング Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `node.kind` を投影の `data-kind` へ同期する規約を定め、複数 kind を外部リソースなしの色とアイコンで区別しながら既存 graph / list 編集を維持する。
+
+**Issue:** 226 (GitHub Issue 紐付けあり)
+
+**Architecture:** `.diagram.html` の node 投影は `data-model-id` を結合キーとし、注入ハーネスがモデルの `node.kind` を同じ要素の `data-kind` へ文字列のまま同期する。ハーネスは kind の値や色・アイコンを解釈せず、投影 CSS の `[data-kind="..."]` と外部参照を使わない Unicode / inline SVG / data URI が見た目を担当するため、Socket.IO、DB、tmux/ttyd、React、モバイル表示経路は変更しない。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Express / Socket.IO / better-sqlite3 / tmux / ttyd
+
+---
+
+## 前提と変更境界
+
+- `packages/server/src/lib/diagram-model.ts:15-21,111-117` は既に任意の文字列 `kind` を保持し、サーバー側で意味を解釈しない。この schema と validation は変更しない。
+- 投影規約は `class` ではなく `data-kind` に統一する。class は layout / tone 等の見た目に使い、意味モデルとの対応は `data-model-id` + `data-kind` で明示する。
+- `packages/server/src/lib/diagram-harness.ts` の補助は、node に対応する既存 `[data-model-id]` へ kind をコピーまたは削除する汎用同期だけとする。kind 別 palette、icon registry、編集 dropdown、図種固有の分岐は追加しない。
+- 同じ node id を複数箇所へ投影している場合は、その node に対応するすべての `[data-model-id]` を同じ `data-kind` に同期する。field / edge / group の id は `getNode()` で解決できないため変更しない。
+- モデル JSON 直接編集パネルで kind を変更した場合も、投影属性を即時同期する。保存時は既存 `buildSubmissionHtml()` が `data-kind` を通常の生成物属性として保持し、ハーネス一時 UI だけを除去する。
+- canonical sample のアイコンは Unicode を CSS pseudo-element で表示し、可視 label は DOM text として残す。skill では inline SVG / data URI も許可するが、外部 URL、外部 font、外部 icon library は禁止する。
+- `docs/diagrams/domain-model.diagram.html` と参照欄の `docs/diagrams/diagram-roadmap.diagram.html` は現 worktree に存在しない。新しい図を推測で増やさず、既存 `docs/diagrams/sample.diagram.html` を複数 kind の graph + list 受入図にし、`docs/diagrams/diagram-harness.diagram.html` の旧 `kind=` 属性も同じ規約へ揃える。
+- group 境界、swimlane、自動レイアウト、edge 張り替え、kind 値の標準 enum 化は対象外。新規 Socket.IO event と SQLite migration も作らない。
+- 各実装タスクは Red → Green → Refactor の順で進める。server 相対 import は `.js` 拡張子を維持し、コミット対象は各 Task の Files に列挙したファイルだけを stage する。
+
+---
+
+## Task 1: kind 投影と graph / list 共存のブラウザ契約を Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts:1-339`
+- Reference: `packages/server/src/lib/diagram-harness.ts:133-174,354-403,622-703,737-814`
+- Reference: `docs/diagrams/sample.diagram.html:1-94`
+
+- [ ] **Step 1: inline fixture に複数 kind と投影 CSS を追加する（2-5分）**
+
+  `model.nodes` の `order` / `user` にそれぞれ `kind: "aggregate"` / `kind: "entity"` を追加する。fixture HTML の node root には意図的に `data-kind` を書かず、CSS だけを次の形で用意して、モデルから属性が供給されることをテストできるようにする。
+
+  ```css
+  .entity { border-left: 4px solid var(--kind-color); background: var(--kind-bg); }
+  [data-kind="aggregate"] { --kind-color: #e0af68; --kind-bg: #332b1f; }
+  [data-kind="entity"] { --kind-color: #7aa2f7; --kind-bg: #1f2a44; }
+  [data-kind="event"] { --kind-color: #9ece6a; --kind-bg: #203222; }
+  [data-kind="aggregate"] .kind-icon::before { content: "◆"; }
+  [data-kind="entity"] .kind-icon::before { content: "●"; }
+  [data-kind="event"] .kind-icon::before { content: "⚡"; }
+  ```
+
+  各 node title に `<span class="kind-icon" aria-hidden="true"></span>` を置く。アイコンだけに意味を持たせず、既存の `Order` / `User` label はそのまま残す。
+
+- [ ] **Step 2: kind 属性・色・アイコンの失敗テストを書く（2-5分）**
+
+  `openDiagram(page)` 後に次を assertion にする。
+
+  - `section[data-model-id="order"]` が `data-kind="aggregate"`、`user` が `data-kind="entity"` になる。
+  - `getComputedStyle()` の background / border color が2 nodeで異なる。
+  - `getComputedStyle(icon, "::before").content` が空や `none` ではなく、2 kind で異なる。
+  - graph の `.ark-harness-edge-layer` と `e_order_user` は従来どおり描画され、各 node 内の field は contenteditable になる。
+
+- [ ] **Step 3: モデル直接編集時の kind 再同期を失敗テストにする（2-5分）**
+
+  既存「モデル直接編集後の node ドラッグ」test で `order.kind` を `event` へ変更する。モデルパネルの「反映」直後に node が `data-kind="event"` となり、computed color と icon が event 用へ変わることを確認する。その後 node を drag して送信し、submission の model に `kind: "event"`、HTML に `data-kind="event"` が入り、`ark-harness-*` 一時要素は残らないことまで assertion にする。
+
+- [ ] **Step 4: Red を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "kind"`
+
+  Expected: FAIL。inline fixture に `data-kind` が付かないため、最初の kind 属性 assertion で失敗する。
+
+---
+
+## Task 2: ハーネスで node.kind を data-kind へ同期する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:172-174,405-449,622-656,737-814`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts:1-47`
+- Test: `e2e/diagram-harness.spec.ts`
+- Reference only: `packages/server/src/lib/diagram-model.ts:15-21,111-117`
+
+- [ ] **Step 1: 注入ハーネスの unit 契約を Red にする（2-5分）**
+
+  `diagram-harness.test.ts` に、注入文字列が node projection の `data-kind` 同期処理とモデル再適用時の呼び出しを含むことを検証する test を追加する。既存の marker 一意性、graph selector、二重注入防止 assertion は残す。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: FAIL。kind 同期 helper がまだ注入 JS に存在しない。
+
+- [ ] **Step 2: opaque な kind 同期 helper を実装する（2-5分）**
+
+  HARNESS_JS に `syncNodeKinds()` を追加する。document 内の `[data-model-id]` を列挙し、ハーネス UI を除外したうえで `getNode(state.model, id)` が返る要素だけを対象にする。`node.kind` が string の場合はその値を `data-kind` へそのまま設定し、string でない場合は stale な `data-kind` を削除する。
+
+  ```js
+  function syncNodeKinds() {
+    document.querySelectorAll("[data-model-id]").forEach(function (el) {
+      if (isInsideHarnessUi(el)) return;
+      var id = el.getAttribute("data-model-id");
+      if (!id) return;
+      var node = getNode(state.model, id);
+      if (!node) return;
+      if (typeof node.kind === "string") {
+        el.setAttribute("data-kind", node.kind);
+      } else {
+        el.removeAttribute("data-kind");
+      }
+    });
+  }
+  ```
+
+  空文字を許容するかは既存 parser と同じく「string なら保持」に合わせ、ハーネス側で独自 validation や enum 化をしない。
+
+- [ ] **Step 3: 初期表示とモデル直接編集へ同期を配線する（2-5分）**
+
+  `init()` で `state.model = model` の直後、toolbar / editing / graph 初期化より前に `syncNodeKinds()` を呼ぶ。モデルパネルの apply handler でも `state.model = parsed` の直後に呼び、panel を閉じる前に computed style が更新されるようにする。kind CSS で node size が変わる場合は既存 `ResizeObserver` が edge を再計算するため、新しい graph 再描画経路は作らない。
+
+- [ ] **Step 4: 保存 cleanup を増やさず data-kind を保持する（2-5分）**
+
+  `buildSubmissionHtml()` の cleanup 対象に `data-kind` を追加しない。E2E で graph drag、field inline edit / reorder、モデル直接編集後の submission HTML に同期済み `data-kind` が残り、CSP meta、graph handle、edge SVG、custom property は従来どおり除去されることを確認する。
+
+- [ ] **Step 5: unit と harness behavior を Green にする（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: PASS。既存4 test と kind 同期契約 test が成功し、marker は1回だけ現れる。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "node.kind を data-kind|モデル直接編集|node ドラッグ"`
+
+  Expected: PASS。inline fixture の kind 同期、直接編集、graph drag、list edit / reorder がすべて成功する。
+
+- [ ] **Step 6: Refactor と実装コミット（2-5分）**
+
+  kind 同期が `getNode()` と `isInsideHarnessUi()` を再利用し、palette や図種名を一切持たないことを確認する。必要以上の DOM scan や graph/list 初期化順変更を避ける。
+
+  ```bash
+  git add packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts e2e/diagram-harness.spec.ts
+  git commit -m "feat(diagram): node kind を投影属性へ同期"
+  ```
+
+---
+
+## Task 3: 複数 kind の色・アイコンを既存図で実例化する
+
+**Files:**
+
+- Modify: `docs/diagrams/sample.diagram.html:1-94`
+- Modify: `docs/diagrams/diagram-harness.diagram.html:25-35,68-194`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: canonical sample の受入テストを Red にする（2-5分）**
+
+  `e2e/diagram-harness.spec.ts` で `node:fs` から `docs/diagrams/sample.diagram.html` を読み、`injectHarness()` して `page.setContent()` する helper を追加する。「sample は複数 kind を色とアイコンで区別する」test で、node kind が2種類以上、各 projection の `data-kind` がモデルと一致、computed color と icon が複数種類、graph edge と list 編集 UI が同時に初期化されることを検証する。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "sample は複数 kind"`
+
+  Expected: FAIL。現行 sample は全 node が `entity` で kind icon がない。
+
+- [ ] **Step 2: sample を2 kind の graph + list 図にする（2-5分）**
+
+  `order.kind` を `aggregate`、`user.kind` を `entity` とし、projection root にも一致する `data-kind` を明示する。共通 card CSS を CSS variables で組み、`[data-kind="aggregate"]` / `[data-kind="entity"]` が別の border / background color と `◆` / `●` icon を供給する。icon 用 span は `aria-hidden="true"`、node label と field text は現在の編集可能な DOM 構造を維持する。
+
+- [ ] **Step 3: graph / list の既存契約を維持する（2-5分）**
+
+  `data-ark-container="graph"`、`node.ext.x/y`、edge、node / field の `data-model-id`、各 node 内の `<ul><li>` を残す。kind の見た目を付けるために wrapper を増やして graph node の直接候補や `findOwnerNodeId()` の祖先探索を壊さない。
+
+- [ ] **Step 4: 既存 diagram-harness 図を data-kind 規約へ移行する（2-5分）**
+
+  CSS の `[kind="step"]` / `[kind="entity"]` / `[kind="asset"]` を `[data-kind="..."]` に変え、projection の `kind="step"` / `kind="asset"` を同値の `data-kind` に置き換える。モデル JSON の `node.kind` は変更せず、非標準の裸 `kind` 属性を残さない。
+
+- [ ] **Step 5: sample acceptance を Green にする（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "sample は複数 kind"`
+
+  Expected: PASS。sample の2 nodeが異なる色と icon で表示され、edge、graph handle、field contenteditable が同時に存在する。
+
+  Run: `rg -n '(^|[[:space:]])kind=|\[kind=' docs/diagrams/*.diagram.html`
+
+  Expected: 出力なし。モデル JSON の `"kind":` と正規の `data-kind=` は残る。
+
+- [ ] **Step 6: 図の更新をコミットする（2-5分）**
+
+  ```bash
+  git add docs/diagrams/sample.diagram.html docs/diagrams/diagram-harness.diagram.html e2e/diagram-harness.spec.ts
+  git commit -m "docs(diagram): kind ごとの色とアイコンを例示"
+  ```
+
+---
+
+## Task 4: diagram-authoring 規約と kind の往復保証を揃える
+
+**Files:**
+
+- Modify: `.claude/skills/diagram-authoring/SKILL.md:11-69`
+- Modify: `packages/server/src/lib/diagram-model.test.ts:1-88`
+- Modify: `packages/server/src/lib/diagram-file.test.ts:134-195`
+- Modify: `packages/server/src/lib/diagram-reader.test.ts:34-88`
+- Reference only: `packages/server/src/lib/diagram-model.ts:15-21,111-117`
+- Reference only: `packages/server/src/lib/diagram-file.ts:83-126`
+- Reference only: `packages/server/src/lib/diagram-reader.ts:112-135`
+
+- [ ] **Step 1: skill の基本例を data-kind 契約へ直す（2-5分）**
+
+  ファイル構造例を `<div data-model-id="order" data-kind="entity" class="entity">` に更新する。「投影 root の `data-kind` は model の `node.kind` と同値にする」「Ark ハーネスも表示時とモデル直接編集時に同期する」「CSS は `[data-kind="..."]` を使う」を守ることへ追記し、現行の動作しない `[kind="..."]` 例を削除する。
+
+- [ ] **Step 2: event storming の色・icon 実例を追記する（2-5分）**
+
+  `command` / `event` / `aggregate` / `policy` を lowercase kebab-case の推奨例として示し、CSS variables と `.kind-icon::before` でそれぞれ色と `▶` / `⚡` / `◆` / `◇` を割り当てる完全な HTML/CSS snippet を載せる。これは推奨語彙であり server enum ではなく、未知 kind には共通 `.node` style が fallback することを明記する。
+
+- [ ] **Step 3: infrastructure icon と外部参照禁止を明記する（2-5分）**
+
+  `service` / `db` / `queue` / `lb` の短い selector 例を載せる。Unicode のほか inline SVG と data URI は使用可、`<img src="https://...">`、外部 stylesheet、icon font、外部 `<use href>` は不可とし、色だけで区別せず icon と可視 label を併用する。
+
+- [ ] **Step 4: arbitrary kind の parse / file / delivery regression を追加する（2-5分）**
+
+  `diagram-model.test.ts` で複数 node の `command` / `event` / `service` 等が文字列のまま保持されることを確認する。`diagram-file.test.ts` で `replaceModelBlock()` → `extractModel()` の往復後も kind が変わらないこと、`diagram-reader.test.ts` で `readDiagram()` 後の model kind と projection `data-kind`、CSP、harness marker がすべて残ることを確認する。production parser / file / reader は既に要件を満たすため変更しない。
+
+- [ ] **Step 5: documentation と server regression を検証する（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts src/lib/diagram-file.test.ts src/lib/diagram-reader.test.ts`
+
+  Expected: PASS。任意 kind は正規化されず、model block と配信経路を往復する。
+
+  Run: `rg -n '\[kind=|<[^>[:space:]]+[^>]*[[:space:]]kind=' .claude/skills/diagram-authoring/SKILL.md docs/diagrams/*.diagram.html`
+
+  Expected: 出力なし。すべて `[data-kind=...]` / `data-kind=...` に統一される。
+
+- [ ] **Step 6: skill と regression test をコミットする（2-5分）**
+
+  ```bash
+  git add .claude/skills/diagram-authoring/SKILL.md packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-file.test.ts packages/server/src/lib/diagram-reader.test.ts
+  git commit -m "docs(diagram): kind スタイリング規約を追加"
+  ```
+
+---
+
+## Task 5: 全回帰と実機受け入れを完了する
+
+**Files:**
+
+- Verify only: `packages/shared/src/types.ts`
+- Verify only: `packages/server/src/index.ts`
+- Verify only: `packages/server/src/lib/database.ts`
+- Verify only: `packages/web/src/hooks/useSocket.ts`
+- Verify only: `packages/web/src/components/DiagramPane.tsx`
+- Verify only: `packages/web/src/components/MobileLayout.tsx`
+- Verify only: `packages/web/src/components/MobileSessionView.tsx`
+- Verify only: `packages/server/src/lib/session-orchestrator.ts`
+- Verify only: `packages/server/src/lib/tmux-manager.ts`
+- Verify only: `packages/server/src/lib/ttyd-manager.ts`
+
+- [ ] **Step 1: Socket.IO / DB / React / lifecycle の非変更を確認する（2-5分）**
+
+  Run: `git diff HEAD~3 -- packages/shared/src/types.ts packages/server/src/index.ts packages/server/src/lib/database.ts packages/web/src/hooks/useSocket.ts packages/web/src/components/DiagramPane.tsx packages/web/src/components/MobileLayout.tsx packages/web/src/components/MobileSessionView.tsx packages/server/src/lib/session-orchestrator.ts packages/server/src/lib/tmux-manager.ts packages/server/src/lib/ttyd-manager.ts`
+
+  Expected: 出力なし。kind は既存 diagram HTML + 注入ハーネス内で完結し、新規 Socket.IO event、DB migration、tmux/ttyd lifecycle、モバイル図 UI を含まない。
+
+- [ ] **Step 2: 型・lint・format を確認する（2-5分）**
+
+  Run: `pnpm exec tsc -b`
+
+  Expected: exit 0、型エラーなし。
+
+  Run: `pnpm exec biome check packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-file.test.ts packages/server/src/lib/diagram-reader.test.ts e2e/diagram-harness.spec.ts`
+
+  Expected: exit 0、format / lint error なし。
+
+- [ ] **Step 3: server test と Playwright を全実行する（2-5分）**
+
+  Run: `pnpm exec vitest run`
+
+  Expected: exit 0、全 test file / test が PASS。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: kind の初期同期、直接編集再同期、sample の色・icon、graph edge / drag、list inline edit / reorder、clean submission、不正座標の全 test が PASS。
+
+- [ ] **Step 4: repository E2E を実行する（2-5分）**
+
+  Run: `pnpm test:e2e`
+
+  Expected: desktop / mobile を含む既存 E2E が PASS（環境変数必須と明記された test は未設定時のみ SKIP）。
+
+- [ ] **Step 5: desktop 実機で完了条件を確認する（各2-5分）**
+
+  1. 稼働中 session から `docs/diagrams/sample.diagram.html` を `board_open` し、Order / User が別の色と icon で判別でき、edge が表示されることを確認する。
+  2. モデル直接編集で Order の kind を `event` へ変え、「反映」直後に色・icon が変わることを確認する。
+  3. Order を drag し、field label を inline edit、field 行を reorder して「変更を送る」。保存 file の model kind と `data-kind` が一致し、位置・field 順・label も保持されることを確認する。
+  4. 図を再読込して同じ style が再投影され、graph edge / drag と list editing が引き続き動くことを確認する。
+  5. DevTools の network で icon / style の外部 request が発生せず、注入 meta CSP が維持されることを確認する。
+
+- [ ] **Step 6: 最終差分を確認する（2-5分）**
+
+  Run: `git diff --check`
+
+  Expected: 出力なし。
+
+  Run: `git diff --stat HEAD~3`
+
+  Expected: production 変更は `diagram-harness.ts` の汎用同期だけで、残りは tests、diagram sample、diagram-authoring skill。group / swimlane / auto-layout、Socket.IO、DB、mobile 変更は含まれない。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { expect, type Locator, type Page, test } from "@playwright/test";
 import { injectHarness } from "../packages/server/src/lib/diagram-harness";
 
@@ -101,6 +102,14 @@ async function openDiagram(page: Page, diagramModel: unknown = model) {
   page.on("pageerror", error => errors.push(error.message));
   await page.setContent(diagramHtml(diagramModel));
   return errors;
+}
+
+async function openSampleDiagram(page: Page) {
+  const html = readFileSync(
+    new URL("../docs/diagrams/sample.diagram.html", import.meta.url),
+    "utf8"
+  );
+  await page.setContent(injectHarness(html));
 }
 
 async function connectSubmissionPort(page: Page) {
@@ -228,6 +237,52 @@ test("node.kind を data-kind へ同期して色とアイコンを区別する",
   ).toHaveAttribute("contenteditable", "true");
   await expect(
     user.locator('li[data-model-id="user_id"] .ark-harness-text')
+  ).toHaveAttribute("contenteditable", "true");
+});
+
+test("sample は複数 kind を色とアイコンで区別する", async ({ page }) => {
+  await openSampleDiagram(page);
+
+  const modelKinds = await page
+    .locator("#ark-diagram-model")
+    .evaluate(element => {
+      const parsed = JSON.parse(element.textContent || "") as {
+        nodes: Array<{ id: string; kind?: string }>;
+      };
+      return Object.fromEntries(parsed.nodes.map(node => [node.id, node.kind]));
+    });
+  const projections = await page
+    .locator('[data-ark-container="graph"] > [data-model-id]')
+    .evaluateAll(elements =>
+      elements.map(element => {
+        const icon = element.querySelector(".kind-icon");
+        const style = getComputedStyle(element);
+        return {
+          id: element.getAttribute("data-model-id"),
+          kind: element.getAttribute("data-kind"),
+          color: `${style.backgroundColor}/${style.borderLeftColor}`,
+          icon: icon ? getComputedStyle(icon, "::before").content : "none",
+        };
+      })
+    );
+
+  expect(new Set(Object.values(modelKinds))).toHaveProperty("size", 2);
+  expect(projections).toHaveLength(2);
+  for (const projection of projections) {
+    expect(projection.kind).toBe(modelKinds[projection.id || ""]);
+    expect(projection.icon).not.toBe("none");
+    expect(projection.icon).not.toBe("");
+  }
+  expect(new Set(projections.map(projection => projection.color)).size).toBe(2);
+  expect(new Set(projections.map(projection => projection.icon)).size).toBe(2);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  await expect(graph.locator('[data-ark-edge-id="e_order_user"]')).toHaveCount(
+    1
+  );
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
+  await expect(
+    graph.locator('li[data-model-id="order_id"] .ark-harness-text')
   ).toHaveAttribute("contenteditable", "true");
 });
 

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -7,6 +7,7 @@ const model = {
     {
       id: "order",
       label: "Order",
+      kind: "aggregate",
       fields: [
         { id: "order_id", label: "id" },
         { id: "order_status", label: "status" },
@@ -16,6 +17,7 @@ const model = {
     {
       id: "user",
       label: "User",
+      kind: "entity",
       fields: [{ id: "user_id", label: "id" }],
       ext: { x: 360, y: 180 },
     },
@@ -33,21 +35,27 @@ function diagramHtml(diagramModel: unknown = model): string {
     <style>
       body { margin: 0; }
       .graph { width: 720px; height: 480px; background: #f8fafc; }
-      .entity { box-sizing: border-box; width: 220px; padding: 12px; border: 1px solid #64748b; background: white; }
+      .entity { box-sizing: border-box; width: 220px; padding: 12px; border: 1px solid #64748b; border-left: 4px solid var(--kind-color); background: var(--kind-bg); }
+      [data-kind="aggregate"] { --kind-color: #e0af68; --kind-bg: #332b1f; }
+      [data-kind="entity"] { --kind-color: #7aa2f7; --kind-bg: #1f2a44; }
+      [data-kind="event"] { --kind-color: #9ece6a; --kind-bg: #203222; }
+      [data-kind="aggregate"] .kind-icon::before { content: "◆"; }
+      [data-kind="entity"] .kind-icon::before { content: "●"; }
+      [data-kind="event"] .kind-icon::before { content: "⚡"; }
     </style>
   </head>
   <body>
     <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
     <div class="graph" data-ark-container="graph">
       <section class="entity" data-model-id="order">
-        <h2 data-model-id="order">Order</h2>
+        <h2 data-model-id="order"><span class="kind-icon" aria-hidden="true"></span>Order</h2>
         <ul>
           <li data-model-id="order_id">id</li>
           <li data-model-id="order_status">status</li>
         </ul>
       </section>
       <section class="entity" data-model-id="user">
-        <h2 data-model-id="user">User</h2>
+        <h2 data-model-id="user"><span class="kind-icon" aria-hidden="true"></span>User</h2>
         <ul><li data-model-id="user_id">id</li></ul>
       </section>
     </div>
@@ -172,6 +180,57 @@ test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ pag
   expect(pointIsOnPerimeter(line.x2, line.y2, userBox)).toBe(true);
 });
 
+test("node.kind を data-kind へ同期して色とアイコンを区別する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const order = graph.locator('section[data-model-id="order"]');
+  const user = graph.locator('section[data-model-id="user"]');
+  await expect(order).toHaveAttribute("data-kind", "aggregate");
+  await expect(user).toHaveAttribute("data-kind", "entity");
+
+  const [orderStyle, userStyle] = await Promise.all([
+    order.evaluate(element => {
+      const style = getComputedStyle(element);
+      const icon = element.querySelector(".kind-icon");
+      return {
+        backgroundColor: style.backgroundColor,
+        borderLeftColor: style.borderLeftColor,
+        icon: icon ? getComputedStyle(icon, "::before").content : "none",
+      };
+    }),
+    user.evaluate(element => {
+      const style = getComputedStyle(element);
+      const icon = element.querySelector(".kind-icon");
+      return {
+        backgroundColor: style.backgroundColor,
+        borderLeftColor: style.borderLeftColor,
+        icon: icon ? getComputedStyle(icon, "::before").content : "none",
+      };
+    }),
+  ]);
+  expect(orderStyle.backgroundColor).not.toBe(userStyle.backgroundColor);
+  expect(orderStyle.borderLeftColor).not.toBe(userStyle.borderLeftColor);
+  expect(orderStyle.icon).not.toBe("none");
+  expect(orderStyle.icon).not.toBe("");
+  expect(userStyle.icon).not.toBe("none");
+  expect(userStyle.icon).not.toBe("");
+  expect(orderStyle.icon).not.toBe(userStyle.icon);
+
+  await expect(graph.locator(".ark-harness-edge-layer")).toHaveCount(1);
+  await expect(graph.locator('[data-ark-edge-id="e_order_user"]')).toHaveCount(
+    1
+  );
+  await expect(
+    order.locator('li[data-model-id="order_id"] .ark-harness-text')
+  ).toHaveAttribute("contenteditable", "true");
+  await expect(
+    user.locator('li[data-model-id="user_id"] .ark-harness-text')
+  ).toHaveAttribute("contenteditable", "true");
+});
+
 test("node ドラッグと list 編集を送信 model と clean HTML に反映する", async ({
   page,
 }) => {
@@ -256,7 +315,7 @@ test("node ドラッグと list 編集を送信 model と clean HTML に反映�
   expect(html).toContain('data-ark-container="graph"');
 });
 
-test("モデル直接編集後の node ドラッグを送信 model に反映する", async ({
+test("モデル直接編集後の kind 再同期と node ドラッグを送信 model に反映する", async ({
   page,
 }) => {
   await openDiagram(page);
@@ -265,16 +324,41 @@ test("モデル直接編集後の node ドラッグを送信 model に反映す�
   const editedModel = {
     ...model,
     nodes: model.nodes.map(node =>
-      node.id === "order" ? { ...node, label: "Edited Order" } : node
+      node.id === "order"
+        ? { ...node, label: "Edited Order", kind: "event" }
+        : node
     ),
   };
+  const order = page.locator('section[data-model-id="order"]');
+  const beforeStyle = await order.evaluate(element => {
+    const icon = element.querySelector(".kind-icon");
+    return {
+      backgroundColor: getComputedStyle(element).backgroundColor,
+      borderLeftColor: getComputedStyle(element).borderLeftColor,
+      icon: icon ? getComputedStyle(icon, "::before").content : "none",
+    };
+  });
   await page
     .getByRole("button", { name: "モデル JSON を直接編集する" })
     .click();
   await page.locator(".ark-harness-textarea").fill(JSON.stringify(editedModel));
   await page.getByRole("button", { name: "反映", exact: true }).click();
 
-  const order = page.locator('section[data-model-id="order"]');
+  await expect(order).toHaveAttribute("data-kind", "event");
+  const afterStyle = await order.evaluate(element => {
+    const icon = element.querySelector(".kind-icon");
+    return {
+      backgroundColor: getComputedStyle(element).backgroundColor,
+      borderLeftColor: getComputedStyle(element).borderLeftColor,
+      icon: icon ? getComputedStyle(icon, "::before").content : "none",
+    };
+  });
+  expect(afterStyle.backgroundColor).not.toBe(beforeStyle.backgroundColor);
+  expect(afterStyle.borderLeftColor).not.toBe(beforeStyle.borderLeftColor);
+  expect(afterStyle.icon).not.toBe("none");
+  expect(afterStyle.icon).not.toBe("");
+  expect(afterStyle.icon).not.toBe(beforeStyle.icon);
+
   const handleBox = await requiredBoundingBox(
     order.locator(".ark-harness-graph-handle")
   );
@@ -307,11 +391,22 @@ test("モデル直接編集後の node ドラッグを送信 model に反映す�
     type: "ark:diagram-submit",
     model: {
       nodes: [
-        { id: "order", label: "Edited Order", ext: { x: 120, y: 110 } },
+        {
+          id: "order",
+          label: "Edited Order",
+          kind: "event",
+          ext: { x: 120, y: 110 },
+        },
         { id: "user" },
       ],
     },
   });
+  const html = (submission as { html: string }).html;
+  expect(html).toContain('data-kind="event"');
+  expect(html).not.toContain("ark-harness-edge-layer");
+  expect(html).not.toContain("ark-harness-graph-handle");
+  expect(html).not.toContain("--ark-harness-graph-x");
+  expect(html).not.toContain("--ark-harness-graph-y");
 });
 
 test("不正座標と graph 外参照を安全に除外する", async ({ page }) => {

--- a/packages/server/src/lib/diagram-file.test.ts
+++ b/packages/server/src/lib/diagram-file.test.ts
@@ -224,6 +224,34 @@ describe("replaceModelBlock", () => {
     }
   });
 
+  it("モデルブロックの往復で任意の node kind を保持する", () => {
+    const html = page(
+      `<script type="application/json" id="ark-diagram-model">${MODEL}</script><div>図</div>`
+    );
+    const nextModel: DiagramModel = {
+      ...MODEL_OBJ,
+      nodes: [
+        { id: "command", label: "Command", kind: "command" },
+        { id: "event", label: "Event", kind: "event" },
+        { id: "service", label: "Service", kind: "service" },
+      ],
+    };
+
+    const replaced = replaceModelBlock(html, nextModel);
+    expect(replaced.ok).toBe(true);
+    if (!replaced.ok) return;
+
+    const extracted = extractModel(replaced.html);
+    expect(extracted.ok).toBe(true);
+    if (extracted.ok) {
+      expect(extracted.model.nodes.map(node => node.kind)).toEqual([
+        "command",
+        "event",
+        "service",
+      ]);
+    }
+  });
+
   it("属性の順序が逆でも差し替えられる", () => {
     const html = page(
       `<script id="ark-diagram-model" type="application/json">${MODEL}</script>`

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -44,4 +44,18 @@ describe("injectHarness", () => {
     expect(out).toContain("ark-harness-graph-handle");
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
+
+  it("node projection の data-kind を初期表示とモデル再適用で同期する", () => {
+    const out = injectHarness(
+      page('<div data-model-id="node" data-kind="stale"></div>')
+    );
+
+    expect(out).toContain("function syncNodeKinds()");
+    expect(out).toContain('document.querySelectorAll("[data-model-id]")');
+    expect(out).toContain('typeof node.kind === "string"');
+    expect(out).toContain('el.setAttribute("data-kind", node.kind)');
+    expect(out).toContain('el.removeAttribute("data-kind")');
+    expect(out.match(/syncNodeKinds\(\);/g)).toHaveLength(2);
+    expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  });
 });

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -470,6 +470,21 @@ const HARNESS_JS = `(function () {
     return !!(el.closest && el.closest("[data-ark-harness-ui]"));
   }
 
+  function syncNodeKinds() {
+    document.querySelectorAll("[data-model-id]").forEach(function (el) {
+      if (isInsideHarnessUi(el)) return;
+      var id = el.getAttribute("data-model-id");
+      if (!id) return;
+      var node = getNode(state.model, id);
+      if (!node) return;
+      if (typeof node.kind === "string") {
+        el.setAttribute("data-kind", node.kind);
+      } else {
+        el.removeAttribute("data-kind");
+      }
+    });
+  }
+
   function markUi(el) {
     el.setAttribute("data-ark-harness-ui", "1");
     return el;
@@ -744,6 +759,7 @@ const HARNESS_JS = `(function () {
         if (!Array.isArray(parsed.edges)) parsed.edges = [];
         if (!Array.isArray(parsed.groups)) parsed.groups = [];
         state.model = parsed;
+        syncNodeKinds();
         error.style.display = "none";
         panel.style.display = "none";
       } catch (e) {
@@ -806,6 +822,7 @@ const HARNESS_JS = `(function () {
       var model = loadModel();
       if (!model) return;
       state.model = model;
+      syncNodeKinds();
       buildToolbar();
       initEditing();
       initGraphs();

--- a/packages/server/src/lib/diagram-model.test.ts
+++ b/packages/server/src/lib/diagram-model.test.ts
@@ -52,6 +52,28 @@ describe("parseDiagramModel", () => {
     }
   });
 
+  it("任意の node kind を文字列のまま保持する", () => {
+    const json = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: "place-order", label: "Place order", kind: "command" },
+        { id: "order-placed", label: "Order placed", kind: "event" },
+        { id: "order-api", label: "Order API", kind: "service" },
+      ],
+    });
+
+    const result = parseDiagramModel(json);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.nodes.map(node => node.kind)).toEqual([
+        "command",
+        "event",
+        "service",
+      ]);
+    }
+  });
+
   it("id が重複するモデルを拒否する", () => {
     const json = JSON.stringify({
       version: 1,

--- a/packages/server/src/lib/diagram-reader.test.ts
+++ b/packages/server/src/lib/diagram-reader.test.ts
@@ -85,6 +85,38 @@ describe("readDiagram", () => {
     }
   });
 
+  it("任意の model kind と投影 data-kind を配信時も保持する", async () => {
+    const kindModel = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: "command", label: "Command", kind: "command" },
+        { id: "service", label: "Service", kind: "service" },
+      ],
+      edges: [],
+      groups: [],
+    });
+    write(
+      "kinds.diagram.html",
+      '<div data-model-id="command" data-kind="command">Command</div>' +
+        '<div data-model-id="service" data-kind="service">Service</div>',
+      kindModel
+    );
+
+    const result = await readDiagram(wt, "kinds.diagram.html");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.nodes.map(node => node.kind)).toEqual([
+        "command",
+        "service",
+      ]);
+      expect(result.html).toContain('data-kind="command"');
+      expect(result.html).toContain('data-kind="service"');
+      expect(result.html).toContain(DIAGRAM_CSP);
+      expect(result.html).toContain(DIAGRAM_HARNESS_MARKER);
+    }
+  });
+
   it("存在しないファイルは 404 を返す", async () => {
     const result = await readDiagram(wt, "missing.diagram.html");
 


### PR DESCRIPTION
## 概要

図解ハーネスの **kind スタイリング**。graph コンテナ (#224) の上に、`node.kind` を投影の `data-kind` 属性へ同期する規約を定め、kind ごとに色・アイコンで視覚的に区別できるようにする。イベントストーミング (#231) とインフラ構成図 (#232) の共通土台。

Closes #226

## 変更点

- **汎用同期**: 注入ハーネスに `syncNodeKinds()` を追加。`[data-model-id]` 要素のうち `getNode(state.model, id)` で解決できるものに `node.kind`（string）を `data-kind` としてコピー（string でなければ削除）。初期表示と「モデルを直接編集」→「反映」後の両方で同期
- **ハーネスは kind を解釈しない**: 色・アイコンは投影 CSS の `[data-kind="..."]` と `diagram-authoring` skill が担当。palette / icon registry / 図種分岐はハーネスに持たない（設計判断 4.3「図種追加は skill 更新だけ」）
- **保存 HTML に data-kind を保持**: `buildSubmissionHtml()` は data-kind を通常の生成物属性として残す（ハーネス一時 UI のみ除去）。再読込時は model から再同期されるため model が正
- **既存図の規約統一**: `sample.diagram.html` を複数 kind（aggregate/entity）の受入図に更新、`diagram-harness.diagram.html` の非標準な `kind=` 属性を `data-kind=` へ移行
- **skill 追記**: `diagram-authoring` に kind スタイリングの書き方 + event storming（command/event/aggregate/policy）と infra（service/db/queue/lb）の実例。**外部リソース禁止**（Unicode / inline SVG / data URI のみ、外部 URL / font / icon-library 不可）を明記

## テスト

- `tsc -b`: pass ・ `vitest run`: 36 ファイル / 518 テスト pass ・ `biome check`: clean
- `playwright e2e/diagram-harness.spec.ts`: 6 テスト pass（kind→data-kind 同期 / sample の色・アイコン区別 / モデル直接編集後の kind 再同期+ドラッグ / graph edge・drag / list 編集 / 不正座標）
- TDD（Red→Green→Refactor）。任意 kind の parse / file round-trip / delivery 回帰も追加

## スコープ外（後続単位）

group 境界・swimlane (#227) / 自動レイアウト (#228) / edge カーディナリティ (#229) / kind の enum 標準化。Socket.IO・DB・tmux/ttyd・モバイルは不変。

## レビュー体制

codex が plan 立案・TDD 実装、Claude が P2（plan）/ P5（実装）レビュー（flow-x 役割逆転。実装者 ≠ レビュアー）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 図のノード種別が表示要素へ反映され、種別ごとに色やアイコンを切り替えられるようになりました。
  * 任意のノード種別を、読み込み・編集・保存・配信の各段階で保持できるようになりました。
  * 初期表示やモデル編集後も、ノード種別の表示が自動的に同期されます。
  * 外部リソースに依存せず、属性に基づくスタイル指定へ統一しました。

* **ドキュメント**
  * 図解オーサリング仕様とサンプル図を更新し、新しい種別表示ルールを明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->