### PR TITLE
図解: イベントストーミング図（6 kind 慣例色 + 時系列 + swimlane・ハーネス変更なし） (#231)

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -76,39 +76,116 @@ node の `kind` フィールドで図の要素型を指定する。サーバー�
 
 ### Event storming の例
 
-`command` / `event` / `aggregate` / `policy` は event storming で使える推奨語彙の例であり、server が制限する enum ではない。色だけに依存せず、Unicode icon と可視 label を併用する。
+`command` / `event` / `aggregate` / `policy` / `actor` / `read-model` は event
+storming で使う推奨語彙であり、server が制限する enum ではない。外部サービスとの
+境界を示す必要がある場合だけ `external-system` も使える。未知 kind は共通
+`.storming-note` style へ fallback させ、model の `node.kind` と node projection root の
+`data-kind` は必ず一致させる。
+
+色は event=橙、command=青、aggregate=黄、policy=紫、actor=小さい桃（黄でも可）、
+read-model=緑を基本にする。各 card には `aria-hidden="true"` の `.kind-icon`、可視の
+`.kind-name`、可視の `.node-label` を併置し、色だけで kind を伝えない。
 
 ```html
-<div class="node" data-model-id="place-order" data-kind="command">
-  <span class="kind-icon" aria-hidden="true"></span><span>Place order</span>
-</div>
-<div class="node" data-model-id="order-placed" data-kind="event">
-  <span class="kind-icon" aria-hidden="true"></span><span>Order placed</span>
-</div>
-<div class="node" data-model-id="order" data-kind="aggregate">
-  <span class="kind-icon" aria-hidden="true"></span><span>Order</span>
-</div>
-<div class="node" data-model-id="payment-policy" data-kind="policy">
-  <span class="kind-icon" aria-hidden="true"></span><span>Payment policy</span>
-</div>
+<article class="storming-note" data-model-id="place-order" data-kind="command">
+  <span class="kind-icon" aria-hidden="true"></span>
+  <span class="kind-name">Command</span>
+  <span class="node-label">Place order</span>
+</article>
 ```
 
 ```css
-.node {
-  --kind-color: #565f89;
-  --kind-bg: #1e202b;
+.storming-note {
+  --kind-color: #94a3b8;
+  --kind-bg: #202b3c;
   border: 1px solid var(--kind-color);
+  border-left: 6px solid var(--kind-color);
   background: var(--kind-bg);
 }
-[data-kind="command"] { --kind-color: #7aa2f7; --kind-bg: #1f2a44; }
-[data-kind="event"] { --kind-color: #9ece6a; --kind-bg: #203222; }
-[data-kind="aggregate"] { --kind-color: #e0af68; --kind-bg: #332b1f; }
-[data-kind="policy"] { --kind-color: #bb9af7; --kind-bg: #302640; }
-[data-kind="command"] .kind-icon::before { content: "▶"; }
+[data-kind="event"] { --kind-color: #f59e0b; --kind-bg: #3b2810; }
+[data-kind="command"] { --kind-color: #60a5fa; --kind-bg: #172a46; }
+[data-kind="aggregate"] { --kind-color: #facc15; --kind-bg: #3a3111; }
+[data-kind="policy"] { --kind-color: #c084fc; --kind-bg: #302044; }
+[data-kind="actor"] { --kind-color: #f472b6; --kind-bg: #3b1e35; width: 7.5rem; }
+[data-kind="read-model"] { --kind-color: #4ade80; --kind-bg: #153522; }
+[data-kind="external-system"] { --kind-color: #94a3b8; --kind-bg: #202b3c; }
 [data-kind="event"] .kind-icon::before { content: "⚡"; }
+[data-kind="command"] .kind-icon::before { content: "▶"; }
 [data-kind="aggregate"] .kind-icon::before { content: "◆"; }
 [data-kind="policy"] .kind-icon::before { content: "◇"; }
+[data-kind="actor"] .kind-icon::before { content: "◎"; }
+[data-kind="read-model"] .kind-icon::before { content: "▤"; }
+[data-kind="external-system"] .kind-icon::before { content: "☁"; }
 ```
+
+時系列は Issue `#228` の auto-layout に依存させず、全 node の `ext.x` / `ext.y` に
+有限数を指定する。actor を起点、read-model を結果として、主要因果列の x を左から
+右へ単調に増やす。因果関係には既存 edge の `from` / `to` / `label` だけを使い、
+event storming 専用 edge schema は作らない。
+
+```json
+{
+  "nodes": [
+    { "id": "customer", "label": "Customer", "kind": "actor", "ext": { "x": 24, "y": 80 } },
+    { "id": "place-order", "label": "Place order", "kind": "command", "ext": { "x": 180, "y": 240 } },
+    { "id": "order", "label": "Order", "kind": "aggregate", "ext": { "x": 340, "y": 240 } },
+    { "id": "order-placed", "label": "Order placed", "kind": "event", "ext": { "x": 500, "y": 240 } },
+    { "id": "payment-policy", "label": "Capture payment policy", "kind": "policy", "ext": { "x": 660, "y": 240 } },
+    { "id": "capture-payment", "label": "Capture payment", "kind": "command", "ext": { "x": 820, "y": 400 } },
+    { "id": "order-status", "label": "Order status", "kind": "read-model", "ext": { "x": 980, "y": 240 } }
+  ],
+  "edges": [
+    { "id": "customer-command", "from": "customer", "to": "place-order", "label": "requests" },
+    { "id": "command-aggregate", "from": "place-order", "to": "order", "label": "targets" },
+    { "id": "aggregate-event", "from": "order", "to": "order-placed", "label": "emits" },
+    { "id": "event-policy", "from": "order-placed", "to": "payment-policy", "label": "triggers" },
+    { "id": "policy-command", "from": "payment-policy", "to": "capture-payment", "label": "issues" },
+    { "id": "command-read-model", "from": "capture-payment", "to": "order-status", "label": "updates" }
+  ]
+}
+```
+
+`Earlier → Later` の目盛りや矢印は projection HTML/CSS の補助表示であり、新しい
+model 語彙ではない。外部 image / font / stylesheet / icon library は使わず、Unicode、
+inline SVG、data URI、生成 CSS の範囲で作る。
+
+swimlane や bounded context は既存の flat group で表す。`groups[].nodes` には node id
+だけを入れ、actor や read-model を含む各 node を該当 lane に直接所属させる。
+
+```json
+{
+  "groups": [
+    { "id": "customer-lane", "label": "Customer", "nodes": ["customer"], "ext": { "role": "swimlane", "lane": "customer" } },
+    { "id": "ordering-lane", "label": "Ordering", "nodes": ["place-order", "order", "order-placed", "payment-policy", "order-status"], "ext": { "role": "swimlane", "lane": "ordering" } },
+    { "id": "payment-lane", "label": "Payment", "nodes": ["capture-payment"], "ext": { "role": "swimlane", "lane": "payment" } }
+  ]
+}
+```
+
+projection root は member node と sibling に置き、既存の
+`[data-ark-group][data-model-id]` + `.group-label` contract を使う。全幅の帯や役割ごとの
+境界は authored class と4つの `--ark-harness-group-*` から組み立てる。
+
+```html
+<section class="event-lane lane-payment" data-ark-group data-model-id="payment-lane">
+  <span class="group-label" data-model-id="payment-lane">Payment</span>
+</section>
+```
+
+```css
+.event-lane {
+  display: none;
+  position: absolute;
+  left: calc(var(--ark-harness-group-x) - 5rem);
+  top: calc(var(--ark-harness-group-y) - 1.5rem);
+  width: calc(var(--ark-harness-group-width) + 10rem);
+  height: calc(var(--ark-harness-group-height) + 3rem);
+}
+.event-lane.ark-harness-graph-group { display: block; }
+```
+
+group nesting、group 一括 drag、snap / grid、auto-layout は未対応で、このパターンでも
+導入しない。完成例は `docs/diagrams/event-storming.diagram.html` を参照する。
 
 ### Infrastructure の例
 

--- a/docs/diagrams/event-storming.diagram.html
+++ b/docs/diagrams/event-storming.diagram.html
@@ -1,0 +1,248 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>Order and Payment Event Storming</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 1.5rem;
+    background: #111827;
+    color: #e5e7eb;
+    font-family: system-ui, sans-serif;
+  }
+  h1 { margin: 0 0 1rem; font-size: 1.25rem; }
+  .graph {
+    width: 1490px;
+    min-height: 680px;
+    overflow: hidden;
+    outline: 1px solid #334155;
+    border-radius: 12px;
+    background: #151d2b;
+  }
+  .timeline-guide {
+    position: absolute;
+    top: 38px;
+    left: 32px;
+    right: 32px;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: #cbd5e1;
+    font-size: .72rem;
+    font-weight: 700;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+  .timeline-line {
+    position: relative;
+    height: 2px;
+    margin: 0 1rem;
+    flex: 1;
+    background: #64748b;
+  }
+  .timeline-line::after {
+    position: absolute;
+    top: 50%;
+    right: -1px;
+    width: 9px;
+    height: 9px;
+    border-top: 2px solid #64748b;
+    border-right: 2px solid #64748b;
+    content: "";
+    transform: translateY(-50%) rotate(45deg);
+  }
+  .storming-note {
+    --kind-color: #94a3b8;
+    --kind-bg: #202b3c;
+    width: 140px;
+    min-height: 112px;
+    padding: .85rem .75rem;
+    border: 1px solid var(--kind-color);
+    border-left: 6px solid var(--kind-color);
+    border-radius: 4px;
+    background: var(--kind-bg);
+    box-shadow: 0 7px 18px rgba(0, 0, 0, .2);
+  }
+  .note-heading { display: flex; align-items: center; gap: .45rem; }
+  .kind-icon {
+    display: inline-grid;
+    width: 1.35rem;
+    height: 1.35rem;
+    flex: 0 0 auto;
+    place-items: center;
+    color: var(--kind-color);
+    font-size: 1rem;
+  }
+  .kind-name {
+    color: var(--kind-color);
+    font-size: .65rem;
+    font-weight: 800;
+    letter-spacing: .06em;
+    text-transform: uppercase;
+  }
+  .node-label {
+    display: block;
+    margin-top: .7rem;
+    font-size: .9rem;
+    font-weight: 750;
+    line-height: 1.25;
+  }
+  [data-kind="event"] { --kind-color: #f59e0b; --kind-bg: #3b2810; }
+  [data-kind="command"] { --kind-color: #60a5fa; --kind-bg: #172a46; }
+  [data-kind="aggregate"] { --kind-color: #facc15; --kind-bg: #3a3111; }
+  [data-kind="policy"] { --kind-color: #c084fc; --kind-bg: #302044; }
+  [data-kind="actor"] {
+    --kind-color: #f472b6;
+    --kind-bg: #3b1e35;
+    width: 120px;
+    min-height: 84px;
+  }
+  [data-kind="read-model"] { --kind-color: #4ade80; --kind-bg: #153522; }
+  [data-kind="event"] .kind-icon::before { content: "⚡"; }
+  [data-kind="command"] .kind-icon::before { content: "▶"; }
+  [data-kind="aggregate"] .kind-icon::before { content: "◆"; }
+  [data-kind="policy"] .kind-icon::before { content: "◇"; }
+  [data-kind="actor"] .kind-icon::before { content: "◎"; }
+  [data-kind="read-model"] .kind-icon::before { content: "▤"; }
+  .event-lane {
+    display: none;
+    position: absolute;
+    left: 0;
+    width: 100%;
+    top: calc(var(--ark-harness-group-y) - 24px);
+    height: calc(var(--ark-harness-group-height) + 48px);
+    border: 1px solid currentColor;
+    border-width: 1px 0;
+    background: color-mix(in srgb, currentColor 5%, transparent);
+    color: #64748b;
+    pointer-events: none;
+  }
+  .event-lane.ark-harness-graph-group { display: block; }
+  .lane-customer { color: #f472b6; }
+  .lane-ordering { color: #60a5fa; }
+  .lane-payment { color: #c084fc; }
+  .group-label {
+    position: absolute;
+    top: .45rem;
+    left: .75rem;
+    padding: .18rem .5rem;
+    border: 1px solid currentColor;
+    border-radius: 999px;
+    background: #151d2b;
+    color: currentColor;
+    font-size: .7rem;
+    font-weight: 800;
+    letter-spacing: .04em;
+  }
+</style>
+</head>
+<body>
+<h1>Order and Payment Event Storming</h1>
+<script type="application/json" id="ark-diagram-model">
+{
+  "version": 1,
+  "title": "Order and Payment Event Storming",
+  "nodes": [
+    { "id": "customer", "label": "Customer", "kind": "actor", "ext": { "x": 32, "y": 110 } },
+    { "id": "place-order", "label": "Place order", "kind": "command", "ext": { "x": 190, "y": 290 } },
+    { "id": "order", "label": "Order", "kind": "aggregate", "ext": { "x": 350, "y": 290 } },
+    { "id": "order-placed", "label": "Order placed", "kind": "event", "ext": { "x": 510, "y": 290 } },
+    { "id": "capture-payment-policy", "label": "Capture payment policy", "kind": "policy", "ext": { "x": 670, "y": 290 } },
+    { "id": "capture-payment", "label": "Capture payment", "kind": "command", "ext": { "x": 830, "y": 480 } },
+    { "id": "payment", "label": "Payment", "kind": "aggregate", "ext": { "x": 990, "y": 480 } },
+    { "id": "payment-captured", "label": "Payment captured", "kind": "event", "ext": { "x": 1150, "y": 480 } },
+    { "id": "order-status", "label": "Order status", "kind": "read-model", "ext": { "x": 1310, "y": 290 } }
+  ],
+  "edges": [
+    { "id": "customer-to-place-order", "from": "customer", "to": "place-order", "label": "requests" },
+    { "id": "place-order-to-order", "from": "place-order", "to": "order", "label": "targets" },
+    { "id": "order-to-order-placed", "from": "order", "to": "order-placed", "label": "emits" },
+    { "id": "order-placed-to-policy", "from": "order-placed", "to": "capture-payment-policy", "label": "triggers" },
+    { "id": "policy-to-capture-payment", "from": "capture-payment-policy", "to": "capture-payment", "label": "issues" },
+    { "id": "capture-payment-to-payment", "from": "capture-payment", "to": "payment", "label": "charges" },
+    { "id": "payment-to-payment-captured", "from": "payment", "to": "payment-captured", "label": "records" },
+    { "id": "payment-captured-to-order-status", "from": "payment-captured", "to": "order-status", "label": "updates" }
+  ],
+  "groups": [
+    {
+      "id": "customer-lane",
+      "label": "Customer",
+      "nodes": ["customer"],
+      "ext": { "role": "swimlane", "lane": "customer" }
+    },
+    {
+      "id": "ordering-lane",
+      "label": "Ordering",
+      "nodes": ["place-order", "order", "order-placed", "capture-payment-policy", "order-status"],
+      "ext": { "role": "swimlane", "lane": "ordering" }
+    },
+    {
+      "id": "payment-lane",
+      "label": "Payment",
+      "nodes": ["capture-payment", "payment", "payment-captured"],
+      "ext": { "role": "swimlane", "lane": "payment" }
+    }
+  ]
+}
+</script>
+
+<div class="graph" data-ark-container="graph">
+  <div class="timeline-guide">
+    <span class="timeline-earlier">Earlier</span>
+    <span class="timeline-line" aria-hidden="true"></span>
+    <span class="timeline-later">Later</span>
+  </div>
+
+  <section class="event-lane lane-customer" data-ark-group data-model-id="customer-lane">
+    <span class="group-label" data-model-id="customer-lane">Customer</span>
+  </section>
+  <section class="event-lane lane-ordering" data-ark-group data-model-id="ordering-lane">
+    <span class="group-label" data-model-id="ordering-lane">Ordering</span>
+  </section>
+  <section class="event-lane lane-payment" data-ark-group data-model-id="payment-lane">
+    <span class="group-label" data-model-id="payment-lane">Payment</span>
+  </section>
+
+  <article class="storming-note" data-model-id="customer" data-kind="actor">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Actor</span></div>
+    <span class="node-label">Customer</span>
+  </article>
+  <article class="storming-note" data-model-id="place-order" data-kind="command">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Command</span></div>
+    <span class="node-label">Place order</span>
+  </article>
+  <article class="storming-note" data-model-id="order" data-kind="aggregate">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Aggregate</span></div>
+    <span class="node-label">Order</span>
+  </article>
+  <article class="storming-note" data-model-id="order-placed" data-kind="event">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Event</span></div>
+    <span class="node-label">Order placed</span>
+  </article>
+  <article class="storming-note" data-model-id="capture-payment-policy" data-kind="policy">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Policy</span></div>
+    <span class="node-label">Capture payment policy</span>
+  </article>
+  <article class="storming-note" data-model-id="capture-payment" data-kind="command">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Command</span></div>
+    <span class="node-label">Capture payment</span>
+  </article>
+  <article class="storming-note" data-model-id="payment" data-kind="aggregate">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Aggregate</span></div>
+    <span class="node-label">Payment</span>
+  </article>
+  <article class="storming-note" data-model-id="payment-captured" data-kind="event">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Event</span></div>
+    <span class="node-label">Payment captured</span>
+  </article>
+  <article class="storming-note" data-model-id="order-status" data-kind="read-model">
+    <div class="note-heading"><span class="kind-icon" aria-hidden="true"></span><span class="kind-name">Read model</span></div>
+    <span class="node-label">Order status</span>
+  </article>
+</div>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-07-22-issue-231.md
+++ b/docs/superpowers/plans/2026-07-22-issue-231.md
@@ -1,0 +1,246 @@
+# issue-231: イベントストーミング図 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 既存の graph / kind / group 語彙だけで、イベントストーミングの要素を慣例色・アイコン・可視ラベルで区別し、因果関係を左から右の時系列と swimlane で読める作図規約と実例を提供する。
+
+**Issue:** 231 (GitHub Issue 紐付けあり)
+
+**Architecture:** `command` / `event` / `aggregate` / `policy` / `actor` / `read-model` は `node.kind` から投影 root の `data-kind` へ同期し、投影 CSS の慣例色・Unicode アイコン・可視 label で区別する。時系列は全 node の `node.ext.x/y` を手動指定して左から右へ並べ、actor / ordering / payment の swimlane は既存の flat `groups` と sibling の `[data-ark-group]` 投影で表し、因果は既存 edge の `from` / `to` / `label` で結ぶ。既存 `syncNodeKinds()` / `renderGraphGroups()` / graph edge で成立するため `diagram-harness.ts`、モデル、diff は変更せず、Socket.IO、DB、React、モバイル、tmux / ttyd にも影響を与えない。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Express / Socket.IO / better-sqlite3 / tmux / ttyd
+
+---
+
+## 前提と変更境界
+
+- `packages/server/src/lib/diagram-model.ts:15-45,111-180` は任意文字列の `node.kind`、図種固有情報と座標を置ける `node.ext`、`edge`、flat な `groups[].nodes` / `groups[].ext` を既に保持する。イベントストーミング専用 enum、lane 型、timeline 型は追加しない。
+- `packages/server/src/lib/diagram-harness.ts:199-467,546-559` は有限数の `node.ext.x/y` による配置、edge 描画、`node.kind` → `data-kind` 同期、member node 外接矩形による group geometry を既に提供する。`syncNodeKinds()` / `renderGraphGroups()` を含むハーネスは変更しない。
+- `event` / `command` / `aggregate` / `policy` / `actor` / `read-model` と、必要に応じた `external-system` は server enum ではない推奨語彙とする。本実例は完了条件を直接覆う前者6 kind を使い、未知 kind には共通 card style を fallback として残す。
+- 色は補助情報とし、event=橙、command=青、aggregate=黄、policy=紫、actor=桃、read-model=緑を基本に、各 card へ相互に異なる Unicode icon、可視の kind 名、可視の node label を併記する。外部 URL、stylesheet、font、icon library、外部 `<use href>` は使わない。
+- #228 の auto-layout は未完了なので、実例の全 node に有限数の `ext.x` / `ext.y` を明記し、主要因果列が左から右へ単調に進むよう手動配置する。自動配置 helper、snap / grid、暗黙の座標 fallback は計画しない。
+- swimlane は `{ id, label, nodes, ext: { role: "swimlane", lane: "..." } }` の flat group と、graph 内で node と sibling の `[data-ark-group][data-model-id]` root で表す。group nesting、group id membership、group 一括 drag は追加せず、lane の全幅帯や label 欄は4つの既存 geometry CSS custom propertyを使う投影 CSS だけで作る。
+- 因果は `actor → command → aggregate → event → policy → command → aggregate → event → read-model` の代表例を既存 edge で結ぶ。edge の張り替えやイベントストーミング固有 edge schema は追加しない。
+- `diagram-diff.ts` は変更せず、図の会話還流は既存挙動のままとする。新規 Socket.IO event、SQLite migration、React / mobile UI、SessionOrchestrator、tmux / ttyd の変更も行わない。
+- 実装対象は `.claude/skills/diagram-authoring/SKILL.md`、新規 `docs/diagrams/event-storming.diagram.html`、`e2e/diagram-harness.spec.ts` の3ファイルだけとする（この plan ファイルを除く）。`sample.diagram.html` と `infrastructure.diagram.html` は既存 graph / kind / group 回帰 fixture として変更しない。
+- 実装タスクは Red → Green → Refactor の順で進め、P5 の `board_open` は人間による desktop 実機受け入れゲートとして最後に行う。
+
+---
+
+## Task 1: イベントストーミング実例のブラウザ受け入れ契約を Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts:151-214,594-760`
+- Reference: `docs/diagrams/infrastructure.diagram.html`
+- Reference: `docs/diagrams/sample.diagram.html`
+- Reference: `packages/server/src/lib/diagram-harness.ts:199-467,546-559`
+- Reference: `packages/server/src/lib/diagram-model.ts:15-45`
+
+- [ ] **Step 1: 既存 authored diagram helper をそのまま再利用する（2-5分）**
+
+  既存 `openAuthoredDiagram(page, filename)`、`requiredBoundingBox()`、`expectBoxToContain()` を使って `event-storming.diagram.html` を実ブラウザ経路で開く。infra test と重複する外部リソース検査を共通 helper に抽出する場合も `e2e/diagram-harness.spec.ts` 内だけに留め、server 側の読み込み・配信経路は変えない。
+
+- [ ] **Step 2: 6 kind・慣例色・因果 edge の失敗 test を書く（2-5分）**
+
+  「event storming sample は6 kindを色・アイコン・可視ラベルで区別し因果を表示する」test を追加し、model block と graph direct child の node projection を対応づけて次を assertion にする。
+
+  - model が `event` / `command` / `aggregate` / `policy` / `actor` / `read-model` の6 kind をすべて含み、projection root の `data-kind` が model と一致する。
+  - computed style の kind color が6種で区別され、event=橙、command=青、aggregate=黄、policy=紫、actor=桃、read-model=緑の authored palette に対応する。actor card は通常の付箋より小さくても、可視 label が欠けない。
+  - `.kind-icon::before` が空でも `none` でもなく6 kind で異なり、各 root に空でない可視 `.kind-name` と `.node-label` がある。色だけで kind を伝えない。
+  - edge 数が model と一致し、`command → aggregate → event → policy → command` を含む代表因果列と、先頭の actor、末尾の read-model までの label 付き接続が描画される。
+  - raw HTML に外部 URL / stylesheet / font / icon library / 外部 `<use href>` がなく、page error が発生しない。
+
+- [ ] **Step 3: 手動 timeline・flat group swimlane の失敗 test を書く（2-5分）**
+
+  「event storming sample は手動 timeline と flat group swimlane で配置する」test を追加する。
+
+  - 全 node が有限数の `ext.x/y` を持ち、主要因果列の x 座標が左から右へ単調増加する。graph 相対 bounding box が authored `ext.x/y` と一致し、表示された `Earlier → Later` の timeline guide と同じ向きに読める。
+  - model の `groups[].ext.role` は `swimlane` で、各 member は node id のみとし、group id を含めない。少なくとも Customer / Ordering / Payment の3 lane があり、全 node がいずれかの lane に属する。
+  - 各 sibling `[data-ark-group]` に `.ark-harness-graph-group` と可視 `.group-label` が付き、lane が全 member node を囲む。3 lane は上から下へ重ならず、投影 CSS の variant で graph 幅の帯として表示される。
+
+- [ ] **Step 4: Red を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "event storming sample"`
+
+  Expected: FAIL。`docs/diagrams/event-storming.diagram.html` がまだ存在しないため authored diagram の読み込みで失敗する。既存 sample / infrastructure / graph / kind / group tests の fixture は変更していない。
+
+---
+
+## Task 2: 手動配置と swimlane を備えた代表的なイベントストーミング図を追加する
+
+**Files:**
+
+- Create: `docs/diagrams/event-storming.diagram.html`
+- Modify: `e2e/diagram-harness.spec.ts`
+- Reference: `docs/diagrams/infrastructure.diagram.html`
+- Reference: `docs/diagrams/sample.diagram.html`
+
+- [ ] **Step 1: 汎用 graph 語彙だけで注文・決済の意味モデルを記述する（2-5分）**
+
+  `ark-diagram-model` に次の代表因果列を作り、全 node に重ならない有限数の `ext.x/y` を指定する。x は因果順に左から右へ増やし、y は Customer / Ordering / Payment lane の3段へ分ける。
+
+  ```text
+  Customer(actor)
+    → Place order(command)
+    → Order(aggregate)
+    → Order placed(event)
+    → Capture payment policy(policy)
+    → Capture payment(command)
+    → Payment(aggregate)
+    → Payment captured(event)
+    → Order status(read-model)
+  ```
+
+  各接続は `from` / `to` / `label` を持つ既存 edge とし、`requests` / `targets` / `emits` / `triggers` / `issues` / `updates` など因果が読める短い label を付ける。イベントストーミング固有 schema、edge component id、auto-layout 用 metadata は作らない。
+
+- [ ] **Step 2: flat group と sibling projection で3本の swimlane を作る（2-5分）**
+
+  model に Customer / Ordering / Payment の3 group を追加し、各 group の `nodes` にはその lane に置く node id だけを列挙する。`ext` は例として `{ "role": "swimlane", "lane": "customer" }` のように図種固有の意味を保持するが、server enum や group kind は前提にしない。
+
+  graph の node と sibling に `<section class="event-lane ..." data-ark-group data-model-id="...">` と同じ id の可視 `.group-label` leaf を置く。left / width は graph 全幅の帯、top / height は `--ark-harness-group-y` / `--ark-harness-group-height` に余白を加えた値とし、3 lane が重ならない y 座標と padding を選ぶ。ハーネス生成 class や custom property の実値は authored HTML に書かない。
+
+- [ ] **Step 3: CSP 準拠の付箋、kind 表現、timeline guide を投影する（2-5分）**
+
+  各 node root に model と一致する `data-model-id` / `data-kind`、`aria-hidden="true"` の `.kind-icon`、可視 `.kind-name`、可視 `.node-label` を置く。共通 `.storming-note` fallback を定義し、次の慣例色と相互に異なる Unicode icon を CSS variables / pseudo-element で割り当てる。
+
+  - `event`: 橙
+  - `command`: 青
+  - `aggregate`: 黄
+  - `policy`: 紫
+  - `actor`: 小さめの桃色 card
+  - `read-model`: 緑
+
+  graph 上部には外部画像を使わない CSS の timeline guide と可視な `Earlier` / `Later` label を置く。色は kind の補助に留め、外部 image / font / stylesheet / script は追加しない。
+
+- [ ] **Step 4: Green と既存 authored sample の回帰を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "event storming sample|infrastructure sample|sample は|sample group"`
+
+  Expected: PASS。6 kind の色・icon・可視 label、手動 timeline、全 edge、3 swimlane が表示され、既存 sample / infrastructure の kind / group acceptance も成功する。
+
+- [ ] **Step 5: HTML を簡潔化して成果物をコミットする（2-5分）**
+
+  重複する付箋 / lane style は CSS variables と共通 class にまとめ、model と projection の id / label / kind、group membership が一致していることを確認する。graph の node / group root は direct sibling を維持し、正式な group nesting は導入しない。
+
+  ```bash
+  git add docs/diagrams/event-storming.diagram.html e2e/diagram-harness.spec.ts
+  git commit -m "docs(diagram): イベントストーミング図の実例を追加"
+  ```
+
+---
+
+## Task 3: diagram-authoring skill の Event storming 節を完全な作図レシピへ拡張する
+
+**Files:**
+
+- Modify: `.claude/skills/diagram-authoring/SKILL.md:77-118`
+- Reference: `.claude/skills/diagram-authoring/SKILL.md:220-315`
+- Reference: `docs/diagrams/event-storming.diagram.html`
+- Reference: `docs/diagrams/infrastructure.diagram.html`
+- Reference: `packages/server/src/lib/diagram-model.ts:15-45`
+
+- [ ] **Step 1: 推奨 kind と慣例色を6種へ拡張する（2-5分）**
+
+  既存の「Event storming の例」を重複節を作らず拡張し、`command` / `event` / `aggregate` / `policy` に `actor` / `read-model` を加える。必要な場合だけ使う `external-system` も補足し、いずれも server enum ではない推奨語彙であること、未知 kind は共通 node style へ fallback すること、model の `node.kind` と projection root の `data-kind` を一致させることを明記する。
+
+  event=橙、command=青、aggregate=黄、policy=紫、actor=小さい黄または桃、read-model=緑という慣例を CSS snippet に反映し、現在の4 kind 例を置き換える。`.kind-icon[aria-hidden]`、可視 kind 名、可視 node label を併用し、色だけで意味を伝えない。
+
+- [ ] **Step 2: 手動 timeline と因果 edge の書き方を例示する（2-5分）**
+
+  model snippet に6 kind と有限数の `ext.x/y` を含め、#228 に依存せず全 node を因果順に左から右へ手動配置する手順を示す。`command → aggregate → event → policy → command` を中心に、actor を起点、read-model を結果としてつなぐ場合も、既存 edge の `from` / `to` / `label` だけで表すことを説明する。
+
+  timeline の目盛りや矢印は投影 HTML/CSS の補助表示であり、新しい model 語彙ではないこと、Unicode / inline SVG / data URI だけを使う CSP 制約を既存規約と一貫させる。
+
+- [ ] **Step 3: swimlane / bounded context の flat group パターンを例示する（2-5分）**
+
+  group model は `{ id, label, nodes, ext: { role: "swimlane", lane: "..." } }` とし、projection は既存 `[data-ark-group][data-model-id]` + `.group-label` contract を使うことを示す。actor / read-model / bounded context など役割ごとの帯や境界は authored projection class と4つの `--ark-harness-group-*` から表現し、`groups[].nodes` には node id だけを入れる。
+
+  group nesting、group 一括 drag、snap / grid、auto-layout は未対応かつ本 Issue のスコープ外であることを Event storming 節からも明示し、詳細な完成例として `docs/diagrams/event-storming.diagram.html` を案内する。
+
+- [ ] **Step 4: skill と実例の契約を静的に照合する（2-5分）**
+
+  Run: `rg -n 'event|command|aggregate|policy|actor|read-model|external-system|swimlane|ext\.x|ext\.y|event-storming\.diagram\.html' .claude/skills/diagram-authoring/SKILL.md`
+
+  Expected: 6つの必須 kind、任意の external-system、手動座標、swimlane、完成例への参照がすべて見つかる。
+
+  Run: `rg -n 'https?://|@import|<link[^>]+stylesheet|icon[- ]library|<use[^>]+href' docs/diagrams/event-storming.diagram.html`
+
+  Expected: 出力なし。実例が外部 URL / font / icon library を参照していない。
+
+- [ ] **Step 5: skill 更新をコミットする（2-5分）**
+
+  ```bash
+  git add .claude/skills/diagram-authoring/SKILL.md
+  git commit -m "docs(diagram): イベントストーミングの作図規約を追加"
+  ```
+
+---
+
+## Task 4: 全回帰と P5 実機受け入れを完了する
+
+**Files:**
+
+- Verify: `.claude/skills/diagram-authoring/SKILL.md`
+- Verify: `docs/diagrams/event-storming.diagram.html`
+- Verify: `e2e/diagram-harness.spec.ts`
+- Verify only: `packages/server/src/lib/diagram-harness.ts`
+- Verify only: `packages/server/src/lib/diagram-model.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.ts`
+- Verify only: `packages/shared/src/types.ts`
+- Verify only: `packages/server/src/index.ts`
+- Verify only: `packages/server/src/lib/database.ts`
+- Verify only: `packages/web/src/hooks/useSocket.ts`
+- Verify only: `packages/web/src/components/DiagramPane.tsx`
+- Verify only: `packages/web/src/components/MobileLayout.tsx`
+- Verify only: `packages/web/src/components/MobileSessionView.tsx`
+
+- [ ] **Step 1: targeted test と静的品質チェックを実行する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "event storming sample"`
+
+  Expected: PASS。6 kind の慣例色・icon・可視 label、手動 timeline、因果 edge、3 swimlane、CSP 制約の acceptance が成功する。
+
+  Run: `pnpm exec biome check e2e/diagram-harness.spec.ts`
+
+  Expected: exit 0、format / lint error なし。
+
+  Run: `pnpm exec tsc -b`
+
+  Expected: exit 0、型エラーなし。
+
+- [ ] **Step 2: diagram と repository の全回帰を実行する（2-5分）**
+
+  Run: `pnpm exec vitest run`
+
+  Expected: exit 0、全 unit / integration test が PASS。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: Event storming acceptance に加え、既存 sample / infrastructure、graph edge / drag、kind 同期、group 追従、list editing、clean submission がすべて PASS。
+
+  Run: `pnpm test:e2e`
+
+  Expected: desktop / mobile を含む repository E2E が PASS（環境条件が明記された test は、その条件が未充足の場合のみ SKIP）。
+
+- [ ] **Step 3: スコープ外レイヤーの非変更を確認する（2-5分）**
+
+  Run: `git diff --name-only main...HEAD`
+
+  Expected: この Issue の実装差分は `.claude/skills/diagram-authoring/SKILL.md`、`docs/diagrams/event-storming.diagram.html`、`e2e/diagram-harness.spec.ts`、`docs/superpowers/plans/2026-07-22-issue-231.md` だけ。`diagram-harness.ts`、`diagram-model.ts`、`diagram-diff.ts`、Socket.IO 型 / handler、DB、React / mobile、tmux / ttyd は含まれない。
+
+  Run: `git diff --check main...HEAD`
+
+  Expected: 出力なし。
+
+- [ ] **Step 4: desktop 実機で `board_open` 受け入れを行う（P5 human gate、各2-5分）**
+
+  1. 稼働中 session から `docs/diagrams/event-storming.diagram.html` を `board_open` し、event / command / aggregate / policy / actor / read-model が慣例色、異なる icon、可視 kind 名、可視 node label で判別できることを確認する。
+  2. Customer actor から Order status read-model までの node が左から右へ時系列で並び、`command → aggregate → event → policy → command` を含む label 付き因果線が正しい endpoint を結ぶことを確認する。
+  3. Customer / Ordering / Payment の3 swimlane が独立した全幅の帯として表示され、各 label と member node が正しい lane に収まり、lane 同士が重ならないことを確認する。これは既存 flat group の投影であり、group nesting がないことも確認する。
+  4. 任意の node を個別 drag し、edge と所属 lane 境界が追従することを確認する。再読込後も authored `ext.x/y` から初期配置され、auto-layout を必要としないことを確認する。
+  5. DevTools の Network / Console で外部 icon / font / stylesheet request と CSP error がなく、page error もないことを確認する。
+
+- [ ] **Step 5: 完了条件を記録する（2-5分）**
+
+  P5 human gate の結果に、(1) 6 kind の色・icon・label、(2) 手動 timeline と因果 edge、(3) flat group swimlane、(4) skill の手順と実例、(5) `board_open` 実機表示の5点を記録する。不合格の場合は `diagram-harness.ts`、モデル、diff、group nesting へ拡張せず、まず authored HTML/CSS、model id / membership、手動座標の範囲で修正する。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -761,6 +761,215 @@ test("infrastructure sample は flat group で region / VPC / subnet を囲む",
   });
 });
 
+test("event storming sample は6 kindを色・アイコン・可視ラベルで区別し因果を表示する", async ({
+  page,
+}) => {
+  const { errors, html } = await openAuthoredDiagram(
+    page,
+    "event-storming.diagram.html"
+  );
+  const diagramModel = await page.locator("#ark-diagram-model").evaluate(
+    element =>
+      JSON.parse(element.textContent || "") as {
+        nodes: Array<{
+          id: string;
+          label: string;
+          kind: string;
+        }>;
+        edges: Array<{
+          id: string;
+          from: string;
+          to: string;
+          label?: string;
+        }>;
+      }
+  );
+  const expectedColors = {
+    event: "rgb(245, 158, 11)",
+    command: "rgb(96, 165, 250)",
+    aggregate: "rgb(250, 204, 21)",
+    policy: "rgb(192, 132, 252)",
+    actor: "rgb(244, 114, 182)",
+    "read-model": "rgb(74, 222, 128)",
+  };
+
+  expect(new Set(diagramModel.nodes.map(node => node.kind))).toEqual(
+    new Set(Object.keys(expectedColors))
+  );
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const iconsByKind = new Map<string, string>();
+  for (const node of diagramModel.nodes) {
+    const projection = graph.locator(
+      `:scope > [data-model-id="${node.id}"]:not([data-ark-group])`
+    );
+    await expect(projection).toHaveAttribute("data-kind", node.kind);
+    await expect(projection.locator(".kind-name")).toBeVisible();
+    await expect(projection.locator(".kind-name")).not.toHaveText("");
+    await expect(projection.locator(".node-label")).toBeVisible();
+    await expect(projection.locator(".node-label")).toHaveText(node.label);
+    const style = await projection.evaluate(element => ({
+      color: getComputedStyle(element).borderLeftColor,
+      icon: getComputedStyle(element.querySelector(".kind-icon"), "::before")
+        .content,
+    }));
+    expect(style.color).toBe(
+      expectedColors[node.kind as keyof typeof expectedColors]
+    );
+    expect(style.icon).not.toBe("none");
+    expect(style.icon).not.toBe("");
+    iconsByKind.set(node.kind, style.icon);
+  }
+  expect(new Set(iconsByKind.values())).toHaveProperty("size", 6);
+
+  expect(diagramModel.edges.map(edge => `${edge.from}->${edge.to}`)).toEqual([
+    "customer->place-order",
+    "place-order->order",
+    "order->order-placed",
+    "order-placed->capture-payment-policy",
+    "capture-payment-policy->capture-payment",
+    "capture-payment->payment",
+    "payment->payment-captured",
+    "payment-captured->order-status",
+  ]);
+  await expect(graph.locator("[data-ark-edge-id]")).toHaveCount(
+    diagramModel.edges.length
+  );
+  for (const edge of diagramModel.edges) {
+    expect(edge.label).toBeTruthy();
+    await expect(graph.locator("text", { hasText: edge.label })).toHaveCount(1);
+  }
+
+  expect(html).not.toMatch(/https?:\/\//i);
+  expect(html).not.toMatch(/\bsrc\s*=\s*["']\s*\/\//i);
+  expect(html).not.toMatch(/url\(\s*["']?\s*\/\//i);
+  expect(html).not.toMatch(/<link[^>]+rel=["']?stylesheet/i);
+  expect(html).not.toMatch(/@import/i);
+  expect(html).not.toMatch(/icon[- ]library/i);
+  expect(html).not.toMatch(
+    /<use\b[^>]*\b(?:href|xlink:href)\s*=\s*["']\s*(?!(?:#|data:))[^"']+/i
+  );
+  expect(errors).toEqual([]);
+});
+
+test("event storming sample は手動 timeline と flat group swimlane で配置する", async ({
+  page,
+}) => {
+  await openAuthoredDiagram(page, "event-storming.diagram.html");
+  const diagramModel = await page.locator("#ark-diagram-model").evaluate(
+    element =>
+      JSON.parse(element.textContent || "") as {
+        nodes: Array<{
+          id: string;
+          ext: { x: number; y: number };
+        }>;
+        groups: Array<{
+          id: string;
+          label: string;
+          nodes: string[];
+          ext: { role: string; lane: string };
+        }>;
+      }
+  );
+  const causalNodeIds = [
+    "customer",
+    "place-order",
+    "order",
+    "order-placed",
+    "capture-payment-policy",
+    "capture-payment",
+    "payment",
+    "payment-captured",
+    "order-status",
+  ];
+  const nodesById = new Map(diagramModel.nodes.map(node => [node.id, node]));
+  for (const node of diagramModel.nodes) {
+    expect(Number.isFinite(node.ext.x)).toBe(true);
+    expect(Number.isFinite(node.ext.y)).toBe(true);
+  }
+  for (let index = 1; index < causalNodeIds.length; index += 1) {
+    const previousNode = nodesById.get(causalNodeIds[index - 1]);
+    const currentNode = nodesById.get(causalNodeIds[index]);
+    expect(previousNode).toBeDefined();
+    expect(currentNode).toBeDefined();
+    if (!previousNode || !currentNode) continue;
+    expect(currentNode.ext.x).toBeGreaterThan(previousNode.ext.x);
+  }
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const graphBox = await requiredBoundingBox(graph);
+  for (const node of diagramModel.nodes) {
+    const projection = graph.locator(
+      `:scope > [data-model-id="${node.id}"]:not([data-ark-group])`
+    );
+    const box = await requiredBoundingBox(projection);
+    expect(box.x - graphBox.x).toBeCloseTo(node.ext.x, 0);
+    expect(box.y - graphBox.y).toBeCloseTo(node.ext.y, 0);
+  }
+  const earlier = graph.locator(".timeline-earlier");
+  const later = graph.locator(".timeline-later");
+  await expect(earlier).toBeVisible();
+  await expect(earlier).toHaveText("Earlier");
+  await expect(later).toBeVisible();
+  await expect(later).toHaveText("Later");
+  const [earlierBox, laterBox] = await Promise.all([
+    requiredBoundingBox(earlier),
+    requiredBoundingBox(later),
+  ]);
+  expect(earlierBox.x).toBeLessThan(laterBox.x);
+
+  const nodeIds = new Set(diagramModel.nodes.map(node => node.id));
+  const groupIds = new Set(diagramModel.groups.map(group => group.id));
+  expect(diagramModel.groups.map(group => group.label)).toEqual([
+    "Customer",
+    "Ordering",
+    "Payment",
+  ]);
+  expect(
+    diagramModel.groups.every(group => group.ext.role === "swimlane")
+  ).toBe(true);
+  const memberships = new Map(diagramModel.nodes.map(node => [node.id, 0]));
+  for (const group of diagramModel.groups) {
+    expect(group.nodes.length).toBeGreaterThan(0);
+    expect(group.nodes.every(nodeId => nodeIds.has(nodeId))).toBe(true);
+    expect(group.nodes.every(nodeId => !groupIds.has(nodeId))).toBe(true);
+    for (const memberId of group.nodes) {
+      memberships.set(memberId, (memberships.get(memberId) || 0) + 1);
+    }
+  }
+  expect([...memberships.values()].every(count => count === 1)).toBe(true);
+
+  const laneBoxes: Array<Awaited<ReturnType<typeof requiredBoundingBox>>> = [];
+  for (const group of diagramModel.groups) {
+    const lane = graph.locator(
+      `:scope > [data-ark-group][data-model-id="${group.id}"]`
+    );
+    await expect(lane).toHaveClass(/ark-harness-graph-group/);
+    await expect(lane).toHaveClass(/event-lane/);
+    await expect(lane.locator(".group-label")).toBeVisible();
+    await expect(lane.locator(".group-label")).toHaveText(group.label);
+    const laneBox = await requiredBoundingBox(lane);
+    laneBoxes.push(laneBox);
+    expect(laneBox.x).toBeCloseTo(graphBox.x, 0);
+    expect(laneBox.width).toBeCloseTo(graphBox.width, 0);
+    for (const memberId of group.nodes) {
+      const memberBox = await requiredBoundingBox(
+        graph.locator(
+          `:scope > [data-model-id="${memberId}"]:not([data-ark-group])`
+        )
+      );
+      expectBoxToContain(laneBox, memberBox);
+    }
+  }
+  for (let index = 1; index < laneBoxes.length; index += 1) {
+    const previousLane = laneBoxes[index - 1];
+    const currentLane = laneBoxes[index];
+    expect(currentLane.y).toBeGreaterThanOrEqual(
+      previousLane.y + previousLane.height
+    );
+  }
+});
+
 test("node ドラッグと list 編集を送信 model と clean HTML に反映する", async ({
   page,
 }) => {


### PR DESCRIPTION
## 概要

図解: **イベントストーミング図**。graph (#224) + kind (#226) + group (#227) の上に、command/event/aggregate/policy/actor/read-model を慣例色の付箋で区別し、因果を左→右の時系列 + swimlane で並べる ES 図の**作図規約と実例**を追加する。

Closes #231

## 設計の要点：新図種はハーネス変更ゼロ（#232 に続く実証）

既存の `syncNodeKinds()`（kind 色）と `renderGraphGroups()`（swimlane 境界）で成立するため、**production コードの変更は一切なし**。変更は 3 ファイルのみ：

- **新規 `docs/diagrams/event-storming.diagram.html`**: `Customer(actor) → Place order(command) → Order(aggregate) → Order placed(event) → Capture payment policy(policy) → … → Order status(read-model)` の因果列を手動座標で左→右に配置。Customer / Ordering / Payment の 3 swimlane（flat group の全幅帯）で分ける
- **`.claude/skills/diagram-authoring/SKILL.md`**: Event storming の作図レシピ（6 kind の慣例色、手動 timeline、swimlane、CSP 制約）
- **`e2e/diagram-harness.spec.ts`**: ES 実例の Playwright 受入テスト（6 kind 色分け・因果 edge・手動 timeline・3 swimlane・CSP）

## 実装上の判断

- **慣例色**: event=橙 / command=青 / aggregate=黄 / policy=紫 / actor=桃 / read-model=緑。色は補助で、アイコン + 可視 kind 名 + 可視 label を併用（色だけに依存しない）
- **時系列は手動座標**（`node.ext.x` を因果順に増加）。**swimlane は flat group**（`ext.role: "swimlane"`）の全幅帯。group nesting / auto-layout はスコープ外
- **アイコン・timeline guide は Unicode / inline SVG / data URI のみ**（外部 URL/font/stylesheet/icon-library/`<use href>` 不使用。CSP 準拠、テストで検証）

## テスト

- `tsc -b`: pass ・ `vitest run`: 523 pass ・ `biome check`: clean
- `playwright e2e/diagram-harness.spec.ts`: 15 テスト pass（ES の6 kind色分け+因果 / 手動 timeline+swimlane / 既存 sample・infrastructure・graph・kind・group・list 回帰）

## スコープ外（後続単位）

group nesting / 自動レイアウト (#228) / ES kind の enum 標準化。production コード（harness/model/diff/Socket.IO/DB/モバイル）は不変。既存 `sample.diagram.html` / `infrastructure.diagram.html` も不変（回帰 fixture）。

## レビュー体制

codex が plan 立案・TDD 実装、Claude が P2（plan）/ P5（実装）レビュー（flow-x 役割逆転。実装者 ≠ レビュアー）。
