### PR TITLE
図解ハーネス: 自動レイアウト（依存なし軽量 layered layout・座標未指定nodeを自動配置） (#228)

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -50,6 +50,37 @@ description: 図解を求められたときに .diagram.html を生成する規�
 - **外部リソースを参照しない。** Unicode、inline SVG、data URI は使えるが、外部 URL の画像・stylesheet・font・icon library・外部 `<use href>` は使わない（外部通信は遮断される）
 - **`<meta http-equiv="Content-Security-Policy">` を自分で書かない。** Ark が注入する
 
+## graph の自動レイアウトと手動座標
+
+graph node は `node.ext.x` と `node.ext.y` の両方が有限数なら manual、それ以外は
+auto として扱われる。標準は node 座標を省略し、図全体の `model.ext.layout` で方向と
+間隔を指定する。厳密な位置を固定したい node だけ x/y の両方を書く。
+
+```json
+{
+  "version": 1,
+  "ext": {
+    "layout": {
+      "direction": "LR",
+      "rankSpacing": 96,
+      "nodeSpacing": 48,
+      "padding": 24
+    }
+  }
+}
+```
+
+- `direction` は `LR`（左から右）または `TB`（上から下）。省略・未知値は `LR`
+- `rankSpacing` は rank 間、`nodeSpacing` は同 rank と衝突回避、`padding` は graph
+  外周の間隔。有限な非負数を使い、不正値や文字列値は既定値、安全上限を超える値は
+  clamp される
+- x/y の片方だけ、文字列、`null`、非有限値は manual 座標にならず、安全に auto
+  配置される。manual node は動かさず、auto node がそれを避ける
+- auto 座標は表示専用で model へ書き戻されない。node をドラッグしたときだけ、その
+  node の有限な x/y が保存され、以後 manual になる
+- group は配置後の member node を囲み、edge は配置後の node 外周を結ぶ。
+  `group.ext` / `edge.ext` の既存語彙は layout 設定とは独立してそのまま使う
+
 ## 語彙: kind
 
 node の `kind` フィールドで図の要素型を指定する。サーバーは `kind` の値を解釈せず、投影側（HTML/CSS）と skill の取り決めに従う。値は lowercase kebab-case を推奨するが、server enum ではなく未知の値もそのまま保持される。
@@ -118,8 +149,8 @@ read-model=緑を基本にする。各 card には `aria-hidden="true"` の `.ki
 [data-kind="external-system"] .kind-icon::before { content: "☁"; }
 ```
 
-時系列は Issue `#228` の auto-layout に依存させず、全 node の `ext.x` / `ext.y` に
-有限数を指定する。actor を起点、read-model を結果として、主要因果列の x を左から
+この例は厳密な時系列と swimlane を表すため、全 node の `ext.x` / `ext.y` に有限数を
+指定して手動配置する。actor を起点、read-model を結果として、主要因果列の x を左から
 右へ単調に増やす。因果関係には既存 edge の `from` / `to` / `label` だけを使い、
 event storming 専用 edge schema は作らない。
 
@@ -184,8 +215,8 @@ projection root は member node と sibling に置き、既存の
 .event-lane.ark-harness-graph-group { display: block; }
 ```
 
-group nesting、group 一括 drag、snap / grid、auto-layout は未対応で、このパターンでも
-導入しない。完成例は `docs/diagrams/event-storming.diagram.html` を参照する。
+group nesting、group 一括 drag、snap / grid は未対応。この例は timeline を固定するため
+auto layout を使わない。完成例は `docs/diagrams/event-storming.diagram.html` を参照する。
 
 ### Infrastructure の例
 
@@ -194,8 +225,8 @@ group nesting、group 一括 drag、snap / grid、auto-layout は未対応で、
 `.infra-node` style を fallback として適用し、model の `node.kind` と node projection
 root の `data-kind` は一致させる。
 
-Issue `#228` の auto-layout に依存せず、graph 内のすべての node に有限数の `ext.x` / `ext.y`
-を指定して手動配置する。外部クライアントも graph 外の特別要素にはせず、
+この例は region / VPC / subnet の境界を厳密に重ねるため、graph 内のすべての node に
+有限数の `ext.x` / `ext.y` を指定して手動配置する。外部クライアントも graph 外の特別要素にはせず、
 `kind: "external"` の通常 node とする。通信や依存関係は既存 edge の `from` / `to` /
 `label` だけで表す。
 
@@ -287,8 +318,8 @@ region / VPC / subnet の階層感が必要でも `groups[].nodes` に group id 
 }
 ```
 
-group nesting、group 一括 drag、auto-layout は未対応で、インフラ構成図でも導入しない。
-完成例は `docs/diagrams/infrastructure.diagram.html` を参照する。
+group nesting、group 一括 drag は未対応。この例は階層境界を固定するため auto layout を
+使わない。完成例は `docs/diagrams/infrastructure.diagram.html` を参照する。
 
 ## 語彙: edge / ER
 
@@ -385,8 +416,9 @@ crow's foot 記号、端点 handle、drag preview、drop indicator は配信時�
 </div>
 ```
 
-全 entity node に有限数の `ext.x` / `ext.y` を指定して手動配置し、auto-layout には
-依存しない。端点 handle の drag は core の `edge.from` / `edge.to` だけを更新するため
+通常は entity node の座標を省略し、`model.ext.layout` の auto layout を使う。ER 固有の
+位置調整が必要な node だけ有限数の `ext.x` / `ext.y` を両方指定する。端点 handle の
+drag は core の `edge.from` / `edge.to` だけを更新するため
 会話へ関連変更として還流する。一方、cardinality / direction / type のような `edge.ext`
 単独変更は diagram file と表示には保存されるが、自動で自然文へ還流しない。
 

