### PR TITLE
図解ハーネス: group 語彙（複数ノードを囲むラベル付き境界・矩形/swimlane） (#227)

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -121,6 +121,102 @@ node の `kind` フィールドで図の要素型を指定する。サーバー�
 [data-kind="lb"] .kind-icon::before { content: "⇄"; }
 ```
 
+## 語彙: group
+
+複数 node をラベル付きの境界でまとめるときは group を使う。model shape は
+`{ id, label, nodes, ext? }` で、`nodes` には同じ model に実在する node id を入れる。
+field id や別 group の id は member にせず、group の入れ子も作らない。bounded context、
+actor、VPC、region、subnet など図種固有の役割が必要なら `ext` に置き、server の
+group kind enum や固定 palette は前提にしない。
+
+graph 上の自動境界配置を使う projection root は、member node と sibling にする。
+root の `data-model-id` は group id と一致させ、可視 label の leaf にも同じ id を
+付けると既存 inline label edit を利用できる。
+
+```html
+<section class="group-boundary" data-ark-group data-model-id="ordering-context">
+  <span class="group-label" data-model-id="ordering-context">Ordering Context</span>
+</section>
+<article class="node" data-model-id="order">…</article>
+<article class="node" data-model-id="user">…</article>
+```
+
+ハーネスは member node の外接矩形を次の CSS custom properties として root に渡す。
+余白、border、background、角丸、label 帯の位置と大きさは projection CSS が決める。
+
+- `--ark-harness-group-x`
+- `--ark-harness-group-y`
+- `--ark-harness-group-width`
+- `--ark-harness-group-height`
+
+### Rectangle boundary の例
+
+全周に余白を足し、label を上辺付近に置く例。geometry が解決できない group は
+表示しないよう、harness class が付いたときだけ表示する。
+
+```css
+.group-boundary {
+  display: none;
+  box-sizing: border-box;
+  position: absolute;
+  left: calc(var(--ark-harness-group-x) - 1.5rem);
+  top: calc(var(--ark-harness-group-y) - 2.25rem);
+  width: calc(var(--ark-harness-group-width) + 3rem);
+  height: calc(var(--ark-harness-group-height) + 3.75rem);
+  border: 1px solid currentColor;
+  border-radius: .75rem;
+  background: rgba(125, 207, 255, .08);
+}
+.group-boundary.ark-harness-graph-group { display: block; }
+.group-boundary .group-label {
+  position: absolute;
+  top: .5rem;
+  left: .75rem;
+  font-weight: 600;
+}
+```
+
+### Swimlane の例
+
+同じ model shape と DOM contract のまま projection class を変え、左側に大きな
+label 帯を確保する例。上帯にしたい場合も同じ4変数から `top` / `height` を
+`calc()` して表現する。
+
+```html
+<section class="group-swimlane" data-ark-group data-model-id="payment-lane">
+  <span class="group-label" data-model-id="payment-lane">Payment</span>
+</section>
+```
+
+```css
+.group-swimlane {
+  display: none;
+  box-sizing: border-box;
+  position: absolute;
+  left: calc(var(--ark-harness-group-x) - 5rem);
+  top: calc(var(--ark-harness-group-y) - 1rem);
+  width: calc(var(--ark-harness-group-width) + 6rem);
+  height: calc(var(--ark-harness-group-height) + 2rem);
+  border: 1px solid currentColor;
+  background: rgba(187, 154, 247, .06);
+}
+.group-swimlane.ark-harness-graph-group { display: block; }
+.group-swimlane .group-label {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 4.5rem;
+  display: grid;
+  place-items: center;
+  border-right: 1px solid currentColor;
+  writing-mode: vertical-rl;
+}
+```
+
+group 自体の drag や member node の一括移動、snap / grid、自動レイアウト、
+group nesting は未対応。node は従来どおり個別に drag し、境界だけが追従する。
+group projection でも外部 stylesheet、font、image は使わず、Unicode、inline SVG、
+data URI、生成 CSS の範囲で可視 label を必ず設ける。
+
 ## 表現
 
 図種は問わない。エンティティ表、スイムレーン、状態機械など、問題に合うものを HTML と CSS で作る。

--- a/docs/diagrams/sample.diagram.html
+++ b/docs/diagrams/sample.diagram.html
@@ -4,6 +4,16 @@
 <style>
   body { font-family: system-ui, sans-serif; background:#1a1b26; color:#c0caf5; padding:1.5rem; }
   .graph { min-height:420px; }
+  .group-boundary {
+    display:none; box-sizing:border-box; position:absolute;
+    left:calc(var(--ark-harness-group-x) - 24px);
+    top:calc(var(--ark-harness-group-y) - 36px);
+    width:calc(var(--ark-harness-group-width) + 48px);
+    height:calc(var(--ark-harness-group-height) + 60px);
+    border:1px solid #2ac3de; border-radius:10px; background:rgba(42,195,222,.08);
+  }
+  .group-boundary.ark-harness-graph-group { display:block; }
+  .group-label { position:absolute; top:.45rem; left:.75rem; color:#7dcfff; font-size:.8rem; font-weight:600; }
   .entity {
     --kind-color:#565f89; --kind-bg:#1e202b;
     width:22rem; border:1px solid #2c2f42; border-left:4px solid var(--kind-color);
@@ -76,11 +86,26 @@
       "label": "belongs to"
     }
   ],
-  "groups": []
+  "groups": [
+    {
+      "id": "ordering-context",
+      "label": "Ordering Context",
+      "nodes": [
+        "order",
+        "user"
+      ],
+      "ext": {
+        "role": "bounded-context"
+      }
+    }
+  ]
 }
 </script>
 
 <div class="graph" data-ark-container="graph">
+  <section class="group-boundary" data-ark-group data-model-id="ordering-context">
+    <span class="group-label" data-model-id="ordering-context">Ordering Context</span>
+  </section>
   <div class="entity" data-model-id="order" data-kind="aggregate">
     <h3><span class="kind-icon" aria-hidden="true"></span>Order</h3>
     <ul>

--- a/docs/superpowers/plans/2026-07-22-issue-227.md
+++ b/docs/superpowers/plans/2026-07-22-issue-227.md
@@ -1,0 +1,319 @@
+# issue-227: group 語彙 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 既存の `model.groups` を graph 上の複数 node を囲むラベル付き境界として投影し、矩形コンテナと swimlane の両方を生成 CSS で表現できるようにする。
+
+**Issue:** 227 (GitHub Issue 紐付けあり)
+
+**Architecture:** `DiagramGroup` の既存 shape（`id` / `label` / `nodes` / `ext`）を正とし、graph 内で opt-in された group 投影をハーネスが member node の外接矩形へ対応づけ、位置と大きさを CSS custom properties として渡す。ラベル付き矩形か swimlane 帯かは投影 HTML/CSS が決め、group を graph node / edge の背面に置きつつ、node drag 時は境界だけ再計算し、一括移動・snap・grid・自動レイアウトは追加しない。図は引き続き `.diagram.html` ファイルが正で、既存 MessageChannel と保存経路を再利用するため、新規 Socket.IO event、SQLite migration、React/モバイル UI、tmux/ttyd lifecycle の変更は行わない。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Express / Socket.IO / better-sqlite3 / tmux / ttyd
+
+---
+
+## 前提と変更境界
+
+- `packages/server/src/lib/diagram-model.ts:32-37,153-180` は既に group の一意な `id`、表示用 `label`、member node id の `nodes: string[]`、図種固有情報用 `ext` を保持し、存在しない member node を拒否する。今回の表示要件には十分なので、`members` への改名、group `kind`、座標、入れ子 group などのコア型追加は行わない。
+- group の図種固有な役割（bounded context / actor / VPC / region / subnet 等）が意味モデルに必要なら `ext` を使えるが、矩形か swimlane かという見た目は projection class と CSS に置く。server enum や palette を追加しない。
+- graph 内の group projection root は `[data-ark-group][data-model-id="<group.id>"]` とする。ラベルを既存 inline editing に載せる場合は、その root 内の leaf 要素にも同じ `data-model-id` を付ける。
+- ハーネスは member node の graph 相対外接矩形を `--ark-harness-group-x` / `--ark-harness-group-y` / `--ark-harness-group-width` / `--ark-harness-group-height` として projection root へ設定する。余白、見出し帯、border、background、角丸は生成 CSS が `calc()` で決める。
+- group は同じ graph 内で全 member node が解決できる場合だけ表示する。空 group、projection のない group、別 graph / graph 外の member を含む group、不正な投影 id は例外を投げず geometry 対象から外す。
+- group layer → edge SVG → graph node → drag handle の順に重なるよう、ハーネス側は汎用 layering だけを保証する。色、アイコン、swimlane の方向や帯幅は解釈しない。
+- node を個別 drag したときは既存 `scheduleGraphRender()` で group 外接矩形も追従させるが、group 自体の drag、一括 node 移動、membership の GUI 編集、snap / grid、自動レイアウトは対象外とする。
+- `buildSubmissionHtml()` は group 用のハーネス class と custom properties を除去し、生成物の `data-ark-group`、`data-model-id`、projection class、ラベル DOM は保持する。group label の既存 inline edit、graph drag、edge、list の追加・削除・並べ替え、kind 同期を壊さない。
+- group label / membership の会話向け意味差分追加は本 Issue の「囲って見せる」範囲外とし、`diagram-diff.ts` は変更しない。保存は既存の構造化 model + clean HTML submission を使う。
+- 各実装タスクは Red → Green → Refactor の順で進める。server 相対 import は `.js` 拡張子を維持し、コミット対象は各 Task の Files に列挙したファイルだけを stage する。
+
+---
+
+## Task 1: 既存 Group shape と file round-trip を characterization test で固定する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-model.test.ts`
+- Modify: `packages/server/src/lib/diagram-file.test.ts`
+- Reference only: `packages/server/src/lib/diagram-model.ts:32-37,153-180`
+- Reference only: `packages/server/src/lib/diagram-file.ts`
+
+- [ ] **Step 1: label / nodes / ext を保持する parser test を追加する（2-5分）**
+
+  2 node と次の group を含む model を `parseDiagramModel()` へ渡し、既存 shape が正規化後もそのまま残ることを検証する。
+
+  ```ts
+  groups: [
+    {
+      id: "ordering-context",
+      label: "Ordering Context",
+      nodes: ["order", "user"],
+      ext: { role: "bounded-context" },
+    },
+  ]
+  ```
+
+  `nodes` が member id の正式フィールドであり、見た目の variant は必須 core field ではないことを test fixture でも明確にする。
+
+- [ ] **Step 2: 存在しない member を拒否する validation test を追加する（2-5分）**
+
+  `nodes: ["order", "missing"]` の group を parse し、`ok: false` と group id / missing member を含む error になることを確認する。node / field / edge / group をまたぐ既存 id 一意性も維持し、production parser の緩和や別 schema を作らない。
+
+- [ ] **Step 3: model block の group round-trip test を追加する（2-5分）**
+
+  `replaceModelBlock()` → `extractModel()` の往復後も group の `id` / `label` / `nodes` / `ext` が一致する test を `diagram-file.test.ts` に追加する。SQLite ではなく `.diagram.html` 内の model block が永続化先であることを固定する。
+
+- [ ] **Step 4: characterization test を実行する（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts src/lib/diagram-file.test.ts`
+
+  Expected: PASS。既存実装だけで Group shape、参照 validation、file round-trip が成立し、`diagram-model.ts` の production 変更が不要と確認できる。
+
+- [ ] **Step 5: schema 変更が不要なことを確認してコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-file.test.ts
+  git commit -m "test(diagram): group モデル契約を固定"
+  ```
+
+---
+
+## Task 2: group 境界・追従・既存編集共存の Playwright test を Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+- Reference: `packages/server/src/lib/diagram-harness.ts:152-391,673-705,750-831`
+
+- [ ] **Step 1: inline graph fixture に group model と projection root を追加する（2-5分）**
+
+  既存 `order` / `user` graph fixture の `groups: []` を、両 node を member に持つ `ordering-context` group へ変える。graph 内には node と sibling になる boundary root を置き、ラベル leaf は既存 group label binding を使える形にする。
+
+  ```html
+  <section class="group-boundary" data-ark-group data-model-id="ordering-context">
+    <span class="group-label" data-model-id="ordering-context">Ordering Context</span>
+  </section>
+  ```
+
+  Fixture CSS は `--ark-harness-group-*` を使って外接矩形より上下左右へ余白を広げる。ハーネスが色や余白を供給しなくても境界が成立することを fixture 自身で示す。
+
+- [ ] **Step 2: 複数 node を囲む label 付き境界の失敗 test を書く（2-5分）**
+
+  初期表示後に次を assertion にする。
+
+  - group root が `.ark-harness-graph-group` を持ち、4つの geometry custom properties が有限 px 値になる。
+  - group bounding box が `order` と `user` の bounding box を padding 込みで内包する。
+  - `Ordering Context` label が可視で、label leaf は既存 inline editing により `contenteditable="true"` になる。
+  - `.ark-harness-edge-layer` と `e_order_user`、node drag handle 2個、node 内 list editor が従来どおり存在する。
+
+- [ ] **Step 3: node drag に境界だけが追従する失敗 test を書く（2-5分）**
+
+  `order` の graph handle を既存 test と同様に drag し、移動後も boundary が `order` / `user` の両方を内包し、edge endpoint も更新されることを確認する。`user` の座標は変わらないことも assertion にして、「group drag による一括移動」は実装しない境界を固定する。
+
+- [ ] **Step 4: invalid / cross-graph group を安全に除外する失敗 test を書く（2-5分）**
+
+  空 `nodes`、存在するが graph 外に投影された node を member に含む group、model に存在しない group id の projection root を fixture に加える。page error が0件で、これらの root は group class / geometry properties を得ず、有効 group だけが表示対象になることを検証する。
+
+- [ ] **Step 5: clean submission の失敗 test を追加する（2-5分）**
+
+  MessageChannel 接続後に group label を編集して送信し、submission model の `groups[0].label` が更新される一方、HTML から `.ark-harness-graph-group` と4 custom propertiesが除去されることを検証する。`data-ark-group`、authored `group-boundary` class、group label DOM、graph container は残ることも確認する。
+
+- [ ] **Step 6: Red を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "group|境界"`
+
+  Expected: FAIL。有効 group root に geometry class / custom properties が付かず、最初の境界 assertion で失敗する。既存 graph / kind / list 初期化自体に page error はない。
+
+---
+
+## Task 3: graph ハーネスで group と member node を結び境界 geometry を同期する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: 注入文字列の unit test を Red にする（2-5分）**
+
+  `injectHarness()` の出力が `[data-ark-group]`、`.ark-harness-graph-group`、4つの group geometry custom property 名、group render helper を含むことを確認する test を追加する。既存 marker 一意性、graph edge / drag、`syncNodeKinds()` の assertion は残す。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: FAIL。group geometry 契約がまだ注入されていない。
+
+- [ ] **Step 2: group lookup と projection root の収集を実装する（2-5分）**
+
+  `getGroup(model, id)` を `getNode()` と同じ opaque lookup として追加する。`wireGraph(container)` では、当該 graph を最も近い graph ancestor とする `[data-ark-group][data-model-id]` だけを集め、model group が解決できる root を `groupsById` に保持する。node candidate の既存 `getNode()` 判定は変えず、group root / label が graph node や drag 対象に誤認されないようにする。
+
+- [ ] **Step 3: member node の外接矩形を projection CSS へ渡す（2-5分）**
+
+  graph の `nodesById` と各 node の `getBoundingClientRect()` を使い、container 相対の `minLeft` / `minTop` / `maxRight` / `maxBottom` を計算する。group の全 member が同じ graph の `nodesById` に存在するときだけ root へ `.ark-harness-graph-group` と次の値を設定する。
+
+  ```text
+  --ark-harness-group-x: minLeft px
+  --ark-harness-group-y: minTop px
+  --ark-harness-group-width: maxRight - minLeft px
+  --ark-harness-group-height: maxBottom - minTop px
+  ```
+
+  ハーネスは padding や label height を加算しない。projection CSS が矩形では全周 padding、swimlane では左または上の label 帯を `calc()` で加える。
+
+- [ ] **Step 4: invalid group の stale geometry を消す（2-5分）**
+
+  empty / unresolved / cross-graph group は `.ark-harness-graph-group` と4 custom propertiesを外して非表示対象にする helper を用意する。モデル直接編集で valid group が invalid になった場合にも以前の geometry を残さない。
+
+- [ ] **Step 5: group / edge / node の再描画と layering を統合する（2-5分）**
+
+  既存 `renderGraph()` の同じ animation frame 内で group geometry と edge geometry を更新する。初期描画、`ResizeObserver`、window resize、node pointer move により境界が追従する。モデル直接編集 panel の apply 後にも全 graph を schedule し、membership 変更を projection DOM が対応できる範囲で即時再計算する。
+
+  HARNESS_STYLE は group の汎用 z-index と graph layer 順だけを定義し、rectangle / swimlane の border、background、label placement は定義しない。edge SVG と node の現行相対順を明示的に調整する場合は、edge が group 背景に隠れず node の背面に留まる test を通す。
+
+- [ ] **Step 6: clean HTML cleanup を追加する（2-5分）**
+
+  `buildSubmissionHtml()` で graph group clone から4 custom propertiesだけを削除し、空になった `style` 属性を消す。既存の `ark-harness-` class cleanup に `.ark-harness-graph-group` を任せ、projection の他 inline style / class / `data-ark-group` は保持する。
+
+- [ ] **Step 7: unit と browser test を Green にする（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: PASS。二重注入、graph、kind、group の注入契約がすべて成功する。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "group|境界|node ドラッグ"`
+
+  Expected: PASS。初期境界、drag 追従、invalid group 除外、label edit、clean submission と既存 graph/list 動作が成功する。
+
+- [ ] **Step 8: Refactor と実装コミット（2-5分）**
+
+  group state は既存 graph state に `groupsById` として閉じ、document 全体の追加 scan や図種名の分岐を作らない。geometry property 名と cleanup 対象を配列または小 helper にまとめ、設定と削除の不一致を防ぐ。
+
+  ```bash
+  git add packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts e2e/diagram-harness.spec.ts
+  git commit -m "feat(diagram): group 境界を graph に投影"
+  ```
+
+---
+
+## Task 4: canonical sample と diagram-authoring skill に rectangle / swimlane 規約を追加する
+
+**Files:**
+
+- Modify: `docs/diagrams/sample.diagram.html`
+- Modify: `.claude/skills/diagram-authoring/SKILL.md`
+- Modify: `e2e/diagram-harness.spec.ts`
+- Modify: `packages/server/src/lib/diagram-reader.test.ts`
+
+- [ ] **Step 1: sample group acceptance を Red にする（2-5分）**
+
+  既存 `openSampleDiagram()` test を拡張し、sample model に2 node を含む group が1件以上あり、対応する `[data-ark-group]` が両 node を囲み、label が可視であることを検証する。既存の2 kind、icon / color、edge、drag handle、field contenteditable assertions は残す。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "sample"`
+
+  Expected: FAIL。現行 sample の `groups` が空で、group projection root が存在しない。
+
+- [ ] **Step 2: sample にラベル付き rectangle boundary を追加する（2-5分）**
+
+  `docs/diagrams/sample.diagram.html` の `groups` に `order` / `user` を member とする group を追加し、graph 内の node より前に `[data-ark-group][data-model-id]` projection root と可視 label leaf を置く。CSS は4 custom propertiesから padding を含む矩形を作り、半透明 background、border、label を持たせる。既存 graph coordinates、edge、kind selectors、node / field `data-model-id`、list 構造は維持する。
+
+- [ ] **Step 3: skill に group model / DOM contract を追記する（2-5分）**
+
+  `.claude/skills/diagram-authoring/SKILL.md` に「語彙: group」を追加し、次を明記する。
+
+  - group は `{ id, label, nodes, ext? }`。`nodes` は実在する node id の配列で、入れ子 group id や field id を入れない。
+  - graph 上の自動境界配置を使う root は `[data-ark-group][data-model-id="group-id"]` とし、member node と sibling に置く。
+  - label leaf に同じ `data-model-id` を付ければ既存 inline label edit を使える。
+  - geometry は `--ark-harness-group-x/y/width/height` から取り、余白と見た目は projection CSS が担当する。
+  - group drag / 一括移動、snap / grid、自動レイアウト、group nesting は未対応。
+
+- [ ] **Step 4: rectangle と swimlane の CSS 実例を載せる（2-5分）**
+
+  rectangle 例は外接矩形の全周へ padding を足し、group label を上辺付近へ置く。swimlane 例は同じ geometry 変数を使い、左帯または上帯の label space を大きく取る。両者とも同じ model shape / DOM contract を使い、`class="group-boundary"` と `class="group-swimlane"` の投影差だけで表現する。
+
+  VPC / region / subnet や actor / bounded context は class / `ext` の利用例として説明するが、server の group kind enum や固定色を示さない。外部 stylesheet / font / image を使わず、可視 label を必須にする。
+
+- [ ] **Step 5: 配信時の group model / projection 保持 test を追加する（2-5分）**
+
+  `diagram-reader.test.ts` に group 付き graph fixture を追加し、`readDiagram()` 後に group `nodes` / `ext`、`data-ark-group` projection、CSP、harness marker がすべて保持されることを確認する。reader / API / Socket.IO の production 変更は加えない。
+
+- [ ] **Step 6: documentation と sample を Green にする（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-reader.test.ts src/lib/diagram-model.test.ts src/lib/diagram-file.test.ts`
+
+  Expected: PASS。group model と projection が parse / file / delivery を往復する。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "sample|group|境界"`
+
+  Expected: PASS。sample の rectangle group が2 nodeを囲み、kind / edge / graph drag / list editing と共存する。
+
+- [ ] **Step 7: sample と authoring 規約をコミットする（2-5分）**
+
+  ```bash
+  git add docs/diagrams/sample.diagram.html .claude/skills/diagram-authoring/SKILL.md e2e/diagram-harness.spec.ts packages/server/src/lib/diagram-reader.test.ts
+  git commit -m "docs(diagram): group と swimlane の作図規約を追加"
+  ```
+
+---
+
+## Task 5: 全回帰とスコープ境界を検証する
+
+**Files:**
+
+- Verify only: `packages/shared/src/types.ts`
+- Verify only: `packages/server/src/index.ts`
+- Verify only: `packages/server/src/lib/database.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.ts`
+- Verify only: `packages/web/src/hooks/useSocket.ts`
+- Verify only: `packages/web/src/components/DiagramPane.tsx`
+- Verify only: `packages/web/src/components/MobileLayout.tsx`
+- Verify only: `packages/web/src/components/MobileSessionView.tsx`
+- Verify only: `packages/server/src/lib/session-orchestrator.ts`
+- Verify only: `packages/server/src/lib/tmux-manager.ts`
+- Verify only: `packages/server/src/lib/ttyd-manager.ts`
+
+- [ ] **Step 1: Socket.IO / DB / UI / lifecycle / diff の非変更を確認する（2-5分）**
+
+  Run: `git diff HEAD~3 -- packages/shared/src/types.ts packages/server/src/index.ts packages/server/src/lib/database.ts packages/server/src/lib/diagram-diff.ts packages/web/src/hooks/useSocket.ts packages/web/src/components/DiagramPane.tsx packages/web/src/components/MobileLayout.tsx packages/web/src/components/MobileSessionView.tsx packages/server/src/lib/session-orchestrator.ts packages/server/src/lib/tmux-manager.ts packages/server/src/lib/ttyd-manager.ts`
+
+  Expected: 出力なし。group 境界は diagram model/file + 注入ハーネス + projection/skill 内で完結し、新規 Socket.IO event、DB migration、React/モバイル図 UI、tmux/ttyd lifecycle、group 会話差分を含まない。
+
+- [ ] **Step 2: formatter / lint / typecheck を実行する（2-5分）**
+
+  Run: `pnpm exec biome check packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-file.test.ts packages/server/src/lib/diagram-reader.test.ts e2e/diagram-harness.spec.ts`
+
+  Expected: exit 0、format / lint error なし。
+
+  Run: `pnpm exec tsc -b`
+
+  Expected: exit 0、型エラーなし。
+
+- [ ] **Step 3: server regression と diagram Playwright を全実行する（2-5分）**
+
+  Run: `pnpm exec vitest run`
+
+  Expected: exit 0、全 server test が PASS。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: group boundary / drag 追従 / invalid group / clean submission / sample に加え、既存 kind 同期、edge、node drag、list inline edit / reorder がすべて PASS。
+
+- [ ] **Step 4: repository E2E を実行する（2-5分）**
+
+  Run: `pnpm test:e2e`
+
+  Expected: desktop / mobile を含む既存 E2E が PASS（環境条件が明記された test は、その条件が未充足の場合のみ SKIP）。
+
+- [ ] **Step 5: desktop 実機で完了条件を確認する（各2-5分）**
+
+  1. 稼働中 session から `docs/diagrams/sample.diagram.html` を `board_open` し、label 付き境界が Order / User の両方を囲み、edge と kind style が見えることを確認する。
+  2. Order を個別 drag し、境界と edge が追従する一方で User は動かないことを確認する。
+  3. group label と field label を inline editし、field row を reorder して「変更を送る」。保存 model に group label、node ext、field label / order が入り、保存 HTML に harness class / geometry properties / edge SVG / handles が残らないことを確認する。
+  4. 図を再読込し、group rectangle、graph edge / drag、kind、list editing が同じ状態で再初期化されることを確認する。
+  5. skill の swimlane snippet を一時 fixture で表示し、同じ group model と geometry variablesだけで label 帯付き lane を描けることを確認する。
+
+- [ ] **Step 6: 最終差分を確認する（2-5分）**
+
+  Run: `git diff --check`
+
+  Expected: 出力なし。
+
+  Run: `git diff --stat HEAD~3`
+
+  Expected: production 変更は `diagram-harness.ts` の汎用 group geometry 補助だけで、残りは model/file/reader/harness tests、Playwright、sample、diagram-authoring skill。group 一括移動、snap / grid、自動レイアウト、group kind enum、Socket.IO、DB、React、mobile 変更は含まれない。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -22,11 +22,29 @@ const model = {
       fields: [{ id: "user_id", label: "id" }],
       ext: { x: 360, y: 180 },
     },
+    {
+      id: "external",
+      label: "External",
+      ext: { x: 20, y: 20 },
+    },
   ],
   edges: [
     { id: "e_order_user", from: "order", to: "user", label: "belongs to" },
   ],
-  groups: [],
+  groups: [
+    {
+      id: "ordering-context",
+      label: "Ordering Context",
+      nodes: ["order", "user"],
+      ext: { role: "bounded-context" },
+    },
+    { id: "empty-context", label: "Empty Context", nodes: [] },
+    {
+      id: "cross-graph-context",
+      label: "Cross Graph Context",
+      nodes: ["order", "external"],
+    },
+  ],
 };
 
 function diagramHtml(diagramModel: unknown = model): string {
@@ -37,6 +55,19 @@ function diagramHtml(diagramModel: unknown = model): string {
       body { margin: 0; }
       .graph { width: 720px; height: 480px; background: #f8fafc; }
       .entity { box-sizing: border-box; width: 220px; padding: 12px; border: 1px solid #64748b; border-left: 4px solid var(--kind-color); background: var(--kind-bg); }
+      .group-boundary {
+        display: none;
+        box-sizing: border-box;
+        position: absolute;
+        left: calc(var(--ark-harness-group-x) - 20px);
+        top: calc(var(--ark-harness-group-y) - 28px);
+        width: calc(var(--ark-harness-group-width) + 40px);
+        height: calc(var(--ark-harness-group-height) + 48px);
+        border: 2px solid #0f766e;
+        background: rgba(15, 118, 110, .08);
+      }
+      .group-boundary.ark-harness-graph-group { display: block; }
+      .group-label { position: absolute; top: 4px; left: 8px; color: #134e4a; }
       [data-kind="aggregate"] { --kind-color: #e0af68; --kind-bg: #332b1f; }
       [data-kind="entity"] { --kind-color: #7aa2f7; --kind-bg: #1f2a44; }
       [data-kind="event"] { --kind-color: #9ece6a; --kind-bg: #203222; }
@@ -48,6 +79,18 @@ function diagramHtml(diagramModel: unknown = model): string {
   <body>
     <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
     <div class="graph" data-ark-container="graph">
+      <section class="group-boundary" data-ark-group data-model-id="ordering-context">
+        <span class="group-label" data-model-id="ordering-context">Ordering Context</span>
+      </section>
+      <section class="group-boundary" data-ark-group data-model-id="empty-context">
+        <span class="group-label" data-model-id="empty-context">Empty Context</span>
+      </section>
+      <section class="group-boundary" data-ark-group data-model-id="cross-graph-context">
+        <span class="group-label" data-model-id="cross-graph-context">Cross Graph Context</span>
+      </section>
+      <section class="group-boundary" data-ark-group data-model-id="missing-context">
+        <span class="group-label" data-model-id="missing-context">Missing Context</span>
+      </section>
       <section class="entity" data-model-id="order">
         <h2 data-model-id="order"><span class="kind-icon" aria-hidden="true"></span>Order</h2>
         <ul>
@@ -60,6 +103,7 @@ function diagramHtml(diagramModel: unknown = model): string {
         <ul><li data-model-id="user_id">id</li></ul>
       </section>
     </div>
+    <section data-model-id="external">External</section>
   </body>
 </html>`);
 }
