### PR TITLE
図解: インフラ構成図（service/db/queue/lb を境界で囲む作図規約と実例・ハーネス変更なし） (#232)

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -112,14 +112,106 @@ node の `kind` フィールドで図の要素型を指定する。サーバー�
 
 ### Infrastructure の例
 
-`service` / `db` / `queue` / `lb` も推奨語彙の例として使える。Unicode の代わりに inline SVG や data URI を使ってもよいが、`<img src="https://...">`、外部 stylesheet、icon font / icon library、外部ファイルを指す `<use href>` は禁止する。
+`service` / `db` / `queue` / `lb` / `cache` / `external` はインフラ構成図で
+使える推奨語彙であり、server が制限する enum ではない。未知 kind にも共通
+`.infra-node` style を fallback として適用し、model の `node.kind` と node projection
+root の `data-kind` は一致させる。
+
+#228 の auto-layout に依存せず、graph 内のすべての node に有限数の `ext.x` / `ext.y`
+を指定して手動配置する。外部クライアントも graph 外の特別要素にはせず、
+`kind: "external"` の通常 node とする。通信や依存関係は既存 edge の `from` / `to` /
+`label` だけで表す。
+
+```json
+{
+  "nodes": [
+    { "id": "client", "label": "Internet Client", "kind": "external", "ext": { "x": 24, "y": 280 } },
+    { "id": "lb", "label": "Load Balancer", "kind": "lb", "ext": { "x": 260, "y": 280 } },
+    { "id": "api", "label": "API Service", "kind": "service", "ext": { "x": 500, "y": 280 } }
+  ],
+  "edges": [
+    { "id": "client-to-lb", "from": "client", "to": "lb", "label": "HTTPS" },
+    { "id": "lb-to-api", "from": "lb", "to": "api", "label": "routes" }
+  ]
+}
+```
+
+各 card には `aria-hidden="true"` の `.kind-icon` と、文字として読める可視 label を
+併置する。色は補助情報に留め、6 kind を異なる icon と label でも判別できるようにする。
 
 ```css
+[data-kind="service"] { --kind-color: #60a5fa; --kind-bg: #182942; }
+[data-kind="db"] { --kind-color: #a78bfa; --kind-bg: #27203d; }
+[data-kind="queue"] { --kind-color: #f59e0b; --kind-bg: #342817; }
+[data-kind="lb"] { --kind-color: #34d399; --kind-bg: #17362f; }
+[data-kind="cache"] { --kind-color: #f472b6; --kind-bg: #382035; }
+[data-kind="external"] { --kind-color: #a3a3a3; --kind-bg: #292929; }
 [data-kind="service"] .kind-icon::before { content: "▣"; }
 [data-kind="db"] .kind-icon::before { content: "◉"; }
 [data-kind="queue"] .kind-icon::before { content: "≋"; }
 [data-kind="lb"] .kind-icon::before { content: "⇄"; }
+[data-kind="cache"] .kind-icon::before { content: "◇"; }
+[data-kind="external"] .kind-icon::before { content: "☁"; }
 ```
+
+```html
+<article class="infra-node" data-model-id="api" data-kind="service">
+  <span class="kind-icon" aria-hidden="true"></span>
+  <span class="node-label">API Service</span>
+</article>
+```
+
+icon は Unicode、inline SVG、data URI の範囲で作る。外部 URL の image / font /
+stylesheet / icon library や、外部ファイルを指す `<use href>` は使わない。
+
+region / VPC / subnet の境界は、既存の flat group を次の形で使う。
+
+```json
+{
+  "groups": [
+    { "id": "tokyo-region", "label": "Tokyo Region", "nodes": ["lb", "api"], "ext": { "role": "region" } },
+    { "id": "production-vpc", "label": "Production VPC", "nodes": ["lb", "api"], "ext": { "role": "vpc" } },
+    { "id": "app-subnet", "label": "Application Subnet", "nodes": ["api"], "ext": { "role": "subnet" } }
+  ]
+}
+```
+
+projection は member node の sibling として既存の
+`[data-ark-group][data-model-id]` + `.group-label` contract を使う。
+
+```html
+<section class="infra-boundary boundary-region" data-ark-group data-model-id="tokyo-region">
+  <span class="group-label" data-model-id="tokyo-region">Tokyo Region</span>
+</section>
+```
+
+region / VPC / subnet の階層感が必要でも `groups[].nodes` に group id は入れない。
+外側 group には配下 node の和集合を列挙し、projection class ごとに4つの
+`--ark-harness-group-*` を `calc()` する padding 差で、重なる矩形として近似する。
+
+```css
+.boundary-region {
+  left: calc(var(--ark-harness-group-x) - 8rem);
+  top: calc(var(--ark-harness-group-y) - 5rem);
+  width: calc(var(--ark-harness-group-width) + 16rem);
+  height: calc(var(--ark-harness-group-height) + 10rem);
+}
+.boundary-vpc {
+  left: calc(var(--ark-harness-group-x) - 5rem);
+  top: calc(var(--ark-harness-group-y) - 3rem);
+  width: calc(var(--ark-harness-group-width) + 10rem);
+  height: calc(var(--ark-harness-group-height) + 6rem);
+}
+.boundary-subnet {
+  left: calc(var(--ark-harness-group-x) - 1.5rem);
+  top: calc(var(--ark-harness-group-y) - 2rem);
+  width: calc(var(--ark-harness-group-width) + 3rem);
+  height: calc(var(--ark-harness-group-height) + 3.5rem);
+}
+```
+
+group nesting、group 一括 drag、auto-layout は未対応で、インフラ構成図でも導入しない。
+完成例は `docs/diagrams/infrastructure.diagram.html` を参照する。
 
 ## 語彙: group
 

--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -117,7 +117,7 @@ node の `kind` フィールドで図の要素型を指定する。サーバー�
 `.infra-node` style を fallback として適用し、model の `node.kind` と node projection
 root の `data-kind` は一致させる。
 
-#228 の auto-layout に依存せず、graph 内のすべての node に有限数の `ext.x` / `ext.y`
+Issue `#228` の auto-layout に依存せず、graph 内のすべての node に有限数の `ext.x` / `ext.y`
 を指定して手動配置する。外部クライアントも graph 外の特別要素にはせず、
 `kind: "external"` の通常 node とする。通信や依存関係は既存 edge の `from` / `to` /
 `label` だけで表す。

--- a/docs/diagrams/infrastructure.diagram.html
+++ b/docs/diagrams/infrastructure.diagram.html
@@ -79,17 +79,17 @@
     letter-spacing: .03em;
   }
   .boundary-region {
-    left: calc(var(--ark-harness-group-x) - 130px);
+    left: calc(var(--ark-harness-group-x) - 48px);
     top: calc(var(--ark-harness-group-y) - 90px);
-    width: calc(var(--ark-harness-group-width) + 260px);
+    width: calc(var(--ark-harness-group-width) + 96px);
     height: calc(var(--ark-harness-group-height) + 180px);
     border-width: 2px;
     color: #38bdf8;
   }
   .boundary-vpc {
-    left: calc(var(--ark-harness-group-x) - 96px);
+    left: calc(var(--ark-harness-group-x) - 36px);
     top: calc(var(--ark-harness-group-y) - 62px);
-    width: calc(var(--ark-harness-group-width) + 192px);
+    width: calc(var(--ark-harness-group-width) + 72px);
     height: calc(var(--ark-harness-group-height) + 124px);
     border-style: dashed;
     color: #22c55e;
@@ -112,12 +112,12 @@
   "title": "Production Infrastructure",
   "nodes": [
     { "id": "client", "label": "Internet Client", "kind": "external", "ext": { "x": 24, "y": 280 } },
-    { "id": "public-lb", "label": "Public Load Balancer", "kind": "lb", "ext": { "x": 260, "y": 280 } },
-    { "id": "api-service", "label": "API Service", "kind": "service", "ext": { "x": 500, "y": 170 } },
-    { "id": "worker-service", "label": "Worker Service", "kind": "service", "ext": { "x": 500, "y": 390 } },
-    { "id": "orders-db", "label": "Orders DB", "kind": "db", "ext": { "x": 800, "y": 120 } },
-    { "id": "jobs-queue", "label": "Jobs Queue", "kind": "queue", "ext": { "x": 800, "y": 280 } },
-    { "id": "session-cache", "label": "Session Cache", "kind": "cache", "ext": { "x": 800, "y": 440 } }
+    { "id": "public-lb", "label": "Public Load Balancer", "kind": "lb", "ext": { "x": 280, "y": 280 } },
+    { "id": "api-service", "label": "API Service", "kind": "service", "ext": { "x": 520, "y": 170 } },
+    { "id": "worker-service", "label": "Worker Service", "kind": "service", "ext": { "x": 520, "y": 390 } },
+    { "id": "orders-db", "label": "Orders DB", "kind": "db", "ext": { "x": 820, "y": 120 } },
+    { "id": "jobs-queue", "label": "Jobs Queue", "kind": "queue", "ext": { "x": 820, "y": 280 } },
+    { "id": "session-cache", "label": "Session Cache", "kind": "cache", "ext": { "x": 820, "y": 440 } }
   ],
   "edges": [
     { "id": "client-to-lb", "from": "client", "to": "public-lb", "label": "HTTPS" },

--- a/docs/diagrams/infrastructure.diagram.html
+++ b/docs/diagrams/infrastructure.diagram.html
@@ -1,0 +1,213 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Production Infrastructure</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 1.5rem;
+    background: #111827;
+    color: #e5e7eb;
+    font-family: system-ui, sans-serif;
+  }
+  h1 { margin: 0 0 1rem; font-size: 1.25rem; }
+  .graph {
+    width: 1080px;
+    min-height: 640px;
+    outline: 1px solid #263244;
+    border-radius: 12px;
+    background: #151d2b;
+  }
+  .infra-node {
+    --kind-color: #94a3b8;
+    --kind-bg: #202b3c;
+    width: 200px;
+    min-height: 96px;
+    padding: 1rem;
+    border: 1px solid var(--kind-color);
+    border-left-width: 5px;
+    border-radius: 10px;
+    background: var(--kind-bg);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, .18);
+  }
+  .node-heading { display: flex; align-items: center; gap: .55rem; }
+  .kind-icon {
+    display: inline-grid;
+    width: 1.5rem;
+    height: 1.5rem;
+    place-items: center;
+    color: var(--kind-color);
+    font-size: 1.2rem;
+  }
+  .node-label { font-weight: 700; line-height: 1.2; }
+  .node-role { margin: .65rem 0 0; color: #b8c2d4; font-size: .78rem; }
+  [data-kind="service"] { --kind-color: #60a5fa; --kind-bg: #182942; }
+  [data-kind="db"] { --kind-color: #a78bfa; --kind-bg: #27203d; }
+  [data-kind="queue"] { --kind-color: #f59e0b; --kind-bg: #342817; }
+  [data-kind="lb"] { --kind-color: #34d399; --kind-bg: #17362f; }
+  [data-kind="cache"] { --kind-color: #f472b6; --kind-bg: #382035; }
+  [data-kind="external"] { --kind-color: #a3a3a3; --kind-bg: #292929; }
+  [data-kind="service"] .kind-icon::before { content: "▣"; }
+  [data-kind="db"] .kind-icon::before { content: "◉"; }
+  [data-kind="queue"] .kind-icon::before { content: "≋"; }
+  [data-kind="lb"] .kind-icon::before { content: "⇄"; }
+  [data-kind="cache"] .kind-icon::before { content: "◇"; }
+  [data-kind="external"] .kind-icon::before { content: "☁"; }
+  .infra-boundary {
+    display: none;
+    box-sizing: border-box;
+    position: absolute;
+    border: 1px solid currentColor;
+    border-radius: 12px;
+    background: transparent;
+    pointer-events: none;
+  }
+  .infra-boundary.ark-harness-graph-group { display: block; }
+  .group-label {
+    position: absolute;
+    top: .45rem;
+    left: .75rem;
+    padding: .15rem .45rem;
+    border-radius: 999px;
+    background: #151d2b;
+    color: currentColor;
+    font-size: .72rem;
+    font-weight: 700;
+    letter-spacing: .03em;
+  }
+  .boundary-region {
+    left: calc(var(--ark-harness-group-x) - 130px);
+    top: calc(var(--ark-harness-group-y) - 90px);
+    width: calc(var(--ark-harness-group-width) + 260px);
+    height: calc(var(--ark-harness-group-height) + 180px);
+    border-width: 2px;
+    color: #38bdf8;
+  }
+  .boundary-vpc {
+    left: calc(var(--ark-harness-group-x) - 96px);
+    top: calc(var(--ark-harness-group-y) - 62px);
+    width: calc(var(--ark-harness-group-width) + 192px);
+    height: calc(var(--ark-harness-group-height) + 124px);
+    border-style: dashed;
+    color: #22c55e;
+  }
+  .boundary-subnet {
+    left: calc(var(--ark-harness-group-x) - 24px);
+    top: calc(var(--ark-harness-group-y) - 42px);
+    width: calc(var(--ark-harness-group-width) + 48px);
+    height: calc(var(--ark-harness-group-height) + 66px);
+    color: #64748b;
+    background: rgba(100, 116, 139, .035);
+  }
+</style>
+</head>
+<body>
+<h1>Production Infrastructure</h1>
+<script type="application/json" id="ark-diagram-model">
+{
+  "version": 1,
+  "title": "Production Infrastructure",
+  "nodes": [
+    { "id": "client", "label": "Internet Client", "kind": "external", "ext": { "x": 24, "y": 280 } },
+    { "id": "public-lb", "label": "Public Load Balancer", "kind": "lb", "ext": { "x": 260, "y": 280 } },
+    { "id": "api-service", "label": "API Service", "kind": "service", "ext": { "x": 500, "y": 170 } },
+    { "id": "worker-service", "label": "Worker Service", "kind": "service", "ext": { "x": 500, "y": 390 } },
+    { "id": "orders-db", "label": "Orders DB", "kind": "db", "ext": { "x": 800, "y": 120 } },
+    { "id": "jobs-queue", "label": "Jobs Queue", "kind": "queue", "ext": { "x": 800, "y": 280 } },
+    { "id": "session-cache", "label": "Session Cache", "kind": "cache", "ext": { "x": 800, "y": 440 } }
+  ],
+  "edges": [
+    { "id": "client-to-lb", "from": "client", "to": "public-lb", "label": "HTTPS" },
+    { "id": "lb-to-api", "from": "public-lb", "to": "api-service", "label": "routes" },
+    { "id": "api-to-db", "from": "api-service", "to": "orders-db", "label": "reads / writes" },
+    { "id": "api-to-queue", "from": "api-service", "to": "jobs-queue", "label": "enqueues" },
+    { "id": "api-to-cache", "from": "api-service", "to": "session-cache", "label": "sessions" },
+    { "id": "queue-to-worker", "from": "jobs-queue", "to": "worker-service", "label": "dispatches" },
+    { "id": "worker-to-db", "from": "worker-service", "to": "orders-db", "label": "persists" }
+  ],
+  "groups": [
+    {
+      "id": "tokyo-region",
+      "label": "Tokyo Region",
+      "nodes": ["public-lb", "api-service", "worker-service", "orders-db", "jobs-queue", "session-cache"],
+      "ext": { "role": "region" }
+    },
+    {
+      "id": "production-vpc",
+      "label": "Production VPC",
+      "nodes": ["public-lb", "api-service", "worker-service", "orders-db", "jobs-queue", "session-cache"],
+      "ext": { "role": "vpc" }
+    },
+    {
+      "id": "public-subnet",
+      "label": "Public Subnet",
+      "nodes": ["public-lb"],
+      "ext": { "role": "subnet" }
+    },
+    {
+      "id": "app-subnet",
+      "label": "Application Subnet",
+      "nodes": ["api-service", "worker-service"],
+      "ext": { "role": "subnet" }
+    },
+    {
+      "id": "data-subnet",
+      "label": "Data Subnet",
+      "nodes": ["orders-db", "jobs-queue", "session-cache"],
+      "ext": { "role": "subnet" }
+    }
+  ]
+}
+</script>
+
+<div class="graph" data-ark-container="graph">
+  <section class="infra-boundary boundary-region" data-ark-group data-model-id="tokyo-region">
+    <span class="group-label" data-model-id="tokyo-region">Tokyo Region</span>
+  </section>
+  <section class="infra-boundary boundary-vpc" data-ark-group data-model-id="production-vpc">
+    <span class="group-label" data-model-id="production-vpc">Production VPC</span>
+  </section>
+  <section class="infra-boundary boundary-subnet" data-ark-group data-model-id="public-subnet">
+    <span class="group-label" data-model-id="public-subnet">Public Subnet</span>
+  </section>
+  <section class="infra-boundary boundary-subnet" data-ark-group data-model-id="app-subnet">
+    <span class="group-label" data-model-id="app-subnet">Application Subnet</span>
+  </section>
+  <section class="infra-boundary boundary-subnet" data-ark-group data-model-id="data-subnet">
+    <span class="group-label" data-model-id="data-subnet">Data Subnet</span>
+  </section>
+
+  <article class="infra-node" data-model-id="client" data-kind="external">
+    <div class="node-heading"><span class="kind-icon" aria-hidden="true"></span><span class="node-label">Internet Client</span></div>
+    <p class="node-role">External request origin</p>
+  </article>
+  <article class="infra-node" data-model-id="public-lb" data-kind="lb">
+    <div class="node-heading"><span class="kind-icon" aria-hidden="true"></span><span class="node-label">Public Load Balancer</span></div>
+    <p class="node-role">Public traffic entry point</p>
+  </article>
+  <article class="infra-node" data-model-id="api-service" data-kind="service">
+    <div class="node-heading"><span class="kind-icon" aria-hidden="true"></span><span class="node-label">API Service</span></div>
+    <p class="node-role">Synchronous application API</p>
+  </article>
+  <article class="infra-node" data-model-id="worker-service" data-kind="service">
+    <div class="node-heading"><span class="kind-icon" aria-hidden="true"></span><span class="node-label">Worker Service</span></div>
+    <p class="node-role">Asynchronous job processor</p>
+  </article>
+  <article class="infra-node" data-model-id="orders-db" data-kind="db">
+    <div class="node-heading"><span class="kind-icon" aria-hidden="true"></span><span class="node-label">Orders DB</span></div>
+    <p class="node-role">Durable order storage</p>
+  </article>
+  <article class="infra-node" data-model-id="jobs-queue" data-kind="queue">
+    <div class="node-heading"><span class="kind-icon" aria-hidden="true"></span><span class="node-label">Jobs Queue</span></div>
+    <p class="node-role">Background work buffer</p>
+  </article>
+  <article class="infra-node" data-model-id="session-cache" data-kind="cache">
+    <div class="node-heading"><span class="kind-icon" aria-hidden="true"></span><span class="node-label">Session Cache</span></div>
+    <p class="node-role">Low-latency session data</p>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-07-22-issue-232.md
+++ b/docs/superpowers/plans/2026-07-22-issue-232.md
@@ -1,0 +1,237 @@
+# issue-232: インフラ構成図 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 既存の graph / kind / group 語彙だけで、主要インフラ要素をアイコン付きで区別し、region / VPC / subnet 境界と接続を表示できる再利用可能な作図規約と実例を提供する。
+
+**Issue:** 232 (GitHub Issue 紐付けあり)
+
+**Architecture:** `service` / `db` / `queue` / `lb` / `cache` / `external` は `node.kind` と投影 root の `data-kind` を結び、投影 CSS の Unicode アイコン・色・可視 label で区別する。region / VPC / subnet は既存の flat `groups` と sibling の `[data-ark-group]` 投影で囲み、正式な group nesting は作らず、必要な階層感は異なる余白を持つ重なった矩形で近似し、全 node は `node.ext.x/y` で手動配置する。既存 `syncNodeKinds()` / `renderGraphGroups()` / graph edge で成立するため `diagram-harness.ts` とモデル型は変更せず、Socket.IO、DB、React、モバイル、tmux/ttyd にも影響を与えない。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Express / Socket.IO / better-sqlite3 / tmux / ttyd
+
+---
+
+## 前提と変更境界
+
+- `packages/server/src/lib/diagram-model.ts:15-45,111-180` は任意文字列の `node.kind`、`node.ext`、`edge`、flat な `groups[].nodes` / `groups[].ext` を既に保持する。infra 固有 enum、group nesting、専用座標型は追加しない。
+- `packages/server/src/lib/diagram-harness.ts:199-467,546-559` は有限数の `node.ext.x/y` による配置、edge、`node.kind` → `data-kind` 同期、member node 外接矩形による group 境界を既に提供する。`syncNodeKinds()` / `renderGraphGroups()` を含むハーネスは変更しない。
+- #228 の auto-layout は未完了なので、実例の全 node に有限数の `ext.x` / `ext.y` を明記する。自動配置 helper や暗黙の fallback は計画しない。
+- region / VPC / subnet はそれぞれ独立した flat group とし、`group.nodes` には node id だけを入れる。外側 group は内側 group の id ではなく配下 node の和集合を member にし、投影 CSS の padding 差で重なる矩形として表示する。
+- kind の意味は投影側の取り決めに留める。アイコンは Unicode（必要に応じて inline SVG / data URI）だけを使い、外部 URL、stylesheet、font、icon library、外部 `<use href>` は使わず、アイコンだけでなく可視 label を必ず残す。
+- `diagram-diff.ts` は変更せず、図の会話還流は既存挙動のままとする。新規 Socket.IO event、SQLite migration、React / mobile UI、SessionOrchestrator、tmux / ttyd の変更も行わない。
+- 実装対象は `.claude/skills/diagram-authoring/SKILL.md`、新規 `docs/diagrams/infrastructure.diagram.html`、`e2e/diagram-harness.spec.ts` の3ファイルだけとする（この plan ファイルを除く）。canonical `sample.diagram.html` は既存 graph / kind / group 回帰 fixture として維持する。
+- 実装タスクは Red → Green → Refactor の順で進め、P5 の `board_open` は人間による実機受け入れゲートとして最後に行う。
+
+---
+
+## Task 1: infra 実例のブラウザ受け入れ契約を Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts:1-209,503-585`
+- Reference: `docs/diagrams/sample.diagram.html`
+- Reference: `packages/server/src/lib/diagram-harness.ts:199-467,546-559`
+- Reference: `packages/server/src/lib/diagram-model.ts:15-45`
+
+- [ ] **Step 1: authored diagram を読む helper を共通化する（2-5分）**
+
+  現在の `openSampleDiagram(page)` が持つ `readFileSync(new URL(...))` と `injectHarness()` / `page.setContent()` を `openAuthoredDiagram(page, filename)` に抽出する。既存 sample test は `openAuthoredDiagram(page, "sample.diagram.html")` を使う薄い wrapper のまま維持し、infra test は `infrastructure.diagram.html` を同じ実ブラウザ経路で開く。
+
+- [ ] **Step 2: kind・手動座標・edge の失敗 test を書く（2-5分）**
+
+  「infrastructure sample は kind アイコンと手動配置で接続を表示する」test を追加し、model block と direct child の node 投影を対応づけて次を assertion にする。
+
+  - model が `service` / `db` / `queue` / `lb` / `cache` / `external` の6 kind をすべて含み、各 node に有限数の `ext.x` / `ext.y` がある。
+  - 各 node root の `data-kind` が model と一致し、`.kind-icon::before` が空でも `none` でもなく、6 kind で異なる。各 root には空でない可視 `.node-label` もある。
+  - node の graph 相対 bounding box が `ext.x/y` と一致し、auto-layout に依存していない。
+  - `[data-ark-edge-id]` の本数が model の edge 数と一致し、`external → lb → service` と service / db / queue / cache 間の代表的な接続 label が表示される。
+  - raw HTML に `http://` / `https://`、`<link rel="stylesheet">`、`@import`、icon library がなく、page error も発生しない。
+
+- [ ] **Step 3: region / VPC / subnet 境界の失敗 test を書く（2-5分）**
+
+  「infrastructure sample は flat group で region / VPC / subnet を囲む」test を追加する。model の `groups[].ext.role` に `region` / `vpc` / `subnet` が揃い、全 group member が node id であって group id を含まないことを確認する。そのうえで各 `[data-ark-group]` が `.ark-harness-graph-group` と可視 `.group-label` を持ち、`requiredBoundingBox()` / `expectBoxToContain()` を再利用して全 member node を囲むことを確認する。
+
+  外側の region と VPC が内部 node の同じ集合を参照しても、`boundary-region` と `boundary-vpc` の authored CSS padding 差で別の重なる矩形になることを bounding box の大小で固定する。public / app / data subnet はそれぞれの member だけを囲み、`external` node はどの infra group の member にもしない。
+
+- [ ] **Step 4: Red を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "infrastructure sample"`
+
+  Expected: FAIL。`docs/diagrams/infrastructure.diagram.html` がまだ存在しないため authored diagram の読み込みで失敗する。既存 sample / graph / kind / group tests の fixture は変更していない。
+
+---
+
+## Task 2: 手動配置の代表的なインフラ構成図を追加する
+
+**Files:**
+
+- Create: `docs/diagrams/infrastructure.diagram.html`
+- Modify: `e2e/diagram-harness.spec.ts`
+- Reference: `docs/diagrams/sample.diagram.html`
+
+- [ ] **Step 1: 意味モデルを graph の汎用語彙だけで記述する（2-5分）**
+
+  `ark-diagram-model` に、少なくとも次の node と kind を作る。各 node は graph 内で重ならない有限数の `ext.x/y` を持たせ、座標は図の左から右へ通信経路が読めるよう手動指定する。
+
+  ```json
+  {
+    "nodes": [
+      { "id": "client", "label": "Internet Client", "kind": "external", "ext": { "x": 24, "y": 280 } },
+      { "id": "public-lb", "label": "Public Load Balancer", "kind": "lb", "ext": { "x": 260, "y": 280 } },
+      { "id": "api-service", "label": "API Service", "kind": "service", "ext": { "x": 500, "y": 170 } },
+      { "id": "worker-service", "label": "Worker Service", "kind": "service", "ext": { "x": 500, "y": 390 } },
+      { "id": "orders-db", "label": "Orders DB", "kind": "db", "ext": { "x": 800, "y": 120 } },
+      { "id": "jobs-queue", "label": "Jobs Queue", "kind": "queue", "ext": { "x": 800, "y": 280 } },
+      { "id": "session-cache", "label": "Session Cache", "kind": "cache", "ext": { "x": 800, "y": 440 } }
+    ]
+  }
+  ```
+
+  `client → public-lb → api-service`、`api-service → orders-db / jobs-queue / session-cache`、`jobs-queue → worker-service → orders-db` を label 付き edge で結ぶ。図種固有 schema や edge component id を作らない。
+
+- [ ] **Step 2: CSP 準拠の kind card とアイコンを投影する（2-5分）**
+
+  graph の direct child として各 node root を置き、`data-model-id` と model と一致する `data-kind`、`aria-hidden="true"` の `.kind-icon`、文字として読める `.node-label`、短い役割説明を持たせる。共通 `.infra-node` fallback を定義し、`[data-kind="service"]` / `db` / `queue` / `lb` / `cache` / `external` で CSS variables と互いに異なる Unicode pseudo-element（例: `▣` / `◉` / `≋` / `⇄` / `◇` / `☁`）を割り当てる。
+
+  色は補助情報として使い、kind 判別を色だけに依存させない。外部 image / font / stylesheet / script は追加しない。
+
+- [ ] **Step 3: flat group の重なる境界で region / VPC / subnet を表す（2-5分）**
+
+  次の group を model と graph 内の sibling projection root の両方に追加する。各 model group の `ext.role` は表示 variant ではなく infra 上の意味を示し、見た目は authored class が担当する。
+
+  - `tokyo-region` (`ext.role: "region"`) — `public-lb` 以降の全内部 node
+  - `production-vpc` (`ext.role: "vpc"`) — 同じ内部 node 集合
+  - `public-subnet` (`ext.role: "subnet"`) — `public-lb`
+  - `app-subnet` (`ext.role: "subnet"`) — `api-service`, `worker-service`
+  - `data-subnet` (`ext.role: "subnet"`) — `orders-db`, `jobs-queue`, `session-cache`
+
+  すべて `<section data-ark-group data-model-id="...">` とし、同じ id の可視 `.group-label` leaf を置く。`.boundary-region` は最大、`.boundary-vpc` はその内側、`.boundary-subnet` は member 近傍になるよう、4つの `--ark-harness-group-*` へ異なる padding を `calc()` で加える。背景は edge / node を隠さない薄い半透明または透明にし、正式な group nesting や group id membership は導入しない。
+
+- [ ] **Step 4: Green と既存 authored sample の回帰を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "infrastructure sample|sample は|sample group"`
+
+  Expected: PASS。infra の6 kind、可視 label、手動座標、全 edge、region / VPC / 3 subnet の境界が表示され、既存 sample の kind / group test も成功する。
+
+- [ ] **Step 5: HTML を簡潔化して成果物をコミットする（2-5分）**
+
+  重複する node / group style は CSS variables と共通 class にまとめ、model と projection の id / label / kind が一致していることを確認する。ハーネス生成 class、edge SVG、geometry custom property の実値は authored HTML に書かない。
+
+  ```bash
+  git add docs/diagrams/infrastructure.diagram.html e2e/diagram-harness.spec.ts
+  git commit -m "docs(diagram): インフラ構成図の実例を追加"
+  ```
+
+---
+
+## Task 3: diagram-authoring skill に infra 作図手順を追加する
+
+**Files:**
+
+- Modify: `.claude/skills/diagram-authoring/SKILL.md:113-122,124-218`
+- Reference: `docs/diagrams/infrastructure.diagram.html`
+- Reference: `packages/server/src/lib/diagram-model.ts:15-45`
+
+- [ ] **Step 1: 既存 Infrastructure 節を完全な作図レシピへ拡張する（2-5分）**
+
+  現在の4 selector だけの「Infrastructure の例」を重複節を作らず拡張し、`service` / `db` / `queue` / `lb` に `cache` / `external` を加える。これらは server enum ではない推奨語彙であり、未知 kind は共通 node style へ fallback すること、model の `node.kind` と projection root の `data-kind` を一致させることを明記する。
+
+- [ ] **Step 2: graph node と edge の書き方を例示する（2-5分）**
+
+  infra node の model snippet に有限数の `ext.x/y` を含め、#228 に依存せず全 node を手動配置する手順を示す。通信や依存は既存 `edge` の `from` / `to` / `label` で表し、外部クライアントも graph 外の特別要素ではなく `kind: "external"` の通常 node として edge endpoint にできることを説明する。
+
+  kind CSS には6種類のアイコンと色の例を載せ、`.kind-icon[aria-hidden]` と可視 label の併用、および Unicode / inline SVG / data URI だけを使う CSP 制約を既存規約と一貫させる。
+
+- [ ] **Step 3: region / VPC / subnet の flat group パターンを例示する（2-5分）**
+
+  group model は `{ id, label, nodes, ext: { role: "region" | "vpc" | "subnet" } }` とし、projection は既存 `[data-ark-group][data-model-id]` + `.group-label` contract を使うことを示す。region / VPC / subnet の階層を必要とする場合も `groups[].nodes` に group id は入れず、外側 group に配下 node の和集合を列挙し、projection class ごとの padding 差で「重なる矩形」として近似する例を載せる。
+
+  group nesting、group 一括 drag、auto-layout は未対応かつ本 Issue のスコープ外であることを infra 節からも明示し、詳細な完成例として `docs/diagrams/infrastructure.diagram.html` を案内する。
+
+- [ ] **Step 4: skill と実例の契約を静的に照合する（2-5分）**
+
+  Run: `rg -n 'service|db|queue|lb|cache|external|region|vpc|subnet|ext\.x|ext\.y|infrastructure\.diagram\.html' .claude/skills/diagram-authoring/SKILL.md`
+
+  Expected: 6 kind、3 boundary role、手動座標、完成例への参照がすべて見つかる。
+
+  Run: `rg -n 'https?://|@import|<link[^>]+stylesheet|icon[- ]library|<use[^>]+href' docs/diagrams/infrastructure.diagram.html`
+
+  Expected: 出力なし。実例が外部 URL / font / icon library を参照していない。
+
+- [ ] **Step 5: skill 更新をコミットする（2-5分）**
+
+  ```bash
+  git add .claude/skills/diagram-authoring/SKILL.md
+  git commit -m "docs(diagram): インフラ構成図の作図規約を追加"
+  ```
+
+---
+
+## Task 4: 全回帰と P5 実機受け入れを完了する
+
+**Files:**
+
+- Verify: `.claude/skills/diagram-authoring/SKILL.md`
+- Verify: `docs/diagrams/infrastructure.diagram.html`
+- Verify: `e2e/diagram-harness.spec.ts`
+- Verify only: `packages/server/src/lib/diagram-harness.ts`
+- Verify only: `packages/server/src/lib/diagram-model.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.ts`
+- Verify only: `packages/shared/src/types.ts`
+- Verify only: `packages/server/src/index.ts`
+- Verify only: `packages/server/src/lib/database.ts`
+- Verify only: `packages/web/src/hooks/useSocket.ts`
+- Verify only: `packages/web/src/components/DiagramPane.tsx`
+- Verify only: `packages/web/src/components/MobileLayout.tsx`
+- Verify only: `packages/web/src/components/MobileSessionView.tsx`
+
+- [ ] **Step 1: targeted test と静的品質チェックを実行する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "infrastructure sample"`
+
+  Expected: PASS。6 kind の icon + label、手動座標、edge、region / VPC / subnet 境界、CSP 制約の acceptance が成功する。
+
+  Run: `pnpm exec biome check e2e/diagram-harness.spec.ts`
+
+  Expected: exit 0、format / lint error なし。
+
+  Run: `pnpm exec tsc -b`
+
+  Expected: exit 0、型エラーなし。
+
+- [ ] **Step 2: diagram と repository の全回帰を実行する（2-5分）**
+
+  Run: `pnpm exec vitest run`
+
+  Expected: exit 0、全 unit / integration test が PASS。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: infra acceptance に加え、既存 graph edge / drag、kind 同期、group 追従、list editing、clean submission がすべて PASS。
+
+  Run: `pnpm test:e2e`
+
+  Expected: desktop / mobile を含む repository E2E が PASS（環境条件が明記された test は、その条件が未充足の場合のみ SKIP）。
+
+- [ ] **Step 3: スコープ外レイヤーの非変更を確認する（2-5分）**
+
+  Run: `git diff --name-only main...HEAD`
+
+  Expected: この Issue の実装差分は `.claude/skills/diagram-authoring/SKILL.md`、`docs/diagrams/infrastructure.diagram.html`、`e2e/diagram-harness.spec.ts` と plan 成果物だけ。`diagram-harness.ts`、`diagram-model.ts`、`diagram-diff.ts`、Socket.IO 型 / handler、DB、React / mobile、tmux / ttyd は含まれない。
+
+  Run: `git diff --check main...HEAD`
+
+  Expected: 出力なし。
+
+- [ ] **Step 4: desktop 実機で `board_open` 受け入れを行う（P5 human gate、各2-5分）**
+
+  1. 稼働中 session から `docs/diagrams/infrastructure.diagram.html` を `board_open` し、Internet Client、Public Load Balancer、API / Worker Service、Orders DB、Jobs Queue、Session Cache が可視 label と異なる icon で判別できることを確認する。
+  2. external から lb、service、db / queue / cache へ接続線と label が表示され、node が重ならず左から右へ読めることを確認する。
+  3. Tokyo Region と Production VPC が異なる外枠として重なり、その内側で Public / Application / Data Subnet が各 member node を囲むことを確認する。これは flat group の視覚的近似であり、正式な nesting UI がないことも確認する。
+  4. 任意の node を個別 drag し、edge と所属 group 境界が追従することを確認する。再読込後も authored `ext.x/y` から初期配置され、auto-layout を必要としないことを確認する。
+  5. DevTools の Network / Console で外部 icon / font / stylesheet request と CSP error がなく、page error もないことを確認する。
+
+- [ ] **Step 5: 完了条件を記録する（2-5分）**
+
+  P5 human gate の結果に、(1) 6 kind の icon + label、(2) region / VPC / subnet 境界、(3) skill の手順と実例、(4) `board_open` 実機表示の4点を記録する。不合格の場合は `diagram-harness.ts` や group nesting へ拡張せず、まず authored HTML/CSS、model id / membership、手動座標の範囲で修正する。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -148,12 +148,19 @@ async function openDiagram(page: Page, diagramModel: unknown = model) {
   return errors;
 }
 
-async function openSampleDiagram(page: Page) {
+async function openAuthoredDiagram(page: Page, filename: string) {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
   const html = readFileSync(
-    new URL("../docs/diagrams/sample.diagram.html", import.meta.url),
+    new URL(`../docs/diagrams/${filename}`, import.meta.url),
     "utf8"
   );
   await page.setContent(injectHarness(html));
+  return { errors, html };
+}
+
+async function openSampleDiagram(page: Page) {
+  await openAuthoredDiagram(page, "sample.diagram.html");
 }
 
 async function connectSubmissionPort(page: Page) {
@@ -582,6 +589,165 @@ test("sample group は2 node を囲むラベル付き境界として表示する
   expectBoxToContain(boundaryBox, secondNodeBox);
   await expect(boundary).toContainText(sampleGroup.label);
   await expect(boundary.locator(".group-label")).toBeVisible();
+});
+
+test("infrastructure sample は kind アイコンと手動配置で接続を表示する", async ({
+  page,
+}) => {
+  const { errors, html } = await openAuthoredDiagram(
+    page,
+    "infrastructure.diagram.html"
+  );
+  const diagramModel = await page.locator("#ark-diagram-model").evaluate(
+    element =>
+      JSON.parse(element.textContent || "") as {
+        nodes: Array<{
+          id: string;
+          label: string;
+          kind: string;
+          ext: { x: number; y: number };
+        }>;
+        edges: Array<{
+          id: string;
+          from: string;
+          to: string;
+          label?: string;
+        }>;
+      }
+  );
+
+  expect(new Set(diagramModel.nodes.map(node => node.kind))).toEqual(
+    new Set(["service", "db", "queue", "lb", "cache", "external"])
+  );
+  for (const node of diagramModel.nodes) {
+    expect(Number.isFinite(node.ext.x)).toBe(true);
+    expect(Number.isFinite(node.ext.y)).toBe(true);
+  }
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const graphBox = await requiredBoundingBox(graph);
+  const iconsByKind = new Map<string, string>();
+  for (const node of diagramModel.nodes) {
+    const projection = graph.locator(
+      `:scope > [data-model-id="${node.id}"]:not([data-ark-group])`
+    );
+    await expect(projection).toHaveAttribute("data-kind", node.kind);
+    await expect(projection.locator(".node-label")).toBeVisible();
+    await expect(projection.locator(".node-label")).not.toHaveText("");
+    const icon = await projection
+      .locator(".kind-icon")
+      .evaluate(element => getComputedStyle(element, "::before").content);
+    expect(icon).not.toBe("none");
+    expect(icon).not.toBe("");
+    iconsByKind.set(node.kind, icon);
+
+    const box = await requiredBoundingBox(projection);
+    expect(box.x - graphBox.x).toBeCloseTo(node.ext.x, 0);
+    expect(box.y - graphBox.y).toBeCloseTo(node.ext.y, 0);
+  }
+  expect(new Set(iconsByKind.values())).toHaveProperty("size", 6);
+
+  expect(diagramModel.edges.map(edge => `${edge.from}->${edge.to}`)).toEqual(
+    expect.arrayContaining([
+      "client->public-lb",
+      "public-lb->api-service",
+      "api-service->orders-db",
+      "api-service->jobs-queue",
+      "api-service->session-cache",
+      "jobs-queue->worker-service",
+      "worker-service->orders-db",
+    ])
+  );
+  await expect(graph.locator("[data-ark-edge-id]")).toHaveCount(
+    diagramModel.edges.length
+  );
+  for (const edge of diagramModel.edges) {
+    expect(edge.label).toBeTruthy();
+    await expect(graph.locator("text", { hasText: edge.label })).toHaveCount(1);
+  }
+
+  expect(html).not.toMatch(/https?:\/\//i);
+  expect(html).not.toMatch(/<link[^>]+rel=["']?stylesheet/i);
+  expect(html).not.toMatch(/@import/i);
+  expect(html).not.toMatch(/icon[- ]library/i);
+  expect(errors).toEqual([]);
+});
+
+test("infrastructure sample は flat group で region / VPC / subnet を囲む", async ({
+  page,
+}) => {
+  await openAuthoredDiagram(page, "infrastructure.diagram.html");
+  const diagramModel = await page.locator("#ark-diagram-model").evaluate(
+    element =>
+      JSON.parse(element.textContent || "") as {
+        nodes: Array<{ id: string }>;
+        groups: Array<{
+          id: string;
+          label: string;
+          nodes: string[];
+          ext: { role: string };
+        }>;
+      }
+  );
+  const nodeIds = new Set(diagramModel.nodes.map(node => node.id));
+  const groupIds = new Set(diagramModel.groups.map(group => group.id));
+  expect(new Set(diagramModel.groups.map(group => group.ext.role))).toEqual(
+    new Set(["region", "vpc", "subnet"])
+  );
+  for (const group of diagramModel.groups) {
+    expect(group.nodes.length).toBeGreaterThan(0);
+    expect(group.nodes.every(nodeId => nodeIds.has(nodeId))).toBe(true);
+    expect(group.nodes.every(nodeId => !groupIds.has(nodeId))).toBe(true);
+  }
+  expect(
+    diagramModel.groups.every(group => !group.nodes.includes("client"))
+  ).toBe(true);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const boxes = new Map<
+    string,
+    Awaited<ReturnType<typeof requiredBoundingBox>>
+  >();
+  for (const group of diagramModel.groups) {
+    const boundary = graph.locator(
+      `:scope > [data-ark-group][data-model-id="${group.id}"]`
+    );
+    await expect(boundary).toHaveClass(/ark-harness-graph-group/);
+    const label = boundary.locator(".group-label");
+    await expect(label).toBeVisible();
+    await expect(label).toHaveText(group.label);
+    const boundaryBox = await requiredBoundingBox(boundary);
+    boxes.set(group.id, boundaryBox);
+    for (const memberId of group.nodes) {
+      const memberBox = await requiredBoundingBox(
+        graph.locator(
+          `:scope > [data-model-id="${memberId}"]:not([data-ark-group])`
+        )
+      );
+      expectBoxToContain(boundaryBox, memberBox);
+    }
+  }
+
+  const regionBox = boxes.get("tokyo-region");
+  const vpcBox = boxes.get("production-vpc");
+  expect(regionBox).toBeDefined();
+  expect(vpcBox).toBeDefined();
+  if (!regionBox || !vpcBox) return;
+  expect(regionBox.x).toBeLessThan(vpcBox.x);
+  expect(regionBox.y).toBeLessThan(vpcBox.y);
+  expect(regionBox.width).toBeGreaterThan(vpcBox.width);
+  expect(regionBox.height).toBeGreaterThan(vpcBox.height);
+
+  const subnetMembers = Object.fromEntries(
+    diagramModel.groups
+      .filter(group => group.ext.role === "subnet")
+      .map(group => [group.id, group.nodes])
+  );
+  expect(subnetMembers).toEqual({
+    "public-subnet": ["public-lb"],
+    "app-subnet": ["api-service", "worker-service"],
+    "data-subnet": ["orders-db", "jobs-queue", "session-cache"],
+  });
 });
 
 test("node ドラッグと list 編集を送信 model と clean HTML に反映する", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -667,9 +667,14 @@ test("infrastructure sample は kind アイコンと手動配置で接続を表�
   }
 
   expect(html).not.toMatch(/https?:\/\//i);
+  expect(html).not.toMatch(/\bsrc\s*=\s*["']\s*\/\//i);
+  expect(html).not.toMatch(/url\(\s*["']?\s*\/\//i);
   expect(html).not.toMatch(/<link[^>]+rel=["']?stylesheet/i);
   expect(html).not.toMatch(/@import/i);
   expect(html).not.toMatch(/icon[- ]library/i);
+  expect(html).not.toMatch(
+    /<use\b[^>]*\b(?:href|xlink:href)\s*=\s*["']\s*(?!(?:#|data:))[^"']+/i
+  );
   expect(errors).toEqual([]);
 });
 
@@ -733,6 +738,12 @@ test("infrastructure sample は flat group で region / VPC / subnet を囲む",
   expect(regionBox).toBeDefined();
   expect(vpcBox).toBeDefined();
   if (!regionBox || !vpcBox) return;
+  const clientBox = await requiredBoundingBox(
+    graph.locator(':scope > [data-model-id="client"]:not([data-ark-group])')
+  );
+  const clientRight = clientBox.x + clientBox.width;
+  expect(clientRight).toBeLessThan(regionBox.x);
+  expect(clientRight).toBeLessThan(vpcBox.x);
   expect(regionBox.x).toBeLessThan(vpcBox.x);
   expect(regionBox.y).toBeLessThan(vpcBox.y);
   expect(regionBox.width).toBeGreaterThan(vpcBox.width);


### PR DESCRIPTION
## 概要

図解: **インフラ構成図**。graph コンテナ (#224) + kind スタイリング (#226) + group 語彙 (#227) の上に、service/db/queue/lb/cache/external をアイコンで区別し、VPC/region/subnet を境界で囲むインフラ構成図の**作図規約と実例**を追加する。

Closes #232

## 設計の要点：新図種はハーネス変更ゼロ

設計原則（判断 4.3「新しい図種は skill 更新だけ / コンテナ追加のみハーネス拡張」）の実証。既存の `syncNodeKinds()`（kind アイコン）と `renderGraphGroups()`（境界）で成立するため、**production コードの変更は一切なし**。変更は 3 ファイルのみ：

- **新規 `docs/diagrams/infrastructure.diagram.html`**: 7 コンポーネント（Internet Client / Public LB / API・Worker Service / Orders DB / Jobs Queue / Session Cache）を手動座標で配置。`external → lb → service → db/queue/cache` を label 付き edge で接続。region / VPC / subnet の 5 group で囲む
- **`.claude/skills/diagram-authoring/SKILL.md`**: インフラ構成図の作図レシピ（6 kind のアイコン、flat group での region/VPC/subnet 表現、手動座標、CSP 制約）
- **`e2e/diagram-harness.spec.ts`**: infra 実例の Playwright 受入テスト（kind アイコン・手動配置・edge・境界・CSP）

## 実装上の判断

- **VPC/region/subnet の階層は flat group の「重なる矩形」で近似**。既存 group は単層（`group.nodes` = node id）なので、外側 group（region/VPC）は配下 node の和集合を member にし、投影 CSS の padding 差で同心矩形として表示。真の group nesting はスコープ外
- **アイコンは Unicode のみ**（`▣`/`◉`/`≋`/`⇄`/`◇`/`☁` 等）。外部 URL/font/stylesheet/icon-library 不使用（CSP 準拠、テストで検証）
- **座標は手動**（`node.ext.x/y`）。自動レイアウト (#228) には依存しない

## テスト

- `tsc -b`: pass ・ `vitest run`: pass ・ `biome check`: clean
- `playwright e2e/diagram-harness.spec.ts`: 13 テスト pass（infra の kind アイコン+手動配置+接続 / region・VPC・subnet 境界 / 既存 graph・kind・group・list 回帰）
- 外部リソース参照なし（CSP）を静的検証

## スコープ外（後続単位）

group nesting（真の入れ子）/ 自動レイアウト (#228) / infra kind の enum 標準化。production コード（harness/model/diff/Socket.IO/DB/モバイル）は不変。

## レビュー体制

codex が plan 立案・TDD 実装、Claude が P2（plan）/ P5（実装）レビュー（flow-x 役割逆転。実装者 ≠ レビュアー）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 本番インフラ構成図を追加しました。
  - クライアント、ロードバランサー、サービス、データベース、キュー、キャッシュを視覚化しました。
  - 東京リージョン、VPC、サブネットの境界とラベルを表示します。
  - ノード間の通信・依存関係を、説明付きの接続線で確認できます。
  - ダークテーマに対応し、外部素材に依存しない構成です。

- **ドキュメント**
  - インフラ構成図の作成ルールと表現方法を拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->