--- a/docs/diagrams/sample.diagram.html
+++ b/docs/diagrams/sample.diagram.html
@@ -34,15 +34,19 @@
 {
   "version": 1,
   "title": "サンプル",
+  "ext": {
+    "layout": {
+      "direction": "LR",
+      "rankSpacing": 72,
+      "nodeSpacing": 40,
+      "padding": 40
+    }
+  },
   "nodes": [
     {
       "id": "order",
       "label": "Order",
       "kind": "aggregate",
-      "ext": {
-        "x": 40,
-        "y": 50
-      },
       "fields": [
         {
           "id": "order_id",
@@ -62,10 +66,6 @@
       "id": "user",
       "label": "User",
       "kind": "entity",
-      "ext": {
-        "x": 360,
-        "y": 180
-      },
       "fields": [
         {
           "id": "user_id",

--- a/docs/superpowers/plans/2026-07-22-issue-228.md
+++ b/docs/superpowers/plans/2026-07-22-issue-228.md
@@ -1,0 +1,411 @@
+# issue-228: 自動レイアウト Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 座標を持たない graph node を依存なしで重なりなく LR / TB 配置し、手動座標・ドラッグ・edge / group / list 編集との共存を維持する。
+
+**Issue:** 228 (GitHub Issue 紐付けあり)
+
+**Architecture:** `injectHarness()` が全図の srcDoc へ毎回インライン注入される構造では、約 1.5MB の elkjs を全配信へ上乗せするコストが大きいため、`diagram-harness.ts` 内に DOM 実測サイズを使う軽量な Sugiyama 風 layered layout を組み込み、依存・外部通信・Worker を増やさず CSP を維持する。有限な `node.ext.x/y` が両方ある node は固定し、未指定 node だけを `model.ext.layout` の LR / TB と間隔設定で表示時に配置する一方、自動座標はモデルへ書き戻さず、ユーザーがドラッグした時点でだけ既存どおり `ext.x/y` へ永続化して非還流契約を守る。変更はハーネス、汎用 model ext の型・parser、テスト、sample / authoring 規約に閉じ、既存 MessageChannel / `diagram:submit` を再利用するため Socket.IO event、DB schema、React / Tailwind UI、tmux / ttyd、モバイル UI の変更はない。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Express / Socket.IO / better-sqlite3 / tmux / ttyd
+
+---
+
+## 設計判断と変更境界
+
+### レイアウトエンジン比較
+
+| 候補 | 配信・CSP コスト | この Issue への適合 | 判断 |
+| --- | --- | --- | --- |
+| 軽量組込み layered layout | `diagram-harness.ts` に数十〜百数十行規模を追加するだけで package / lockfile 変更なし。既存インライン script の数 KB 増に留まり、外部 URL / Worker / Blob 不要 | 数〜数十 node の graph、LR / TB、間隔、循環・孤立 node、手動座標との共存を満たせる | **採用** |
+| elkjs 同梱 | minified でも約 1.5MB を `readDiagram()` → `injectHarness()` 経由ですべての図の srcDoc に毎回埋め込む。Worker を使わない構成でも Promise ベースの初期化順制御が要り、Worker / Blob を使う構成は現行 CSP と相性が悪い | 複雑な port routing や大規模 graph には強いが、本 Issue の典型規模には過剰 | **不採用**。高機能化が必要になった時点で、図種別の条件付き注入方式を別 Issue で先に設計する |
+
+- 現在の `packages/server/src/lib/diagram-harness.ts` 自体は約 47.7KB であり、elkjs は桁違いの増加になる。`package.json` / `packages/server/package.json` / `pnpm-lock.yaml` に `elkjs` を追加しない。
+- `packages/server/src/lib/diagram-reader.ts:104-117` は全図の配信 HTML に `injectHarness(injectCsp(raw))` を適用し、`packages/web/src/components/DiagramPane.tsx:253-257` はその全文を `sandbox="allow-scripts"` の srcDoc に渡す。自動レイアウトはこの既存インライン script 内だけで同期的に完結させる。
+- `packages/server/src/lib/diagram-file.ts:25-27` の meta CSP（`default-src 'none'`、inline script/style のみ許可、image は data のみ）を変更しない。外部 fetch、dynamic import、Worker、Blob URL、WASM を使わない。
+
+### モデル・配置契約
+
+- 図全体の設定は新しい汎用 `DiagramModel.ext?: Record<string, unknown>` に置き、正式な形を次に固定する。
+
+  ```json
+  {
+    "version": 1,
+    "ext": {
+      "layout": {
+        "direction": "LR",
+        "rankSpacing": 96,
+        "nodeSpacing": 48,
+        "padding": 24
+      }
+    }
+  }
+  ```
+
+- `direction` は `LR` / `TB` のみ、既定値は `LR`。`rankSpacing` / `nodeSpacing` / `padding` は有限な非負数だけを採用し、安全な上限へ clamp する。欠損・未知値・文字列数値・`NaN` 相当は既定値へ戻し、モデル parser 自体は ext を opaque data として保持する。
+- 有限な `node.ext.x` と `node.ext.y` が**両方**ある node は manual node とする。片方欠損、文字列、`null`、非有限値は manual 座標としては不成立なので auto node として安全に配置する。manual-manual の既存重なりは作者の指定を優先して動かさないが、auto node は manual node および先に配置した auto node と重ならないようにする。
+- graph 内の投影 node と、その graph 内で両端を解決できる edge だけを layout graph に使う。self-edge は rank へ影響させず、循環は strongly connected component (SCC) に畳んで component DAG の longest depth を rank とし、同一 SCC・同一 rank・孤立 node は model 順で決定的に並べる。
+- LR は rank ごとの最大幅を使って x を累積し、rank 内では実測 height と `nodeSpacing` で y を累積する。TB は width / height と x / y を入れ替える。auto rectangle が manual rectangle と交差する間は secondary axis へ送る決定的な greedy packing とし、無限 loop を避ける明示的な上限・fallback を持つ。
+- node の幅・高さは `getBoundingClientRect()` で測る。配置後の最大 right / bottom と `padding` から graph container の一時 min-width / min-height を確保し、node・edge・group が authored container より大きい場合も切れないようにする。この一時 style / CSS custom property は submission HTML から除去する。
+- auto 座標は graph state の `positionsById` にだけ保持する。初期表示、resize、text / list 編集、model JSON 再適用で再計算しても `state.model.nodes[].ext` は変更しない。「変更を送る」で auto 座標は保存されず、次回表示で再計算される。
+- auto node の drag は `positionsById` の表示座標を start に使い、最初の pointer move で `node.ext.x/y` を両方作る。その node は以後 manual node となり、送信 model と `.diagram.html` の model block に保存される。`diagram-diff.ts` は ext を見ないため位置だけの変更は会話へ還流しない。
+- `groups` は配置後の node rectangle から現行どおり再計算し、edge geometry / endpoint handles も配置後に描く。kind 同期、field inline edit、list reorder、edge cardinality / direction / type、endpoint rewire、self-edge、clean HTML の既存契約を変えない。
+
+### 変更しない層
+
+- `packages/server/src/lib/diagram-diff.ts` の production code は変更しない。model-level layout ext と node position ext が意味差分に出ないことだけを characterization test で固定する。
+- `packages/shared/src/types.ts`、`packages/server/src/index.ts` の Socket.IO handler、`packages/web/src/components/DiagramPane.tsx`、`packages/web/src/hooks/useSocket.ts` は変更しない。既存 `ark:diagram-submit` → MessageChannel → `diagram:submit` を再利用する。
+- SQLite、`SessionOrchestrator`、tmux / ttyd、PC pane 構造、現行で diagram を描画しない mobile UI は変更しない。
+- 各実装タスクは Red → Green → Refactor の順で進める。テスト command は実装時に実行し、この plan 作成時には実行しない。
+
+---
+
+## Task 1: model.ext の round-trip と非還流契約を固定する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-model.ts:39-45,181-190`
+- Modify: `packages/server/src/lib/diagram-model.test.ts`
+- Modify: `packages/server/src/lib/diagram-file.test.ts`
+- Modify: `packages/server/src/lib/diagram-diff.test.ts`
+- Reference only: `packages/server/src/lib/diagram-file.ts:74-117`
+- Reference only: `packages/server/src/index.ts:2256-2282`
+
+- [ ] **Step 1: top-level ext 保持の parser test を Red にする（2-5分）**
+
+  `parseDiagramModel()` へ `ext.layout` を持つモデルを渡し、`direction`、spacing、未知の追加 key までそのまま残る test を追加する。object でない top-level `ext` は node / edge / group ext と同じく `undefined` へ正規化されることも確認する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts`
+
+  Expected: FAIL。現在の `DiagramModel` と parser return は top-level ext を持たない。
+
+- [ ] **Step 2: DiagramModel の汎用 ext を実装して Green にする（2-5分）**
+
+  `DiagramModel` に `ext?: Record<string, unknown>` を加え、正規化結果に `ext: asExt(raw.ext)` を含める。layout 固有値の allowlist / default / clamp は browser harness の責務とし、server parser は図種固有情報を解釈しない既存方針を維持する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts`
+
+  Expected: PASS。node / edge / group の既存 validation も維持される。
+
+- [ ] **Step 3: submit 保存経路の round-trip test を追加する（2-5分）**
+
+  `replaceModelBlock()` → `extractModel()` の往復後も `model.ext.layout` が保持される test を `diagram-file.test.ts` に追加する。これにより `diagram:submit` が受信 model を `parseDiagramModel()` で正規化して block を差し替える際に layout 設定を落とさないことを固定する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-file.test.ts`
+
+  Expected: PASS。production の file helper 変更は不要。
+
+- [ ] **Step 4: layout / position ext の非還流 test を追加する（2-5分）**
+
+  次の case で `describeModelDiff()` が `[]` を返す test を追加する。
+
+  - `before.ext.layout.direction = "LR"` から `after.ext.layout.direction = "TB"` だけを変更。
+  - node に auto 座標が無い before と、drag 後の `ext.x/y` がある after。
+  - layout ext / node ext 変更と field label 変更を同時に行うと、field 変更文だけを返す。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-diff.test.ts`
+
+  Expected: PASS。`diagram-diff.ts` は nodes / fields / edge core semantics だけを見る現行実装のまま。
+
+- [ ] **Step 5: model 契約をコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-model.ts packages/server/src/lib/diagram-model.test.ts packages/server/src/lib/diagram-file.test.ts packages/server/src/lib/diagram-diff.test.ts
+  git commit -m "feat(diagram): layout 設定のモデル契約を追加"
+  ```
+
+---
+
+## Task 2: auto layout の browser acceptance test を Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+- Reference: `packages/server/src/lib/diagram-harness.ts:229-237,429-525,690-819`
+
+- [ ] **Step 1: 座標なし graph fixture と overlap helper を追加する（2-5分）**
+
+  幅・高さが異なる 5〜7 node、分岐 edge、self-edge、2 node cycle、孤立 node を含み、どの node にも `ext.x/y` がない fixture を作る。bounding box 同士が padding 込みで交差しないことを判定する helper を追加し、graph 外に同じ model id があっても対象外になる既存境界も残す。
+
+- [ ] **Step 2: LR の配置・edge / group 描画を Red にする（2-5分）**
+
+  `model.ext.layout = { direction: "LR", rankSpacing: 80, nodeSpacing: 36, padding: 20 }` で次を assertion にする。
+
+  - 全 node が `.ark-harness-graph-node` と drag handle を持ち、全 bounding box が有限。
+  - auto node 同士が重ならず、edge で後続 rank になる代表 node の x が先行 node より大きい。
+  - 指定 spacing が node 外周間の最小 gap に反映される。
+  - cycle / self-edge / disconnected node が page error や無限待機を起こさず、解決可能な edge が全て描かれる。
+  - group boundary が auto 配置された member node を囲む。
+
+- [ ] **Step 3: TB と不正設定 fallback を Red にする（2-5分）**
+
+  同じ fixture を `direction: "TB"` で開き、代表 edge の後続 node の y が増えること、rank 内 node が x 方向へ離れることを確認する。未知 direction、負値 / string / 極端な spacing は default / clamp へ落ち、全 node が重ならず表示されることも固定する。
+
+- [ ] **Step 4: manual / auto 混在を Red にする（2-5分）**
+
+  2つの manual node（有限な x/y）、完全欠損 node、x だけある node、文字列 x を持つ node を同じ graph に置く。
+
+  - manual node の graph 相対座標は指定値と一致する。
+  - partial / invalid node は除外されず auto 配置され、manual / auto と重ならない。
+  - manual-manual が作者指定で重なる case は勝手に動かさないことを別 assertion で固定する。
+  - edge は manual / auto の組合せに関係なく両端外周を結ぶ。
+
+- [ ] **Step 5: 表示時非永続化と drag 昇格を Red にする（2-5分）**
+
+  MessageChannel を接続し、まず何も drag せず送信して、auto node に `ext.x/y` が追加されていないことを確認する。次に auto node を `(60, 40)` drag して送信し、その node だけが表示開始位置 + delta の有限な `ext.x/y` を持ち、未操作 auto node は座標なし、元 manual node は元座標のままであることを確認する。
+
+- [ ] **Step 6: 既存 invalid-coordinate test の期待値を新契約へ更新する（2-5分）**
+
+  `e2e/diagram-harness.spec.ts:1892-1920` は string / null 座標 node を「除外」する旧契約なので、auto 配置され handle と edge を持つ期待値へ変更する。graph 外 node / edge は引き続き除外し、page error 0件を維持する。
+
+- [ ] **Step 7: Red を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "自動配置|LR|TB|座標未指定|手動座標"`
+
+  Expected: FAIL。最初の座標なし node が graph node class / handle を持たない、または bounding box が重なる assertion で失敗する。
+
+---
+
+## Task 3: 依存なし layered layout を harness に実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:92-139,165-237,429-525,748-819`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+- Reference only: `package.json`
+- Reference only: `packages/server/package.json`
+- Reference only: `pnpm-lock.yaml`
+
+- [ ] **Step 1: 注入・サイズ・依存なし契約の unit test を Red にする（2-5分）**
+
+  `injectHarness()` の出力が layout config reader、auto position state、layer assignment helper、LR / TB selector を含むことを test に加える。また最小 page へ注入した UTF-8 byte 数が 128KiB 未満で、`elkjs`、external URL、`new Worker`、`blob:` を含まないことを guard にし、marker 出現回数 1 の既存 assertion を維持する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: FAIL。layout helper がまだ存在しない。
+
+- [ ] **Step 2: layout config を安全に解釈する（2-5分）**
+
+  `state.model.ext.layout` を record 判定して読み、`direction` の allowlist、finite number 判定、default、clamp を一箇所にまとめる。値を HTML / CSS 文字列へ直接連結する前に number として確定し、未知 ext は無視して model object 自体は変更しない。
+
+- [ ] **Step 3: graph topology を決定的な rank へ変換する（5-10分）**
+
+  `wireGraph()` が同一 graph 内で model node と一致する投影を、座標有無にかかわらず `nodesById` へ登録するよう変更する。model 順 index、同一 graph で解決できる edge adjacency を作り、次の順で rank を算出する。
+
+  1. self-edge を除いた adjacency に Tarjan SCC を適用する。
+  2. SCC を component DAG に畳み、indegree 0 から Kahn traversal して `rank[to] = max(rank[to], rank[from] + 1)` とする。
+  3. queue、component member、同 rank node は model 順 index で安定化する。
+  4. 孤立 node は rank 0、同一 SCC member は同 rank とする。
+
+  edge 順や Map iteration の偶然に依存させず、同じ model / DOM size / config なら毎回同じ座標になるようにする。
+
+- [ ] **Step 4: DOM 実測サイズで LR / TB slot を作る（5-10分）**
+
+  すべての graph node を absolute positioning 対象にしたうえで `getBoundingClientRect()` の width / height を取得する。rank ごとの primary size 最大値を計算し、`padding + preceding rank sizes + rankSpacing` で primary 座標、rank 内の実寸合計 + `nodeSpacing` で secondary 座標を作る。LR と TB は axis accessor を共通化してロジックを重複させない。
+
+- [ ] **Step 5: manual obstacle と auto node の collision packing を実装する（5-10分）**
+
+  manual node は指定 x/y をそのまま `positionsById` と occupied rectangle に入れる。auto node は topology slot から始め、manual rectangle または配置済み auto rectangleと gap 込みで交差する間、secondary axis を衝突 rectangle の末尾 + `nodeSpacing` へ進める。最大反復数を node 数から導き、到達時は末尾へ deterministic fallback して無限 loop を防ぐ。manual node の座標 object は一切変更しない。
+
+- [ ] **Step 6: layout → group → edge の render 順を統合する（2-5分）**
+
+  `renderGraph()` の最初に layout を計算・適用し、その後 `renderGraphGroups()`、edge geometry、cardinality、endpoint handles の順に描く。graph state に `positionsById` と layout extent / signature を持たせ、同一座標なら style write を省く。`ResizeObserver` と `requestAnimationFrame` の既存 batching を維持し、observer 自身が起こす無限 reflow を防ぐ。
+
+- [ ] **Step 7: graph container の表示領域を確保する（2-5分）**
+
+  manual / auto 全 node の最大 right / bottom + padding から harness 用 CSS custom property を graph container に設定し、既存 authored width / height を縮めず min-width / min-height だけを拡張する。SVG / handle layer は拡張後 container を基準にし、edge や group が切れないことを browser test で確認する。
+
+- [ ] **Step 8: unit / core browser test を Green にする（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: PASS。注入 size は 128KiB 未満、marker は1回、外部 loader / Worker なし。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "自動配置|LR|TB|循環|座標未指定"`
+
+  Expected: PASS。全 auto node が重ならず、方向・spacing・cycle / disconnected fallback・edge / group が Green。
+
+- [ ] **Step 9: Refactor と依存差分確認（2-5分）**
+
+  topology、axis、rectangle collision、DOM write の helper を分離し、図種や kind / label による分岐を作らない。`package.json`、`packages/server/package.json`、`pnpm-lock.yaml` に差分がなく、`elkjs` が追加されていないことを確認する。
+
+- [ ] **Step 10: layout core をコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts e2e/diagram-harness.spec.ts
+  git commit -m "feat(diagram): 軽量な自動レイアウトを追加"
+  ```
+
+---
+
+## Task 4: manual / auto の drag・再計算・clean submission を共存させる
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:690-819,1090-1146,1177-1193`
+- Modify: `e2e/diagram-harness.spec.ts`
+- Reference only: `packages/server/src/lib/diagram-diff.ts:104-166`
+
+- [ ] **Step 1: auto node の drag start を表示座標へ切り替える（2-5分）**
+
+  `attachGraphHandle()` の pointerdown は `graphPosition(currentNode)` が null の場合も拒否せず、`graph.positionsById.get(id)` を表示上の start position として使う。manual node でも同じ display map を source of truth とし、pointer move で初めて `node.ext = { ...existingExt, x, y }` を作る。
+
+- [ ] **Step 2: drag 中に node を manual へ昇格させる（2-5分）**
+
+  pointer move で x/y を整数・0以上に clamp する既存契約を維持し、style と `positionsById` を同時更新する。layout 再計算はその node を manual obstacle として尊重し、他の auto node だけを必要に応じて再配置する。pointerup / cancel、edge drag との排他、pointer capture cleanup は現行のまま保つ。
+
+- [ ] **Step 3: content / resize / model JSON 再適用で再 layout する（2-5分）**
+
+  field label 編集・行追加削除・node resize 後は実測 size signature が変わった graph だけを再配置する。モデル直接編集の「反映」は `state.model` を差し替えた後に kind 同期だけでなく layout invalidation を行い、direction / spacing / x/y の追加・削除が次 frame に反映されるようにする。DOM に存在しない新規 node は現行どおり生成せず、安全に無視する。
+
+- [ ] **Step 4: clean HTML から layout 痕跡を除く（2-5分）**
+
+  `buildSubmissionHtml()` で既存 node の `--ark-harness-graph-x/y`、group geometry、generated layer / handle を除く処理に加え、graph container の harness 用 min-size custom property / class を除去する。authored inline style、`data-ark-container="graph"`、node / group / list DOM、model block は残す。auto 座標は state.model に書いていないため model payload にも現れない。
+
+- [ ] **Step 5: mixed / drag / submission test を Green にする（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "手動座標|自動配置.*ドラッグ|非永続|clean HTML"`
+
+  Expected: PASS。manual 座標は不変、auto は重ならず、drag した node だけ ext 座標を得て、clean HTML に harness geometry がない。
+
+- [ ] **Step 6: 既存 graph / list / edge / group regression を通す（5-10分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: PASS。手動配置の既存 geometry、node drag、field inline edit / list reorder、group boundary、edge cardinality / direction / endpoint rewire、self-edge、invalid graph boundary の全 test が成功する。旧 invalid-coordinate test だけは Task 2 の新しい auto fallback 契約になっている。
+
+- [ ] **Step 7: coexistence をコミットする（2-5分）**
+
+  ```bash
+  git add packages/server/src/lib/diagram-harness.ts e2e/diagram-harness.spec.ts
+  git commit -m "fix(diagram): 自動配置と既存編集を共存させる"
+  ```
+
+---
+
+## Task 5: sample と diagram authoring 規約を座標省略対応へ更新する
+
+**Files:**
+
+- Modify: `docs/diagrams/sample.diagram.html:31-105`
+- Modify: `.claude/skills/diagram-authoring/SKILL.md:121,187-197,290,388`
+- Modify: `e2e/diagram-harness.spec.ts:1095-1177`
+
+- [ ] **Step 1: sample の node 座標を外して layout 設定を追加する（2-5分）**
+
+  `order` / `user` の `node.ext.x/y` を削除し、model top-level に次を加える。
+
+  ```json
+  "ext": {
+    "layout": {
+      "direction": "LR",
+      "rankSpacing": 72,
+      "nodeSpacing": 40,
+      "padding": 40
+    }
+  }
+  ```
+
+  kind、fields、edge semantics、group、graph / list DOM、外部 resource なしの authored HTML は維持する。
+
+- [ ] **Step 2: sample E2E を auto layout の artifact test に更新する（2-5分）**
+
+  model block の全 node に x/y が無いことを先に確認し、それでも2 node が重ならず LR 順に表示され、edge / handle / kind icon / editable list / group boundary が成立することを assertion にする。自動座標が script block へ実行時に書き戻されていないことも確認する。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "sample"`
+
+  Expected: PASS。sample が issue の最小実例兼回帰 artifact になる。
+
+- [ ] **Step 3: diagram-authoring の座標規約を更新する（2-5分）**
+
+  graph node は有限な `ext.x/y` の両方があれば manual、なければ auto であること、標準は座標省略 + `model.ext.layout`、細かな調整を固定したい node だけ x/y を書くことを記載する。LR / TB と3 spacing key、partial / invalid coordinate の fallback、auto 結果は表示専用で drag 後だけ永続化されること、group / edge ext の既存語彙を説明する。Issue #228 未対応とする既存文言は削除する。
+
+- [ ] **Step 4: sample / authoring をコミットする（2-5分）**
+
+  ```bash
+  git add docs/diagrams/sample.diagram.html .claude/skills/diagram-authoring/SKILL.md e2e/diagram-harness.spec.ts
+  git commit -m "docs(diagram): 自動レイアウトの作図規約を追加"
+  ```
+
+---
+
+## Task 6: 全回帰・サイズ・実機 board_open を受け入れる
+
+**Files:**
+
+- Test: `packages/server/src/lib/diagram-model.test.ts`
+- Test: `packages/server/src/lib/diagram-file.test.ts`
+- Test: `packages/server/src/lib/diagram-reader.test.ts`
+- Test: `packages/server/src/lib/diagram-diff.test.ts`
+- Test: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+- Verify only: `package.json`
+- Verify only: `packages/server/package.json`
+- Verify only: `pnpm-lock.yaml`
+
+- [ ] **Step 1: server の model / file / reader / diff / harness test を実行する（5-10分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run \
+    src/lib/diagram-model.test.ts \
+    src/lib/diagram-file.test.ts \
+    src/lib/diagram-reader.test.ts \
+    src/lib/diagram-diff.test.ts \
+    src/lib/diagram-harness.test.ts
+  ```
+
+  Expected: PASS。top-level ext round-trip、CSP / harness 二重注入防止、非還流、128KiB size guard がすべて Green。
+
+- [ ] **Step 2: diagram harness の Chromium E2E を実行する（5-10分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: PASS。auto LR / TB、manual coexistence、cycle / disconnected、drag persistence、edge / group / list、sample artifact の全 test が Green。
+
+- [ ] **Step 3: 静的検査と build を実行する（5-10分）**
+
+  Run: `pnpm check`
+
+  Expected: PASS。Biome と TypeScript project references が error 0件。
+
+  Run: `pnpm build`
+
+  Expected: PASS。server / web / desktop の既存 build が成功する。
+
+- [ ] **Step 4: バンドル・CSP 境界を確認する（2-5分）**
+
+  - `package.json`、`packages/server/package.json`、`pnpm-lock.yaml` に依存差分がなく `elkjs` が無い。
+  - injected harness の unit guard が 128KiB 未満で、外部 URL / Worker / Blob loader が無い。
+  - `DIAGRAM_CSP` と `DiagramPane` の `sandbox="allow-scripts"` に変更が無い。
+  - Socket.IO event、SQLite schema、mobile component に差分が無い。
+
+- [ ] **Step 5: P5 human で board_open 実機確認を行う（5-10分）**
+
+  稼働中 PC session から `docs/diagrams/sample.diagram.html` を `board_open` し、次を目視・操作確認する。
+
+  1. 座標なし Order / User が LR に重ならず表示され、edge と group boundary が追従する。
+  2. Order を drag すると User の auto 配置を壊さず移動し、「変更を送る」後の model では Order だけに x/y が保存される。
+  3. list label 編集 / reorder と edge endpoint 操作が従来どおり動く。
+  4. Network panel に図由来の外部 request がなく、srcDoc が約 1.5MB 増えていない。
+
+  Expected: P5 human PASS。表示・操作・CSP・payload size に回帰なし。
+
+- [ ] **Step 6: 最終 verification をコミットする（2-5分）**
+
+  実機確認でコード修正が不要なら追加 commit は作らない。テスト調整が必要だった場合は対象ファイルだけを明示的に stage し、`test(diagram): 自動レイアウトの回帰を固定` として commit してから Step 1〜5 を再実行する。
+
+---
+
+## 完了条件チェック
+
+- [ ] 座標なし nodes + edges だけで、LR / TB のどちらも実寸 node が重ならず、cycle / self-edge / disconnected node を含めて表示できる。
+- [ ] 有限な manual x/y は完全に尊重され、auto node だけが配置される。drag した node は x/y を保存し、未操作 auto node は座標なしのまま再計算される。
+- [ ] edge、group、kind、field inline edit、list reorder、endpoint rewire、clean HTML が回帰していない。
+- [ ] CSP は外部通信なし・inline の現行境界を維持し、Worker / Blob / external resource を使わない。
+- [ ] elkjs および新規 runtime dependency を追加せず、全図の injected HTML を MB 単位で肥大化させない。
+- [ ] `diagram-diff.ts` production code、DB schema、Socket.IO event、React / mobile UI、tmux / ttyd に変更がない。
+- [ ] server unit、Chromium E2E、`pnpm check`、`pnpm build`、P5 human `board_open` がすべて成功する。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -185,8 +185,8 @@ function autoLayoutHtml(
     body { margin: 0; }
     .graph { width: 360px; height: 260px; background: #f8fafc; }
     .node { box-sizing: border-box; width: 128px; min-height: 64px; padding: 10px; border: 1px solid #64748b; background: white; }
-    [data-model-id="branch_a"] { width: 196px; height: 82px; }
-    [data-model-id="cycle_b"] { width: 148px; height: 104px; }
+    [data-model-id="branch_a"] { width: 196px; min-height: 82px; }
+    [data-model-id="cycle_b"] { width: 148px; min-height: 104px; }
     .group-boundary {
       display: none;
       position: absolute;
@@ -389,11 +389,15 @@ async function readEdge(page: Page) {
 
 async function readNamedEdge(page: Page, edgeId: string) {
   return page
-    .locator(
-      `line[data-ark-edge-id="${edgeId}"], path[data-ark-edge-id="${edgeId}"]`
-    )
-    .first()
-    .evaluate(edge => {
+    .locator('[data-ark-container="graph"]')
+    .evaluate((graph, expectedEdgeId) => {
+      const edge = Array.from(
+        graph.querySelectorAll("line[data-ark-edge-id], path[data-ark-edge-id]")
+      ).find(
+        candidate =>
+          candidate.getAttribute("data-ark-edge-id") === expectedEdgeId
+      );
+      if (!edge) throw new Error("edge がありません");
       const svg = edge.ownerSVGElement;
       if (!svg) throw new Error("edge SVG がありません");
       const svgRect = svg.getBoundingClientRect();
@@ -414,7 +418,7 @@ async function readNamedEdge(page: Page, edgeId: string) {
         x2: svgRect.x + end.x,
         y2: svgRect.y + end.y,
       };
-    });
+    }, edgeId);
 }
 
 async function requiredBoundingBox(locator: Locator) {
@@ -699,6 +703,58 @@ test("表示時は座標を非永続化し、ドラッグした node だけ手�
     x: 30,
     y: 40,
   });
+  const cleanHtml = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { html: string };
+        }
+      ).arkHarnessSubmission?.html
+  );
+  expect(cleanHtml).not.toContain("--ark-harness-graph-min-width");
+  expect(cleanHtml).not.toContain("--ark-harness-graph-min-height");
+  expect(cleanHtml).not.toContain("ark-harness-graph-layout");
+});
+
+test("自動配置は text resize とモデル JSON 再適用で再計算する", async ({
+  page,
+}) => {
+  await page.setContent(autoLayoutHtml());
+  let boxes = await graphNodeBoxes(page);
+  let byId = Object.fromEntries(boxes.map(box => [box.id, box]));
+  const branchBBefore = byId.branch_b.y;
+  await page
+    .locator('[data-model-id="branch_a"] h2[data-model-id="branch_a"]')
+    .fill("Branch A with enough text to wrap ".repeat(10));
+  await expect
+    .poll(async () => {
+      boxes = await graphNodeBoxes(page);
+      byId = Object.fromEntries(boxes.map(box => [box.id, box]));
+      return byId.branch_b.y;
+    })
+    .toBeGreaterThan(branchBBefore + 20);
+
+  const editedModel = await page
+    .locator("#ark-diagram-model")
+    .evaluate(element => {
+      const parsed = JSON.parse(element.textContent || "") as {
+        ext: { layout: { direction: string } };
+      };
+      parsed.ext.layout.direction = "TB";
+      return parsed;
+    });
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  await page.locator(".ark-harness-textarea").fill(JSON.stringify(editedModel));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+  await expect
+    .poll(async () => {
+      boxes = await graphNodeBoxes(page);
+      byId = Object.fromEntries(boxes.map(box => [box.id, box]));
+      return byId.branch_a.y > byId.source.y + byId.source.height;
+    })
+    .toBe(true);
 });
 
 test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ page }) => {
@@ -760,10 +816,16 @@ test("cardinality・方向・type を edge SVG に安全に投影する", async 
 
   await expect(fromCardinality.locator("line")).toHaveCount(1);
   expect(
-    await fromCardinality.locator("line").evaluate(element => ({
-      length: (element as SVGLineElement).getTotalLength(),
-      stroke: getComputedStyle(element).stroke,
-    }))
+    await graph.evaluate(container => {
+      const element = container.querySelector(
+        '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"] line'
+      ) as SVGLineElement | null;
+      if (!element) throw new Error("from cardinality がありません");
+      return {
+        length: element.getTotalLength(),
+        stroke: getComputedStyle(element).stroke,
+      };
+    })
   ).toMatchObject({ length: expect.any(Number), stroke: "rgb(100, 116, 139)" });
   await expect(toCardinality.locator("circle")).toBeVisible();
   await expect(toCardinality.locator("circle")).toHaveCount(1);

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1537,14 +1537,40 @@ test("node.kind を data-kind へ同期して色とアイコンを区別する",
 test("sample は複数 kind を色とアイコンで区別する", async ({ page }) => {
   await openSampleDiagram(page);
 
-  const modelKinds = await page
-    .locator("#ark-diagram-model")
-    .evaluate(element => {
-      const parsed = JSON.parse(element.textContent || "") as {
-        nodes: Array<{ id: string; kind?: string }>;
-      };
-      return Object.fromEntries(parsed.nodes.map(node => [node.id, node.kind]));
-    });
+  const modelScript = page.locator("#ark-diagram-model");
+  const initialModelText = await modelScript.textContent();
+  const sampleModel = await modelScript.evaluate(
+    element =>
+      JSON.parse(element.textContent || "") as {
+        ext: {
+          layout: {
+            direction: string;
+            rankSpacing: number;
+            nodeSpacing: number;
+            padding: number;
+          };
+        };
+        nodes: Array<{
+          id: string;
+          kind?: string;
+          ext?: Record<string, unknown>;
+        }>;
+      }
+  );
+  expect(sampleModel.ext.layout).toEqual({
+    direction: "LR",
+    rankSpacing: 72,
+    nodeSpacing: 40,
+    padding: 40,
+  });
+  expect(
+    sampleModel.nodes.every(
+      node => node.ext?.x === undefined && node.ext?.y === undefined
+    )
+  ).toBe(true);
+  const modelKinds = Object.fromEntries(
+    sampleModel.nodes.map(node => [node.id, node.kind])
+  );
   const projections = await page
     .locator(
       '[data-ark-container="graph"] > [data-model-id]:not([data-ark-group])'
@@ -1573,6 +1599,12 @@ test("sample は複数 kind を色とアイコンで区別する", async ({ page
   expect(new Set(projections.map(projection => projection.icon)).size).toBe(2);
 
   const graph = page.locator('[data-ark-container="graph"]');
+  const [orderBox, userBox] = await Promise.all([
+    requiredBoundingBox(graph.locator('[data-model-id="order"]').first()),
+    requiredBoundingBox(graph.locator('[data-model-id="user"]').first()),
+  ]);
+  expect(boxesOverlap(orderBox, userBox)).toBe(false);
+  expect(userBox.x - (orderBox.x + orderBox.width)).toBeGreaterThanOrEqual(71);
   await expect(
     graph.locator('.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
   ).toHaveCount(1);
@@ -1580,6 +1612,7 @@ test("sample は複数 kind を色とアイコンで区別する", async ({ page
   await expect(
     graph.locator('li[data-model-id="order_id"] .ark-harness-text')
   ).toHaveAttribute("contenteditable", "true");
+  expect(await modelScript.textContent()).toBe(initialModelText);
 });
 
 test("sample group は2 node を囲むラベル付き境界として表示する", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -141,6 +141,123 @@ function invalidCoordinateHtml(): string {
   </body></html>`);
 }
 
+const autoLayoutNodes = [
+  { id: "source", label: "Source" },
+  { id: "branch_a", label: "Branch A with a wider label" },
+  { id: "branch_b", label: "Branch B" },
+  { id: "cycle_a", label: "Cycle A" },
+  { id: "cycle_b", label: "Cycle B with two lines" },
+  { id: "self", label: "Self edge" },
+  { id: "isolated", label: "Isolated" },
+];
+
+const autoLayoutEdges = [
+  { id: "e_source_a", from: "source", to: "branch_a" },
+  { id: "e_source_b", from: "source", to: "branch_b" },
+  { id: "e_a_cycle", from: "branch_a", to: "cycle_a" },
+  { id: "e_cycle_ab", from: "cycle_a", to: "cycle_b" },
+  { id: "e_cycle_ba", from: "cycle_b", to: "cycle_a" },
+  { id: "e_self", from: "self", to: "self" },
+];
+
+function autoLayoutHtml(
+  layout: Record<string, unknown> = {
+    direction: "LR",
+    rankSpacing: 80,
+    nodeSpacing: 36,
+    padding: 20,
+  }
+): string {
+  const autoModel = {
+    version: 1,
+    ext: { layout },
+    nodes: autoLayoutNodes,
+    edges: autoLayoutEdges,
+    groups: [
+      {
+        id: "cycle_group",
+        label: "Cycle Group",
+        nodes: ["cycle_a", "cycle_b"],
+      },
+    ],
+  };
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .graph { width: 360px; height: 260px; background: #f8fafc; }
+    .node { box-sizing: border-box; width: 128px; min-height: 64px; padding: 10px; border: 1px solid #64748b; background: white; }
+    [data-model-id="branch_a"] { width: 196px; height: 82px; }
+    [data-model-id="cycle_b"] { width: 148px; height: 104px; }
+    .group-boundary {
+      display: none;
+      position: absolute;
+      left: calc(var(--ark-harness-group-x) - 12px);
+      top: calc(var(--ark-harness-group-y) - 24px);
+      width: calc(var(--ark-harness-group-width) + 24px);
+      height: calc(var(--ark-harness-group-height) + 36px);
+      border: 2px solid #0f766e;
+    }
+    .group-boundary.ark-harness-graph-group { display: block; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(autoModel)}</script>
+    <div class="graph" data-ark-container="graph">
+      <section class="group-boundary" data-ark-group data-model-id="cycle_group"><span data-model-id="cycle_group">Cycle Group</span></section>
+      ${autoLayoutNodes
+        .map(
+          node =>
+            `<section class="node" data-model-id="${node.id}"><h2 data-model-id="${node.id}">${node.label}</h2></section>`
+        )
+        .join("\n")}
+    </div>
+    <section data-model-id="source">Outside duplicate</section>
+  </body></html>`);
+}
+
+function mixedLayoutHtml(): string {
+  const mixedModel = {
+    version: 1,
+    ext: {
+      layout: {
+        direction: "LR",
+        rankSpacing: 64,
+        nodeSpacing: 28,
+        padding: 16,
+      },
+    },
+    nodes: [
+      { id: "manual_a", label: "Manual A", ext: { x: 30, y: 40 } },
+      { id: "manual_b", label: "Manual B", ext: { x: 30, y: 40 } },
+      { id: "auto_missing", label: "Auto Missing" },
+      { id: "auto_partial", label: "Auto Partial", ext: { x: 90 } },
+      {
+        id: "auto_invalid",
+        label: "Auto Invalid",
+        ext: { x: "120", y: 80 },
+      },
+    ],
+    edges: [
+      { id: "e_manual_auto", from: "manual_a", to: "auto_missing" },
+      { id: "e_auto_partial", from: "auto_missing", to: "auto_partial" },
+      { id: "e_partial_invalid", from: "auto_partial", to: "auto_invalid" },
+    ],
+    groups: [],
+  };
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .graph { width: 320px; height: 220px; }
+    .node { box-sizing: border-box; width: 150px; height: 72px; padding: 10px; border: 1px solid #64748b; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(mixedModel)}</script>
+    <div class="graph" data-ark-container="graph">
+      ${mixedModel.nodes
+        .map(
+          node =>
+            `<section class="node" data-model-id="${node.id}"><h2 data-model-id="${node.id}">${node.label}</h2></section>`
+        )
+        .join("\n")}
+    </div>
+  </body></html>`);
+}
+
 const edgeSemanticsModel = {
   version: 1,
   nodes: [
@@ -320,6 +437,269 @@ function expectBoxToContain(
     member.y + member.height
   );
 }
+
+function boxesOverlap(
+  left: { x: number; y: number; width: number; height: number },
+  right: { x: number; y: number; width: number; height: number },
+  gap = 0
+) {
+  return !(
+    left.x + left.width + gap <= right.x ||
+    right.x + right.width + gap <= left.x ||
+    left.y + left.height + gap <= right.y ||
+    right.y + right.height + gap <= left.y
+  );
+}
+
+async function graphNodeBoxes(page: Page) {
+  const nodes = page.locator(
+    '[data-ark-container="graph"] > .ark-harness-graph-node'
+  );
+  await expect
+    .poll(() =>
+      nodes.evaluateAll(elements =>
+        elements.every(element =>
+          Boolean(
+            (element as HTMLElement).style.getPropertyValue(
+              "--ark-harness-graph-x"
+            )
+          )
+        )
+      )
+    )
+    .toBe(true);
+  return nodes.evaluateAll(elements =>
+    elements.map(element => {
+      const box = element.getBoundingClientRect();
+      return {
+        id: element.getAttribute("data-model-id") || "",
+        x: box.x,
+        y: box.y,
+        width: box.width,
+        height: box.height,
+      };
+    })
+  );
+}
+
+function expectNoOverlaps(
+  boxes: Array<{
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }>,
+  gap = 0
+) {
+  for (let left = 0; left < boxes.length; left += 1) {
+    for (let right = left + 1; right < boxes.length; right += 1) {
+      expect(
+        boxesOverlap(boxes[left], boxes[right], gap),
+        `${boxes[left].id} と ${boxes[right].id} が重なっています`
+      ).toBe(false);
+    }
+  }
+}
+
+test("自動配置 LR は分岐・循環・self-edge・孤立 node を決定的に配置する", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
+  await page.setContent(autoLayoutHtml());
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  await expect(graph.locator(":scope > .ark-harness-graph-node")).toHaveCount(
+    autoLayoutNodes.length
+  );
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(
+    autoLayoutNodes.length
+  );
+  await expect(
+    graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
+  ).toHaveCount(autoLayoutEdges.length);
+
+  const boxes = await graphNodeBoxes(page);
+  expect(boxes).toHaveLength(autoLayoutNodes.length);
+  expect(
+    boxes.every(box =>
+      [box.x, box.y, box.width, box.height].every(Number.isFinite)
+    )
+  ).toBe(true);
+  expectNoOverlaps(boxes);
+  const byId = Object.fromEntries(boxes.map(box => [box.id, box]));
+  expect(
+    byId.branch_a.x - (byId.source.x + byId.source.width)
+  ).toBeGreaterThanOrEqual(79);
+  expect(byId.branch_a.x).toBeGreaterThan(byId.source.x);
+  expect(
+    Math.abs(byId.branch_b.y - (byId.branch_a.y + byId.branch_a.height))
+  ).toBeGreaterThanOrEqual(35);
+
+  const group = graph.locator('[data-ark-group][data-model-id="cycle_group"]');
+  await expect(group).toHaveClass(/ark-harness-graph-group/);
+  const [groupBox, cycleABox, cycleBBox] = await Promise.all([
+    requiredBoundingBox(group),
+    requiredBoundingBox(graph.locator('[data-model-id="cycle_a"]').first()),
+    requiredBoundingBox(graph.locator('[data-model-id="cycle_b"]').first()),
+  ]);
+  expectBoxToContain(groupBox, cycleABox);
+  expectBoxToContain(groupBox, cycleBBox);
+  expect(errors).toEqual([]);
+});
+
+test("自動配置 TB と不正 layout 設定は安全な fallback で重なりを避ける", async ({
+  page,
+}) => {
+  await page.setContent(
+    autoLayoutHtml({
+      direction: "TB",
+      rankSpacing: 80,
+      nodeSpacing: 36,
+      padding: 20,
+    })
+  );
+  let boxes = await graphNodeBoxes(page);
+  expectNoOverlaps(boxes);
+  let byId = Object.fromEntries(boxes.map(box => [box.id, box]));
+  expect(
+    byId.branch_a.y - (byId.source.y + byId.source.height)
+  ).toBeGreaterThanOrEqual(79);
+  expect(byId.branch_b.x).not.toBeCloseTo(byId.branch_a.x, 0);
+
+  await page.setContent(
+    autoLayoutHtml({
+      direction: "diagonal",
+      rankSpacing: -40,
+      nodeSpacing: "huge",
+      padding: 1_000_000,
+    })
+  );
+  boxes = await graphNodeBoxes(page);
+  expect(boxes).toHaveLength(autoLayoutNodes.length);
+  expectNoOverlaps(boxes);
+  byId = Object.fromEntries(boxes.map(box => [box.id, box]));
+  expect(byId.branch_a.x).toBeGreaterThan(byId.source.x);
+});
+
+test("手動座標と座標未指定 node を混在させ、manual 同士の重なりだけを保持する", async ({
+  page,
+}) => {
+  await page.setContent(mixedLayoutHtml());
+  const graph = page.locator('[data-ark-container="graph"]');
+  const graphBox = await requiredBoundingBox(graph);
+  const boxes = await graphNodeBoxes(page);
+  expect(boxes).toHaveLength(5);
+  const byId = Object.fromEntries(boxes.map(box => [box.id, box]));
+  for (const id of ["manual_a", "manual_b"]) {
+    expect(byId[id].x - graphBox.x).toBeCloseTo(30, 0);
+    expect(byId[id].y - graphBox.y).toBeCloseTo(40, 0);
+  }
+  expect(boxesOverlap(byId.manual_a, byId.manual_b)).toBe(true);
+  for (const autoId of ["auto_missing", "auto_partial", "auto_invalid"]) {
+    await expect(
+      graph.locator(`[data-model-id="${autoId}"] .ark-harness-graph-handle`)
+    ).toHaveCount(1);
+    expect(boxesOverlap(byId[autoId], byId.manual_a)).toBe(false);
+    expect(boxesOverlap(byId[autoId], byId.manual_b)).toBe(false);
+  }
+  expectNoOverlaps(boxes.filter(box => box.id.startsWith("auto_")));
+  await expect(
+    graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
+  ).toHaveCount(3);
+});
+
+test("表示時は座標を非永続化し、ドラッグした node だけ手動座標へ昇格する", async ({
+  page,
+}) => {
+  await page.setContent(mixedLayoutHtml());
+  await connectSubmissionPort(page);
+  const submit = page.getByRole("button", {
+    name: "変更を親フレームへ送信する",
+  });
+  await submit.click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const initialNodes = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: {
+            model: { nodes: Array<{ id: string; ext?: unknown }> };
+          };
+        }
+      ).arkHarnessSubmission?.model.nodes
+  );
+  expect(
+    initialNodes?.find(node => node.id === "auto_missing")?.ext
+  ).toBeUndefined();
+  expect(initialNodes?.find(node => node.id === "auto_partial")?.ext).toEqual({
+    x: 90,
+  });
+
+  const autoNode = page.locator('[data-model-id="auto_missing"]').first();
+  const before = await requiredBoundingBox(autoNode);
+  const handle = await requiredBoundingBox(
+    autoNode.locator(".ark-harness-graph-handle")
+  );
+  await page.evaluate(() => {
+    delete (window as typeof window & { arkHarnessSubmission?: unknown })
+      .arkHarnessSubmission;
+  });
+  await page.mouse.move(
+    handle.x + handle.width / 2,
+    handle.y + handle.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    handle.x + handle.width / 2 + 60,
+    handle.y + handle.height / 2 + 40
+  );
+  await page.mouse.up();
+  await submit.click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submittedNodes = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: {
+            model: {
+              nodes: Array<{
+                id: string;
+                ext?: Record<string, unknown>;
+              }>;
+            };
+          };
+        }
+      ).arkHarnessSubmission?.model.nodes
+  );
+  const dragged = submittedNodes?.find(node => node.id === "auto_missing");
+  const graphBox = await requiredBoundingBox(
+    page.locator('[data-ark-container="graph"]')
+  );
+  expect(dragged?.ext?.x).toBeCloseTo(before.x - graphBox.x + 60, 0);
+  expect(dragged?.ext?.y).toBeCloseTo(before.y - graphBox.y + 40, 0);
+  expect(submittedNodes?.find(node => node.id === "auto_invalid")?.ext).toEqual(
+    {
+      x: "120",
+      y: 80,
+    }
+  );
+  expect(submittedNodes?.find(node => node.id === "manual_a")?.ext).toEqual({
+    x: 30,
+    y: 40,
+  });
+});
 
 test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ page }) => {
   await openDiagram(page);
@@ -1889,7 +2269,9 @@ test("モデル直接編集後の kind 再同期と node ドラッグを送信 m
   expect(html).not.toContain("--ark-harness-graph-y");
 });
 
-test("不正座標と graph 外参照を安全に除外する", async ({ page }) => {
+test("不正座標は座標未指定として自動配置し graph 外参照だけを除外する", async ({
+  page,
+}) => {
   const errors: string[] = [];
   page.on("pageerror", error => errors.push(error.message));
   await page.setContent(invalidCoordinateHtml());
@@ -1902,19 +2284,20 @@ test("不正座標と graph 外参照を安全に除外する", async ({ page })
     graph.locator(
       '.ark-harness-edge-main[data-ark-edge-id="invalid_coordinate_edge"]'
     )
-  ).toHaveCount(0);
+  ).toHaveCount(1);
   await expect(
     graph.locator('.ark-harness-edge-main[data-ark-edge-id="outside_edge"]')
   ).toHaveCount(0);
   await expect(
     graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
-  ).toHaveCount(1);
-  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
+  ).toHaveCount(2);
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(4);
   await expect(
     graph.locator('[data-model-id="string_x"] .ark-harness-graph-handle')
-  ).toHaveCount(0);
+  ).toHaveCount(1);
   await expect(
     graph.locator('[data-model-id="null_y"] .ark-harness-graph-handle')
-  ).toHaveCount(0);
+  ).toHaveCount(1);
+  expectNoOverlaps(await graphNodeBoxes(page));
   expect(errors).toEqual([]);
 });

--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -396,6 +396,50 @@ describe("describeModelDiff（境界ケース）", () => {
     ]);
   });
 
+  it("top-level ext.layout の変更は意味差分に含めない", () => {
+    const before: DiagramModel = {
+      ...model([order]),
+      ext: { layout: { direction: "LR" } },
+    };
+    const after: DiagramModel = {
+      ...model([order]),
+      ext: { layout: { direction: "TB" } },
+    };
+
+    expect(describeModelDiff(before, after)).toEqual([]);
+  });
+
+  it("座標なし node が drag 後に ext.x/y を得ても意味差分に含めない", () => {
+    const before = model([order]);
+    const after = model([{ ...order, ext: { x: 120, y: 110 } }]);
+
+    expect(describeModelDiff(before, after)).toEqual([]);
+  });
+
+  it("layout / node ext と field label の同時変更では field 変更だけを述べる", () => {
+    const before: DiagramModel = {
+      ...model([order]),
+      ext: { layout: { direction: "LR" } },
+    };
+    const after: DiagramModel = {
+      ...model([
+        {
+          ...order,
+          fields: [
+            { id: "f_id", label: "id" },
+            { id: "f_status", label: "state" },
+          ],
+          ext: { x: 120, y: 110 },
+        },
+      ]),
+      ext: { layout: { direction: "TB" } },
+    };
+
+    expect(describeModelDiff(before, after)).toEqual([
+      "Order の status を state に変更",
+    ]);
+  });
+
   it("label の「」はエスケープせずそのまま埋め込むが、改行は無害化で落ちる", () => {
     const after = model([
       {

--- a/packages/server/src/lib/diagram-file.test.ts
+++ b/packages/server/src/lib/diagram-file.test.ts
@@ -224,6 +224,29 @@ describe("replaceModelBlock", () => {
     }
   });
 
+  it("モデルブロックの往復で top-level ext.layout を保持する", () => {
+    const html = page(
+      `<script type="application/json" id="ark-diagram-model">${MODEL}</script><div>図</div>`
+    );
+    const layout = {
+      direction: "LR",
+      rankSpacing: 80,
+      nodeSpacing: 36,
+      padding: 20,
+      futureOption: "keep-me",
+    };
+    const replaced = replaceModelBlock(html, {
+      ...MODEL_OBJ,
+      ext: { layout },
+    });
+    expect(replaced.ok).toBe(true);
+    if (!replaced.ok) return;
+
+    const extracted = extractModel(replaced.html);
+    expect(extracted.ok).toBe(true);
+    if (extracted.ok) expect(extracted.model.ext?.layout).toEqual(layout);
+  });
+
   it("モデルブロックの往復で edge.ext のセマンティクスを保持する", () => {
     const html = page(
       `<script type="application/json" id="ark-diagram-model">${MODEL}</script><div>図</div>`

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -50,6 +50,28 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
+  it("依存なし auto layout と注入サイズの契約を満たす", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain("function readLayoutConfig(");
+    expect(out).toContain("function assignLayerRanks(");
+    expect(out).toContain("function layoutGraph(");
+    expect(out).toContain("positionsById");
+    expect(out).toContain('direction === "TB"');
+    expect(Buffer.byteLength(out, "utf8")).toBeLessThan(128 * 1024);
+    expect(out).not.toContain("elkjs");
+    expect(out).not.toContain("new Worker");
+    expect(out).not.toContain("blob:");
+    expect(out).not.toContain("fetch(");
+    expect(out).not.toContain("import(");
+    expect(out).not.toContain("https://");
+    expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  });
+
   it("edge ext の cardinality・direction・type 投影契約を注入する", () => {
     const out = injectHarness(
       page(

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -157,6 +157,10 @@ const HARNESS_JS = `(function () {
     "--ark-harness-group-width",
     "--ark-harness-group-height"
   ];
+  var GRAPH_LAYOUT_PROPERTIES = [
+    "--ark-harness-graph-min-width",
+    "--ark-harness-graph-min-height"
+  ];
 
   var BLOCK_TAGS = {
     DIV: 1, UL: 1, OL: 1, LI: 1, TABLE: 1, THEAD: 1, TBODY: 1, TR: 1, TD: 1, TH: 1,
@@ -880,7 +884,7 @@ const HARNESS_JS = `(function () {
     edgeDrag = null;
     if (commit && candidate) {
       var currentEdge = getEdge(state.model, drag.edgeId);
-      if (currentEdge && graphPosition(getNode(state.model, candidate.id))) {
+      if (currentEdge && drag.graph.positionsById.has(candidate.id)) {
         currentEdge[drag.end] = candidate.id;
       }
     }
@@ -986,7 +990,7 @@ const HARNESS_JS = `(function () {
       var id = el.getAttribute("data-model-id");
       if (!id) return;
       var currentNode = getNode(state.model, id);
-      var position = graphPosition(currentNode);
+      var position = graphPosition(currentNode) || graph.positionsById.get(id);
       if (!position) return;
       event.preventDefault();
       handle.setPointerCapture(event.pointerId);
@@ -1013,6 +1017,7 @@ const HARNESS_JS = `(function () {
       if (!isRecordObject(drag.node.ext)) drag.node.ext = {};
       drag.node.ext.x = x;
       drag.node.ext.y = y;
+      drag.graph.positionsById.set(drag.node.id, { x: x, y: y });
       drag.el.style.setProperty("--ark-harness-graph-x", x + "px");
       drag.el.style.setProperty("--ark-harness-graph-y", y + "px");
       scheduleGraphRender(drag.graph);
@@ -1372,6 +1377,12 @@ const HARNESS_JS = `(function () {
     clone.querySelectorAll(".ark-harness-graph-node").forEach(function (el) {
       el.style.removeProperty("--ark-harness-graph-x");
       el.style.removeProperty("--ark-harness-graph-y");
+      if (el.style.length === 0) el.removeAttribute("style");
+    });
+    clone.querySelectorAll('[data-ark-container="graph"]').forEach(function (el) {
+      GRAPH_LAYOUT_PROPERTIES.forEach(function (property) {
+        el.style.removeProperty(property);
+      });
       if (el.style.length === 0) el.removeAttribute("style");
     });
     clone.querySelectorAll(".ark-harness-graph-group").forEach(function (el) {

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -90,6 +90,9 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 }
 .ark-harness-add-row:hover { border-color: #38bdf8; color: #38bdf8; }
 [data-ark-container="graph"] { position: relative; }
+[data-ark-container="graph"].ark-harness-graph-layout {
+  min-width: var(--ark-harness-graph-min-width); min-height: var(--ark-harness-graph-min-height);
+}
 .ark-harness-graph-group { position: absolute; z-index: 0; }
 .ark-harness-graph-node {
   position: absolute; left: var(--ark-harness-graph-x); top: var(--ark-harness-graph-y); z-index: 2;
@@ -234,6 +237,279 @@ const HARNESS_JS = `(function () {
     if (!node || !isRecordObject(node.ext)) return null;
     if (!finiteNumber(node.ext.x) || !finiteNumber(node.ext.y)) return null;
     return { x: node.ext.x, y: node.ext.y };
+  }
+
+  function readLayoutConfig(model) {
+    var layout = isRecordObject(model && model.ext) && isRecordObject(model.ext.layout)
+      ? model.ext.layout
+      : {};
+    var bounded = function (value, fallback, maximum) {
+      return finiteNumber(value) && value >= 0 ? Math.min(value, maximum) : fallback;
+    };
+    return {
+      direction: layout.direction === "TB" ? "TB" : "LR",
+      rankSpacing: bounded(layout.rankSpacing, 96, 512),
+      nodeSpacing: bounded(layout.nodeSpacing, 48, 512),
+      padding: bounded(layout.padding, 24, 256)
+    };
+  }
+
+  function graphModelNodes(graph) {
+    var result = [];
+    var nodes = state.model && Array.isArray(state.model.nodes) ? state.model.nodes : [];
+    nodes.forEach(function (node, index) {
+      if (!node || typeof node.id !== "string") return;
+      var el = graph.nodesById.get(node.id);
+      if (el) result.push({ id: node.id, node: node, el: el, index: index });
+    });
+    return result;
+  }
+
+  function assignLayerRanks(graph) {
+    var entries = graphModelNodes(graph);
+    var indexById = new Map();
+    var adjacency = new Map();
+    entries.forEach(function (entry) {
+      indexById.set(entry.id, entry.index);
+      adjacency.set(entry.id, []);
+    });
+    var seenEdges = new Set();
+    var edges = state.model && Array.isArray(state.model.edges) ? state.model.edges : [];
+    edges.forEach(function (edge) {
+      if (!edge || edge.from === edge.to || !adjacency.has(edge.from) || !adjacency.has(edge.to)) {
+        return;
+      }
+      var key = edge.from + "\u0000" + edge.to;
+      if (seenEdges.has(key)) return;
+      seenEdges.add(key);
+      adjacency.get(edge.from).push(edge.to);
+    });
+    adjacency.forEach(function (targets) {
+      targets.sort(function (left, right) {
+        return indexById.get(left) - indexById.get(right);
+      });
+    });
+
+    var nextIndex = 0;
+    var stack = [];
+    var onStack = new Set();
+    var indexes = new Map();
+    var lowLinks = new Map();
+    var components = [];
+    var visit = function (id) {
+      indexes.set(id, nextIndex);
+      lowLinks.set(id, nextIndex);
+      nextIndex += 1;
+      stack.push(id);
+      onStack.add(id);
+      adjacency.get(id).forEach(function (target) {
+        if (!indexes.has(target)) {
+          visit(target);
+          lowLinks.set(id, Math.min(lowLinks.get(id), lowLinks.get(target)));
+        } else if (onStack.has(target)) {
+          lowLinks.set(id, Math.min(lowLinks.get(id), indexes.get(target)));
+        }
+      });
+      if (lowLinks.get(id) !== indexes.get(id)) return;
+      var component = [];
+      var member = null;
+      do {
+        member = stack.pop();
+        onStack.delete(member);
+        component.push(member);
+      } while (member !== id);
+      component.sort(function (left, right) {
+        return indexById.get(left) - indexById.get(right);
+      });
+      components.push(component);
+    };
+    entries.forEach(function (entry) {
+      if (!indexes.has(entry.id)) visit(entry.id);
+    });
+    components.sort(function (left, right) {
+      return indexById.get(left[0]) - indexById.get(right[0]);
+    });
+
+    var componentById = new Map();
+    var componentOrder = [];
+    components.forEach(function (component, componentIndex) {
+      componentOrder[componentIndex] = indexById.get(component[0]);
+      component.forEach(function (id) { componentById.set(id, componentIndex); });
+    });
+    var outgoing = components.map(function () { return new Set(); });
+    var indegrees = components.map(function () { return 0; });
+    adjacency.forEach(function (targets, from) {
+      var fromComponent = componentById.get(from);
+      targets.forEach(function (to) {
+        var toComponent = componentById.get(to);
+        if (fromComponent === toComponent || outgoing[fromComponent].has(toComponent)) return;
+        outgoing[fromComponent].add(toComponent);
+        indegrees[toComponent] += 1;
+      });
+    });
+    var queue = [];
+    indegrees.forEach(function (degree, componentIndex) {
+      if (degree === 0) queue.push(componentIndex);
+    });
+    var byOrder = function (left, right) {
+      return componentOrder[left] - componentOrder[right];
+    };
+    queue.sort(byOrder);
+    var componentRanks = components.map(function () { return 0; });
+    while (queue.length > 0) {
+      var current = queue.shift();
+      Array.from(outgoing[current]).sort(byOrder).forEach(function (target) {
+        componentRanks[target] = Math.max(
+          componentRanks[target],
+          componentRanks[current] + 1
+        );
+        indegrees[target] -= 1;
+        if (indegrees[target] === 0) {
+          queue.push(target);
+          queue.sort(byOrder);
+        }
+      });
+    }
+    var ranks = new Map();
+    entries.forEach(function (entry) {
+      ranks.set(entry.id, componentRanks[componentById.get(entry.id)] || 0);
+    });
+    return ranks;
+  }
+
+  function rectanglesCollide(left, right, gap) {
+    return left.x < right.x + right.width + gap &&
+      left.x + left.width + gap > right.x &&
+      left.y < right.y + right.height + gap &&
+      left.y + left.height + gap > right.y;
+  }
+
+  function layoutGraph(graph) {
+    var config = readLayoutConfig(state.model);
+    var direction = config.direction;
+    var entries = graphModelNodes(graph);
+    var ranksById = assignLayerRanks(graph);
+    var measured = new Map();
+    var ranks = [];
+    entries.forEach(function (entry) {
+      var rect = entry.el.getBoundingClientRect();
+      var size = { width: rect.width, height: rect.height };
+      measured.set(entry.id, size);
+      var rank = ranksById.get(entry.id) || 0;
+      if (!ranks[rank]) ranks[rank] = [];
+      ranks[rank].push(entry);
+    });
+
+    var primaryStarts = [];
+    var primary = config.padding;
+    ranks.forEach(function (rankEntries, rank) {
+      primaryStarts[rank] = primary;
+      var largest = 0;
+      rankEntries.forEach(function (entry) {
+        var size = measured.get(entry.id);
+        largest = Math.max(largest, direction === "TB" ? size.height : size.width);
+      });
+      primary += largest + config.rankSpacing;
+    });
+
+    var occupied = [];
+    var nextPositions = new Map();
+    entries.forEach(function (entry) {
+      var manual = graphPosition(entry.node);
+      if (!manual) return;
+      var size = measured.get(entry.id);
+      var rectangle = {
+        id: entry.id,
+        x: manual.x,
+        y: manual.y,
+        width: size.width,
+        height: size.height
+      };
+      nextPositions.set(entry.id, manual);
+      occupied.push(rectangle);
+    });
+
+    ranks.forEach(function (rankEntries, rank) {
+      var secondary = config.padding;
+      rankEntries.forEach(function (entry) {
+        if (nextPositions.has(entry.id)) return;
+        var size = measured.get(entry.id);
+        var position = direction === "TB"
+          ? { x: secondary, y: primaryStarts[rank] }
+          : { x: primaryStarts[rank], y: secondary };
+        var rectangle = {
+          id: entry.id,
+          x: position.x,
+          y: position.y,
+          width: size.width,
+          height: size.height
+        };
+        var maximumAttempts = entries.length * 4 + 8;
+        var attempts = 0;
+        while (attempts < maximumAttempts) {
+          var collision = null;
+          for (var i = 0; i < occupied.length; i++) {
+            if (rectanglesCollide(rectangle, occupied[i], config.nodeSpacing)) {
+              collision = occupied[i];
+              break;
+            }
+          }
+          if (!collision) break;
+          secondary = direction === "TB"
+            ? collision.x + collision.width + config.nodeSpacing
+            : collision.y + collision.height + config.nodeSpacing;
+          if (direction === "TB") rectangle.x = secondary;
+          else rectangle.y = secondary;
+          attempts += 1;
+        }
+        if (attempts === maximumAttempts) {
+          var fallback = config.padding;
+          occupied.forEach(function (other) {
+            fallback = Math.max(
+              fallback,
+              (direction === "TB" ? other.x + other.width : other.y + other.height) +
+                config.nodeSpacing
+            );
+          });
+          secondary = fallback;
+          if (direction === "TB") rectangle.x = fallback;
+          else rectangle.y = fallback;
+        }
+        nextPositions.set(entry.id, { x: rectangle.x, y: rectangle.y });
+        occupied.push(rectangle);
+        secondary = (direction === "TB"
+          ? rectangle.x + rectangle.width
+          : rectangle.y + rectangle.height) + config.nodeSpacing;
+      });
+    });
+
+    var maxRight = 0;
+    var maxBottom = 0;
+    entries.forEach(function (entry) {
+      var position = nextPositions.get(entry.id);
+      var size = measured.get(entry.id);
+      if (!position || !size) return;
+      var previous = graph.positionsById.get(entry.id);
+      if (!previous || previous.x !== position.x || previous.y !== position.y) {
+        entry.el.style.setProperty("--ark-harness-graph-x", position.x + "px");
+        entry.el.style.setProperty("--ark-harness-graph-y", position.y + "px");
+      }
+      maxRight = Math.max(maxRight, position.x + size.width);
+      maxBottom = Math.max(maxBottom, position.y + size.height);
+    });
+    graph.positionsById = nextPositions;
+
+    var minWidth = Math.ceil(maxRight + config.padding) + "px";
+    var minHeight = Math.ceil(maxBottom + config.padding) + "px";
+    if (graph.layoutExtent.width !== minWidth) {
+      graph.container.style.setProperty("--ark-harness-graph-min-width", minWidth);
+      graph.layoutExtent.width = minWidth;
+    }
+    if (graph.layoutExtent.height !== minHeight) {
+      graph.container.style.setProperty("--ark-harness-graph-min-height", minHeight);
+      graph.layoutExtent.height = minHeight;
+    }
+    graph.container.classList.add("ark-harness-graph-layout");
   }
 
   function svgElement(name) {
@@ -476,6 +752,7 @@ const HARNESS_JS = `(function () {
 
   function renderGraph(graph) {
     graph.scheduled = false;
+    layoutGraph(graph);
     renderGraphGroups(graph);
     while (graph.svg.firstChild) graph.svg.removeChild(graph.svg.firstChild);
     appendGraphMarker(graph.svg, graph.markerId);
@@ -762,13 +1039,10 @@ const HARNESS_JS = `(function () {
       var id = el.getAttribute("data-model-id");
       if (!id || nodesById.has(id)) return;
       var node = getNode(state.model, id);
-      var position = graphPosition(node);
-      if (!position) return;
+      if (!node) return;
       nodesById.set(id, el);
       modelNodesById.set(id, node);
       el.classList.add("ark-harness-graph-node");
-      el.style.setProperty("--ark-harness-graph-x", position.x + "px");
-      el.style.setProperty("--ark-harness-graph-y", position.y + "px");
     });
 
     var svg = svgElement("svg");
@@ -788,6 +1062,8 @@ const HARNESS_JS = `(function () {
       edgeGeometryById: new Map(),
       handleLayer: handleLayer,
       edgeHandlesByKey: new Map(),
+      positionsById: new Map(),
+      layoutExtent: { width: null, height: null },
       resizeObserver: null,
       scheduled: false,
       markerId: "ark-harness-arrow-" + graphSequence

--- a/packages/server/src/lib/diagram-model.test.ts
+++ b/packages/server/src/lib/diagram-model.test.ts
@@ -71,17 +71,19 @@ describe("parseDiagramModel", () => {
     if (result.ok) expect(result.model.ext).toEqual(ext);
   });
 
-  it.each(["invalid", null, [], 42])(
-    "object でない top-level ext (%j) は undefined に正規化する",
-    ext => {
-      const result = parseDiagramModel(
-        JSON.stringify({ version: 1, nodes: [], ext })
-      );
+  it.each([
+    "invalid",
+    null,
+    [],
+    42,
+  ])("object でない top-level ext (%j) は undefined に正規化する", ext => {
+    const result = parseDiagramModel(
+      JSON.stringify({ version: 1, nodes: [], ext })
+    );
 
-      expect(result.ok).toBe(true);
-      if (result.ok) expect(result.model.ext).toBeUndefined();
-    }
-  );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.model.ext).toBeUndefined();
+  });
 
   it("edge のセマンティクスを ext に保持する", () => {
     const ext = {

--- a/packages/server/src/lib/diagram-model.test.ts
+++ b/packages/server/src/lib/diagram-model.test.ts
@@ -52,6 +52,37 @@ describe("parseDiagramModel", () => {
     }
   });
 
+  it("図全体の layout 設定と未知の情報を top-level ext に保持する", () => {
+    const ext = {
+      layout: {
+        direction: "TB",
+        rankSpacing: 80,
+        nodeSpacing: 36,
+        padding: 20,
+        futureOption: "keep-me",
+      },
+      custom: { theme: "night" },
+    };
+    const result = parseDiagramModel(
+      JSON.stringify({ version: 1, nodes: [], ext })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.model.ext).toEqual(ext);
+  });
+
+  it.each(["invalid", null, [], 42])(
+    "object でない top-level ext (%j) は undefined に正規化する",
+    ext => {
+      const result = parseDiagramModel(
+        JSON.stringify({ version: 1, nodes: [], ext })
+      );
+
+      expect(result.ok).toBe(true);
+      if (result.ok) expect(result.model.ext).toBeUndefined();
+    }
+  );
+
   it("edge のセマンティクスを ext に保持する", () => {
     const ext = {
       from_card: "one",

--- a/packages/server/src/lib/diagram-model.ts
+++ b/packages/server/src/lib/diagram-model.ts
@@ -42,6 +42,7 @@ export interface DiagramModel {
   nodes: DiagramNode[];
   edges: DiagramEdge[];
   groups: DiagramGroup[];
+  ext?: Record<string, unknown>;
 }
 
 export type ParseResult =
@@ -187,6 +188,7 @@ export function parseDiagramModel(json: string): ParseResult {
       nodes,
       edges,
       groups,
+      ext: asExt(raw.ext),
     },
   };
 }


### PR DESCRIPTION
## 概要

図解ハーネス: **自動レイアウト**。座標未指定の graph node を自動配置し、Claude が `nodes + edges` を与えるだけで重ならない図を描けるようにする。全図種の自動生成が安定して楽になる基盤。

Closes #228

## 設計判断：elkjs 不採用、依存なしの軽量 layered layout

ハーネスは**全図の srcDoc にインライン注入**されるため、elkjs（~1.5MB）を同梱すると全図の HTML が激重になる。→ **依存なしの Sugiyama 風 layered layout（~300行）を `diagram-harness.ts` に組込**。

- **注入サイズ 54.8KB < 128KiB**（unit test で guard）。`package.json` / `pnpm-lock.yaml` に依存追加なし、外部 URL / Worker / Blob / WASM なし（CSP 準拠）
- 高機能化が必要になれば、図種別の条件付き注入を別 Issue で設計する

## 変更点

- **軽量 layered layout**: Tarjan SCC（循環対応）→ component DAG → Kahn longest-path で rank 決定 → DOM 実測サイズで LR/TB slot 配置 → 衝突 packing（反復上限 + deterministic fallback で無限 loop 防止）。同じ model/DOM/config なら毎回同じ座標（決定的）
- **手動座標との共存**: 有限 `ext.x/y` 両方ある node は固定、未指定のみ auto。**auto 座標は model に書き戻さない**（図が可搬・毎回再計算）、ドラッグした node だけ `ext.x/y` に昇格（manual 化）
- **レイアウト設定**: `model.ext.layout`（`direction: LR/TB`、`rankSpacing`/`nodeSpacing`/`padding`）。allowlist + clamp、不正値は default へ fallback
- **model.ext**（図全体設定）を追加（既存の node/edge/group ext と同じ opaque パターン、parser +2行）
- sample.diagram.html を座標省略 + layout 設定へ更新（自動レイアウトの canonical 実例に）、`diagram-authoring` skill に座標省略規約を追記

## テスト

- `tsc -b` / `pnpm check`: pass ・ `vitest run`: 540 pass ・ `biome`: clean ・ `build`: pass
- `playwright e2e/diagram-harness.spec.ts`: 28 テスト pass（LR/TB 決定的配置・分岐/循環/self-edge/孤立 node・手動auto混在・非永続+drag昇格・resize/model再適用での再計算・不正設定 fallback・既存 graph/kind/group/edge/list 回帰）
- **注入サイズ <128KiB・elkjs/外部URL/Worker/Blob なし**を unit test で guard

## スコープ外

複雑な port routing / 大規模 graph 向けの高機能レイアウト（必要時に別 Issue）。`diagram-diff.ts`（位置・layout ext は非還流）・Socket.IO・DB・モバイルは不変。

## レビュー体制

codex が plan 立案・TDD 実装、Claude が P2（plan）/ P5（実装）レビュー（flow-x 役割逆転。実装者 ≠ レビュアー）。**elkjs vs 軽量組込みのトレードオフを P2 で評価し軽量を選択**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ノード座標を省略した図で、自動レイアウトを利用できるようになりました。
  - レイアウト方向や間隔などを図単位で設定できます。
  - 手動配置したノードは自動配置と共存し、ドラッグ後の位置を保持します。
  - 複雑な接続や孤立ノードを含む図でも、ノードの重なりを抑えて配置します。

- **ドキュメント**
  - 自動配置と手動配置の使い分けに関する作成ガイドを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->