### PR TITLE
図解編集UX: レイアウト方向トグル（LR⇄TB を直接操作で・生JSON編集を置換） (#240)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-issue-240.md
+++ b/docs/superpowers/plans/2026-07-22-issue-240.md
@@ -1,0 +1,213 @@
+# issue-240: レイアウト方向トグル Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** graph のレイアウト方向をツールバーから LR / TB に直接切り替え、即時再配置と既存の model.ext.layout round-trip を通じた保存を実現する。
+
+**Issue:** 240 (GitHub Issue 紐付けあり)
+
+**Architecture:** graph コンテナがある編集ハーネスのツールバーで「モデルを直接編集」の手前に、現在の `readLayoutConfig(state.model).direction` を表示する単一の方向トグルを追加する。押下時は `isRecordObject` で既存値を守りながら必要なら `state.model.ext` / `state.model.ext.layout` を作り、`direction` だけを LR / TB へ反転して全 `graphs` を `scheduleGraphRender()` するため、#228 の `renderGraph()` / auto-layout が同じ frame で node・group・edge を再配置する。ボタンは `markUi()` により保存 HTML から除去し、効果だけを既存 MessageChannel → `diagram:submit` → model block 差し替えで保存する一方、`describeModelDiff()` は top-level `ext` を見ないため会話へ還流せず、graph / kind / group / edge / list 編集と共存する。新規 Socket.IO event、DB schema、React / Tailwind、tmux / ttyd、モバイル UI の変更はない。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Express / Socket.IO / better-sqlite3 / tmux / ttyd
+
+---
+
+## 設計判断と変更境界
+
+- 方向 UI は graph のレイアウト設定なので、`document.querySelector('[data-ark-container="graph"]')` がある文書だけに表示する。graph がある限り auto node の有無にかかわらず表示し、全 node が手動座標でも model の direction 更新・保存は許可する。graph がない文書では既存 toolbar を維持し、意味のない方向 UI を増やさない。
+- ツールバー順は `方向: LR|TB` → `モデルを直接編集` → spacer → status → `変更を送る` とする。方向ボタンの可視 text、`aria-label`、`title` は現在値と次の操作を同期し、初期モデルが TB の場合、未知値 / 欠損で LR fallback の場合、モデル直接編集で direction が変わった場合にも表示を更新する。
+- 反転時は `state.model.ext` と `state.model.ext.layout` が record object なら既存の未知 key、`rankSpacing`、`nodeSpacing`、`padding` を保持する。欠損または array / primitive なら、その階層だけを新しい object に置き換え、`direction` のみを書き込む。未知 direction は `readLayoutConfig()` と同じく現在 LR とみなし、最初の押下で TB を保存する。
+- 再配置は新しい layout engine や DOM 再構築を作らず、`graphs.forEach(scheduleGraphRender)` を使う。`renderGraph()` が既に layout → group → edge → endpoint handle の順で描くため、auto node は LR / TB に移動し、手動 node は位置を保ち、group / edge は新しい geometry に追従する。
+- direction button 自身と toolbar は `data-ark-harness-ui` のため `buildSubmissionHtml()` で除去される。一方 `handleSubmit()` は `state.model` を送るので、変更した `model.ext.layout.direction` は server の既存 `parseDiagramModel()` / `replaceModelBlock()` 経路で `.diagram.html` の model block に残る。
+- `packages/server/src/lib/diagram-file.test.ts` には top-level `ext.layout` の往復、`packages/server/src/lib/diagram-diff.test.ts` には LR → TB が `[]` となる非還流 characterization が既にある。これらを回帰として実行するが、`diagram-file.ts`、`diagram-model.ts`、`diagram-diff.ts` の production code / test contract は変更しない。
+- 実装差分は `packages/server/src/lib/diagram-harness.ts`、`packages/server/src/lib/diagram-harness.test.ts`、`e2e/diagram-harness.spec.ts` とこの plan に限定する。spacing GUI、kind picker、edge control、node 追加削除は含めない。
+- 各実装タスクは Red → Green → Refactor の順で進める。以下の test command は実装時に実行し、この plan 作成時には実行しない。
+
+---
+
+## Task 1: 方向トグルの browser acceptance を Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts:151-265,340-507,509-759`
+- Reference: `packages/server/src/lib/diagram-harness.ts:177-254,757-806,1088-1094,1371-1531`
+- Reference: `packages/server/src/lib/diagram-diff.ts:161-165`
+
+- [ ] **Step 1: auto-layout fixture の LR / TB geometry を再利用する（2-5分）**
+
+  既存 `autoLayoutHtml()`、`graphNodeBoxes()`、`expectNoOverlaps()`、`requiredBoundingBox()` と `connectSubmissionPort()` を使う。新しい layout fixture や配置 algorithm は作らず、既存の分岐、cycle、self-edge、孤立 node、group を含む fixture でトグル操作を観測する。
+
+- [ ] **Step 2: LR → TB の即時再配置 test を追加する（2-5分）**
+
+  初期 `direction: "LR"` の auto-layout 図を開き、方向ボタンが toolbar の「モデルを直接編集」より前にあり、可視 text / accessible name が現在 LR と次の TB 操作を示すことを確認する。押下後は polling で `branch_a` が `source` の下へ移ること、全 node が重ならないこと、group boundary が member を囲むこと、edge と endpoint handle の件数が変わらないことを assertion にする。
+
+- [ ] **Step 3: state model・clean HTML・非還流 test を追加する（2-5分）**
+
+  MessageChannel を接続して LR → TB 後に「変更を送る」を押し、submission model の `ext.layout` が既存 spacing / padding / 未知 key を保ったまま `direction: "TB"` になることを確認する。初期モデルと submission model を test process 側の `describeModelDiff()` に渡して `[]` を確認し、direction だけでは会話へ送る意味差分が生じないことを Playwright acceptance に含める。submission HTML には方向ボタンの text / class / `data-ark-harness-ui` がなく、authored graph と model script は残ることも確認する。
+
+- [ ] **Step 4: 欠損階層・初期 TB・モデル直接編集との同期 test を追加する（2-5分）**
+
+  top-level `ext` を持たない既存 `diagramHtml()` を使い、手動座標だけの graph でもボタンは LR を表示し、押下後の submission model に `{ ext: { layout: { direction: "TB" } } }` が作られること、node 座標や graph / kind / group / edge / list の意味モデルが変わらないことを確認する。別 case では初期 TB を表示し、モデル直接編集の「反映」で LR に戻した直後にボタン表示も LR へ同期することを固定する。
+
+- [ ] **Step 5: graph がない文書では方向 UI を出さない test を追加する（2-5分）**
+
+  model block と通常の編集対象だけを持つ最小 HTML に harness を注入し、既存の「モデルを直接編集」「変更を送る」は存在するが、レイアウト方向ボタンだけは存在しないことを確認する。
+
+- [ ] **Step 6: Red を確認する（2-5分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "レイアウト方向"`
+
+  Expected: FAIL。方向ボタンが未実装のため、最初の role / accessible name assertion で失敗する。
+
+---
+
+## Task 2: model を安全に反転する toolbar UI を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:38-56,177-254,1197-1208,1460-1531`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts:30-73`
+- Test: `e2e/diagram-harness.spec.ts`
+- Reference only: `packages/server/src/lib/diagram-model.ts:39-45,181-192`
+
+- [ ] **Step 1: injected harness の静的契約 test を Red にする（2-5分）**
+
+  `diagram-harness.test.ts` の graph 編集 UI test に、方向ボタンの class / label、direction 同期 helper、安全な ext/layout object 作成、全 graph の `scheduleGraphRender()` 呼び出しが注入文字列に含まれる assertion を追加する。marker 出現回数 1、128KiB 未満、外部依存なしの既存 guard は維持する。
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: FAIL。方向 UI / helper がまだ注入されていない。
+
+- [ ] **Step 2: 方向ボタンの状態と表示同期 helper を追加する（2-5分）**
+
+  `sendBtn` と同じ harness closure に `layoutDirectionBtn` を保持し、現在値を必ず `readLayoutConfig(state.model).direction` から得る helper を作る。同期 helper は可視 text を `方向: LR` / `方向: TB` にし、`aria-label` と `title` には現在値と「TB に切り替える」/「LR に切り替える」を含める。CSS は既存 `.ark-harness-btn-secondary` を再利用し、必要なら横幅の揺れを抑える `ark-harness-layout-direction` だけを追加する。
+
+- [ ] **Step 3: ext.layout.direction の安全な反転を実装する（2-5分）**
+
+  click handler では現在値を `readLayoutConfig()` で LR / TB に正規化してから反対値を決める。`state.model.ext` が record でなければ `{}`、その `layout` が record でなければ `{}` を代入し、既存 record の spacing / padding / unknown keys は保持したまま `layout.direction` だけを更新する。更新後に方向表示を同期し、`graphs.forEach(function (graph) { scheduleGraphRender(graph); })` で全 graph を再描画する。
+
+- [ ] **Step 4: graph のある toolbar にだけボタンを配置する（2-5分）**
+
+  `buildToolbar()` 内で graph container の存在を調べ、存在する場合だけ `createButton()` で方向ボタンを作って `editModelBtn` の直前へ append する。`createButton()` が既に `markUi()` を行う契約を使い、保存用 DOM に個別 cleanup を追加しない。`buildToolbar()` は `initGraphs()` より先に呼ばれるが authored graph DOM は既に存在し、click 可能になるまでの同期的な `init()` 内で `graphs` も構築されるため初期化順を変更しない。
+
+- [ ] **Step 5: モデル直接編集の反映後も表示を同期する（2-5分）**
+
+  `buildModelPanel()` の apply 成功 path で `state.model = parsed` と `syncNodeKinds()` の後に方向表示も同期してから、既存どおり全 graph を schedule する。直接編集 panel、error 表示、kind 同期、graph render の順序や挙動は変えない。
+
+- [ ] **Step 6: unit と targeted browser test を Green にする（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+
+  Expected: PASS。方向 UI 契約、marker 一意性、size / CSP guard がすべて Green。
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --grep "レイアウト方向"`
+
+  Expected: PASS。LR / TB 表示、即時再配置、欠損 object 作成、直接編集同期、submission、graph なし非表示が成功する。
+
+- [ ] **Step 7: Refactor と実装コミットを行う（2-5分）**
+
+  direction の読取は `readLayoutConfig()` に一本化し、button 表示、model mutation、render scheduling の責務を短い helper に分ける。新たな JSON clone、model script の直接書換え、個別 graph layout 実装、Socket.IO 呼出しを持ち込まない。
+
+  ```bash
+  git add packages/server/src/lib/diagram-harness.ts packages/server/src/lib/diagram-harness.test.ts e2e/diagram-harness.spec.ts
+  git commit -m "feat(diagram): レイアウト方向トグルを追加"
+  ```
+
+---
+
+## Task 3: round-trip・非還流・既存編集の回帰を固定する
+
+**Files:**
+
+- Verify: `packages/server/src/lib/diagram-harness.ts`
+- Verify: `packages/server/src/lib/diagram-harness.test.ts`
+- Verify: `e2e/diagram-harness.spec.ts`
+- Verify only: `packages/server/src/lib/diagram-model.ts`
+- Verify only: `packages/server/src/lib/diagram-model.test.ts`
+- Verify only: `packages/server/src/lib/diagram-file.ts`
+- Verify only: `packages/server/src/lib/diagram-file.test.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.test.ts`
+
+- [ ] **Step 1: model.ext の parser / file round-trip 回帰を実行する（2-5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run \
+    src/lib/diagram-model.test.ts \
+    src/lib/diagram-file.test.ts
+  ```
+
+  Expected: PASS。top-level `ext.layout` と direction / spacing / unknown key が parse と `replaceModelBlock()` → `extractModel()` の往復で保持される。production model / parser / file helper の変更は不要。
+
+- [ ] **Step 2: direction の非還流 characterization を実行する（2-5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-diff.test.ts`
+
+  Expected: PASS。既存の「top-level ext.layout の変更は意味差分に含めない」が LR → TB に `[]` を返し、layout と field label を同時変更した case では field の意味差分だけを返す。`diagram-diff.ts` は変更しない。
+
+- [ ] **Step 3: diagram harness の全 Chromium 回帰を実行する（5-10分）**
+
+  Run: `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium`
+
+  Expected: PASS。方向トグルに加え、自動配置 LR / TB、不正 layout fallback、manual / auto 混在、node drag、text resize、model 再適用、kind、group、edge cardinality / endpoint rewire、self-edge、field inline edit、list reorder、clean submission、authored samples がすべて Green。
+
+- [ ] **Step 4: 静的検査と build を実行する（5-10分）**
+
+  Run: `pnpm check`
+
+  Expected: PASS。Biome と TypeScript project references が error 0件。
+
+  Run: `pnpm build`
+
+  Expected: PASS。server / web / desktop の既存 build が成功する。
+
+- [ ] **Step 5: スコープ外レイヤーの非変更を確認する（2-5分）**
+
+  Run: `git diff --name-only origin/main...HEAD`
+
+  Expected: Issue 実装差分は `packages/server/src/lib/diagram-harness.ts`、`packages/server/src/lib/diagram-harness.test.ts`、`e2e/diagram-harness.spec.ts`、`docs/superpowers/plans/2026-07-22-issue-240.md` だけ。`diagram-diff.ts`、`diagram-model.ts`、Socket.IO 型 / handler、DB、React / mobile、tmux / ttyd、sample、spacing GUI は含まれない。
+
+  Run: `git diff --check origin/main...HEAD`
+
+  Expected: 出力なし。
+
+---
+
+## Task 4: P5 human の board_open で保存と操作共存を受け入れる
+
+**Files:**
+
+- Verify: `docs/diagrams/sample.diagram.html`
+- Verify: `packages/server/src/lib/diagram-harness.ts`
+- Verify only: `packages/server/src/index.ts:2207-2340`
+- Verify only: `packages/web/src/components/DiagramPane.tsx:146-210`
+
+- [ ] **Step 1: desktop 実機で LR → TB の直接操作を確認する（2-5分）**
+
+  稼働中 PC session から `docs/diagrams/sample.diagram.html` を `board_open` し、toolbar が `方向: LR` → `モデルを直接編集` → status → `変更を送る` の順で表示されることを確認する。方向ボタンを押し、Order / User が横並びから縦方向へ即時再配置され、edge、group boundary、node / edge handle が新しい位置へ追従することを確認する。
+
+- [ ] **Step 2: 変更を送って model block の保存と非還流を確認する（2-5分）**
+
+  TB のまま「変更を送る」を押し、保存後に図を再読込して方向表示と配置が TB のままであること、`.diagram.html` の `ark-diagram-model` block に `ext.layout.direction: "TB"` が入り既存 spacing が保持されることを確認する。方向だけの変更では会話に「図を編集しました」メッセージが追加されず、server ACK の `sent` が空になる既存 `describeModelDiff()` 境界と一致することを確認する。
+
+- [ ] **Step 3: power-user fallback と既存編集を確認する（5-10分）**
+
+  「モデルを直接編集」で direction を LR に戻して反映し、方向ボタン表示と graph が LR へ同期することを確認する。その後、代表的な node drag、field inline edit / list reorder、edge endpoint rewire を行い、方向トグルが各操作を妨げず、意味変更だけが従来どおり送信されることを確認する。手動座標だけの graph では方向を切り替えても node が動かないが、direction は保存できることも確認する。
+
+- [ ] **Step 4: P5 human gate と最終成果物を確定する（2-5分）**
+
+  Expected: P5 human PASS。即時再配置、model block 保存、表示設定の非還流、既存 graph / kind / group / edge / list 編集との共存が確認できる。実機確認で修正が不要なら追加 commit は作らず、調整が必要なら Task 1 の acceptance を先に更新して Red → Green を再実行する。
+
+---
+
+## 完了条件チェック
+
+- [ ] graph の toolbar が現在の LR / TB を示し、押下ごとに反転して auto node・group・edge・handle を即時再配置する。
+- [ ] `model.ext` / `model.ext.layout` の欠損や不正形状を安全に扱い、既存 spacing / padding / unknown key を壊さず direction だけを保存する。
+- [ ] 方向 UI は clean submission HTML から除去され、direction の効果は既存 `diagram:submit` round-trip で `.diagram.html` の model block に残る。
+- [ ] direction だけの変更は `describeModelDiff()` で空差分となり、会話へ還流しない。
+- [ ] graph / kind / group / edge / list / model 直接編集、manual / auto 配置、node / endpoint drag が回帰していない。
+- [ ] `diagram-diff.ts` / `diagram-model.ts` production code、Socket.IO event、DB、React / mobile、tmux / ttyd、spacing GUI に変更がない。
+- [ ] server unit、Chromium diagram E2E、`pnpm check`、`pnpm build`、P5 human `board_open` がすべて成功する。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 import { expect, type Locator, type Page, test } from "@playwright/test";
+import { describeModelDiff } from "../packages/server/src/lib/diagram-diff";
 import { injectHarness } from "../packages/server/src/lib/diagram-harness";
+import type { DiagramModel } from "../packages/server/src/lib/diagram-model";
 
 const model = {
   version: 1,
@@ -160,15 +162,15 @@ const autoLayoutEdges = [
   { id: "e_self", from: "self", to: "self" },
 ];
 
-function autoLayoutHtml(
+function autoLayoutModel(
   layout: Record<string, unknown> = {
     direction: "LR",
     rankSpacing: 80,
     nodeSpacing: 36,
     padding: 20,
   }
-): string {
-  const autoModel = {
+): DiagramModel {
+  return {
     version: 1,
     ext: { layout },
     nodes: autoLayoutNodes,
@@ -181,6 +183,17 @@ function autoLayoutHtml(
       },
     ],
   };
+}
+
+function autoLayoutHtml(
+  layout: Record<string, unknown> = {
+    direction: "LR",
+    rankSpacing: 80,
+    nodeSpacing: 36,
+    padding: 20,
+  }
+): string {
+  const autoModel = autoLayoutModel(layout);
   return injectHarness(`<!doctype html><html><head><style>
     body { margin: 0; }
     .graph { width: 360px; height: 260px; background: #f8fafc; }
@@ -505,6 +518,234 @@ function expectNoOverlaps(
     }
   }
 }
+
+test("レイアウト方向を LR から TB へ切り替えて再配置・保存する", async ({
+  page,
+}) => {
+  const layout = {
+    direction: "LR",
+    rankSpacing: 80,
+    nodeSpacing: 36,
+    padding: 20,
+    routing: "orthogonal",
+  };
+  const initialModel = autoLayoutModel(layout);
+  await page.setContent(autoLayoutHtml(layout));
+  await connectSubmissionPort(page);
+
+  const toolbar = page.locator(".ark-harness-toolbar");
+  const directionButton = page.getByRole("button", {
+    name: "現在のレイアウト方向は LR。TB に切り替える",
+  });
+  const editModelButton = page.getByRole("button", {
+    name: "モデル JSON を直接編集する",
+  });
+  await expect(directionButton).toHaveText("方向: LR");
+  await expect(directionButton).toHaveAttribute(
+    "title",
+    "現在のレイアウト方向は LR。TB に切り替える"
+  );
+  expect(
+    await toolbar
+      .locator("button")
+      .evaluateAll(buttons => buttons.map(button => button.textContent))
+  ).toEqual(["方向: LR", "モデルを直接編集", "変更を送る"]);
+  expect(
+    await directionButton.evaluate(
+      (button, editButton) =>
+        Boolean(
+          button.compareDocumentPosition(editButton) &
+            Node.DOCUMENT_POSITION_FOLLOWING
+        ),
+      await editModelButton.elementHandle()
+    )
+  ).toBe(true);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const beforeBoxes = await graphNodeBoxes(page);
+  const beforeById = Object.fromEntries(beforeBoxes.map(box => [box.id, box]));
+  const edgeCount = await graph
+    .locator(".ark-harness-edge-main[data-ark-edge-id]")
+    .count();
+  const endpointHandleCount = await graph
+    .locator(".ark-harness-edge-handle")
+    .count();
+
+  await directionButton.click();
+  const toggledButton = page.getByRole("button", {
+    name: "現在のレイアウト方向は TB。LR に切り替える",
+  });
+  await expect(toggledButton).toHaveText("方向: TB");
+  await expect(toggledButton).toHaveAttribute(
+    "title",
+    "現在のレイアウト方向は TB。LR に切り替える"
+  );
+  await expect
+    .poll(async () => {
+      const boxes = await graphNodeBoxes(page);
+      const byId = Object.fromEntries(boxes.map(box => [box.id, box]));
+      return byId.branch_a.y > byId.source.y + byId.source.height;
+    })
+    .toBe(true);
+
+  const afterBoxes = await graphNodeBoxes(page);
+  const afterById = Object.fromEntries(afterBoxes.map(box => [box.id, box]));
+  expect(afterById.branch_a.y).toBeGreaterThan(beforeById.branch_a.y);
+  expectNoOverlaps(afterBoxes);
+  const group = graph.locator('[data-ark-group][data-model-id="cycle_group"]');
+  const [groupBox, cycleABox, cycleBBox] = await Promise.all([
+    requiredBoundingBox(group),
+    requiredBoundingBox(graph.locator('[data-model-id="cycle_a"]').first()),
+    requiredBoundingBox(graph.locator('[data-model-id="cycle_b"]').first()),
+  ]);
+  expectBoxToContain(groupBox, cycleABox);
+  expectBoxToContain(groupBox, cycleBBox);
+  await expect(
+    graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
+  ).toHaveCount(edgeCount);
+  await expect(graph.locator(".ark-harness-edge-handle")).toHaveCount(
+    endpointHandleCount
+  );
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel; html: string };
+        }
+      ).arkHarnessSubmission
+  );
+  expect(submission?.model.ext?.layout).toEqual({
+    ...layout,
+    direction: "TB",
+  });
+  if (!submission) throw new Error("submission がありません");
+  expect(describeModelDiff(initialModel, submission.model)).toEqual([]);
+  expect(submission.html).not.toContain("方向: TB");
+  expect(submission.html).not.toContain("ark-harness-layout-direction");
+  expect(submission.html).not.toContain("data-ark-harness-ui");
+  expect(submission.html).toContain('data-ark-container="graph"');
+  expect(submission.html).toContain('id="ark-diagram-model"');
+});
+
+test("レイアウト方向は ext 欠損を補い、モデル直接編集後も同期する", async ({
+  page,
+}) => {
+  await page.setContent(diagramHtml());
+  await connectSubmissionPort(page);
+  const directionButton = page.getByRole("button", {
+    name: "現在のレイアウト方向は LR。TB に切り替える",
+  });
+  await expect(directionButton).toHaveText("方向: LR");
+  await directionButton.click();
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submittedModel = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel };
+        }
+      ).arkHarnessSubmission?.model
+  );
+  expect(submittedModel).toEqual({
+    ...model,
+    ext: { layout: { direction: "TB" } },
+  });
+
+  for (const [invalidExt, expectedExt] of [
+    [[], { layout: { direction: "TB" } }],
+    [
+      { scope: "preserved", layout: [] },
+      { scope: "preserved", layout: { direction: "TB" } },
+    ],
+  ] as const) {
+    await page.setContent(diagramHtml({ ...model, ext: invalidExt }));
+    await page
+      .getByRole("button", {
+        name: "現在のレイアウト方向は LR。TB に切り替える",
+      })
+      .click();
+    await page
+      .getByRole("button", { name: "モデル JSON を直接編集する" })
+      .click();
+    const currentModel = JSON.parse(
+      await page.locator(".ark-harness-textarea").inputValue()
+    ) as DiagramModel;
+    expect(currentModel.ext).toEqual(expectedExt);
+  }
+
+  const tbModel = autoLayoutModel({
+    direction: "TB",
+    rankSpacing: 80,
+    nodeSpacing: 36,
+    padding: 20,
+  });
+  await page.setContent(
+    autoLayoutHtml(tbModel.ext?.layout as Record<string, unknown>)
+  );
+  const tbButton = page.getByRole("button", {
+    name: "現在のレイアウト方向は TB。LR に切り替える",
+  });
+  await expect(tbButton).toHaveText("方向: TB");
+  tbModel.ext = {
+    ...tbModel.ext,
+    layout: {
+      ...(tbModel.ext?.layout as Record<string, unknown>),
+      direction: "LR",
+    },
+  };
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  await page.locator(".ark-harness-textarea").fill(JSON.stringify(tbModel));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+  await expect(
+    page.getByRole("button", {
+      name: "現在のレイアウト方向は LR。TB に切り替える",
+    })
+  ).toHaveText("方向: LR");
+});
+
+test("レイアウト方向 UI は graph がない文書には表示しない", async ({
+  page,
+}) => {
+  await page.setContent(
+    injectHarness(`<!doctype html><html><body>
+      <script id="ark-diagram-model" type="application/json">${JSON.stringify({
+        version: 1,
+        nodes: [{ id: "note", label: "Note" }],
+        edges: [],
+        groups: [],
+      })}</script>
+      <p data-model-id="note">Note</p>
+    </body></html>`)
+  );
+
+  await expect(
+    page.getByRole("button", { name: "モデル JSON を直接編集する" })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "変更を親フレームへ送信する" })
+  ).toBeVisible();
+  await expect(page.locator(".ark-harness-layout-direction")).toHaveCount(0);
+});
 
 test("自動配置 LR は分岐・循環・self-edge・孤立 node を決定的に配置する", async ({
   page,

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -535,7 +535,7 @@ test("レイアウト方向を LR から TB へ切り替えて再配置・保存
 
   const toolbar = page.locator(".ark-harness-toolbar");
   const directionButton = page.getByRole("button", {
-    name: "現在のレイアウト方向は LR。TB に切り替える",
+    name: "方向: LR（現在 LR。TB に切り替える）",
   });
   const editModelButton = page.getByRole("button", {
     name: "モデル JSON を直接編集する",
@@ -543,7 +543,7 @@ test("レイアウト方向を LR から TB へ切り替えて再配置・保存
   await expect(directionButton).toHaveText("方向: LR");
   await expect(directionButton).toHaveAttribute(
     "title",
-    "現在のレイアウト方向は LR。TB に切り替える"
+    "方向: LR（現在 LR。TB に切り替える）"
   );
   expect(
     await toolbar
@@ -573,12 +573,12 @@ test("レイアウト方向を LR から TB へ切り替えて再配置・保存
 
   await directionButton.click();
   const toggledButton = page.getByRole("button", {
-    name: "現在のレイアウト方向は TB。LR に切り替える",
+    name: "方向: TB（現在 TB。LR に切り替える）",
   });
   await expect(toggledButton).toHaveText("方向: TB");
   await expect(toggledButton).toHaveAttribute(
     "title",
-    "現在のレイアウト方向は TB。LR に切り替える"
+    "方向: TB（現在 TB。LR に切り替える）"
   );
   await expect
     .poll(async () => {
@@ -643,7 +643,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
   await page.setContent(diagramHtml());
   await connectSubmissionPort(page);
   const directionButton = page.getByRole("button", {
-    name: "現在のレイアウト方向は LR。TB に切り替える",
+    name: "方向: LR（現在 LR。TB に切り替える）",
   });
   await expect(directionButton).toHaveText("方向: LR");
   await directionButton.click();
@@ -679,7 +679,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
     await page.setContent(diagramHtml({ ...model, ext: invalidExt }));
     await page
       .getByRole("button", {
-        name: "現在のレイアウト方向は LR。TB に切り替える",
+        name: "方向: LR（現在 LR。TB に切り替える）",
       })
       .click();
     await page
@@ -701,7 +701,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
     autoLayoutHtml(tbModel.ext?.layout as Record<string, unknown>)
   );
   const tbButton = page.getByRole("button", {
-    name: "現在のレイアウト方向は TB。LR に切り替える",
+    name: "方向: TB（現在 TB。LR に切り替える）",
   });
   await expect(tbButton).toHaveText("方向: TB");
   tbModel.ext = {
@@ -718,7 +718,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
   await page.getByRole("button", { name: "反映", exact: true }).click();
   await expect(
     page.getByRole("button", {
-      name: "現在のレイアウト方向は LR。TB に切り替える",
+      name: "方向: LR（現在 LR。TB に切り替える）",
     })
   ).toHaveText("方向: LR");
 });

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -47,6 +47,20 @@ describe("injectHarness", () => {
     expect(out).toContain("function syncEdgeHandles(");
     expect(out).toContain("function finishEdgeDrag(");
     expect(out).toContain("getEdge(state.model, drag.edgeId)");
+    expect(out).toContain("ark-harness-layout-direction");
+    expect(out).toContain("function syncLayoutDirectionButton(");
+    expect(out).toContain("function toggleLayoutDirection(");
+    expect(out).toContain("現在のレイアウト方向は ");
+    expect(out).toContain(
+      "if (!isRecordObject(state.model.ext)) state.model.ext = {};"
+    );
+    expect(out).toContain(
+      "if (!isRecordObject(state.model.ext.layout)) state.model.ext.layout = {};"
+    );
+    expect(out).toContain("state.model.ext.layout.direction = nextDirection;");
+    expect(out).toContain(
+      "graphs.forEach(function (graph) { scheduleGraphRender(graph); });"
+    );
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -264,8 +264,9 @@ const HARNESS_JS = `(function () {
     if (!layoutDirectionBtn || !state.model) return;
     var direction = readLayoutConfig(state.model).direction;
     var nextDirection = direction === "LR" ? "TB" : "LR";
-    var label = "現在のレイアウト方向は " + direction + "。" + nextDirection + " に切り替える";
-    layoutDirectionBtn.textContent = "方向: " + direction;
+    var visibleLabel = "方向: " + direction;
+    var label = visibleLabel + "（現在 " + direction + "。" + nextDirection + " に切り替える）";
+    layoutDirectionBtn.textContent = visibleLabel;
     layoutDirectionBtn.setAttribute("aria-label", label);
     layoutDirectionBtn.title = label;
   }

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -51,6 +51,7 @@ const HARNESS_STYLE = `<style data-ark-harness-ui="1">
 }
 .ark-harness-btn:hover { background: #232732; }
 .ark-harness-btn:disabled { opacity: .45; cursor: not-allowed; }
+.ark-harness-layout-direction { min-width: 5.5rem; }
 .ark-harness-btn-primary { background: #0ea5b7; border-color: #0ea5b7; color: #05201f; font-weight: 600; }
 .ark-harness-btn-primary:hover { background: #14b8c9; }
 .ark-harness-btn-primary:disabled { background: #1b1e27; border-color: #333947; color: #8b93a7; }
@@ -178,6 +179,7 @@ const HARNESS_JS = `(function () {
   var graphSequence = 0;
   var statusEl = null;
   var sendBtn = null;
+  var layoutDirectionBtn = null;
 
   function isRecordObject(v) {
     return v !== null && typeof v === "object" && !Array.isArray(v);
@@ -256,6 +258,27 @@ const HARNESS_JS = `(function () {
       nodeSpacing: bounded(layout.nodeSpacing, 48, 512),
       padding: bounded(layout.padding, 24, 256)
     };
+  }
+
+  function syncLayoutDirectionButton() {
+    if (!layoutDirectionBtn || !state.model) return;
+    var direction = readLayoutConfig(state.model).direction;
+    var nextDirection = direction === "LR" ? "TB" : "LR";
+    var label = "現在のレイアウト方向は " + direction + "。" + nextDirection + " に切り替える";
+    layoutDirectionBtn.textContent = "方向: " + direction;
+    layoutDirectionBtn.setAttribute("aria-label", label);
+    layoutDirectionBtn.title = label;
+  }
+
+  function toggleLayoutDirection() {
+    if (!state.model) return;
+    var direction = readLayoutConfig(state.model).direction;
+    var nextDirection = direction === "LR" ? "TB" : "LR";
+    if (!isRecordObject(state.model.ext)) state.model.ext = {};
+    if (!isRecordObject(state.model.ext.layout)) state.model.ext.layout = {};
+    state.model.ext.layout.direction = nextDirection;
+    syncLayoutDirectionButton();
+    graphs.forEach(function (graph) { scheduleGraphRender(graph); });
   }
 
   function graphModelNodes(graph) {
@@ -1470,6 +1493,7 @@ const HARNESS_JS = `(function () {
         if (!Array.isArray(parsed.groups)) parsed.groups = [];
         state.model = parsed;
         syncNodeKinds();
+        syncLayoutDirectionButton();
         graphs.forEach(function (graph) { scheduleGraphRender(graph); });
         error.style.display = "none";
         panel.style.display = "none";
@@ -1491,6 +1515,13 @@ const HARNESS_JS = `(function () {
     var bar = document.createElement("div");
     bar.className = "ark-harness-toolbar";
     markUi(bar);
+
+    if (document.querySelector('[data-ark-container="graph"]')) {
+      layoutDirectionBtn = createButton("", "ark-harness-btn ark-harness-btn-secondary ark-harness-layout-direction");
+      syncLayoutDirectionButton();
+      layoutDirectionBtn.addEventListener("click", toggleLayoutDirection);
+      bar.appendChild(layoutDirectionBtn);
+    }
 
     var editModelBtn = createButton("モデルを直接編集", "ark-harness-btn ark-harness-btn-secondary", "モデル JSON を直接編集する");
 


### PR DESCRIPTION
## 概要

図解編集 UX の第一歩: **レイアウト方向トグル**。graph のレイアウト方向（LR⇄TB）を、生 JSON を編集せずツールバーのトグルで直接切り替えられるようにする。

Closes #240

## 背景

図解ハーネスの編集は移動・張り替え・インライン編集・並べ替えは直接操作なのに、**レイアウト方向の変更だけ「モデルを直接編集」で生 JSON を書く**必要があった。方向を変えるのに JSON を書かせるのは編集 UX としてセンスがない。これを直接操作に置き換える（「直接操作の編集レイヤ」#240-243 の 1 つめ）。生 JSON エディタは power-user 向けの逃げ道として残す。

## 変更点（harness +31行のみ）

- ツールバー（graph がある文書だけ）に **方向トグル**を追加。現在の `readLayoutConfig(state.model).direction` を `方向: LR/TB` として表示、aria-label/title で次操作を案内
- 押下で `model.ext.layout.direction` を LR⇄TB 反転（`isRecordObject` で既存 spacing/padding/未知 key を保持、欠損なら安全に生成）→ `graphs.forEach(scheduleGraphRender)` で **#228 の自動レイアウトが即時再配置**
- ボタンは `createButton()`（`markUi` 済み）で保存 HTML から除去。**効果（direction 値）は既存 `diagram:submit` round-trip で `.diagram.html` の model block に保存**
- 表示は初期 TB / fallback / **モデル直接編集の反映後**にも同期

## 設計上の判断

- **方向は表示設定なので会話へ還流しない**（top-level `ext` は `describeModelDiff` が見ない。#228 の非還流 characterization を再利用）。`diagram-diff.ts` / `diagram-model.ts` は不変
- 全ノード手動座標の図ではトグルしても見た目は動かないが、`direction` は保存できる（無害・正直な挙動）

## テスト

- `tsc -b` / `pnpm check`: pass ・ `vitest run`: 540 pass ・ `biome`: clean ・ `build`: pass
- `playwright e2e/diagram-harness.spec.ts`: 31 テスト pass（LR→TB 切替+再配置+保存 / ext 欠損補完+モデル直接編集同期 / graph なしは非表示 / 既存 graph・kind・group・edge・list・自動レイアウト回帰）

## スコープ外

spacing の GUI 調整 / kind ピッカー (#241) / edge コントロール (#242) / ノード追加削除 (#243)。DB・Socket.IO・diagram-diff・diagram-model・モバイルは不変。注入サイズ <128KiB guard 維持。

## レビュー体制

codex が plan 立案・TDD 実装、Claude が P2（plan）/ P5（実装）レビュー（flow-x 役割逆転。実装者 ≠ レビュアー）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - グラフ編集画面のツールバーから、レイアウト方向を左→右（LR）／上→下（TB）へ切り替えられるようになりました。
  - 切り替え後、グラフのノードやエッジが自動的に再配置されます。
  - レイアウト方向は保存・再読み込み後も維持されます。
  - グラフを含まない文書では、レイアウト方向ボタンは表示されません。

- **テスト**
  - レイアウト切り替え、保存、復元、入力値不正時の動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->