@@ -149,6 +193,20 @@ async function requiredBoundingBox(locator: Locator) {
   return box;
 }
 
+function expectBoxToContain(
+  container: { x: number; y: number; width: number; height: number },
+  member: { x: number; y: number; width: number; height: number }
+) {
+  expect(container.x).toBeLessThanOrEqual(member.x);
+  expect(container.y).toBeLessThanOrEqual(member.y);
+  expect(container.x + container.width).toBeGreaterThanOrEqual(
+    member.x + member.width
+  );
+  expect(container.y + container.height).toBeGreaterThanOrEqual(
+    member.y + member.height
+  );
+}
+
 test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ page }) => {
   await openDiagram(page);
 
@@ -187,6 +245,208 @@ test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ pag
   };
   expect(pointIsOnPerimeter(line.x1, line.y1, orderBox)).toBe(true);
   expect(pointIsOnPerimeter(line.x2, line.y2, userBox)).toBe(true);
+});
+
+test("group は複数 node を囲むラベル付き境界として投影する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const group = graph.locator(
+    '[data-ark-group][data-model-id="ordering-context"]'
+  );
+  const order = graph.locator('section[data-model-id="order"]');
+  const user = graph.locator('section[data-model-id="user"]');
+
+  await expect(group).toHaveClass(/ark-harness-graph-group/);
+  const geometry = await group.evaluate(element => {
+    const style = (element as HTMLElement).style;
+    return [
+      "--ark-harness-group-x",
+      "--ark-harness-group-y",
+      "--ark-harness-group-width",
+      "--ark-harness-group-height",
+    ].map(name => style.getPropertyValue(name));
+  });
+  for (const value of geometry) {
+    expect(value).toMatch(/^-?\d+(?:\.\d+)?px$/);
+    expect(Number.isFinite(Number.parseFloat(value))).toBe(true);
+  }
+
+  const [groupBox, orderBox, userBox] = await Promise.all([
+    requiredBoundingBox(group),
+    requiredBoundingBox(order),
+    requiredBoundingBox(user),
+  ]);
+  expectBoxToContain(groupBox, orderBox);
+  expectBoxToContain(groupBox, userBox);
+  expect(groupBox.x).toBeLessThan(orderBox.x);
+  expect(groupBox.y).toBeLessThan(orderBox.y);
+
+  const label = group.locator('.group-label[data-model-id="ordering-context"]');
+  await expect(label).toBeVisible();
+  await expect(label).toHaveText("Ordering Context");
+  await expect(label).toHaveAttribute("contenteditable", "true");
+  await expect(graph.locator(".ark-harness-edge-layer")).toHaveCount(1);
+  await expect(graph.locator('[data-ark-edge-id="e_order_user"]')).toHaveCount(
+    1
+  );
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
+  await expect(
+    order.locator('li[data-model-id="order_id"] .ark-harness-text')
+  ).toHaveAttribute("contenteditable", "true");
+});
+
+test("node ドラッグで group 境界と edge だけが追従する", async ({ page }) => {
+  await openDiagram(page);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const group = graph.locator(
+    '[data-ark-group][data-model-id="ordering-context"]'
+  );
+  const order = graph.locator('section[data-model-id="order"]');
+  const user = graph.locator('section[data-model-id="user"]');
+  const beforeGroup = await requiredBoundingBox(group);
+  const beforeOrder = await requiredBoundingBox(order);
+  const beforeUser = await requiredBoundingBox(user);
+  const beforeEdge = await readEdge(page);
+  const handleBox = await requiredBoundingBox(
+    order.locator(".ark-harness-graph-handle")
+  );
+
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2 + 80,
+    handleBox.y + handleBox.height / 2 + 60
+  );
+  await page.mouse.up();
+
+  await expect
+    .poll(async () => (await order.boundingBox())?.x)
+    .toBeCloseTo(beforeOrder.x + 80, 0);
+  const [afterGroup, afterOrder, afterUser, afterEdge] = await Promise.all([
+    requiredBoundingBox(group),
+    requiredBoundingBox(order),
+    requiredBoundingBox(user),
+    readEdge(page),
+  ]);
+  expectBoxToContain(afterGroup, afterOrder);
+  expectBoxToContain(afterGroup, afterUser);
+  expect(afterGroup.x).not.toBeCloseTo(beforeGroup.x, 0);
+  expect(afterUser.x).toBeCloseTo(beforeUser.x, 0);
+  expect(afterUser.y).toBeCloseTo(beforeUser.y, 0);
+  expect(afterEdge.x1).not.toBeCloseTo(beforeEdge.x1, 0);
+});
+
+test("invalid / cross-graph group 境界を安全に除外する", async ({ page }) => {
+  const errors = await openDiagram(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const invalidGroups = graph.locator(
+    '[data-ark-group][data-model-id]:not([data-model-id="ordering-context"])'
+  );
+
+  await expect(invalidGroups).toHaveCount(3);
+  for (const group of await invalidGroups.all()) {
+    await expect(group).not.toHaveClass(/ark-harness-graph-group/);
+    const geometry = await group.evaluate(element =>
+      (element.getAttribute("style") || "").includes("--ark-harness-group-")
+    );
+    expect(geometry).toBe(false);
+  }
+
+  const orderingGroup = graph.locator(
+    '[data-ark-group][data-model-id="ordering-context"]'
+  );
+  await expect(orderingGroup).toHaveClass(/ark-harness-graph-group/);
+  const invalidatedModel = {
+    ...model,
+    groups: model.groups.map(group =>
+      group.id === "ordering-context"
+        ? { ...group, nodes: ["order", "external"] }
+        : group
+    ),
+  };
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  await page
+    .locator(".ark-harness-textarea")
+    .fill(JSON.stringify(invalidatedModel));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+
+  await expect(orderingGroup).not.toHaveClass(/ark-harness-graph-group/);
+  const staleGeometry = await orderingGroup.evaluate(element =>
+    (element.getAttribute("style") || "").includes("--ark-harness-group-")
+  );
+  expect(staleGeometry).toBe(false);
+  expect(errors).toEqual([]);
+});
+
+test("group label 編集を model に反映し clean HTML から境界 geometry を除く", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  await connectSubmissionPort(page);
+
+  const label = page.locator(
+    '[data-ark-group][data-model-id="ordering-context"] .group-label'
+  );
+  await label.fill("Orders & Users");
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+  );
+
+  expect(submission).toMatchObject({ type: "ark:diagram-submit" });
+  const submittedGroups = (
+    submission as {
+      model: { groups: Array<{ id: string; label: string; nodes: string[] }> };
+    }
+  ).model.groups;
+  expect(submittedGroups[0]).toMatchObject({
+    id: "ordering-context",
+    label: "Orders & Users",
+    nodes: ["order", "user"],
+  });
+  const html = (submission as { html: string }).html;
+  const cleanProjection = await page.evaluate(cleanHtml => {
+    const document = new DOMParser().parseFromString(cleanHtml, "text/html");
+    const group = document.querySelector(
+      '[data-ark-group][data-model-id="ordering-context"]'
+    );
+    return {
+      groupHtml: group?.outerHTML || "",
+      groupClass: group?.getAttribute("class") || "",
+      groupStyle: group?.getAttribute("style") || "",
+      hasGraph: Boolean(document.querySelector('[data-ark-container="graph"]')),
+    };
+  }, html);
+  expect(cleanProjection.groupClass).toBe("group-boundary");
+  expect(cleanProjection.groupStyle).not.toContain("--ark-harness-group-x");
+  expect(cleanProjection.groupStyle).not.toContain("--ark-harness-group-y");
+  expect(cleanProjection.groupStyle).not.toContain("--ark-harness-group-width");
+  expect(cleanProjection.groupStyle).not.toContain(
+    "--ark-harness-group-height"
+  );
+  expect(cleanProjection.groupHtml).toContain('data-ark-group=""');
+  expect(cleanProjection.groupHtml).toContain('class="group-label"');
+  expect(cleanProjection.groupHtml).toContain("Orders &amp; Users");
+  expect(cleanProjection.hasGraph).toBe(true);
 });
 
 test("node.kind を data-kind へ同期して色とアイコンを区別する", async ({
@@ -359,6 +619,7 @@ test("node ドラッグと list 編集を送信 model と clean HTML に反映�
           ],
         },
         { id: "user" },
+        { id: "external" },
       ],
     },
   });
