### PR TITLE
fix(web): ペインリサイズがカーソル追従し縮小できない不具合を修正

### DIFF
--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -227,8 +227,18 @@ export function SplitViewPane(props: SplitViewPaneProps) {
       )}
 
       <div ref={containerRef} className="flex-1 min-h-0 flex relative">
-        {/* 左ペイン: ターミナル（常時表示） */}
-        <div className="h-full flex-1 min-w-0 overflow-hidden">
+        {/* 左ペイン: ターミナル（常時表示）
+            リサイズ中は pointer-events-none にする。ターミナルは ttyd の iframe
+            （別ブラウジングコンテキスト）で、分割線を左へドラッグしてカーソルが
+            この上に乗ると mousemove / mouseup を iframe が飲み込み、window の
+            リスナーへ届かなくなる。結果、幅が更新されず（ターミナルが狭くならない）、
+            mouseup も発火せずドラッグが解除されない（カーソル追従が止まらない）。
+            右ペイン（ボード）と同様に透過させて window リスナーへ届かせる。 */}
+        <div
+          className={`h-full flex-1 min-w-0 overflow-hidden ${
+            isDragging ? "pointer-events-none" : ""
+          }`}
+        >
           <TerminalPane
             session={props.session}
             worktree={props.worktree}


### PR DESCRIPTION
## 概要

`SplitViewPane` のターミナル/ボード分割リサイズの不具合を修正する。

## 不具合

分割線ドラッグで:
- **カーソルをずっと追従してしまう**（ドラッグが解除されない）
- **ターミナルが狭くなる方向に動かない**（右＝広くする方向だけ動く）

## 根本原因

リサイザは `window` の `mousemove`/`mouseup` で追従し、ドラッグ中は右ペイン（ボード iframe）に `pointer-events-none` を付けてイベントを透過させている。しかし**左ペイン（ターミナルの ttyd iframe）には付いていなかった**。

分割線を左へドラッグ（ターミナルを狭く）するとカーソルがターミナル iframe（別ブラウジングコンテキスト）の上に乗り、`mousemove`/`mouseup` を iframe が飲み込む → `window` リスナーへ届かない。結果:
- 幅（`boardWidth`）が更新されず、ターミナルが狭くならない
- `mouseup` が発火せず `isDragging` が true のまま → カーソル追従が止まらない

右へのドラッグ（ターミナルを広く）はカーソルが `pointer-events-none` のボード側に乗るため動く ← 「片方向だけ動く」の説明。

## 修正

左ペインにも、右ペインと同様にドラッグ中の `pointer-events-none` を付ける（`isDragging` 時）。1 ファイル・実質 1 行。

## 検証

- `biome check`（変更ファイル）: clean ・ `tsc -b`: 型エラーなし
- **codex レビュー: APPROVE**（根本原因分析正しい・2 症状とも解消・副作用なし・指摘なし。iframe 内イベントは親 window へバブルしないため hit-testing から外す本修正が妥当）

## レビュー体制

Claude が実装、**codex がレビュー**（CLAUDE.md: 実装者 ≠ レビュアー、Claude 実装は別 AI がレビュー）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ターミナルを含む分割ペインのサイズ変更中に、ドラッグ操作が途中で解除されたり幅の更新が止まったりする問題を修正しました。
  - ドラッグ中もペインのリサイズ操作が安定して完了するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->