### PR TITLE
図解ハーネス: edge セマンティクス（カーディナリティ・方向・端点張り替え） (#229)

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -290,6 +290,110 @@ region / VPC / subnet の階層感が必要でも `groups[].nodes` に group id 
 group nesting、group 一括 drag、auto-layout は未対応で、インフラ構成図でも導入しない。
 完成例は `docs/diagrams/infrastructure.diagram.html` を参照する。
 
+## 語彙: edge / ER
+
+edge の core field は `id` / `from` / `to` / `label` である。`from` と `to` は同じ
+graph に投影した実在 node の id を参照し、self-edge（同じ id 同士）も使える。
+ER 図の多重度・矢印方向・線の用途は、core 語彙を増やさず `edge.ext` に置く。
+
+- `from_card` / `to_card` は、それぞれ `from` / `to` node 側の cardinality
+- cardinality は `one`（1）、`many`（N）、`zero-or-one`（0..1）、
+  `one-or-many`（1..N）、`zero-or-many`（0..N）の5値
+- `direction` は `forward`（from → to）、`reverse`（to → from）、`both`（双方向）、
+  `none`（矢印なし）の4値。省略または未知値は `forward`
+- `type` は lowercase kebab-case 推奨の opaque string。server enum ではない
+
+1:N、0..1、N:M の例：
+
+```json
+{
+  "edges": [
+    {
+      "id": "customer-orders",
+      "from": "customer",
+      "to": "order",
+      "label": "places",
+      "ext": {
+        "from_card": "one",
+        "to_card": "zero-or-many",
+        "direction": "forward",
+        "type": "identifying"
+      }
+    },
+    {
+      "id": "order-featured-product",
+      "from": "order",
+      "to": "product",
+      "label": "features",
+      "ext": {
+        "from_card": "one",
+        "to_card": "zero-or-one",
+        "direction": "none",
+        "type": "optional-reference"
+      }
+    },
+    {
+      "id": "order-products",
+      "from": "order",
+      "to": "product",
+      "label": "contains",
+      "ext": {
+        "from_card": "zero-or-many",
+        "to_card": "zero-or-many",
+        "direction": "both",
+        "type": "association"
+      }
+    }
+  ]
+}
+```
+
+edge の main line / path には、harness が解釈済みの
+`data-ark-edge-direction` と string の `data-ark-edge-type` を付ける。authored CSS は
+これらを selector に使える。harness の汎用線 style より詳細度を高くするため、graph
+root と generated main class も組み合わせる。
+
+```css
+[data-ark-container="graph"] .ark-harness-edge-main[data-ark-edge-type="identifying"] {
+  stroke: #f59e0b;
+  stroke-width: 2.25;
+}
+[data-ark-container="graph"] .ark-harness-edge-main[data-ark-edge-type="association"] {
+  stroke-dasharray: 7 5;
+}
+```
+
+ER projection の最小 HTML は通常の graph / entity / field list だけを書く。edge line、
+crow's foot 記号、端点 handle、drag preview、drop indicator は配信時に harness が生成する
+ため、authored HTML に重複して書かない。
+
+```html
+<div class="er-graph" data-ark-container="graph">
+  <section class="entity" data-model-id="customer" data-kind="entity">
+    <h2 data-model-id="customer">Customer</h2>
+    <ul>
+      <li data-model-id="customer_id">id PK</li>
+    </ul>
+  </section>
+  <section class="entity" data-model-id="order" data-kind="entity">
+    <h2 data-model-id="order">Order</h2>
+    <ul>
+      <li data-model-id="order_id">id PK</li>
+      <li data-model-id="order_customer_id">customer_id FK</li>
+    </ul>
+  </section>
+</div>
+```
+
+全 entity node に有限数の `ext.x` / `ext.y` を指定して手動配置し、auto-layout には
+依存しない。端点 handle の drag は core の `edge.from` / `edge.to` だけを更新するため
+会話へ関連変更として還流する。一方、cardinality / direction / type のような `edge.ext`
+単独変更は diagram file と表示には保存されるが、自動で自然文へ還流しない。
+
+ER projection でも外部 URL、stylesheet、font、image、script、外部 `<use href>` は使わず、
+inline CSS / SVG の範囲に留める。完成例は
+`docs/diagrams/er-edge-semantics.diagram.html` を参照する。
+
 ## 語彙: group
 
 複数 node をラベル付きの境界でまとめるときは group を使う。model shape は

--- a/docs/diagrams/er-edge-semantics.diagram.html
+++ b/docs/diagrams/er-edge-semantics.diagram.html
@@ -1,0 +1,163 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>ER edge semantics</title>
+<style>
+  :root { color-scheme: dark; }
+  body { margin:0; padding:1.5rem; background:#111827; color:#e5e7eb; font-family:system-ui,sans-serif; }
+  h1 { margin:0 0 .35rem; font-size:1.2rem; }
+  .legend { margin:0 0 1rem; color:#9ca3af; font-size:.8rem; }
+  .er-graph { width:980px; height:600px; border:1px solid #374151; border-radius:12px; background:#172033; }
+  .entity { width:220px; box-sizing:border-box; border:1px solid #4b5563; border-top:4px solid #60a5fa; border-radius:8px; background:#1f2937; box-shadow:0 8px 24px rgba(0,0,0,.25); }
+  .entity-label { margin:0; padding:.65rem .85rem; border-bottom:1px solid #374151; color:#dbeafe; font-size:.95rem; }
+  .entity ul { list-style:none; margin:0; padding:.45rem 0 .65rem; }
+  .entity li { padding:.2rem .85rem; color:#d1d5db; font-family:ui-monospace,monospace; font-size:.76rem; }
+  .entity li:first-child { color:#fbbf24; }
+  [data-ark-container="graph"] .ark-harness-edge-main[data-ark-edge-type="identifying"] { stroke:#f59e0b; stroke-width:2.25; }
+  [data-ark-container="graph"] .ark-harness-edge-main[data-ark-edge-type="association"] { stroke:#a78bfa; stroke-dasharray:7 5; }
+  [data-ark-container="graph"] .ark-harness-edge-main[data-ark-edge-type="optional-reference"] { stroke:#34d399; }
+</style>
+</head>
+<body>
+<h1>注文ドメイン ER 図</h1>
+<p class="legend">1:N、0..1、N:M と方向・種別を edge.ext から投影</p>
+<script type="application/json" id="ark-diagram-model">
+{
+  "version": 1,
+  "title": "注文ドメイン ER 図",
+  "nodes": [
+    {
+      "id": "customer",
+      "label": "Customer",
+      "kind": "entity",
+      "ext": { "x": 40, "y": 70 },
+      "fields": [
+        { "id": "customer_id", "label": "id PK" },
+        { "id": "customer_email", "label": "email" }
+      ]
+    },
+    {
+      "id": "order",
+      "label": "Order",
+      "kind": "entity",
+      "ext": { "x": 360, "y": 70 },
+      "fields": [
+        { "id": "order_id", "label": "id PK" },
+        { "id": "order_customer_id", "label": "customer_id FK" },
+        { "id": "order_featured_product_id", "label": "featured_product_id FK NULL" }
+      ]
+    },
+    {
+      "id": "order-item",
+      "label": "OrderItem",
+      "kind": "entity",
+      "ext": { "x": 360, "y": 340 },
+      "fields": [
+        { "id": "order_item_id", "label": "id PK" },
+        { "id": "order_item_order_id", "label": "order_id FK" },
+        { "id": "order_item_product_id", "label": "product_id FK" },
+        { "id": "order_item_quantity", "label": "quantity" }
+      ]
+    },
+    {
+      "id": "product",
+      "label": "Product",
+      "kind": "entity",
+      "ext": { "x": 700, "y": 320 },
+      "fields": [
+        { "id": "product_id", "label": "id PK" },
+        { "id": "product_name", "label": "name" },
+        { "id": "product_price", "label": "price" }
+      ]
+    }
+  ],
+  "edges": [
+    {
+      "id": "e_order_customer",
+      "from": "order",
+      "to": "customer",
+      "label": "placed by",
+      "ext": {
+        "from_card": "one",
+        "to_card": "zero-or-many",
+        "direction": "forward",
+        "type": "belongs-to"
+      }
+    },
+    {
+      "id": "e_order_items",
+      "from": "order",
+      "to": "order-item",
+      "label": "contains",
+      "ext": {
+        "from_card": "one",
+        "to_card": "one-or-many",
+        "direction": "forward",
+        "type": "identifying"
+      }
+    },
+    {
+      "id": "e_order_featured_product",
+      "from": "order",
+      "to": "product",
+      "label": "features",
+      "ext": {
+        "from_card": "one",
+        "to_card": "zero-or-one",
+        "direction": "none",
+        "type": "optional-reference"
+      }
+    },
+    {
+      "id": "e_item_product",
+      "from": "order-item",
+      "to": "product",
+      "label": "catalog association",
+      "ext": {
+        "from_card": "zero-or-many",
+        "to_card": "zero-or-many",
+        "direction": "both",
+        "type": "association"
+      }
+    }
+  ],
+  "groups": []
+}
+</script>
+<div class="er-graph" data-ark-container="graph">
+  <section class="entity" data-model-id="customer" data-kind="entity">
+    <h2 class="entity-label" data-model-id="customer">Customer</h2>
+    <ul>
+      <li data-model-id="customer_id">id PK</li>
+      <li data-model-id="customer_email">email</li>
+    </ul>
+  </section>
+  <section class="entity" data-model-id="order" data-kind="entity">
+    <h2 class="entity-label" data-model-id="order">Order</h2>
+    <ul>
+      <li data-model-id="order_id">id PK</li>
+      <li data-model-id="order_customer_id">customer_id FK</li>
+      <li data-model-id="order_featured_product_id">featured_product_id FK NULL</li>
+    </ul>
+  </section>
+  <section class="entity" data-model-id="order-item" data-kind="entity">
+    <h2 class="entity-label" data-model-id="order-item">OrderItem</h2>
+    <ul>
+      <li data-model-id="order_item_id">id PK</li>
+      <li data-model-id="order_item_order_id">order_id FK</li>
+      <li data-model-id="order_item_product_id">product_id FK</li>
+      <li data-model-id="order_item_quantity">quantity</li>
+    </ul>
+  </section>
+  <section class="entity" data-model-id="product" data-kind="entity">
+    <h2 class="entity-label" data-model-id="product">Product</h2>
+    <ul>
+      <li data-model-id="product_id">id PK</li>
+      <li data-model-id="product_name">name</li>
+      <li data-model-id="product_price">price</li>
+    </ul>
+  </section>
+</div>
+</body>
+</html>

--- a/docs/superpowers/plans/2026-07-22-issue-229.md
+++ b/docs/superpowers/plans/2026-07-22-issue-229.md
@@ -1,0 +1,424 @@
+# issue-229: edge セマンティクス Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `edge.ext` の標準語彙からカーディナリティ・方向・種別を投影し、graph / list 編集を壊さず edge の from / to 端点を別 node へドラッグで張り替えられるようにする。
+
+**Issue:** 229 (GitHub Issue 紐付けあり)
+
+**Architecture:** `DiagramEdge.ext` の `from_card` / `to_card` / `direction` / `type` を既存 parser の opaque な拡張情報として保持し、`renderGraph()` が生成する SVG edge layer に CSP 準拠の inline SVG primitive で crow's foot 記号と矢印方向を描き、`type` は投影 CSS が選択できる data 属性へ写す。端点 handle は group(0) / edge(1) / node(2) より前面の harness UI layer(3) に置き、Pointer Events の drag/drop で同一 graph 内の node を解決して `edge.from` または `edge.to` だけを更新するため、既存 `describeModelDiff()` が張り替えを自然に意味差分へ還流する一方、opaque な `edge.ext` 単独変更は非還流のままとし production の `diagram-diff.ts` は変更しない（よって同ファイルの追加 human security review は不要）。保存と通知は既存 MessageChannel / `diagram:submit` / diagram file を再利用し、新規 Socket.IO event、DB schema、React / Tailwind UI、SessionOrchestrator、tmux / ttyd、現行で diagram を描画しない mobile UI への変更はない。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Express / Socket.IO / better-sqlite3 / tmux / ttyd
+
+---
+
+## 前提と変更境界
+
+- `packages/server/src/lib/diagram-model.ts:24-30,122-152` は `DiagramEdge.ext?: Record<string, unknown>` を既に持ち、`parseDiagramModel()` も `asExt(e.ext)` で保持する。コア型、model version、parser production code は変更せず、characterization test でこの契約を固定する。
+- edge 拡張語彙は次に固定する。`from_card` / `to_card` は `one` / `many` / `zero-or-one` / `one-or-many` / `zero-or-many`、`direction` は `forward` / `reverse` / `both` / `none`、`type` は投影用の opaque string とする。`direction` 省略時または未知値は現行互換の `forward`、未知 cardinality は記号を描かず安全に無視する。
+- `from_card` は `edge.from` 側、`to_card` は `edge.to` 側の多重度を表す。`forward` は from → to、`reverse` は to → from、`both` は双方向、`none` は矢印なしとし、`from` / `to` の参照関係自体は direction に関係なく維持する。
+- harness は endpoint、接線単位ベクトル、垂直単位ベクトルを使って `|` / circle / crow's foot を SVG の `line` / `circle` / `path` で組み立てる。外部 image、font、stylesheet、icon library、外部 `<use href>` は使わず、ext 値を `innerHTML` へ挿入しない。
+- edge の main line/path には `data-ark-edge-id` を残し、解釈済み direction と string の type を `data-ark-edge-direction` / `data-ark-edge-type` へ投影する。cardinality primitive には endpoint と値を識別できる `data-ark-edge-end` / `data-ark-edge-cardinality` を付け、ER 図固有の色・線種は authored CSS / skill 側で選べるようにする。
+- 端点 handle、drag preview、drop target highlight、handle layer はすべて `data-ark-harness-ui="1"` を持つ生成 DOM とし、`buildSubmissionHtml()` から除去する。authored node 自体へ `data-ark-harness-ui` は付けない（clone cleanup で node 全体が消えるため）。
+- endpoint drag と既存 node drag は別 state で管理し、どちらか一方だけを active にする。field の HTML Drag and Drop、contenteditable、group geometry、ResizeObserver / requestAnimationFrame による edge 再描画は現状維持する。
+- drop 先は pointer 座標にある同一 graph の `nodesById` だけから解決する。graph 外 node、不正座標 node、空白への drop、pointer cancel では model を変えず、同一 node や self-edge への張り替えは parser が許す既存 model 契約どおり扱う。
+- 還流判断: cardinality / direction / type は意味を持ち得るが、図種固有で任意値を取る `ext` を server が自然文へ展開するとコア語彙固定と注入境界を崩すため、この Issue では diagram file に保存して投影するだけに留める。GUI が変更する core field の `edge.from` / `edge.to` は既存 `edgeText()` により還流し、`edge.ext` のみの変更は `[]`、ext 変更と張り替えの同時発生は張り替え文だけになることを test で明示する。
+- production の `packages/server/src/lib/diagram-diff.ts` は変更しない。実装中に ext の自然文化が必要と判明した場合はこの plan の境界変更なので作業を止め、同ファイルを human review 対象に追加して設計承認を取り直す。
+- Issue #228 の auto-layout には依存せず、inline fixture と ER 実例の全 node に有限数の `node.ext.x/y` を手動指定する。DB schema、新規 Socket.IO event、mobile diagram UI、undo/redo、edge の追加・削除 UI、cardinality / direction の GUI editor は対象外とする。
+- 各実装タスクは Red → Green → Refactor の順で進める。server 相対 import は `.js` 拡張子を維持し、各 commit では Files に列挙した対象だけを明示的に stage する。
+
+---
+
+## Task 1: edge.ext の保持と還流境界を characterization test で固定する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-model.test.ts`
+- Modify: `packages/server/src/lib/diagram-file.test.ts`
+- Modify: `packages/server/src/lib/diagram-diff.test.ts`
+- Reference only: `packages/server/src/lib/diagram-model.ts:24-30,122-152`
+- Reference only: `packages/server/src/lib/diagram-diff.ts:127-166`
+- Reference only: `packages/server/src/index.ts:2207-2342`
+
+- [ ] **Step 1: edge.ext parser 保持 test を追加する（2-5分）**
+
+  `order` / `user` edge に次の ext を持たせて `parseDiagramModel()` を呼び、正規化後も値が欠落しないことを確認する。
+
+  ```ts
+  ext: {
+    from_card: "one",
+    to_card: "zero-or-many",
+    direction: "forward",
+    type: "belongs-to",
+  }
+  ```
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts`
+
+  Expected: PASS。既存 `asExt(e.ext)` で成立し、`DiagramEdge` や parser production code の変更が不要だと確認できる。
+
+- [ ] **Step 2: diagram file round-trip test を追加する（2-5分）**
+
+  `replaceModelBlock()` → `extractModel()` の往復後も edge の `id` / `from` / `to` / `label` / `ext` が一致する test を追加する。保存先が SQLite ではなく `.diagram.html` の model block であることを固定する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-file.test.ts`
+
+  Expected: PASS。production file helper の変更なしで edge.ext が永続化される。
+
+- [ ] **Step 3: endpoint 張り替えの既存意味差分を明示する（2-5分）**
+
+  `Order -> User` の edge を同じ id / label / ext のまま `Order -> Account` へ変え、`describeModelDiff()` が変更前後の node label と edge label を含む1件の関連変更文を返す test を追加する。`from` 側を別 node へ変える case も同じ core 差分判定に入ることを確認する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-diff.test.ts --testNamePattern "edge|端点|関連"`
+
+  Expected: PASS。既存 `prev.from !== e.from || prev.to !== e.to` で成立する。
+
+- [ ] **Step 4: edge.ext 単独変更を非還流に固定する（2-5分）**
+
+  次の2 case を追加する。
+
+  - `from_card` / `to_card` / `direction` / `type` だけを変更したときは `[]`。
+  - ext 変更と `to: "user" -> "account"` を同時に行ったときは endpoint 張り替え文だけを返す。
+
+  label / node label の既存無害化 test は残し、ext 値を生成文へ混ぜないことを security contract として固定する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-diff.test.ts`
+
+  Expected: PASS。production `diagram-diff.ts` は変更しない。
+
+- [ ] **Step 5: characterization test をコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-file.test.ts packages/server/src/lib/diagram-diff.test.ts
+  git commit -m "test(diagram): edge セマンティクスのモデル契約を固定"
+  ```
+
+---
+
+## Task 2: cardinality 表示と endpoint rewire の browser acceptance test を Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+- Reference: `packages/server/src/lib/diagram-harness.ts:92-113,285-418,445-467,750-776`
+
+- [ ] **Step 1: edge semantics 専用 fixture を追加する（2-5分）**
+
+  既存共通 fixture の handle count を変えないよう、`order` / `user` / `account` の3 node を手動座標で持つ専用 helper を追加する。`e_order_owner` は `from_card: "one"`、`to_card: "zero-or-many"`、`direction: "forward"`、`type: "belongs-to"` を持たせ、既存 ext なし edge も1本残して default forward の互換性を検証できるようにする。
+
+- [ ] **Step 2: cardinality / direction / type projection の失敗 test を書く（2-5分）**
+
+  実ブラウザで次を assertion にする。
+
+  - from 側に `one`、to 側に `zero-or-many` の識別可能な SVG primitive が可視である。
+  - main edge に `data-ark-edge-direction="forward"` と `data-ark-edge-type="belongs-to"` があり、marker-end だけが設定される。
+  - `reverse` / `both` / `none` を model 直接反映したとき marker-start / marker-end の組合せが規約どおりになる。
+  - ext を持たない既存 edge は従来どおり marker-end と label を持ち、page error がない。
+
+- [ ] **Step 3: endpoint handle と layering の失敗 test を書く（2-5分）**
+
+  `e_order_owner` の from / to に2個の `.ark-harness-edge-handle` があり、それぞれ `data-ark-edge-end` と endpoint を説明する aria-label を持つことを確認する。computed z-index は group 0 / edge SVG 1 / node 2 より前面の3で、既存 `.ark-harness-graph-handle` と同水準であることも固定する。
+
+- [ ] **Step 4: to endpoint を Account へ drag する失敗 test を書く（2-5分）**
+
+  to handle の中心から Account node の中心へ `page.mouse` で drag し、pointer move 中に preview と drop target indicator が現れ、pointer up 後に edge 終点・to cardinality・handle が Account 外周へ移ることを確認する。MessageChannel 接続後に送信し、model が次を満たすことを assertion にする。
+
+  ```ts
+  expect(submittedEdge).toMatchObject({
+    id: "e_order_owner",
+    from: "order",
+    to: "account",
+    ext: {
+      from_card: "one",
+      to_card: "zero-or-many",
+      direction: "forward",
+      type: "belongs-to",
+    },
+  });
+  ```
+
+- [ ] **Step 5: invalid drop / cleanup /既存編集の失敗 test を書く（2-5分）**
+
+  空白と graph 外 node への drop、`pointercancel` では from/to が変わらないことを確認する。送信 HTML から edge handle layer、handle、preview、drop indicator、generated cardinality SVG が除かれ、authored graph / node / list DOM は残ることを確認する。既存 node drag と field inline edit / list reorder の test は削らず、edge handle の追加後も全て同時に動くことを回帰条件にする。
+
+- [ ] **Step 6: Red を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "cardinality|カーディナリティ|端点|張り替え"`
+
+  Expected: FAIL。cardinality primitive または `.ark-harness-edge-handle` が見つからない最初の assertion で失敗し、既存 graph 初期化自体には page error がない。
+
+---
+
+## Task 3: SVG edge layer に cardinality・direction・type を投影する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: 注入文字列の unit test を Red にする（2-5分）**
+
+  `injectHarness()` の結果が edge ext key、cardinality primitive class/data 属性、direction helper、edge type data 属性を含み、`DIAGRAM_HARNESS_MARKER` は引き続き1回だけ現れることを test へ追加する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: FAIL。edge semantics の helper / selector が未実装。
+
+- [ ] **Step 2: edge ext を安全に読む helper を追加する（2-5分）**
+
+  `isRecordObject(edge.ext)` と string 判定だけを使い、cardinality は allowlist、direction は4値 allowlist + `forward` fallback、type は string の場合だけ返す helper を HARNESS_JS 内へ追加する。model parser の validation を厳しくせず、未知拡張を round-trip できる opaque ext 契約は維持する。
+
+- [ ] **Step 3: line と self-loop の endpoint geometry を共通化する（2-5分）**
+
+  現行 `renderGraph()` の矩形外周計算と self-loop cubic path 計算を、main geometry に加えて from / to endpoint と「node から edge 内側を向く接線単位ベクトル」を返す小 helper へ整理する。main line/path、cardinality、endpoint handle が同じ geometry を参照し、node drag / ResizeObserver / window resize 後にずれないようにする。
+
+- [ ] **Step 4: direction ごとに marker を適用する（2-5分）**
+
+  既存 `appendGraphMarker()` と `orient="auto-start-reverse"` を再利用し、`forward` は marker-end、`reverse` は marker-start、`both` は両方、`none` はどちらも付けない。省略 edge は `forward` となり、既存 line / self-loop / label の見た目を維持する。
+
+- [ ] **Step 5: endpoint cardinality primitive を描く（2-5分）**
+
+  endpoint 接線と垂線を使い、次を inline SVG で組み立てる。
+
+  - `one`: endpoint 近傍の垂直 bar。
+  - `many`: 3本の fan stroke（crow's foot）。
+  - `zero-or-one`: circle + bar。
+  - `one-or-many`: bar + crow's foot。
+  - `zero-or-many`: circle + crow's foot。
+
+  from / to の各 primitive root に edge id、endpoint、cardinality value を data 属性で付ける。stroke / fill の汎用 default だけを harness CSS に置き、`type` に応じた色や線種は ER 実例の authored CSS へ寄せる。label と記号が重なる場合は label 中点は維持しつつ endpoint から一定距離内だけを記号用に使う。
+
+- [ ] **Step 6: type / direction を projection selector として公開する（2-5分）**
+
+  main line/path に `data-ark-edge-type` と解釈済み `data-ark-edge-direction` を `setAttribute()` で付け、値を HTML 文字列として連結しない。cardinality group にも edge id を持たせ、authored CSS が `data-ark-edge-type="belongs-to"` 等で見た目を変えられるようにする。
+
+- [ ] **Step 7: unit / browser test を Green にして Refactor する（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: PASS。marker 一意性、graph / group / kind の既存注入契約も維持される。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "cardinality|カーディナリティ|方向|type"`
+
+  Expected: PASS。5 cardinality 語彙、4 direction、default forward、type selector、self-loop が例外なく投影される。
+
+  Refactor: magic number（bar 間隔、circle 半径、foot 幅）は helper 冒頭の局所定数へまとめ、図種名や ER 固有 label による分岐を作らない。
+
+- [ ] **Step 8: edge projection をコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts e2e/diagram-harness.spec.ts
+  git commit -m "feat(diagram): edge のカーディナリティと方向を投影"
+  ```
+
+---
+
+## Task 4: Pointer Events で edge endpoint を張り替える
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: handle layer と graph state を追加する（2-5分）**
+
+  graph container に `div.ark-harness-edge-handle-layer[data-ark-harness-ui="1"]` を1つ追加し、z-index 3 / pointer-events none とする。各 button handle だけ pointer-events auto / touch-action none とし、graph state に `edgeHandlesByKey`（`${edge.id}:from|to`）、handle layer、active preview / indicator を保持する。
+
+  `renderGraph()` ごとに全 handle を作り直すと active pointer capture が失われるため、描画済み edge geometry を使う `syncEdgeHandles()` で keyed create / position update / stale removal を行う。model 直接編集で edge が追加・削除・張り替えされた場合も次 frame で同期する。
+
+- [ ] **Step 2: endpoint handle の accessibility と位置を実装する（2-5分）**
+
+  from / to endpoint に小さい button を置き、edge label があれば label、なければ id を使って「〜の始点/終点をドラッグして張り替え」の aria-label / title を設定する。handle には edge id / endpoint data 属性を付け、cardinality primitive より node 側の endpoint 上へ置き、group / edge / node より前面かつ既存 node handle と同水準にする。
+
+- [ ] **Step 3: endpoint drag state と preview を実装する（2-5分）**
+
+  `edgeDrag` を `graphDrag` と排他的にし、pointerdown で `preventDefault()` / `stopPropagation()`、pointer capture、edge id、endpoint、開始 geometry を保持する。pointermove 中は model をまだ変更せず、pointer までの一時 line/pathと候補 node の highlight を生成 UI として更新する。
+
+  drop candidate は `document.elementsFromPoint(clientX, clientY)` または graph node の bounding box から、`closest('[data-ark-container="graph"]') === graph.container` かつ `nodesById` にある node だけを選ぶ。handle や overlay 自身が event target でも、その下の node を解決できるよう `event.target` だけに依存しない。
+
+- [ ] **Step 4: pointerup で core endpoint だけを commit する（2-5分）**
+
+  pointerup 時に edge id から現在の `state.model.edges` を再解決し、有効 candidate があれば endpoint に応じて `edge.from = nodeId` または `edge.to = nodeId` を代入する。ext、label、反対 endpoint は変更せず、preview / highlight / capture / drag class を片付けて `scheduleGraphRender(graph)` を呼ぶ。
+
+  空白、graph 外、不正 node への drop と pointercancel は model mutation なしで終了する。edge / node がモデル直接編集で消えていても例外を出さない。
+
+- [ ] **Step 5: node drag / list drag との競合を防ぐ（2-5分）**
+
+  node handle の pointerdown は `edgeDrag` 中なら開始せず、edge handle は node 内へ置かない。既存 graph node handle、contenteditable、field の HTML Drag and Drop listener は変更を最小限にし、endpoint drag 後も node drag で edge / symbol / handle / group が同じ frame に追従することを確認する。
+
+- [ ] **Step 6: clean submission を保証する（2-5分）**
+
+  handle layer / button / preview / indicator は `markUi()` された生成 DOM の内側に閉じ、既存 `clone.querySelectorAll('[data-ark-harness-ui]')` で除去する。authored node に一時 data 属性を付けず、もし drag class を付ける場合は `ark-harness-` prefix cleanup と終了処理の両方で残留を防ぐ。
+
+- [ ] **Step 7: endpoint browser test と全 harness regression を Green にする（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "端点|張り替え|node ドラッグ|list 編集|clean HTML"`
+
+  Expected: PASS。to / from の張り替え、invalid drop、cancel、self-edge、node drag 共存、list edit 共存、submission model / cleanup が全て成功する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts src/lib/diagram-file.test.ts src/lib/diagram-diff.test.ts`
+
+  Expected: PASS。注入、model round-trip、還流境界の回帰なし。
+
+- [ ] **Step 8: endpoint rewire をコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts e2e/diagram-harness.spec.ts
+  git commit -m "feat(diagram): edge 端点の張り替えを追加"
+  ```
+
+---
+
+## Task 5: ER 実例と diagram-authoring の edge 規約を追加する
+
+**Files:**
+
+- Create: `docs/diagrams/er-edge-semantics.diagram.html`
+- Modify: `.claude/skills/diagram-authoring/SKILL.md`
+- Modify: `e2e/diagram-harness.spec.ts`
+- Modify: `packages/server/src/lib/diagram-reader.test.ts`
+- Reference only: `docs/diagrams/sample.diagram.html`
+
+- [ ] **Step 1: authored ER acceptance test を Red にする（2-5分）**
+
+  既存 `openAuthoredDiagram()` helper で `er-edge-semantics.diagram.html` を開く test を追加し、次を要求する。
+
+  - 3件以上の `kind: "entity"` node が有限 `ext.x/y` で手動配置される。
+  - 1:N、0..1、N:M を示す複数 edge があり、両 endpoint 記号、label、direction、type が投影される。
+  - entity の可視 label、field list、`data-model-id`、`data-kind` が model と対応する。
+  - 外部 URL / stylesheet / font / image / script を含まない。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "ER edge semantics"`
+
+  Expected: FAIL。実例ファイルがまだ存在しない。
+
+- [ ] **Step 2: 手動座標の ER 実例を作る（2-5分）**
+
+  `Customer` / `Order` / `OrderItem` / `Product` 等を通常 node と field list で表し、`one -> zero-or-many`、`one -> zero-or-one`、`zero-or-many <-> zero-or-many` の代表 edge を置く。全 node の `ext.x/y` は有限数を明示し、#228 の auto-layout を使わない。
+
+  projection CSS は既存 graph / kind / group 規約を使い、`[data-ark-edge-type="identifying"]` 等の selector で線色・dash を変える例を示す。crow's foot DOM や endpoint handle を authored HTML に複製せず、配信時 harness に任せる。
+
+- [ ] **Step 3: ER 実例上で endpoint drag を受け入れる（2-5分）**
+
+  実例の `Order -> Customer` edge の to handle を別 entity へ drag し、表示終点と cardinality が移動すること、送信 model の `edge.to` が更新され ext は保持されること、clean HTML に harness UI が残らないことを Playwright で確認する。これを inline fixture だけでなく実際の `docs/diagrams/` artifact の受入条件にする。
+
+- [ ] **Step 4: diagram-authoring skill に edge 語彙を追記する（2-5分）**
+
+  `.claude/skills/diagram-authoring/SKILL.md` に「語彙: edge / ER」を追加し、次を明記する。
+
+  - core の `id` / `from` / `to` / `label` と ext の `from_card` / `to_card` / `direction` / `type` の役割。
+  - cardinality 5値と表示意味、direction 4値と default forward。
+  - type は lowercase kebab-case 推奨の opaque 語彙で、generated edge の data 属性を authored CSS から選べること。
+  - edge / symbol / handle は harness が生成するため HTML に重複して書かないこと。
+  - endpoint drag は from/to を更新し会話へ還流するが、ext 単独変更は file に保存されても自動還流しないこと。
+  - 外部参照禁止、self-edge 可、同一 graph 内の実在 node 参照、手動 ext.x/y、auto-layout 非依存。
+
+  1:N / 0..1 / N:M の JSON 例と、ER projection root / field list の最小 HTML 例を載せる。
+
+- [ ] **Step 5: reader の edge.ext / ER projection 保持 test を追加する（2-5分）**
+
+  `readDiagram()` に edge.ext 付き graph fixture を通し、model の ext、authored graph / node projection、CSP、harness marker が保持されることを確認する。reader、API、Socket.IO production code は変更しない。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-reader.test.ts src/lib/diagram-model.test.ts src/lib/diagram-file.test.ts`
+
+  Expected: PASS。edge semantics が parse / file / delivery を往復する。
+
+- [ ] **Step 6: authored ER test を Green にする（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "ER edge semantics|カーディナリティ|端点"`
+
+  Expected: PASS。実例の記号、direction / type、endpoint drag、from/to submission が成功する。
+
+- [ ] **Step 7: ER artifact と作図規約をコミットする（2-5分）**
+
+  ```bash
+  git add docs/diagrams/er-edge-semantics.diagram.html .claude/skills/diagram-authoring/SKILL.md e2e/diagram-harness.spec.ts packages/server/src/lib/diagram-reader.test.ts
+  git commit -m "docs(diagram): ER edge 記法と実例を追加"
+  ```
+
+---
+
+## Task 6: 全回帰・非変更境界・実機受け入れを完了する
+
+**Files:**
+
+- Verify only: `packages/server/src/lib/diagram-diff.ts`
+- Verify only: `packages/shared/src/types.ts`
+- Verify only: `packages/server/src/index.ts`
+- Verify only: `packages/server/src/lib/database.ts`
+- Verify only: `packages/web/src/hooks/useSocket.ts`
+- Verify only: `packages/web/src/components/DiagramPane.tsx`
+- Verify only: `packages/web/src/components/SplitViewPane.tsx`
+- Verify only: `packages/web/src/components/MobileLayout.tsx`
+- Verify only: `packages/web/src/components/MobileSessionView.tsx`
+- Verify only: `packages/server/src/lib/session-orchestrator.ts`
+- Verify only: `packages/server/src/lib/tmux-manager.ts`
+- Verify only: `packages/server/src/lib/ttyd-manager.ts`
+
+- [ ] **Step 1: diagram-diff / Socket.IO / DB / UI / lifecycle の非変更を確認する（2-5分）**
+
+  Run:
+
+  ```bash
+  git diff main...HEAD -- packages/server/src/lib/diagram-diff.ts packages/shared/src/types.ts packages/server/src/index.ts packages/server/src/lib/database.ts packages/web/src/hooks/useSocket.ts packages/web/src/components/DiagramPane.tsx packages/web/src/components/SplitViewPane.tsx packages/web/src/components/MobileLayout.tsx packages/web/src/components/MobileSessionView.tsx packages/server/src/lib/session-orchestrator.ts packages/server/src/lib/tmux-manager.ts packages/server/src/lib/ttyd-manager.ts
+  ```
+
+  Expected: 出力なし。edge semantics は diagram model tests + 注入 harness + authored projection / skill 内で完結し、production diff、新規 Socket.IO event、DB migration、React / mobile、tmux / ttyd lifecycle を変更していない。`diagram-diff.ts` が差分に出た場合は先へ進まず human review 対象として設計承認を取り直す。
+
+- [ ] **Step 2: targeted server tests を実行する（2-5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts src/lib/diagram-file.test.ts src/lib/diagram-reader.test.ts src/lib/diagram-diff.test.ts src/lib/diagram-harness.test.ts
+  ```
+
+  Expected: PASS。edge.ext 保持、file round-trip、delivery、core endpoint 還流、ext 非還流、harness 注入の全 test が成功する。
+
+- [ ] **Step 3: harness Playwright regression を実行する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: PASS。既存 graph geometry / arrow / label / self-edge / group / kind / node drag / list edit / clean HTML / invalid coordinate と、新規 cardinality / direction / type / endpoint rewire / invalid drop / ER artifact が全て成功する。
+
+- [ ] **Step 4: 型・format・全 test を実行する（2-5分）**
+
+  Run: `pnpm exec tsc -b`
+
+  Expected: exit 0、型エラーなし。
+
+  Run: `pnpm exec biome check packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-file.test.ts packages/server/src/lib/diagram-reader.test.ts packages/server/src/lib/diagram-diff.test.ts e2e/diagram-harness.spec.ts`
+
+  Expected: exit 0、format / lint error なし。
+
+  Run: `pnpm exec vitest run`
+
+  Expected: 全 test file が PASS。
+
+  Run: `pnpm test:e2e`
+
+  Expected: desktop / mobile を含む既存 E2E が PASS（明示的な外部 credential 必須 test は環境変数未設定時のみ既存条件どおり SKIP）。
+
+- [ ] **Step 5: desktop 実機を P5 human 確認へ渡す（各2-5分）**
+
+  1. 稼働中 session で `docs/diagrams/er-edge-semantics.diagram.html` を `board_open` し、PC 右 `DiagramPane` に 1:N / 0..1 / N:M の endpoint 記号と direction / type の投影が見えることを human が確認する。
+  2. edge の to endpoint を別 entity へ drag し、preview / target highlight、drop 後の line / symbol / handle、node drag 後の追従を確認する。
+  3. 「変更を送る」後に diagram file の `edge.to` が更新され ext が保持され、会話には既存 `edgeText()` 由来の関連変更文だけが届くことを確認する。
+  4. model 直接編集で cardinality / direction / type だけを変えて送信し、file と表示は更新されるが会話へは通知されないことを確認する。node 位置だけの変更も従来どおり非還流であることを併せて確認する。
+  5. field の inline edit / list reorder、node drag、group 境界、図 tab の再読込、pane resize が壊れていないことを確認する。
+
+- [ ] **Step 6: mobile とスコープ境界を確認する（2-5分）**
+
+  現行 `MobileSessionView` は diagram tab を描画しないため mobile component を変更せず、既存 mobile E2E の PASS を回帰条件とする。DB に edge semantics を保存する列、新規 diagram event、auto-layout、edge semantics editor、group / list の新機構が差分に紛れ込んでいないことを確認する。
+
+- [ ] **Step 7: 最終差分の hygiene を確認する（2-5分）**
+
+  Run: `git diff --check`
+
+  Expected: 出力なし。
+
+  Run: `git status --short`
+
+  Expected: 意図した実装・test・ER 実例・skill・plan の成果物だけが表示され、生成物や無関係な変更がない。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1176,6 +1176,160 @@ test("sample group は2 node を囲むラベル付き境界として表示する
   await expect(boundary.locator(".group-label")).toBeVisible();
 });
 
+test("ER edge semantics artifact は記号を投影して端点を張り替えられる", async ({
+  page,
+}) => {
+  const { errors, html } = await openAuthoredDiagram(
+    page,
+    "er-edge-semantics.diagram.html"
+  );
+  const diagramModel = await page.locator("#ark-diagram-model").evaluate(
+    element =>
+      JSON.parse(element.textContent || "") as {
+        nodes: Array<{
+          id: string;
+          label: string;
+          kind: string;
+          fields: Array<{ id: string; label: string }>;
+          ext: { x: number; y: number };
+        }>;
+        edges: Array<{
+          id: string;
+          from: string;
+          to: string;
+          label: string;
+          ext: {
+            from_card: string;
+            to_card: string;
+            direction: string;
+            type: string;
+          };
+        }>;
+      }
+  );
+
+  expect(diagramModel.nodes.length).toBeGreaterThanOrEqual(3);
+  expect(diagramModel.nodes.every(node => node.kind === "entity")).toBe(true);
+  for (const node of diagramModel.nodes) {
+    expect(Number.isFinite(node.ext.x)).toBe(true);
+    expect(Number.isFinite(node.ext.y)).toBe(true);
+    expect(node.fields.length).toBeGreaterThan(0);
+  }
+  expect(
+    diagramModel.edges.map(edge => `${edge.ext.from_card}->${edge.ext.to_card}`)
+  ).toEqual(
+    expect.arrayContaining([
+      "one->zero-or-many",
+      "one->zero-or-one",
+      "zero-or-many->zero-or-many",
+    ])
+  );
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  for (const node of diagramModel.nodes) {
+    const projection = graph.locator(
+      `:scope > [data-model-id="${node.id}"]:not([data-ark-group])`
+    );
+    await expect(projection).toHaveAttribute("data-kind", "entity");
+    await expect(projection.locator(".entity-label")).toHaveText(node.label);
+    for (const field of node.fields) {
+      await expect(
+        projection.locator(`li[data-model-id="${field.id}"]`)
+      ).toContainText(field.label);
+    }
+  }
+  for (const edge of diagramModel.edges) {
+    const main = graph.locator(
+      `.ark-harness-edge-main[data-ark-edge-id="${edge.id}"]`
+    );
+    await expect(main).toHaveAttribute(
+      "data-ark-edge-direction",
+      edge.ext.direction
+    );
+    await expect(main).toHaveAttribute("data-ark-edge-type", edge.ext.type);
+    await expect(
+      graph.locator(
+        `.ark-harness-edge-cardinality[data-ark-edge-id="${edge.id}"][data-ark-edge-end="from"]`
+      )
+    ).toHaveAttribute("data-ark-edge-cardinality", edge.ext.from_card);
+    await expect(
+      graph.locator(
+        `.ark-harness-edge-cardinality[data-ark-edge-id="${edge.id}"][data-ark-edge-end="to"]`
+      )
+    ).toHaveAttribute("data-ark-edge-cardinality", edge.ext.to_card);
+    await expect(graph.locator("text", { hasText: edge.label })).toHaveCount(1);
+  }
+
+  expect(html).not.toMatch(/https?:\/\//i);
+  expect(html).not.toMatch(/<link[^>]+rel=["']?stylesheet/i);
+  expect(html).not.toMatch(/<script(?![^>]*type=["']application\/json["'])/i);
+  expect(html).not.toMatch(/<(?:img|image)\b/i);
+  expect(html).not.toMatch(/@import|@font-face/i);
+
+  await connectSubmissionPort(page);
+  const product = graph.locator(
+    ':scope > [data-model-id="product"]:not([data-ark-group])'
+  );
+  const toHandle = graph.locator(
+    '.ark-harness-edge-handle[data-ark-edge-id="e_order_customer"][data-ark-edge-end="to"]'
+  );
+  const [handleBox, productBox] = await Promise.all([
+    requiredBoundingBox(toHandle),
+    requiredBoundingBox(product),
+  ]);
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    productBox.x + productBox.width / 2,
+    productBox.y + productBox.height / 2,
+    { steps: 5 }
+  );
+  await expect(graph.locator(".ark-harness-edge-preview")).toBeVisible();
+  await expect(graph.locator(".ark-harness-edge-drop-indicator")).toBeVisible();
+  await page.mouse.up();
+  await expect
+    .poll(async () => (await readNamedEdge(page, "e_order_customer")).x2)
+    .toBeGreaterThan(productBox.x - 2);
+  const movedEdge = await readNamedEdge(page, "e_order_customer");
+  expect(movedEdge.x2).toBeLessThan(productBox.x + productBox.width + 2);
+  expect(movedEdge.y2).toBeGreaterThan(productBox.y - 2);
+  expect(movedEdge.y2).toBeLessThan(productBox.y + productBox.height + 2);
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+  );
+  const submittedEdge = (
+    submission as {
+      model: { edges: typeof diagramModel.edges };
+    }
+  ).model.edges.find(edge => edge.id === "e_order_customer");
+  expect(submittedEdge).toMatchObject({
+    from: "order",
+    to: "product",
+    ext: diagramModel.edges.find(edge => edge.id === "e_order_customer")?.ext,
+  });
+  const cleanHtml = (submission as { html: string }).html;
+  expect(cleanHtml).not.toContain("ark-harness-edge-handle");
+  expect(cleanHtml).not.toContain("ark-harness-edge-cardinality");
+  expect(cleanHtml).toContain('data-ark-container="graph"');
+  expect(cleanHtml).toContain('data-model-id="product"');
+  expect(errors).toEqual([]);
+});
+
 test("infrastructure sample は kind アイコンと手動配置で接続を表示する", async ({
   page,
 }) => {

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -141,10 +141,82 @@ function invalidCoordinateHtml(): string {
   </body></html>`);
 }
 
+const edgeSemanticsModel = {
+  version: 1,
+  nodes: [
+    {
+      id: "order",
+      label: "Order",
+      kind: "entity",
+      fields: [{ id: "order_id", label: "id" }],
+      ext: { x: 40, y: 60 },
+    },
+    {
+      id: "user",
+      label: "User",
+      kind: "entity",
+      fields: [{ id: "user_id", label: "id" }],
+      ext: { x: 340, y: 60 },
+    },
+    {
+      id: "account",
+      label: "Account",
+      kind: "entity",
+      fields: [{ id: "account_id", label: "id" }],
+      ext: { x: 610, y: 260 },
+    },
+    { id: "outside", label: "Outside", ext: { x: 10, y: 10 } },
+  ],
+  edges: [
+    {
+      id: "e_order_owner",
+      from: "order",
+      to: "user",
+      label: "owned by",
+      ext: {
+        from_card: "one",
+        to_card: "zero-or-many",
+        direction: "forward",
+        type: "belongs-to",
+      },
+    },
+    {
+      id: "e_account_user",
+      from: "account",
+      to: "user",
+      label: "legacy edge",
+    },
+  ],
+  groups: [],
+};
+
+function edgeSemanticsHtml(): string {
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .graph { width: 860px; height: 520px; background: #f8fafc; }
+    .entity { box-sizing: border-box; width: 180px; min-height: 90px; padding: 12px; border: 1px solid #64748b; background: white; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(edgeSemanticsModel)}</script>
+    <div class="graph" data-ark-container="graph">
+      <section class="entity" data-model-id="order"><h2 data-model-id="order">Order</h2><ul><li data-model-id="order_id">id</li></ul></section>
+      <section class="entity" data-model-id="user"><h2 data-model-id="user">User</h2><ul><li data-model-id="user_id">id</li></ul></section>
+      <section class="entity" data-model-id="account"><h2 data-model-id="account">Account</h2><ul><li data-model-id="account_id">id</li></ul></section>
+    </div>
+    <section data-model-id="outside">Outside</section>
+  </body></html>`);
+}
+
 async function openDiagram(page: Page, diagramModel: unknown = model) {
   const errors: string[] = [];
   page.on("pageerror", error => errors.push(error.message));
   await page.setContent(diagramHtml(diagramModel));
+  return errors;
+}
+
+async function openEdgeSemanticsDiagram(page: Page) {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
+  await page.setContent(edgeSemanticsHtml());
   return errors;
 }
 
@@ -191,6 +263,36 @@ async function readEdge(page: Page) {
       y2: svgRect.y + Number(line.getAttribute("y2")),
     };
   });
+}
+
+async function readNamedEdge(page: Page, edgeId: string) {
+  return page
+    .locator(
+      `line[data-ark-edge-id="${edgeId}"], path[data-ark-edge-id="${edgeId}"]`
+    )
+    .first()
+    .evaluate(edge => {
+      const svg = edge.ownerSVGElement;
+      if (!svg) throw new Error("edge SVG がありません");
+      const svgRect = svg.getBoundingClientRect();
+      if (edge.tagName.toLowerCase() === "line") {
+        return {
+          x1: svgRect.x + Number(edge.getAttribute("x1")),
+          y1: svgRect.y + Number(edge.getAttribute("y1")),
+          x2: svgRect.x + Number(edge.getAttribute("x2")),
+          y2: svgRect.y + Number(edge.getAttribute("y2")),
+        };
+      }
+      const path = edge as SVGPathElement;
+      const start = path.getPointAtLength(0);
+      const end = path.getPointAtLength(path.getTotalLength());
+      return {
+        x1: svgRect.x + start.x,
+        y1: svgRect.y + start.y,
+        x2: svgRect.x + end.x,
+        y2: svgRect.y + end.y,
+      };
+    });
 }
 
 async function requiredBoundingBox(locator: Locator) {
@@ -252,6 +354,328 @@ test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ pag
   };
   expect(pointIsOnPerimeter(line.x1, line.y1, orderBox)).toBe(true);
   expect(pointIsOnPerimeter(line.x2, line.y2, userBox)).toBe(true);
+});
+
+test("cardinality・方向・type を edge SVG に安全に投影する", async ({
+  page,
+}) => {
+  const errors = await openEdgeSemanticsDiagram(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const edge = graph.locator(
+    'line[data-ark-edge-id="e_order_owner"], path[data-ark-edge-id="e_order_owner"]'
+  );
+  const fromCardinality = graph.locator(
+    '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"][data-ark-edge-cardinality="one"]'
+  );
+  const toCardinality = graph.locator(
+    '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"][data-ark-edge-cardinality="zero-or-many"]'
+  );
+
+  await expect(fromCardinality.locator("line")).toHaveCount(1);
+  expect(
+    await fromCardinality.locator("line").evaluate(element => ({
+      length: (element as SVGLineElement).getTotalLength(),
+      stroke: getComputedStyle(element).stroke,
+    }))
+  ).toMatchObject({ length: expect.any(Number), stroke: "rgb(100, 116, 139)" });
+  await expect(toCardinality.locator("circle")).toBeVisible();
+  await expect(toCardinality.locator("circle")).toHaveCount(1);
+  await expect(toCardinality.locator("line")).toHaveCount(3);
+  await expect(edge).toHaveAttribute("data-ark-edge-direction", "forward");
+  await expect(edge).toHaveAttribute("data-ark-edge-type", "belongs-to");
+  await expect(edge).not.toHaveAttribute("marker-start", /.+/);
+  await expect(edge).toHaveAttribute("marker-end", /url\(.+\)/);
+
+  const editButton = page.getByRole("button", {
+    name: "モデル JSON を直接編集する",
+  });
+  for (const [direction, markerStart, markerEnd] of [
+    ["reverse", true, false],
+    ["both", true, true],
+    ["none", false, false],
+  ] as const) {
+    const nextModel = structuredClone(edgeSemanticsModel);
+    const semanticEdge = nextModel.edges.find(
+      candidate => candidate.id === "e_order_owner"
+    );
+    if (!semanticEdge?.ext) throw new Error("semantic edge がありません");
+    semanticEdge.ext.direction = direction;
+    await editButton.click();
+    await page.locator(".ark-harness-textarea").fill(JSON.stringify(nextModel));
+    await page.getByRole("button", { name: "反映", exact: true }).click();
+    if (markerStart) {
+      await expect(edge).toHaveAttribute("marker-start", /url\(.+\)/);
+    } else {
+      await expect(edge).not.toHaveAttribute("marker-start", /.+/);
+    }
+    if (markerEnd) {
+      await expect(edge).toHaveAttribute("marker-end", /url\(.+\)/);
+    } else {
+      await expect(edge).not.toHaveAttribute("marker-end", /.+/);
+    }
+  }
+
+  await page.reload();
+  await page.setContent(edgeSemanticsHtml());
+  const legacyEdge = page.locator(
+    'line[data-ark-edge-id="e_account_user"], path[data-ark-edge-id="e_account_user"]'
+  );
+  await expect(legacyEdge).toHaveAttribute(
+    "data-ark-edge-direction",
+    "forward"
+  );
+  await expect(legacyEdge).toHaveAttribute("marker-end", /url\(.+\)/);
+  await expect(page.locator("text", { hasText: "legacy edge" })).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test("カーディナリティ 5 語彙を self-loop にも投影する", async ({ page }) => {
+  const errors = await openEdgeSemanticsDiagram(page);
+  const editButton = page.getByRole("button", {
+    name: "モデル JSON を直接編集する",
+  });
+  const cases = [
+    ["one", 1, 0],
+    ["many", 3, 0],
+    ["zero-or-one", 1, 1],
+    ["one-or-many", 4, 0],
+    ["zero-or-many", 3, 1],
+  ] as const;
+
+  for (const [cardinality, lineCount, circleCount] of cases) {
+    const nextModel = structuredClone(edgeSemanticsModel);
+    const semanticEdge = nextModel.edges[0];
+    semanticEdge.to = "order";
+    semanticEdge.ext.from_card = cardinality;
+    semanticEdge.ext.direction = "both";
+    await editButton.click();
+    await page.locator(".ark-harness-textarea").fill(JSON.stringify(nextModel));
+    await page.getByRole("button", { name: "反映", exact: true }).click();
+
+    const main = page.locator(
+      'path.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
+    );
+    const primitive = page.locator(
+      `.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"][data-ark-edge-cardinality="${cardinality}"]`
+    );
+    await expect(main).toHaveAttribute("marker-start", /url\(.+\)/);
+    await expect(main).toHaveAttribute("marker-end", /url\(.+\)/);
+    await expect(primitive.locator("line")).toHaveCount(lineCount);
+    await expect(primitive.locator("circle")).toHaveCount(circleCount);
+  }
+
+  expect(errors).toEqual([]);
+});
+
+test("edge 端点 handle を最前面の専用 layer に配置する", async ({ page }) => {
+  await openEdgeSemanticsDiagram(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const layer = graph.locator(".ark-harness-edge-handle-layer");
+  const handles = layer.locator(
+    '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"]'
+  );
+
+  await expect(layer).toHaveAttribute("data-ark-harness-ui", "1");
+  await expect(handles).toHaveCount(2);
+  await expect(handles.nth(0)).toHaveAttribute("data-ark-edge-end", /from|to/);
+  await expect(handles.nth(1)).toHaveAttribute("data-ark-edge-end", /from|to/);
+  await expect(
+    layer.locator(
+      '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"]'
+    )
+  ).toHaveAttribute("aria-label", /owned by.*始点.*ドラッグ.*張り替え/);
+  await expect(
+    layer.locator(
+      '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]'
+    )
+  ).toHaveAttribute("aria-label", /owned by.*終点.*ドラッグ.*張り替え/);
+
+  expect(
+    await layer.evaluate(element => getComputedStyle(element).zIndex)
+  ).toBe("3");
+  expect(
+    await graph
+      .locator(".ark-harness-edge-layer")
+      .evaluate(element => getComputedStyle(element).zIndex)
+  ).toBe("1");
+  expect(
+    await graph
+      .locator('[data-model-id="order"]')
+      .evaluate(element => getComputedStyle(element).zIndex)
+  ).toBe("2");
+  expect(
+    await graph
+      .locator(".ark-harness-graph-handle")
+      .first()
+      .evaluate(element => getComputedStyle(element).zIndex)
+  ).toBe("3");
+});
+
+test("edge 終点を張り替えて記号と clean HTML を同期する", async ({ page }) => {
+  await openEdgeSemanticsDiagram(page);
+  await connectSubmissionPort(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const account = graph.locator('[data-model-id="account"]').first();
+  const toHandle = graph.locator(
+    '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]'
+  );
+  const [handleBox, accountBox] = await Promise.all([
+    requiredBoundingBox(toHandle),
+    requiredBoundingBox(account),
+  ]);
+  const before = await readNamedEdge(page, "e_order_owner");
+
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    accountBox.x + accountBox.width / 2,
+    accountBox.y + accountBox.height / 2,
+    { steps: 5 }
+  );
+  await expect(graph.locator(".ark-harness-edge-preview")).toBeVisible();
+  await expect(graph.locator(".ark-harness-edge-drop-indicator")).toBeVisible();
+  await page.mouse.up();
+
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
+  await expect(graph.locator(".ark-harness-edge-drop-indicator")).toHaveCount(
+    0
+  );
+  await expect
+    .poll(async () => (await readNamedEdge(page, "e_order_owner")).x2)
+    .not.toBeCloseTo(before.x2, 0);
+  const after = await readNamedEdge(page, "e_order_owner");
+  expect(after.x2).toBeGreaterThan(accountBox.x - 2);
+  expect(after.x2).toBeLessThan(accountBox.x + accountBox.width + 2);
+  expect(after.y2).toBeGreaterThan(accountBox.y - 2);
+  expect(after.y2).toBeLessThan(accountBox.y + accountBox.height + 2);
+
+  const movedCardinality = graph.locator(
+    '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"][data-ark-edge-cardinality="zero-or-many"]'
+  );
+  const movedHandle = graph.locator(
+    '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]'
+  );
+  for (const locator of [movedCardinality, movedHandle]) {
+    const box = await requiredBoundingBox(locator);
+    expect(box.x + box.width / 2).toBeGreaterThan(accountBox.x - 12);
+    expect(box.x + box.width / 2).toBeLessThan(
+      accountBox.x + accountBox.width + 12
+    );
+    expect(box.y + box.height / 2).toBeGreaterThan(accountBox.y - 12);
+    expect(box.y + box.height / 2).toBeLessThan(
+      accountBox.y + accountBox.height + 12
+    );
+  }
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+  );
+  const submittedEdge = (
+    submission as {
+      model: { edges: Array<(typeof edgeSemanticsModel.edges)[number]> };
+    }
+  ).model.edges.find(edge => edge.id === "e_order_owner");
+  expect(submittedEdge).toMatchObject({
+    id: "e_order_owner",
+    from: "order",
+    to: "account",
+    ext: {
+      from_card: "one",
+      to_card: "zero-or-many",
+      direction: "forward",
+      type: "belongs-to",
+    },
+  });
+
+  const html = (submission as { html: string }).html;
+  expect(html).not.toContain("ark-harness-edge-handle-layer");
+  expect(html).not.toContain("ark-harness-edge-handle");
+  expect(html).not.toContain("ark-harness-edge-preview");
+  expect(html).not.toContain("ark-harness-edge-drop-indicator");
+  expect(html).not.toContain("ark-harness-edge-cardinality");
+  expect(html).toContain('data-ark-container="graph"');
+  expect(html).toContain('data-model-id="account"');
+  expect(html).toContain('data-model-id="account_id"');
+});
+
+test("edge 端点の invalid drop と pointercancel は model を変更しない", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  await connectSubmissionPort(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const graphBox = await requiredBoundingBox(graph);
+  const outside = page.locator('body > [data-model-id="outside"]');
+  const outsideBox = await requiredBoundingBox(outside);
+  const handleSelector =
+    '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]';
+
+  for (const target of [
+    { x: graphBox.x + 820, y: graphBox.y + 30 },
+    {
+      x: outsideBox.x + outsideBox.width / 2,
+      y: outsideBox.y + outsideBox.height / 2,
+    },
+  ]) {
+    const handleBox = await requiredBoundingBox(graph.locator(handleSelector));
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2,
+      handleBox.y + handleBox.height / 2
+    );
+    await page.mouse.down();
+    await page.mouse.move(target.x, target.y, { steps: 3 });
+    await page.mouse.up();
+  }
+
+  const handle = graph.locator(handleSelector);
+  const cancelBox = await requiredBoundingBox(handle);
+  await page.mouse.move(
+    cancelBox.x + cancelBox.width / 2,
+    cancelBox.y + cancelBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(graphBox.x + 700, graphBox.y + 400);
+  await handle.dispatchEvent("pointercancel", { pointerId: 1 });
+  await page.mouse.up();
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submittedEdge = await page.evaluate(() => {
+    const submission = (
+      window as typeof window & {
+        arkHarnessSubmission?: {
+          model: { edges: Array<{ id: string; from: string; to: string }> };
+        };
+      }
+    ).arkHarnessSubmission;
+    return submission?.model.edges.find(edge => edge.id === "e_order_owner");
+  });
+  expect(submittedEdge).toMatchObject({ from: "order", to: "user" });
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
+  await expect(graph.locator(".ark-harness-edge-drop-indicator")).toHaveCount(
+    0
+  );
 });
 
 test("group は複数 node を囲むラベル付き境界として投影する", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -182,21 +182,21 @@ const edgeSemanticsModel = {
     },
     {
       id: "e_account_user",
-      from: "account",
-      to: "user",
+      from: "order",
+      to: "account",
       label: "legacy edge",
     },
   ],
   groups: [],
 };
 
-function edgeSemanticsHtml(): string {
+function edgeSemanticsHtml(diagramModel: unknown = edgeSemanticsModel): string {
   return injectHarness(`<!doctype html><html><head><style>
     body { margin: 0; }
     .graph { width: 860px; height: 520px; background: #f8fafc; }
     .entity { box-sizing: border-box; width: 180px; min-height: 90px; padding: 12px; border: 1px solid #64748b; background: white; }
   </style></head><body>
-    <script id="ark-diagram-model" type="application/json">${JSON.stringify(edgeSemanticsModel)}</script>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
     <div class="graph" data-ark-container="graph">
       <section class="entity" data-model-id="order"><h2 data-model-id="order">Order</h2><ul><li data-model-id="order_id">id</li></ul></section>
       <section class="entity" data-model-id="user"><h2 data-model-id="user">User</h2><ul><li data-model-id="user_id">id</li></ul></section>
@@ -213,10 +213,13 @@ async function openDiagram(page: Page, diagramModel: unknown = model) {
   return errors;
 }
 
-async function openEdgeSemanticsDiagram(page: Page) {
+async function openEdgeSemanticsDiagram(
+  page: Page,
+  diagramModel: unknown = edgeSemanticsModel
+) {
   const errors: string[] = [];
   page.on("pageerror", error => errors.push(error.message));
-  await page.setContent(edgeSemanticsHtml());
+  await page.setContent(edgeSemanticsHtml(diagramModel));
   return errors;
 }
 
@@ -252,17 +255,19 @@ async function connectSubmissionPort(page: Page) {
 }
 
 async function readEdge(page: Page) {
-  return page.locator('[data-ark-edge-id="e_order_user"]').evaluate(line => {
-    const svg = line.ownerSVGElement;
-    if (!svg) throw new Error("edge SVG がありません");
-    const svgRect = svg.getBoundingClientRect();
-    return {
-      x1: svgRect.x + Number(line.getAttribute("x1")),
-      y1: svgRect.y + Number(line.getAttribute("y1")),
-      x2: svgRect.x + Number(line.getAttribute("x2")),
-      y2: svgRect.y + Number(line.getAttribute("y2")),
-    };
-  });
+  return page
+    .locator('.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
+    .evaluate(line => {
+      const svg = line.ownerSVGElement;
+      if (!svg) throw new Error("edge SVG がありません");
+      const svgRect = svg.getBoundingClientRect();
+      return {
+        x1: svgRect.x + Number(line.getAttribute("x1")),
+        y1: svgRect.y + Number(line.getAttribute("y1")),
+        x2: svgRect.x + Number(line.getAttribute("x2")),
+        y2: svgRect.y + Number(line.getAttribute("y2")),
+      };
+    });
 }
 
 async function readNamedEdge(page: Page, edgeId: string) {
@@ -333,7 +338,9 @@ test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ pag
   expect(userBox.x - graphBox.x).toBeCloseTo(360, 0);
   expect(userBox.y - graphBox.y).toBeCloseTo(180, 0);
 
-  const edge = graph.locator('[data-ark-edge-id="e_order_user"]');
+  const edge = graph.locator(
+    '.ark-harness-edge-main[data-ark-edge-id="e_order_user"]'
+  );
   await expect(edge).toHaveCount(1);
   await expect(graph.locator("text", { hasText: "belongs to" })).toHaveCount(1);
   await expect(
@@ -500,7 +507,7 @@ test("edge 端点 handle を最前面の専用 layer に配置する", async ({ 
   ).toBe("1");
   expect(
     await graph
-      .locator('[data-model-id="order"]')
+      .locator('.ark-harness-graph-node[data-model-id="order"]')
       .evaluate(element => getComputedStyle(element).zIndex)
   ).toBe("2");
   expect(
@@ -560,11 +567,11 @@ test("edge 終点を張り替えて記号と clean HTML を同期する", async 
   );
   for (const locator of [movedCardinality, movedHandle]) {
     const box = await requiredBoundingBox(locator);
-    expect(box.x + box.width / 2).toBeGreaterThan(accountBox.x - 12);
+    expect(box.x + box.width / 2).toBeGreaterThan(accountBox.x - 32);
     expect(box.x + box.width / 2).toBeLessThan(
       accountBox.x + accountBox.width + 12
     );
-    expect(box.y + box.height / 2).toBeGreaterThan(accountBox.y - 12);
+    expect(box.y + box.height / 2).toBeGreaterThan(accountBox.y - 32);
     expect(box.y + box.height / 2).toBeLessThan(
       accountBox.y + accountBox.height + 12
     );
@@ -610,6 +617,160 @@ test("edge 終点を張り替えて記号と clean HTML を同期する", async 
   expect(html).toContain('data-ark-container="graph"');
   expect(html).toContain('data-model-id="account"');
   expect(html).toContain('data-model-id="account_id"');
+});
+
+test("edge 始点の張り替えと self-edge を同じ handle 機構で扱う", async ({
+  page,
+}) => {
+  const errors = await openEdgeSemanticsDiagram(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const dragEndToAccount = async (end: "from" | "to") => {
+    const accountBox = await requiredBoundingBox(
+      graph.locator('.ark-harness-graph-node[data-model-id="account"]')
+    );
+    const handle = graph.locator(
+      `.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="${end}"]`
+    );
+    const box = await requiredBoundingBox(handle);
+    const hit = await page.evaluate(
+      ({ x, y }) =>
+        document
+          .elementsFromPoint(x, y)
+          .slice(0, 4)
+          .map(element => ({
+            className: element.getAttribute("class"),
+            edgeId: element.getAttribute("data-ark-edge-id"),
+            edgeEnd: element.getAttribute("data-ark-edge-end"),
+          })),
+      { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+    );
+    expect(hit[0]).toMatchObject({
+      className: expect.stringContaining("ark-harness-edge-handle"),
+      edgeId: "e_order_owner",
+      edgeEnd: end,
+    });
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    expect(errors).toEqual([]);
+    await expect(graph.locator(".ark-harness-edge-preview")).toBeVisible();
+    await page.mouse.move(
+      accountBox.x + accountBox.width / 2,
+      accountBox.y + accountBox.height / 2,
+      { steps: 4 }
+    );
+    await expect(
+      graph.locator(".ark-harness-edge-drop-indicator")
+    ).toBeVisible();
+    await page.mouse.up();
+  };
+
+  await dragEndToAccount("from");
+  await expect(
+    graph.locator(
+      'line.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
+    )
+  ).toHaveCount(1);
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  const rewiredFromModel = JSON.parse(
+    await page.locator(".ark-harness-textarea").inputValue()
+  ) as typeof edgeSemanticsModel;
+  expect(rewiredFromModel.edges[0]).toMatchObject({
+    from: "account",
+    to: "user",
+  });
+
+  await page.goto("about:blank");
+  const selfEdgeStartModel = structuredClone(edgeSemanticsModel);
+  selfEdgeStartModel.edges[0].from = "account";
+  await openEdgeSemanticsDiagram(page, selfEdgeStartModel);
+  await dragEndToAccount("to");
+  await expect(
+    graph.locator(
+      'path.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
+    )
+  ).toHaveCount(1);
+  await expect(
+    graph.locator(
+      '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"]'
+    )
+  ).toHaveCount(2);
+
+  await connectSubmissionPort(page);
+  await expect(
+    graph.locator('.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"]')
+  ).toHaveCount(2);
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submittedEdge = await page.evaluate(() => {
+    const submission = (
+      window as typeof window & {
+        arkHarnessSubmission?: {
+          model: { edges: Array<Record<string, unknown>> };
+        };
+      }
+    ).arkHarnessSubmission;
+    return submission?.model.edges.find(edge => edge.id === "e_order_owner");
+  });
+  expect(submittedEdge).toMatchObject({
+    from: "account",
+    to: "account",
+    ext: edgeSemanticsModel.edges[0].ext,
+  });
+});
+
+test("端点 drag 中の model 直接削除でも stale edge を更新しない", async ({
+  page,
+}) => {
+  const errors = await openEdgeSemanticsDiagram(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const handle = graph.locator(
+    '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]'
+  );
+  const handleBox = await requiredBoundingBox(handle);
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(handleBox.x + 80, handleBox.y + 100);
+  await expect(graph.locator(".ark-harness-edge-preview")).toBeVisible();
+
+  const withoutDraggedEdge = {
+    ...edgeSemanticsModel,
+    edges: edgeSemanticsModel.edges.filter(edge => edge.id !== "e_order_owner"),
+  };
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .evaluate(element => (element as HTMLButtonElement).click());
+  await page
+    .locator(".ark-harness-textarea")
+    .fill(JSON.stringify(withoutDraggedEdge));
+  await page
+    .getByRole("button", { name: "反映", exact: true })
+    .evaluate(element => (element as HTMLButtonElement).click());
+  await expect(
+    graph.locator('.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"]')
+  ).toHaveCount(0);
+  await page.mouse.up();
+
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
+  await expect(graph.locator(".ark-harness-edge-drop-indicator")).toHaveCount(
+    0
+  );
+  await expect(
+    graph.locator('.ark-harness-edge-main[data-ark-edge-id="e_account_user"]')
+  ).toHaveCount(1);
+  expect(errors).toEqual([]);
 });
 
 test("edge 端点の invalid drop と pointercancel は model を変更しない", async ({
@@ -720,9 +881,9 @@ test("group は複数 node を囲むラベル付き境界として投影する",
   await expect(label).toHaveText("Ordering Context");
   await expect(label).toHaveAttribute("contenteditable", "true");
   await expect(graph.locator(".ark-harness-edge-layer")).toHaveCount(1);
-  await expect(graph.locator('[data-ark-edge-id="e_order_user"]')).toHaveCount(
-    1
-  );
+  await expect(
+    graph.locator('.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
+  ).toHaveCount(1);
   await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
   await expect(
     order.locator('li[data-model-id="order_id"] .ark-harness-text')
@@ -920,9 +1081,9 @@ test("node.kind を data-kind へ同期して色とアイコンを区別する",
   expect(orderStyle.icon).not.toBe(userStyle.icon);
 
   await expect(graph.locator(".ark-harness-edge-layer")).toHaveCount(1);
-  await expect(graph.locator('[data-ark-edge-id="e_order_user"]')).toHaveCount(
-    1
-  );
+  await expect(
+    graph.locator('.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
+  ).toHaveCount(1);
   await expect(
     order.locator('li[data-model-id="order_id"] .ark-harness-text')
   ).toHaveAttribute("contenteditable", "true");
@@ -970,9 +1131,9 @@ test("sample は複数 kind を色とアイコンで区別する", async ({ page
   expect(new Set(projections.map(projection => projection.icon)).size).toBe(2);
 
   const graph = page.locator('[data-ark-container="graph"]');
-  await expect(graph.locator('[data-ark-edge-id="e_order_user"]')).toHaveCount(
-    1
-  );
+  await expect(
+    graph.locator('.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
+  ).toHaveCount(1);
   await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
   await expect(
     graph.locator('li[data-model-id="order_id"] .ark-harness-text')
@@ -1082,9 +1243,9 @@ test("infrastructure sample は kind アイコンと手動配置で接続を表�
       "worker-service->orders-db",
     ])
   );
-  await expect(graph.locator("[data-ark-edge-id]")).toHaveCount(
-    diagramModel.edges.length
-  );
+  await expect(
+    graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
+  ).toHaveCount(diagramModel.edges.length);
   for (const edge of diagramModel.edges) {
     expect(edge.label).toBeTruthy();
     await expect(graph.locator("text", { hasText: edge.label })).toHaveCount(1);
@@ -1256,9 +1417,9 @@ test("event storming sample は6 kindを色・アイコン・可視ラベルで�
     "payment->payment-captured",
     "payment-captured->order-status",
   ]);
-  await expect(graph.locator("[data-ark-edge-id]")).toHaveCount(
-    diagramModel.edges.length
-  );
+  await expect(
+    graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
+  ).toHaveCount(diagramModel.edges.length);
   for (const edge of diagramModel.edges) {
     expect(edge.label).toBeTruthy();
     await expect(graph.locator("text", { hasText: edge.label })).toHaveCount(1);
@@ -1580,14 +1741,20 @@ test("不正座標と graph 外参照を安全に除外する", async ({ page })
   await page.setContent(invalidCoordinateHtml());
 
   const graph = page.locator('[data-ark-container="graph"]');
-  await expect(graph.locator('[data-ark-edge-id="valid_edge"]')).toHaveCount(1);
   await expect(
-    graph.locator('[data-ark-edge-id="invalid_coordinate_edge"]')
+    graph.locator('.ark-harness-edge-main[data-ark-edge-id="valid_edge"]')
+  ).toHaveCount(1);
+  await expect(
+    graph.locator(
+      '.ark-harness-edge-main[data-ark-edge-id="invalid_coordinate_edge"]'
+    )
   ).toHaveCount(0);
-  await expect(graph.locator('[data-ark-edge-id="outside_edge"]')).toHaveCount(
-    0
-  );
-  await expect(graph.locator("[data-ark-edge-id]")).toHaveCount(1);
+  await expect(
+    graph.locator('.ark-harness-edge-main[data-ark-edge-id="outside_edge"]')
+  ).toHaveCount(0);
+  await expect(
+    graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
+  ).toHaveCount(1);
   await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
   await expect(
     graph.locator('[data-model-id="string_x"] .ark-harness-graph-handle')

--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -177,17 +177,132 @@ describe("describeModelDiff（境界ケース）", () => {
 
   it("edge の to が変わったとき、変更前後を明示して述べる", () => {
     const user = { id: "user", label: "User" };
-    const product = { id: "product", label: "Product" };
-    const nodes = [order, user, product];
+    const account = { id: "account", label: "Account" };
+    const nodes = [order, user, account];
+    const ext = {
+      from_card: "one",
+      to_card: "zero-or-many",
+      direction: "forward",
+      type: "belongs-to",
+    };
     const before = model(nodes, [
-      { id: "e1", from: "order", to: "user", label: "ships to" },
+      {
+        id: "e1",
+        from: "order",
+        to: "user",
+        label: "belongs to",
+        ext,
+      },
     ]);
     const after = model(nodes, [
-      { id: "e1", from: "order", to: "product", label: "ships to" },
+      {
+        id: "e1",
+        from: "order",
+        to: "account",
+        label: "belongs to",
+        ext,
+      },
     ]);
 
     expect(describeModelDiff(before, after)).toEqual([
-      "Order から User への関連「ships to」を Order から Product への関連「ships to」 に変更",
+      "Order から User への関連「belongs to」を Order から Account への関連「belongs to」 に変更",
+    ]);
+  });
+
+  it("edge の from が変わったとき、変更前後を明示して述べる", () => {
+    const user = { id: "user", label: "User" };
+    const account = { id: "account", label: "Account" };
+    const nodes = [order, user, account];
+    const ext = {
+      from_card: "one",
+      to_card: "zero-or-many",
+      direction: "forward",
+      type: "belongs-to",
+    };
+    const before = model(nodes, [
+      {
+        id: "e1",
+        from: "order",
+        to: "user",
+        label: "belongs to",
+        ext,
+      },
+    ]);
+    const after = model(nodes, [
+      {
+        id: "e1",
+        from: "account",
+        to: "user",
+        label: "belongs to",
+        ext,
+      },
+    ]);
+
+    expect(describeModelDiff(before, after)).toEqual([
+      "Order から User への関連「belongs to」を Account から User への関連「belongs to」 に変更",
+    ]);
+  });
+
+  it("edge.ext だけの変更は意味差分に含めない", () => {
+    const user = { id: "user", label: "User" };
+    const nodes = [order, user];
+    const before = model(nodes, [
+      {
+        id: "e1",
+        from: "order",
+        to: "user",
+        label: "belongs to",
+        ext: {
+          from_card: "one",
+          to_card: "zero-or-many",
+          direction: "forward",
+          type: "belongs-to",
+        },
+      },
+    ]);
+    const after = model(nodes, [
+      {
+        id: "e1",
+        from: "order",
+        to: "user",
+        label: "belongs to",
+        ext: {
+          from_card: "zero-or-one",
+          to_card: "one-or-many",
+          direction: "both",
+          type: "identifying",
+        },
+      },
+    ]);
+
+    expect(describeModelDiff(before, after)).toEqual([]);
+  });
+
+  it("edge.ext と端点を同時に変えても端点の意味差分だけを述べる", () => {
+    const user = { id: "user", label: "User" };
+    const account = { id: "account", label: "Account" };
+    const nodes = [order, user, account];
+    const before = model(nodes, [
+      {
+        id: "e1",
+        from: "order",
+        to: "user",
+        label: "belongs to",
+        ext: { direction: "forward", type: "belongs-to" },
+      },
+    ]);
+    const after = model(nodes, [
+      {
+        id: "e1",
+        from: "order",
+        to: "account",
+        label: "belongs to",
+        ext: { direction: "both", type: "identifying" },
+      },
+    ]);
+
+    expect(describeModelDiff(before, after)).toEqual([
+      "Order から User への関連「belongs to」を Order から Account への関連「belongs to」 に変更",
     ]);
   });
 

--- a/packages/server/src/lib/diagram-file.test.ts
+++ b/packages/server/src/lib/diagram-file.test.ts
@@ -224,6 +224,40 @@ describe("replaceModelBlock", () => {
     }
   });
 
+  it("モデルブロックの往復で edge.ext のセマンティクスを保持する", () => {
+    const html = page(
+      `<script type="application/json" id="ark-diagram-model">${MODEL}</script><div>図</div>`
+    );
+    const edge = {
+      id: "e_order_user",
+      from: "order",
+      to: "user",
+      label: "belongs to",
+      ext: {
+        from_card: "one",
+        to_card: "zero-or-many",
+        direction: "forward",
+        type: "belongs-to",
+      },
+    };
+    const nextModel: DiagramModel = {
+      ...MODEL_OBJ,
+      nodes: [
+        { id: "order", label: "Order" },
+        { id: "user", label: "User" },
+      ],
+      edges: [edge],
+    };
+
+    const replaced = replaceModelBlock(html, nextModel);
+    expect(replaced.ok).toBe(true);
+    if (!replaced.ok) return;
+
+    const extracted = extractModel(replaced.html);
+    expect(extracted.ok).toBe(true);
+    if (extracted.ok) expect(extracted.model.edges[0]).toEqual(edge);
+  });
+
   it("モデルブロックの往復で任意の node kind を保持する", () => {
     const html = page(
       `<script type="application/json" id="ark-diagram-model">${MODEL}</script><div>図</div>`

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -45,6 +45,24 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
+  it("edge ext の cardinality・direction・type 投影契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain("from_card");
+    expect(out).toContain("to_card");
+    expect(out).toContain("function edgeDirection(");
+    expect(out).toContain("function appendEdgeCardinality(");
+    expect(out).toContain("ark-harness-edge-cardinality");
+    expect(out).toContain("data-ark-edge-cardinality");
+    expect(out).toContain("data-ark-edge-direction");
+    expect(out).toContain("data-ark-edge-type");
+    expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  });
+
   it("group projection と geometry 同期の契約を注入する", () => {
     const out = injectHarness(
       page(

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -42,6 +42,11 @@ describe("injectHarness", () => {
     expect(out).toContain('[data-ark-container="graph"]');
     expect(out).toContain("ark-harness-edge-layer");
     expect(out).toContain("ark-harness-graph-handle");
+    expect(out).toContain("ark-harness-edge-handle-layer");
+    expect(out).toContain("ark-harness-edge-handle");
+    expect(out).toContain("function syncEdgeHandles(");
+    expect(out).toContain("function finishEdgeDrag(");
+    expect(out).toContain("getEdge(state.model, drag.edgeId)");
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -111,6 +111,25 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   fill: #475569; font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
   font-size: 12px; text-anchor: middle; dominant-baseline: central;
 }
+.ark-harness-edge-handle-layer {
+  position: absolute; inset: 0; z-index: 3; pointer-events: none;
+}
+.ark-harness-edge-handle {
+  position: absolute; transform: translate(-50%, -50%); z-index: 3;
+  width: 18px; height: 18px; padding: 0; border: 2px solid #0ea5b7; border-radius: 999px;
+  background: #fff; color: #0e7490; cursor: crosshair; line-height: 14px; font-size: 9px;
+  pointer-events: auto; touch-action: none;
+}
+.ark-harness-edge-preview {
+  position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; pointer-events: none;
+}
+.ark-harness-edge-preview line {
+  stroke: #0ea5b7; stroke-width: 2; stroke-dasharray: 5 4;
+}
+.ark-harness-edge-drop-indicator {
+  position: absolute; box-sizing: border-box; border: 2px solid #0ea5b7;
+  border-radius: 6px; background: rgba(14,165,183,.1); pointer-events: none;
+}
 .ark-harness-graph-handle {
   position: absolute; top: .25rem; right: .25rem; z-index: 3;
   border: 1px solid rgba(100,116,139,.45); border-radius: 4px; background: rgba(255,255,255,.9);
@@ -147,6 +166,7 @@ const HARNESS_JS = `(function () {
   var submitPort = null;
   var dragSrcLi = null;
   var graphDrag = null;
+  var edgeDrag = null;
   var graphs = [];
   var graphSequence = 0;
   var statusEl = null;
@@ -194,6 +214,14 @@ const HARNESS_JS = `(function () {
     var groups = model.groups || [];
     for (var i = 0; i < groups.length; i++) {
       if (groups[i].id === id) return groups[i];
+    }
+    return null;
+  }
+
+  function getEdge(model, id) {
+    var edges = model.edges || [];
+    for (var i = 0; i < edges.length; i++) {
+      if (edges[i].id === id) return edges[i];
     }
     return null;
   }
@@ -487,12 +515,176 @@ const HARNESS_JS = `(function () {
       );
       appendGraphLabel(graph.svg, edge.label, geometry.label.x, geometry.label.y);
     });
+    syncEdgeHandles(graph, edges);
   }
 
   function scheduleGraphRender(graph) {
     if (graph.scheduled) return;
     graph.scheduled = true;
     window.requestAnimationFrame(function () { renderGraph(graph); });
+  }
+
+  function positionEdgeHandle(handle, endpoint) {
+    handle.style.left = endpoint.x + "px";
+    handle.style.top = endpoint.y + "px";
+  }
+
+  function findEdgeDropCandidate(graph, clientX, clientY) {
+    var elements = document.elementsFromPoint(clientX, clientY);
+    for (var i = 0; i < elements.length; i++) {
+      var current = elements[i];
+      while (current && current !== graph.container) {
+        var id = current.getAttribute && current.getAttribute("data-model-id");
+        var nodeEl = id ? graph.nodesById.get(id) : null;
+        if (nodeEl && getNode(state.model, id) &&
+            nodeEl.closest('[data-ark-container="graph"]') === graph.container) {
+          return { id: id, el: nodeEl };
+        }
+        current = current.parentElement;
+      }
+    }
+    return null;
+  }
+
+  function removeEdgeDragUi(drag) {
+    if (drag.preview && drag.preview.parentNode) drag.preview.parentNode.removeChild(drag.preview);
+    if (drag.indicator && drag.indicator.parentNode) {
+      drag.indicator.parentNode.removeChild(drag.indicator);
+    }
+    drag.preview = null;
+    drag.previewLine = null;
+    drag.indicator = null;
+    drag.candidateId = null;
+  }
+
+  function updateEdgeDropIndicator(drag, candidate) {
+    if (!candidate) {
+      if (drag.indicator && drag.indicator.parentNode) {
+        drag.indicator.parentNode.removeChild(drag.indicator);
+      }
+      drag.indicator = null;
+      drag.candidateId = null;
+      return;
+    }
+    if (!drag.indicator) {
+      drag.indicator = document.createElement("div");
+      drag.indicator.className = "ark-harness-edge-drop-indicator";
+      markUi(drag.indicator);
+      drag.graph.handleLayer.appendChild(drag.indicator);
+    }
+    var containerRect = drag.graph.container.getBoundingClientRect();
+    var nodeRect = candidate.el.getBoundingClientRect();
+    drag.indicator.style.left = nodeRect.left - containerRect.left + "px";
+    drag.indicator.style.top = nodeRect.top - containerRect.top + "px";
+    drag.indicator.style.width = nodeRect.width + "px";
+    drag.indicator.style.height = nodeRect.height + "px";
+    drag.candidateId = candidate.id;
+  }
+
+  function updateEdgeDrag(event) {
+    if (!edgeDrag || event.pointerId !== edgeDrag.pointerId) return;
+    var drag = edgeDrag;
+    var containerRect = drag.graph.container.getBoundingClientRect();
+    drag.previewLine.setAttribute("x2", String(event.clientX - containerRect.left));
+    drag.previewLine.setAttribute("y2", String(event.clientY - containerRect.top));
+    updateEdgeDropIndicator(
+      drag,
+      findEdgeDropCandidate(drag.graph, event.clientX, event.clientY)
+    );
+  }
+
+  function finishEdgeDrag(event, commit) {
+    if (!edgeDrag) return;
+    if (event && event.pointerId !== edgeDrag.pointerId) return;
+    var drag = edgeDrag;
+    var candidate = commit && event
+      ? findEdgeDropCandidate(drag.graph, event.clientX, event.clientY)
+      : null;
+    edgeDrag = null;
+    if (commit && candidate) {
+      var currentEdge = getEdge(state.model, drag.edgeId);
+      if (currentEdge && graphPosition(getNode(state.model, candidate.id))) {
+        currentEdge[drag.end] = candidate.id;
+      }
+    }
+    removeEdgeDragUi(drag);
+    if (drag.handle.hasPointerCapture(drag.pointerId)) {
+      drag.handle.releasePointerCapture(drag.pointerId);
+    }
+    scheduleGraphRender(drag.graph);
+  }
+
+  function createEdgeHandle(graph, edge, end) {
+    var handle = createButton("", "ark-harness-edge-handle");
+    handle.setAttribute("data-ark-edge-id", edge.id);
+    handle.setAttribute("data-ark-edge-end", end);
+    handle.addEventListener("pointerdown", function (event) {
+      if (graphDrag || edgeDrag) return;
+      var currentEdge = getEdge(state.model, handle.getAttribute("data-ark-edge-id"));
+      var geometry = currentEdge && graph.edgeGeometryById.get(currentEdge.id);
+      var endpoint = geometry && geometry[end];
+      if (!currentEdge || !endpoint) return;
+      event.preventDefault();
+      event.stopPropagation();
+      handle.setPointerCapture(event.pointerId);
+
+      var preview = svgElement("svg");
+      preview.classList.add("ark-harness-edge-preview");
+      markUi(preview);
+      var line = svgElement("line");
+      line.setAttribute("x1", String(endpoint.x));
+      line.setAttribute("y1", String(endpoint.y));
+      line.setAttribute("x2", String(endpoint.x));
+      line.setAttribute("y2", String(endpoint.y));
+      preview.appendChild(line);
+      graph.handleLayer.insertBefore(preview, graph.handleLayer.firstChild);
+      edgeDrag = {
+        pointerId: event.pointerId,
+        handle: handle,
+        graph: graph,
+        edgeId: currentEdge.id,
+        end: end,
+        preview: preview,
+        previewLine: line,
+        indicator: null,
+        candidateId: null
+      };
+    });
+    handle.addEventListener("pointermove", updateEdgeDrag);
+    handle.addEventListener("pointerup", function (event) { finishEdgeDrag(event, true); });
+    handle.addEventListener("pointercancel", function (event) { finishEdgeDrag(event, false); });
+    graph.handleLayer.appendChild(handle);
+    return handle;
+  }
+
+  function syncEdgeHandles(graph, edges) {
+    var activeKeys = new Set();
+    edges.forEach(function (edge) {
+      var geometry = graph.edgeGeometryById.get(edge.id);
+      if (!geometry) return;
+      ["from", "to"].forEach(function (end) {
+        var key = edge.id + ":" + end;
+        activeKeys.add(key);
+        var handle = graph.edgeHandlesByKey.get(key);
+        if (!handle) {
+          handle = createEdgeHandle(graph, edge, end);
+          graph.edgeHandlesByKey.set(key, handle);
+        }
+        handle.setAttribute("data-ark-edge-id", edge.id);
+        handle.setAttribute("data-ark-edge-end", end);
+        var name = (typeof edge.label === "string" && edge.label) || edge.id;
+        var endLabel = end === "from" ? "始点" : "終点";
+        var ariaLabel = name + " の" + endLabel + "をドラッグして張り替え";
+        handle.setAttribute("aria-label", ariaLabel);
+        handle.title = ariaLabel;
+        positionEdgeHandle(handle, geometry[end]);
+      });
+    });
+    graph.edgeHandlesByKey.forEach(function (handle, key) {
+      if (activeKeys.has(key)) return;
+      if (handle.parentNode) handle.parentNode.removeChild(handle);
+      graph.edgeHandlesByKey.delete(key);
+    });
   }
 
   function finishGraphDrag(event) {
@@ -513,7 +705,7 @@ const HARNESS_JS = `(function () {
       (node.label || node.id) + " をドラッグして移動"
     );
     handle.addEventListener("pointerdown", function (event) {
-      if (graphDrag) return;
+      if (graphDrag || edgeDrag) return;
       var id = el.getAttribute("data-model-id");
       if (!id) return;
       var currentNode = getNode(state.model, id);
@@ -583,6 +775,10 @@ const HARNESS_JS = `(function () {
     svg.classList.add("ark-harness-edge-layer");
     markUi(svg);
     container.appendChild(svg);
+    var handleLayer = document.createElement("div");
+    handleLayer.className = "ark-harness-edge-handle-layer";
+    markUi(handleLayer);
+    container.appendChild(handleLayer);
     graphSequence += 1;
     var graph = {
       container: container,
@@ -590,6 +786,8 @@ const HARNESS_JS = `(function () {
       groupsById: groupsById,
       svg: svg,
       edgeGeometryById: new Map(),
+      handleLayer: handleLayer,
+      edgeHandlesByKey: new Map(),
       resizeObserver: null,
       scheduled: false,
       markerId: "ark-harness-arrow-" + graphSequence
@@ -611,6 +809,12 @@ const HARNESS_JS = `(function () {
     containers.forEach(function (container) { graphs.push(wireGraph(container)); });
     window.addEventListener("resize", function () {
       graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+    });
+    window.addEventListener("pointerup", function (event) {
+      finishEdgeDrag(event, true);
+    });
+    window.addEventListener("pointercancel", function (event) {
+      finishEdgeDrag(event, false);
     });
   }
 

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -101,6 +101,12 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-edge-layer line, .ark-harness-edge-layer path {
   fill: none; stroke: #64748b; stroke-width: 1.5;
 }
+.ark-harness-edge-cardinality circle {
+  fill: #fff; stroke: #64748b; stroke-width: 1.5;
+}
+.ark-harness-edge-cardinality line {
+  stroke: #64748b; stroke-width: 1.5;
+}
 .ark-harness-edge-layer text {
   fill: #475569; font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
   font-size: 12px; text-anchor: middle; dominant-baseline: central;
@@ -234,6 +240,164 @@ const HARNESS_JS = `(function () {
     svg.appendChild(text);
   }
 
+  function edgeDirection(edge) {
+    if (!edge || !isRecordObject(edge.ext)) return "forward";
+    var direction = edge.ext.direction;
+    return direction === "reverse" || direction === "both" || direction === "none"
+      ? direction
+      : "forward";
+  }
+
+  function edgeCardinality(edge, end) {
+    if (!edge || !isRecordObject(edge.ext)) return null;
+    var value = edge.ext[end === "from" ? "from_card" : "to_card"];
+    return value === "one" || value === "many" || value === "zero-or-one" ||
+      value === "one-or-many" || value === "zero-or-many" ? value : null;
+  }
+
+  function edgeType(edge) {
+    if (!edge || !isRecordObject(edge.ext)) return null;
+    return typeof edge.ext.type === "string" ? edge.ext.type : null;
+  }
+
+  function edgeGeometry(graph, edge) {
+    var fromEl = graph.nodesById.get(edge.from);
+    var toEl = graph.nodesById.get(edge.to);
+    if (!fromEl || !toEl) return null;
+
+    var svgRect = graph.svg.getBoundingClientRect();
+    var fromRect = fromEl.getBoundingClientRect();
+    var toRect = toEl.getBoundingClientRect();
+    var fromCx = fromRect.left + fromRect.width / 2 - svgRect.left;
+    var fromCy = fromRect.top + fromRect.height / 2 - svgRect.top;
+    var toCx = toRect.left + toRect.width / 2 - svgRect.left;
+    var toCy = toRect.top + toRect.height / 2 - svgRect.top;
+
+    if (edge.from === edge.to) {
+      var startX = fromRect.right - svgRect.left;
+      var startY = fromCy;
+      var endX = fromCx;
+      var endY = fromRect.top - svgRect.top;
+      var loopSize = Math.max(36, Math.min(fromRect.width, fromRect.height) / 2);
+      return {
+        kind: "path",
+        path: "M " + startX + " " + startY + " C " +
+          (startX + loopSize) + " " + startY + ", " +
+          fromCx + " " + (endY - loopSize) + ", " + endX + " " + endY,
+        from: { x: startX, y: startY, tx: 1, ty: 0 },
+        to: { x: endX, y: endY, tx: 0, ty: -1 },
+        label: { x: startX + loopSize * 0.7, y: endY - loopSize * 0.45 }
+      };
+    }
+
+    var dx = toCx - fromCx;
+    var dy = toCy - fromCy;
+    var length = Math.sqrt(dx * dx + dy * dy) || 1;
+    var ux = dx / length;
+    var uy = dy / length;
+    var fromRadius = Math.min(
+      Math.abs(ux) > 0 ? fromRect.width / 2 / Math.abs(ux) : Infinity,
+      Math.abs(uy) > 0 ? fromRect.height / 2 / Math.abs(uy) : Infinity
+    );
+    var toRadius = Math.min(
+      Math.abs(ux) > 0 ? toRect.width / 2 / Math.abs(ux) : Infinity,
+      Math.abs(uy) > 0 ? toRect.height / 2 / Math.abs(uy) : Infinity
+    );
+    var x1 = fromCx + ux * fromRadius;
+    var y1 = fromCy + uy * fromRadius;
+    var x2 = toCx - ux * toRadius;
+    var y2 = toCy - uy * toRadius;
+    return {
+      kind: "line",
+      from: { x: x1, y: y1, tx: ux, ty: uy },
+      to: { x: x2, y: y2, tx: -ux, ty: -uy },
+      label: { x: (x1 + x2) / 2, y: (y1 + y2) / 2 }
+    };
+  }
+
+  function setEdgeProjectionAttributes(main, edge, direction) {
+    main.classList.add("ark-harness-edge-main");
+    main.setAttribute("data-ark-edge-id", edge.id);
+    main.setAttribute("data-ark-edge-direction", direction);
+    var type = edgeType(edge);
+    if (type !== null) main.setAttribute("data-ark-edge-type", type);
+  }
+
+  function applyEdgeMarkers(main, markerId, direction) {
+    var marker = "url(#" + markerId + ")";
+    if (direction === "reverse" || direction === "both") {
+      main.setAttribute("marker-start", marker);
+    }
+    if (direction === "forward" || direction === "both") {
+      main.setAttribute("marker-end", marker);
+    }
+  }
+
+  function appendCardinalityLine(group, a, b) {
+    var line = svgElement("line");
+    line.setAttribute("x1", String(a.x));
+    line.setAttribute("y1", String(a.y));
+    line.setAttribute("x2", String(b.x));
+    line.setAttribute("y2", String(b.y));
+    group.appendChild(line);
+  }
+
+  function appendEdgeCardinality(svg, edge, end, endpoint, value) {
+    if (!value) return;
+    var barDistance = 12;
+    var secondDistance = 22;
+    var halfWidth = 7;
+    var circleRadius = 4;
+    var nx = -endpoint.ty;
+    var ny = endpoint.tx;
+    var point = function (distance, perpendicular) {
+      return {
+        x: endpoint.x + endpoint.tx * distance + nx * perpendicular,
+        y: endpoint.y + endpoint.ty * distance + ny * perpendicular
+      };
+    };
+    var group = svgElement("g");
+    group.classList.add("ark-harness-edge-cardinality");
+    group.setAttribute("data-ark-edge-id", edge.id);
+    group.setAttribute("data-ark-edge-end", end);
+    group.setAttribute("data-ark-edge-cardinality", value);
+    markUi(group);
+
+    var appendBar = function (distance) {
+      appendCardinalityLine(group, point(distance, -halfWidth), point(distance, halfWidth));
+    };
+    var appendCircle = function (distance) {
+      var circle = svgElement("circle");
+      var center = point(distance, 0);
+      circle.setAttribute("cx", String(center.x));
+      circle.setAttribute("cy", String(center.y));
+      circle.setAttribute("r", String(circleRadius));
+      group.appendChild(circle);
+    };
+    var appendMany = function (distance) {
+      var tip = point(distance - 7, 0);
+      appendCardinalityLine(group, tip, point(distance, -halfWidth));
+      appendCardinalityLine(group, tip, point(distance, 0));
+      appendCardinalityLine(group, tip, point(distance, halfWidth));
+    };
+
+    if (value === "one") appendBar(barDistance);
+    if (value === "many") appendMany(barDistance + 7);
+    if (value === "zero-or-one") {
+      appendCircle(barDistance);
+      appendBar(secondDistance);
+    }
+    if (value === "one-or-many") {
+      appendBar(barDistance);
+      appendMany(secondDistance);
+    }
+    if (value === "zero-or-many") {
+      appendCircle(barDistance);
+      appendMany(secondDistance);
+    }
+    svg.appendChild(group);
+  }
+
   function clearGroupGeometry(el) {
     el.classList.remove("ark-harness-graph-group");
     GROUP_GEOMETRY_PROPERTIES.forEach(function (property) {
@@ -288,66 +452,40 @@ const HARNESS_JS = `(function () {
     while (graph.svg.firstChild) graph.svg.removeChild(graph.svg.firstChild);
     appendGraphMarker(graph.svg, graph.markerId);
 
-    var svgRect = graph.svg.getBoundingClientRect();
+    graph.edgeGeometryById.clear();
     var edges = state.model && state.model.edges ? state.model.edges : [];
     edges.forEach(function (edge) {
-      var fromEl = graph.nodesById.get(edge.from);
-      var toEl = graph.nodesById.get(edge.to);
-      if (!fromEl || !toEl) return;
-
-      var fromRect = fromEl.getBoundingClientRect();
-      var toRect = toEl.getBoundingClientRect();
-      var fromCx = fromRect.left + fromRect.width / 2 - svgRect.left;
-      var fromCy = fromRect.top + fromRect.height / 2 - svgRect.top;
-      var toCx = toRect.left + toRect.width / 2 - svgRect.left;
-      var toCy = toRect.top + toRect.height / 2 - svgRect.top;
-
-      if (edge.from === edge.to) {
-        var loop = svgElement("path");
-        var startX = fromRect.right - svgRect.left;
-        var startY = fromCy;
-        var endX = fromCx;
-        var endY = fromRect.top - svgRect.top;
-        var loopSize = Math.max(36, Math.min(fromRect.width, fromRect.height) / 2);
-        loop.setAttribute("data-ark-edge-id", edge.id);
-        loop.setAttribute(
-          "d",
-          "M " + startX + " " + startY + " C " +
-            (startX + loopSize) + " " + startY + ", " +
-            fromCx + " " + (endY - loopSize) + ", " + endX + " " + endY
-        );
-        loop.setAttribute("marker-end", "url(#" + graph.markerId + ")");
-        graph.svg.appendChild(loop);
-        appendGraphLabel(graph.svg, edge.label, startX + loopSize * 0.7, endY - loopSize * 0.45);
-        return;
+      var geometry = edgeGeometry(graph, edge);
+      if (!geometry) return;
+      graph.edgeGeometryById.set(edge.id, geometry);
+      var direction = edgeDirection(edge);
+      var main = svgElement(geometry.kind);
+      setEdgeProjectionAttributes(main, edge, direction);
+      if (geometry.kind === "path") {
+        main.setAttribute("d", geometry.path);
+      } else {
+        main.setAttribute("x1", String(geometry.from.x));
+        main.setAttribute("y1", String(geometry.from.y));
+        main.setAttribute("x2", String(geometry.to.x));
+        main.setAttribute("y2", String(geometry.to.y));
       }
-
-      var dx = toCx - fromCx;
-      var dy = toCy - fromCy;
-      var length = Math.sqrt(dx * dx + dy * dy) || 1;
-      var ux = dx / length;
-      var uy = dy / length;
-      var fromRadius = Math.min(
-        Math.abs(ux) > 0 ? fromRect.width / 2 / Math.abs(ux) : Infinity,
-        Math.abs(uy) > 0 ? fromRect.height / 2 / Math.abs(uy) : Infinity
+      applyEdgeMarkers(main, graph.markerId, direction);
+      graph.svg.appendChild(main);
+      appendEdgeCardinality(
+        graph.svg,
+        edge,
+        "from",
+        geometry.from,
+        edgeCardinality(edge, "from")
       );
-      var toRadius = Math.min(
-        Math.abs(ux) > 0 ? toRect.width / 2 / Math.abs(ux) : Infinity,
-        Math.abs(uy) > 0 ? toRect.height / 2 / Math.abs(uy) : Infinity
+      appendEdgeCardinality(
+        graph.svg,
+        edge,
+        "to",
+        geometry.to,
+        edgeCardinality(edge, "to")
       );
-      var x1 = fromCx + ux * fromRadius;
-      var y1 = fromCy + uy * fromRadius;
-      var x2 = toCx - ux * toRadius;
-      var y2 = toCy - uy * toRadius;
-      var line = svgElement("line");
-      line.setAttribute("data-ark-edge-id", edge.id);
-      line.setAttribute("x1", String(x1));
-      line.setAttribute("y1", String(y1));
-      line.setAttribute("x2", String(x2));
-      line.setAttribute("y2", String(y2));
-      line.setAttribute("marker-end", "url(#" + graph.markerId + ")");
-      graph.svg.appendChild(line);
-      appendGraphLabel(graph.svg, edge.label, (x1 + x2) / 2, (y1 + y2) / 2);
+      appendGraphLabel(graph.svg, edge.label, geometry.label.x, geometry.label.y);
     });
   }
 
@@ -451,6 +589,7 @@ const HARNESS_JS = `(function () {
       nodesById: nodesById,
       groupsById: groupsById,
       svg: svg,
+      edgeGeometryById: new Map(),
       resizeObserver: null,
       scheduled: false,
       markerId: "ark-harness-arrow-" + graphSequence

--- a/packages/server/src/lib/diagram-model.test.ts
+++ b/packages/server/src/lib/diagram-model.test.ts
@@ -52,6 +52,36 @@ describe("parseDiagramModel", () => {
     }
   });
 
+  it("edge のセマンティクスを ext に保持する", () => {
+    const ext = {
+      from_card: "one",
+      to_card: "zero-or-many",
+      direction: "forward",
+      type: "belongs-to",
+    };
+    const json = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: "order", label: "Order" },
+        { id: "user", label: "User" },
+      ],
+      edges: [
+        {
+          id: "e_order_user",
+          from: "order",
+          to: "user",
+          label: "belongs to",
+          ext,
+        },
+      ],
+    });
+
+    const result = parseDiagramModel(json);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.model.edges[0]?.ext).toEqual(ext);
+  });
+
   it("任意の node kind を文字列のまま保持する", () => {
     const json = JSON.stringify({
       version: 1,

--- a/packages/server/src/lib/diagram-reader.test.ts
+++ b/packages/server/src/lib/diagram-reader.test.ts
@@ -85,6 +85,50 @@ describe("readDiagram", () => {
     }
   });
 
+  it("edge.ext と ER projection を配信時も保持する", async () => {
+    const edge = {
+      id: "e_order_user",
+      from: "order",
+      to: "user",
+      label: "belongs to",
+      ext: {
+        from_card: "one",
+        to_card: "zero-or-many",
+        direction: "forward",
+        type: "belongs-to",
+      },
+    };
+    const graphModel = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: "order", label: "Order", kind: "entity", ext: { x: 40, y: 50 } },
+        { id: "user", label: "User", kind: "entity", ext: { x: 360, y: 180 } },
+      ],
+      edges: [edge],
+      groups: [],
+    });
+    write(
+      "er.diagram.html",
+      '<div class="er-graph" data-ark-container="graph">' +
+        '<section class="entity" data-model-id="order" data-kind="entity">Order</section>' +
+        '<section class="entity" data-model-id="user" data-kind="entity">User</section></div>',
+      graphModel
+    );
+
+    const result = await readDiagram(wt, "er.diagram.html");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.edges[0]).toEqual(edge);
+      expect(result.html).toContain('class="er-graph"');
+      expect(result.html).toContain('data-kind="entity"');
+      expect(result.html).toContain(DIAGRAM_CSP);
+      expect(result.html).toContain(DIAGRAM_HARNESS_MARKER);
+      expect(result.html).toContain("from_card");
+      expect(result.html).toContain("data-ark-edge-cardinality");
+    }
+  });
+
   it("group model と graph projection を配信時も保持する", async () => {
     const groupModel = JSON.stringify({
       version: 1,


### PR DESCRIPTION
## 概要

図解ハーネス: **edge セマンティクス**。graph コンテナ (#224) の edge を「ラベル付きの線」から拡張し、**カーディナリティ（1:N / 0..1 / N:M の crow's foot 記号）・方向・種別**を持たせ、**edge の端点を別ノードへドラッグで張り替え**られるようにする。ER 図 (#230) の土台。

Closes #229

## 変更点

- **edge.ext 語彙**（既存の `DiagramEdge.ext`。型変更なし）: `from_card`/`to_card`（one/many/zero-or-one/one-or-many/zero-or-many）・`direction`（forward/reverse/both/none）・`type`（opaque string）
- **投影**（`renderGraph` 拡張）: 端点に crow's foot 記号を inline SVG で描画、`direction` に応じた矢印 marker、`type`/`direction` を `data-ark-edge-*` 属性へ（authored CSS が線色/線種を選べる）
- **端点張り替え**（Pointer Events）: 端点ハンドルを最前面レイヤ（z3）に置き、別ノードへ drag → drop で `edge.from`/`edge.to` を更新
- **ER 実例** `docs/diagrams/er-edge-semantics.diagram.html` + `diagram-authoring` skill に edge/ER 記法を追記

## 設計上の判断（還流とセキュリティ）

- **端点張り替え = `edge.from`/`to`（コア語彙）変更** → 既存 `describeModelDiff` が自然に会話へ還流（関連の変更）。**カーディナリティ/方向/種別 = `edge.ext`** → 非還流（位置変更と同じ扱い）。`diagram-diff.ts` は**不変**（server が opaque な ext 値を散文化しない = コア語彙固定 + 注入境界の維持）
- **注入安全**: ext 値は allowlist（cardinality 5値 / direction 4値）または string 判定のみ。属性は **`setAttribute`** で設定（`innerHTML` へ連結しない）。記号は inline SVG、外部参照なし（CSP 準拠）
- **既存機構と共存**: `edgeDrag` は node drag（`graphDrag`）と排他、drop は同一 graph の node のみ、pointerup で `state.model.edges` から再解決（model 直接編集/削除にも安全）、一時 UI は `data-ark-harness-ui` で保存 HTML から除去、レイヤリング group0/edge1/node2/handle3 を維持

## テスト

- `tsc -b`: pass ・ `vitest run`: 530 pass ・ `biome check`: clean
- `playwright e2e/diagram-harness.spec.ts`: 23 テスト pass（カーディナリティ5語彙+self-loop / 方向 marker / 端点 handle 最前面 / 終点・始点張り替え / self-edge / model直接削除でのstale防御 / invalid drop・cancel / ER実例 / 既存 graph・kind・group・list 回帰）
- モデル契約の characterization（edge.ext 保持・from/to 還流・ext 非還流）も固定

## スコープ外（後続単位）

自動レイアウト (#228) / cardinality・direction の GUI editor / edge の追加削除 UI / undo-redo。production の `diagram-diff.ts`・`diagram-model.ts`・Socket.IO・DB・モバイルは不変。

## レビュー体制

codex が plan 立案・TDD 実装、Claude が P2（plan）/ P5（実装）レビュー（flow-x 役割逆転。実装者 ≠ レビュアー）。**本 PR はセッション最大のハーネス変更（+455行）のため P5 を特に丁寧にレビュー**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ER図のエッジに、カーディナリティ・方向・種類を設定できるようになりました。
  * エッジの始点・終点をドラッグして接続先を変更できるようになりました。
  * エッジの種類に応じた線、矢印、記号を表示します。
  * ER図のサンプルと作成ガイドを追加しました。

* **改善**
  * 無効な接続やキャンセル操作では、図の内容が変更されないようになりました。
  * 図の編集・保存時に、エッジの詳細情報を保持できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->