@@ -453,6 +714,7 @@ test("モデル直接編集後の kind 再同期と node ドラッグを送信 m
           ext: { x: 120, y: 110 },
         },
         { id: "user" },
+        { id: "external" },
       ],
     },
   });

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -512,7 +512,9 @@ test("sample は複数 kind を色とアイコンで区別する", async ({ page
       return Object.fromEntries(parsed.nodes.map(node => [node.id, node.kind]));
     });
   const projections = await page
-    .locator('[data-ark-container="graph"] > [data-model-id]')
+    .locator(
+      '[data-ark-container="graph"] > [data-model-id]:not([data-ark-group])'
+    )
     .evaluateAll(elements =>
       elements.map(element => {
         const icon = element.querySelector(".kind-icon");
@@ -544,6 +546,42 @@ test("sample は複数 kind を色とアイコンで区別する", async ({ page
   await expect(
     graph.locator('li[data-model-id="order_id"] .ark-harness-text')
   ).toHaveAttribute("contenteditable", "true");
+});
+
+test("sample group は2 node を囲むラベル付き境界として表示する", async ({
+  page,
+}) => {
+  await openSampleDiagram(page);
+
+  const groups = await page.locator("#ark-diagram-model").evaluate(element => {
+    const parsed = JSON.parse(element.textContent || "") as {
+      groups: Array<{ id: string; label: string; nodes: string[] }>;
+    };
+    return parsed.groups;
+  });
+  expect(groups.length).toBeGreaterThanOrEqual(1);
+  const sampleGroup = groups[0];
+  expect(sampleGroup).toBeDefined();
+  if (!sampleGroup) return;
+  expect(sampleGroup.nodes).toHaveLength(2);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const boundary = graph.locator(
+    `[data-ark-group][data-model-id="${sampleGroup.id}"]`
+  );
+  const [boundaryBox, firstNodeBox, secondNodeBox] = await Promise.all([
+    requiredBoundingBox(boundary),
+    requiredBoundingBox(
+      graph.locator(`[data-model-id="${sampleGroup.nodes[0]}"]`).first()
+    ),
+    requiredBoundingBox(
+      graph.locator(`[data-model-id="${sampleGroup.nodes[1]}"]`).first()
+    ),
+  ]);
+  expectBoxToContain(boundaryBox, firstNodeBox);
+  expectBoxToContain(boundaryBox, secondNodeBox);
+  await expect(boundary).toContainText(sampleGroup.label);
+  await expect(boundary.locator(".group-label")).toBeVisible();
 });
 
 test("node ドラッグと list 編集を送信 model と clean HTML に反映する", async ({

--- a/packages/server/src/lib/diagram-file.test.ts
+++ b/packages/server/src/lib/diagram-file.test.ts
@@ -252,6 +252,34 @@ describe("replaceModelBlock", () => {
     }
   });
 
+  it("モデルブロックの往復で group の label / nodes / ext を保持する", () => {
+    const html = page(
+      `<script type="application/json" id="ark-diagram-model">${MODEL}</script><div>図</div>`
+    );
+    const group = {
+      id: "ordering-context",
+      label: "Ordering Context",
+      nodes: ["order", "user"],
+      ext: { role: "bounded-context" },
+    };
+    const nextModel: DiagramModel = {
+      ...MODEL_OBJ,
+      nodes: [
+        { id: "order", label: "Order" },
+        { id: "user", label: "User" },
+      ],
+      groups: [group],
+    };
+
+    const replaced = replaceModelBlock(html, nextModel);
+    expect(replaced.ok).toBe(true);
+    if (!replaced.ok) return;
+
+    const extracted = extractModel(replaced.html);
+    expect(extracted.ok).toBe(true);
+    if (extracted.ok) expect(extracted.model.groups).toEqual([group]);
+  });
+
   it("属性の順序が逆でも差し替えられる", () => {
     const html = page(
       `<script id="ark-diagram-model" type="application/json">${MODEL}</script>`

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -45,6 +45,23 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
+  it("group projection と geometry 同期の契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><section data-ark-group data-model-id="group"></section></div>'
+      )
+    );
+
+    expect(out).toContain("[data-ark-group]");
+    expect(out).toContain("ark-harness-graph-group");
+    expect(out).toContain("--ark-harness-group-x");
+    expect(out).toContain("--ark-harness-group-y");
+    expect(out).toContain("--ark-harness-group-width");
+    expect(out).toContain("--ark-harness-group-height");
+    expect(out).toContain("function renderGraphGroups(");
+    expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  });
+
   it("node projection の data-kind を初期表示とモデル再適用で同期する", () => {
     const out = injectHarness(
       page('<div data-model-id="node" data-kind="stale"></div>')

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -90,11 +90,12 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 }
 .ark-harness-add-row:hover { border-color: #38bdf8; color: #38bdf8; }
 [data-ark-container="graph"] { position: relative; }
+.ark-harness-graph-group { position: absolute; z-index: 0; }
 .ark-harness-graph-node {
-  position: absolute; left: var(--ark-harness-graph-x); top: var(--ark-harness-graph-y); z-index: 1;
+  position: absolute; left: var(--ark-harness-graph-x); top: var(--ark-harness-graph-y); z-index: 2;
 }
 .ark-harness-edge-layer {
-  position: absolute; inset: 0; z-index: 0; width: 100%; height: 100%;
+  position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%;
   overflow: visible; pointer-events: none;
 }
 .ark-harness-edge-layer line, .ark-harness-edge-layer path {
@@ -105,11 +106,11 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   font-size: 12px; text-anchor: middle; dominant-baseline: central;
 }
 .ark-harness-graph-handle {
-  position: absolute; top: .25rem; right: .25rem; z-index: 2;
+  position: absolute; top: .25rem; right: .25rem; z-index: 3;
   border: 1px solid rgba(100,116,139,.45); border-radius: 4px; background: rgba(255,255,255,.9);
   color: #64748b; cursor: grab; line-height: 1; padding: .25rem; touch-action: none;
 }
-.ark-harness-graph-dragging { z-index: 2; }
+.ark-harness-graph-dragging { z-index: 3; }
 body { padding-bottom: 3.4rem !important; }
 </style>`;
 
@@ -122,6 +123,12 @@ const HARNESS_JS = `(function () {
   "use strict";
 
   var MODEL_SCRIPT_ID = "${MODEL_SCRIPT_ID}";
+  var GROUP_GEOMETRY_PROPERTIES = [
+    "--ark-harness-group-x",
+    "--ark-harness-group-y",
+    "--ark-harness-group-width",
+    "--ark-harness-group-height"
+  ];
 
   var BLOCK_TAGS = {
     DIV: 1, UL: 1, OL: 1, LI: 1, TABLE: 1, THEAD: 1, TBODY: 1, TR: 1, TD: 1, TH: 1,
@@ -177,6 +184,14 @@ const HARNESS_JS = `(function () {
     return null;
   }
 
+  function getGroup(model, id) {
+    var groups = model.groups || [];
+    for (var i = 0; i < groups.length; i++) {
+      if (groups[i].id === id) return groups[i];
+    }
+    return null;
+  }
+
   function finiteNumber(v) {
     return typeof v === "number" && Number.isFinite(v);
   }
@@ -219,8 +234,57 @@ const HARNESS_JS = `(function () {
     svg.appendChild(text);
   }
 
+  function clearGroupGeometry(el) {
+    el.classList.remove("ark-harness-graph-group");
+    GROUP_GEOMETRY_PROPERTIES.forEach(function (property) {
+      el.style.removeProperty(property);
+    });
+    if (el.style.length === 0) el.removeAttribute("style");
+  }
+
+  function renderGraphGroups(graph) {
+    var containerRect = graph.container.getBoundingClientRect();
+    graph.groupsById.forEach(function (el, id) {
+      var group = getGroup(state.model, id);
+      if (!group || !Array.isArray(group.nodes) || group.nodes.length === 0) {
+        clearGroupGeometry(el);
+        return;
+      }
+
+      var memberEls = [];
+      for (var i = 0; i < group.nodes.length; i++) {
+        var memberEl = graph.nodesById.get(group.nodes[i]);
+        if (!memberEl) {
+          clearGroupGeometry(el);
+          return;
+        }
+        memberEls.push(memberEl);
+      }
+
+      var firstRect = memberEls[0].getBoundingClientRect();
+      var minLeft = firstRect.left;
+      var minTop = firstRect.top;
+      var maxRight = firstRect.right;
+      var maxBottom = firstRect.bottom;
+      for (var j = 1; j < memberEls.length; j++) {
+        var memberRect = memberEls[j].getBoundingClientRect();
+        minLeft = Math.min(minLeft, memberRect.left);
+        minTop = Math.min(minTop, memberRect.top);
+        maxRight = Math.max(maxRight, memberRect.right);
+        maxBottom = Math.max(maxBottom, memberRect.bottom);
+      }
+
+      el.classList.add("ark-harness-graph-group");
+      el.style.setProperty("--ark-harness-group-x", minLeft - containerRect.left + "px");
+      el.style.setProperty("--ark-harness-group-y", minTop - containerRect.top + "px");
+      el.style.setProperty("--ark-harness-group-width", maxRight - minLeft + "px");
+      el.style.setProperty("--ark-harness-group-height", maxBottom - minTop + "px");
+    });
+  }
+
   function renderGraph(graph) {
     graph.scheduled = false;
+    renderGraphGroups(graph);
     while (graph.svg.firstChild) graph.svg.removeChild(graph.svg.firstChild);
     appendGraphMarker(graph.svg, graph.markerId);
 
@@ -354,6 +418,14 @@ const HARNESS_JS = `(function () {
   function wireGraph(container) {
     var nodesById = new Map();
     var modelNodesById = new Map();
+    var groupsById = new Map();
+    var groupCandidates = container.querySelectorAll("[data-ark-group][data-model-id]");
+    groupCandidates.forEach(function (el) {
+      if (el.closest('[data-ark-container="graph"]') !== container) return;
+      var id = el.getAttribute("data-model-id");
+      if (!id || groupsById.has(id) || !getGroup(state.model, id)) return;
+      groupsById.set(id, el);
+    });
     var candidates = container.querySelectorAll("[data-model-id]");
     candidates.forEach(function (el) {
       if (el.closest('[data-ark-container="graph"]') !== container) return;
@@ -377,6 +449,7 @@ const HARNESS_JS = `(function () {
     var graph = {
       container: container,
       nodesById: nodesById,
+      groupsById: groupsById,
       svg: svg,
       resizeObserver: null,
       scheduled: false,
@@ -658,6 +731,7 @@ const HARNESS_JS = `(function () {
     var editableEls = document.querySelectorAll("[data-model-id]");
     editableEls.forEach(function (el) {
       if (isInsideHarnessUi(el)) return;
+      if (el.hasAttribute("data-ark-group")) return;
       if (!isLeaf(el)) return;
       var rowInfo = null;
       if (el.tagName === "LI" && el.parentElement) {
@@ -679,6 +753,12 @@ const HARNESS_JS = `(function () {
     clone.querySelectorAll(".ark-harness-graph-node").forEach(function (el) {
       el.style.removeProperty("--ark-harness-graph-x");
       el.style.removeProperty("--ark-harness-graph-y");
+      if (el.style.length === 0) el.removeAttribute("style");
+    });
+    clone.querySelectorAll(".ark-harness-graph-group").forEach(function (el) {
+      GROUP_GEOMETRY_PROPERTIES.forEach(function (property) {
+        el.style.removeProperty(property);
+      });
       if (el.style.length === 0) el.removeAttribute("style");
     });
     clone.querySelectorAll("[data-ark-harness-wrap]").forEach(function (span) {
@@ -760,6 +840,7 @@ const HARNESS_JS = `(function () {
         if (!Array.isArray(parsed.groups)) parsed.groups = [];
         state.model = parsed;
         syncNodeKinds();
+        graphs.forEach(function (graph) { scheduleGraphRender(graph); });
         error.style.display = "none";
         panel.style.display = "none";
       } catch (e) {

--- a/packages/server/src/lib/diagram-model.test.ts
+++ b/packages/server/src/lib/diagram-model.test.ts
@@ -74,6 +74,38 @@ describe("parseDiagramModel", () => {
     }
   });
 
+  it("group の label / nodes / ext を保持する", () => {
+    const json = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: "order", label: "Order" },
+        { id: "user", label: "User" },
+      ],
+      groups: [
+        {
+          id: "ordering-context",
+          label: "Ordering Context",
+          nodes: ["order", "user"],
+          ext: { role: "bounded-context" },
+        },
+      ],
+    });
+
+    const result = parseDiagramModel(json);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.groups).toEqual([
+        {
+          id: "ordering-context",
+          label: "Ordering Context",
+          nodes: ["order", "user"],
+          ext: { role: "bounded-context" },
+        },
+      ]);
+    }
+  });
+
   it("id が重複するモデルを拒否する", () => {
     const json = JSON.stringify({
       version: 1,
@@ -100,6 +132,28 @@ describe("parseDiagramModel", () => {
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain("missing");
+  });
+
+  it("存在しないノードを含む group を拒否する", () => {
+    const json = JSON.stringify({
+      version: 1,
+      nodes: [{ id: "order", label: "Order" }],
+      groups: [
+        {
+          id: "ordering-context",
+          label: "Ordering Context",
+          nodes: ["order", "missing"],
+        },
+      ],
+    });
+
+    const result = parseDiagramModel(json);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("ordering-context");
+      expect(result.error).toContain("missing");
+    }
   });
 
   it("壊れた JSON を拒否する", () => {

--- a/packages/server/src/lib/diagram-reader.test.ts
+++ b/packages/server/src/lib/diagram-reader.test.ts
@@ -85,6 +85,52 @@ describe("readDiagram", () => {
     }
   });
 
+  it("group model と graph projection を配信時も保持する", async () => {
+    const groupModel = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: "order", label: "Order", ext: { x: 40, y: 50 } },
+        { id: "user", label: "User", ext: { x: 360, y: 180 } },
+      ],
+      edges: [],
+      groups: [
+        {
+          id: "ordering-context",
+          label: "Ordering Context",
+          nodes: ["order", "user"],
+          ext: { role: "bounded-context" },
+        },
+      ],
+    });
+    write(
+      "group.diagram.html",
+      '<div data-ark-container="graph">' +
+        '<section class="group-boundary" data-ark-group data-model-id="ordering-context">' +
+        '<span data-model-id="ordering-context">Ordering Context</span></section>' +
+        '<div data-model-id="order">Order</div>' +
+        '<div data-model-id="user">User</div></div>',
+      groupModel
+    );
+
+    const result = await readDiagram(wt, "group.diagram.html");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.groups).toEqual([
+        {
+          id: "ordering-context",
+          label: "Ordering Context",
+          nodes: ["order", "user"],
+          ext: { role: "bounded-context" },
+        },
+      ]);
+      expect(result.html).toContain("data-ark-group");
+      expect(result.html).toContain('class="group-boundary"');
+      expect(result.html).toContain(DIAGRAM_CSP);
+      expect(result.html).toContain(DIAGRAM_HARNESS_MARKER);
+    }
+  });
+
   it("任意の model kind と投影 data-kind を配信時も保持する", async () => {
     const kindModel = JSON.stringify({
       version: 1,


### PR DESCRIPTION
## 概要

図解ハーネスの **group 語彙**。graph コンテナ (#224) の上に、`model.groups` を graph 上の複数ノードを囲む**ラベル付き境界**として投影する。矩形コンテナと swimlane の両方を投影 CSS で表現でき、イベントストーミングの swimlane (#231) とインフラ構成図の VPC/region/subnet 境界 (#232) の共通土台になる。

Closes #227

## 変更点

- **汎用 geometry 同期**: 注入ハーネスに `renderGraphGroups()` を追加。`[data-ark-group][data-model-id]` の group root に対し、member node 群の外接矩形を計算して `--ark-harness-group-x/y/width/height` を設定。余白・見出し帯・border・background は投影 CSS が `calc()` で決める（ハーネスは矩形/swimlane を解釈しない）
- **既存 `DiagramGroup`(id/label/nodes/ext) を再利用**、型追加なし。member 非存在の拒否も既存 parser のまま
- **レイヤリング**: group(z:0) → edge(z:1) → node(z:2) → handle(z:3)。境界は edge/node の背面に留まる
- **ドラッグ追従**: node 個別ドラッグで境界だけ再計算（既存 `scheduleGraphRender` に統合）。group 一括移動・snap・grid・自動レイアウトはスコープ外
- **group label は既存 inline edit**（`findEntry` が既に groups を処理）で編集・保存。**防御的**（空/未解決/graph 外 member の group は `clearGroupGeometry` で非表示、例外を投げない）
- **clean HTML**: `buildSubmissionHtml()` が group geometry properties と `.ark-harness-graph-group` class を除去、`data-ark-group`/投影 class/label DOM は保持
- **skill 追記**: `diagram-authoring` に「語彙: group」+ rectangle / swimlane の CSS 実例（外部リソース禁止、可視 label 必須）。`sample.diagram.html` に矩形 group を追加

## テスト

- `tsc -b`: pass ・ `vitest run`: 36 ファイル / 523 テスト pass ・ `biome check`: clean
- `playwright e2e/diagram-harness.spec.ts`: 11 テスト pass（group 境界投影 / ドラッグ追従(一括移動なし) / invalid・cross-graph group 除外 / label 編集→model+clean HTML / sample group / 既存 kind・edge・drag・list 回帰）
- TDD（Red→Green→Refactor）。group モデル契約・file round-trip・delivery 保持の回帰も追加

## スコープ外（後続単位）

group 一括移動 / snap / grid / 自動レイアウト (#228) / group nesting / group kind enum / group の会話還流。Socket.IO・DB・diagram-model・diagram-diff・tmux/ttyd・モバイルは不変。

## レビュー体制

codex が plan 立案・TDD 実装、Claude が P2（plan）/ P5（実装）レビュー（flow-x 役割逆転。実装者 ≠ レビュアー）。
