### PR TITLE
feat(diagram): kind ピッカー（ノード上で kind を直接選ぶ） (#241)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-issue-241.md
+++ b/docs/superpowers/plans/2026-07-23-issue-241.md
@@ -1,0 +1,388 @@
+# issue-241: graph node kind ピッカー Implementation Plan
+
+> **実装担当者向け:** 各チェック項目を Red → Green → Refactor の順で進めること。各 Step は 2〜5 分で完了できる粒度にしている。
+
+**Goal:** graph node 上の直接操作 UI から、その図の投影 CSS が定義する kind を選び、`node.kind` と投影の `data-kind` を即時同期して、既存の「変更を送る」経路で model block に保存する。
+
+**Issue:** 241 (GitHub Issue 紐付けあり)
+
+**Architecture:** サーバーが `.diagram.html` の `srcDoc` に注入する `diagram-harness.ts` の graph 初期化時に、authored inline CSS の `[data-kind=…]` selector から図ローカルの候補を抽出し、各 graph node root に小さな `<select>` を付ける。選択時は id から現在の `state.model` の node を引き直して `node.kind` を更新し、#226 の `syncNodeKinds()` で同じ node id の全投影へ `data-kind` を `setAttribute` してから graph を再描画する。ピッカーは #240 の方向トグルと同じく `data-ark-harness-ui` を持つ一時 UI とし、既存 `buildSubmissionHtml()` が除去する。保存は MessageChannel → `DiagramPane` → `diagram:submit` → `parseDiagramModel()` / `replaceModelBlock()` をそのまま使う。既存 `describeModelDiff()` は kind を明示的に無視しているため、kind は model block へ保存する一方、会話には還流しない。
+
+**Tech Stack:** TypeScript / injected vanilla DOM・CSS / Vitest / Playwright / React 19 / Socket.IO
+
+---
+
+## 調査結果と設計判断
+
+- #226 の `syncNodeKinds()` は、ハーネス UI を除く全 `[data-model-id]` を走査し、`getNode()` で node と解決できた全投影へ `data-kind` を `setAttribute`、kind 欠損時は `removeAttribute` する。kind ピッカーはこの関数を唯一の投影同期経路として再利用し、個別要素だけを書き換える別実装を作らない。
+- #229 の edge control は graph ごとの node 解決、前面の一時 UI、model 更新後の再描画、clean submission の共存例である。kind 変更によって node の寸法が変わり得るため、`syncNodeKinds()` 後に対象 graph の `scheduleGraphRender()` を呼び、group・edge・endpoint handle の geometry も追従させる。
+- #240 の方向トグルは「ハーネス内の直接操作 UI → `state.model` 更新 → 即時投影 → 既存の `diagram:submit` で保存 → UI は submission HTML から除去」という同型の手本である。kind ピッカーも新規 Socket.IO event や React state を作らない。
+- `DiagramPane.tsx` はハーネスから `{ type: "ark:diagram-submit", model, html }` を MessageChannel で受け、既存の `diagram:submit` に中継している。kind 固有の payload や UI は不要なので変更しない。
+- `diagram-model.ts` は `node.kind?: string` をすでに opaque string として保持し、`diagram-file.ts` は更新後 model で JSON block を差し替える。server enum、kind 用 schema、DB migration は不要である。
+- `diagram-diff.test.ts` には「kind / ext の変更はサーバーが解釈しない要素なので無視される」という既存契約があり、`diffNodes()` は label・field だけを見る。Issue の「既存踏襲」と非還流契約を優先し、kind 単独変更は `describeModelDiff()` で `[]` のままにする。production `diagram-diff.ts` は変更しない。
+- kind はコア語彙だが値は opaque であり、サーバー固定 enum や既定 palette は置かない。候補は authored inline stylesheet の CSS rule selector に現れる `[data-kind=…]` の値を宣言順に重複排除して得る。`@media` / `@supports` / `@layer` 等の入れ子 rule も再帰走査し、`data-ark-harness-ui` の付いた注入 stylesheet は候補源から除外する。
+- 候補抽出は CSSOM の selector rule だけを対象にし、declaration、コメント、モデル label、DOM の現在値を候補定義として誤認しない。引用符あり・なしの attribute selector を扱い、CSS escape は実値へ戻す。候補数・表示長には UI の資源上限を置いてもよいが、それは picker の防御であり、server validation や kind enum にはしない。
+- node の現在 kind が CSS 候補に無い場合も model と投影は変更しない。select には現在値を安全に示す disabled option を置き、選択可能なのは CSS 由来 allowlist だけにする。候補が一件もない graph node には無効な UI を出さず、モデル直接編集という既存 fallback を残す。
+- UI は graph node root の左上、既存 drag handle は右上に置く。node の hover / `:focus-within` で表示し、キーボード Tab でも到達できる native `<select>` とする。accessible name は node label と現在 kind を示す。select 操作は graph drag、edge endpoint drag、contenteditable、list reorder を開始させない。
+- 候補と node label は信頼しない。option は `document.createElement("option")` と `textContent` / `value`、投影は既存 `setAttribute("data-kind", value)` のみを使い、`innerHTML`、selector 文字列への再挿入、script 生成を禁止する。
+- ピッカー、option を含む wrapper、必要な補助 DOM はすべて `markUi()` で `data-ark-harness-ui` を持たせる。`buildSubmissionHtml()` の汎用 cleanup に任せ、authored `data-kind` は保存 HTML に残す。
+- アイコンが必要でも Unicode または inline SVG のみとし、外部 URL、image、font、stylesheet、icon library、外部 `<use href>`、`fetch()`、dynamic `import()`、Worker / blob URL は追加しない。
+- 実装差分は原則 `packages/server/src/lib/diagram-harness.ts`、`packages/server/src/lib/diagram-harness.test.ts`、`packages/server/src/lib/diagram-diff.test.ts`、`e2e/diagram-harness.spec.ts`、本 plan に限定する。`DiagramPane.tsx`、`diagram-model.ts`、`diagram-file.ts`、`diagram-diff.ts`、server submit handler、shared Socket.IO types、DB、sample / authoring skill は変更しない。
+- 注入後 HTML の既存 `<128KiB` guard は必ず維持する。上限に近づく場合は候補 parser と UI helper の重複を整理し、guard の緩和や外部 bundle 化はしない。
+- 以下のコマンドは実装時に Red / Green を確認するためのもの。この plan 作成時には production code や test code を変更・実行しない。
+
+---
+
+## Task 1: kind ピッカーの browser acceptance を先に Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts:7-110,1727-1775,2513-2606`
+- Reference: `packages/server/src/lib/diagram-harness.ts:93-142,1006-1124,1190-1224,1395-1450`
+- Reference: `packages/server/src/lib/diagram-diff.ts:96-117,161-165`
+
+- [ ] **Step 1: 既存 fixture を CSS 候補抽出の検証用に固定する（2〜5分）**
+
+  `diagramHtml()` の authored CSS にある `aggregate` / `entity` / `event` を候補源として再利用する。model では `aggregate` / `entity` だけを使用しているため、未使用だが CSS が定義する `event` も picker に現れることを確認できる。候補専用の server enum や test-only model 設定は作らない。
+
+- [ ] **Step 2: node root だけに picker が付く test を追加する（2〜5分）**
+
+  graph 内の `order` / `user` node root には node label を含む accessible name の select が一つずつ存在し、option が CSS 宣言順で重複なしの `aggregate`, `entity`, `event` になることを assertion にする。group root、同じ id の内側 `h2`、field、edge、graph 外の `external` 投影には picker が付かないことも固定する。
+
+- [ ] **Step 3: 選択直後の model と投影変化を test にする（2〜5分）**
+
+  `order` の select で `event` を選び、モデル直接編集 panel を開かなくても root と同 id の内側投影が `data-kind="event"` になり、computed background / border / icon が event 用へ即時変化することを確認する。変更前の label、fields、ext、edge、group は変わらないことも確認する。
+
+- [ ] **Step 4: geometry 追従を test にする（2〜5分）**
+
+  kind 切替で node の width / height が変わる CSS rule を fixture に一つ追加し、変更後に group boundary が member node を囲み続け、edge main line と両 endpoint handle が新しい外周へ追従することを polling で確認する。node kind の変更が graph render を迂回しないことを acceptance にする。
+
+- [ ] **Step 5: 保存・clean HTML・非還流を test にする（2〜5分）**
+
+  `connectSubmissionPort()` 後に kind を選び、既存「変更を送る」を押す。submission model の対象 node だけが `kind: "event"`、submission HTML の authored node 投影が `data-kind="event"` であることを確認する。一方、picker の class / option / `data-ark-harness-ui` は HTML に残らず、`describeModelDiff(initialModel, submission.model)` は `[]` になることを固定する。
+
+- [ ] **Step 6: Red を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "kind ピッカー"
+  ```
+
+  Expected: FAIL。現状は graph node 上に select がないため、最初の role assertion で失敗する。
+
+---
+
+## Task 2: CSS 由来の diagram-local kind allowlist を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.test.ts:30-82,124-136`
+- Modify: `packages/server/src/lib/diagram-harness.ts:37-144,151-175,1006-1124,1190-1224`
+- Test: `e2e/diagram-harness.spec.ts`
+- Reference only: `.claude/skills/diagram-authoring/SKILL.md`
+
+- [ ] **Step 1: injected harness の静的契約 test を Red にする（2〜5分）**
+
+  `diagram-harness.test.ts` に、authored style rule の走査 helper、`data-kind` selector からの候補抽出、候補重複排除、kind picker の生成、`node.kind` 更新、`syncNodeKinds()`、`scheduleGraphRender()` が注入文字列に含まれる assertion を追加する。固定 kind 名や palette がハーネスへ入っていないことも確認する。
+
+- [ ] **Step 2: security と size guard を test に加える（2〜5分）**
+
+  既存 marker 一意性と `<128KiB` assertion を維持し、kind picker 実装にも `innerHTML`、`insertAdjacentHTML`、`fetch(`、`import(`、`https://`、外部 font / stylesheet がないことを固定する。安全な option 作成に `textContent` / `value`、投影に `setAttribute("data-kind", …)` を使う契約を assertion にする。
+
+- [ ] **Step 3: authored CSS rule の候補収集 helper を実装する（2〜5分）**
+
+  `style:not([data-ark-harness-ui])` の same-document stylesheet だけを列挙し、利用可能な `cssRules` を宣言順に再帰走査する。style rule の `selectorText` にある `[data-kind=…]` の属性値だけを CSS の escape 規則に従って文字列へ戻し、空でない値を重複排除して返す。CSSOM access が例外になる style は無視し、外部 stylesheet を読みに行かない。
+
+- [ ] **Step 4: opaque 性と UI resource bound を分離する（2〜5分）**
+
+  candidate collector に server 語彙や kebab-case validation を入れない。候補数・表示長を防御的に制限する場合は、超過候補を picker に出さないだけにし、既存 `node.kind` の保持、`syncNodeKinds()`、server parser の round-trip には影響させない。
+
+- [ ] **Step 5: nested rule と selector variant の E2E を追加する（2〜5分）**
+
+  quoted / single-quoted / unquoted selector、selector list、同じ kind の複数 rule、`@media` 等の nested rule を含む小さな inline fixture を追加する。候補が宣言順かつ一意であり、declaration 内の文字列やコメント中の `[data-kind=…]` は候補にならないことを確認する。
+
+- [ ] **Step 6: candidate collector を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts
+  ```
+
+  Expected: PASS。CSS 候補抽出の静的契約、marker 一意性、外部依存禁止、注入サイズ guard がすべて Green。
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "kind 候補"
+  ```
+
+  Expected: PASS。CSS rule variant と重複排除が browser 上で Green。
+
+---
+
+## Task 3: graph node 上の安全な直接操作 UI を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:93-142,1006-1124,1190-1224,1460-1575`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: picker の DOM と CSS を追加する（2〜5分）**
+
+  node 左上に置く harness wrapper と native select の style を追加する。通常時は node 内容を邪魔しない控えめな表示にし、node hover と `:focus-within` で判読可能にする。既存 `.ark-harness-graph-handle` は右上のまま保ち、picker と重ならない。browser native の矢印または Unicode だけを使う。
+
+- [ ] **Step 2: option を DOM API だけで構築する（2〜5分）**
+
+  CSS 由来 allowlist を一度受け取り、各 option を `createElement`、`textContent`、`value` で生成する。node label と現在値を accessible name / title に設定するときも property または `setAttribute` だけを使う。現在 kind が allowlist 外なら disabled な現在値 option を表示し、候補へ昇格させない。
+
+- [ ] **Step 3: graph node root へだけ picker を attach する（2〜5分）**
+
+  `wireGraph()` がすでに確定する `nodesById` を使い、各 root に一個だけ picker を付ける。`data-model-id` の重複投影、group、field、edge、graph 外 node へ誤って付けない。wrapper と全 control は `markUi()` で一時 UI として識別する。
+
+- [ ] **Step 4: change で最新 model の node.kind を更新する（2〜5分）**
+
+  handler は attach 時の node object を保持せず、root の id から `getNode(state.model, id)` で現在 node を引き直す。選択値が diagram-local allowlist に含まれることを再確認してから `node.kind` を更新し、`syncNodeKinds()` を呼ぶ。allowlist 外の programmatic value、node 消失、空 id は何も変更せず終了する。
+
+- [ ] **Step 5: style 変更後の graph を再描画する（2〜5分）**
+
+  `syncNodeKinds()` の直後に対象 graph の `scheduleGraphRender(graph)` を呼ぶ。新しい kind CSS による node size を ResizeObserver と次 frame の render に反映し、node、group、edge、endpoint handle の順序を既存 `renderGraph()` に任せる。
+
+- [ ] **Step 6: drag・inline edit と入力イベントを分離する（2〜5分）**
+
+  picker の pointer / click / keyboard 操作が graph handle drag、edge endpoint drag、contenteditable の入力、list drag を起動しないことを必要最小限の event handling で保証する。node 全体への新しい drag listener や document-level click menu は追加しない。
+
+- [ ] **Step 7: モデル直接編集後に picker 表示を再同期する（2〜5分）**
+
+  model panel の apply 成功 path で `state.model = parsed` 後、既存 `syncNodeKinds()` に続けて全 picker の選択値・accessible name を現在 node に合わせる。CSS 候補リストは authored CSS 由来のままとし、直接入力した未知 kind は disabled current option として安全に示す。既存の方向ボタン同期と全 graph render の順序を壊さない。
+
+- [ ] **Step 8: unit と直接操作 E2E を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts
+  ```
+
+  Expected: PASS。picker contract、cleanup marker、size / CSP guard が Green。
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "kind ピッカー"
+  ```
+
+  Expected: PASS。候補表示、直接変更、即時 style / geometry 同期、保存、clean HTML が Green。
+
+- [ ] **Step 9: Refactor する（2〜5分）**
+
+  candidate collection、option construction、picker state sync、model mutation を短い helper に分ける。`syncNodeKinds()`、`getNode()`、`markUi()`、`scheduleGraphRender()` を再利用し、固定 enum、duplicate DOM scan、JSON block の直接書換え、Socket.IO 呼出しをハーネスへ持ち込まない。
+
+---
+
+## Task 4: 境界ケースとセキュリティ回帰を固定する
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+- Modify: `packages/server/src/lib/diagram-diff.test.ts:357-372`
+- Verify only: `packages/server/src/lib/diagram-model.ts`
+- Verify only: `packages/server/src/lib/diagram-file.ts`
+- Verify only: `packages/web/src/components/DiagramPane.tsx`
+
+- [ ] **Step 1: kind 単独の非還流 characterization を明確化する（2〜5分）**
+
+  `diagram-diff.test.ts` の kind / ext 複合 case を分けるか kind 単独 caseを追加し、同一 id / label / fields の node が `entity` から `aggregate` へ変わっても `describeModelDiff()` が `[]` を返すことを明示する。production `diagram-diff.ts` は変更しない。
+
+- [ ] **Step 2: 非還流 test を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run src/lib/diagram-diff.test.ts
+  ```
+
+  Expected: PASS。kind は model に保存されるが会話用意味差分にはならず、既存 node label / field / edge endpoint の意味差分は従来どおり残る。
+
+- [ ] **Step 3: 候補なし・候補外 current kind を test にする（2〜5分）**
+
+  `[data-kind=…]` rule がない図では picker が出ず、node と既存編集 UI は動作することを確認する。現在 kind が CSS 候補外の図では model / `data-kind` を維持し、disabled current option と CSS 候補を区別でき、候補選択後だけ kind が変わることを確認する。
+
+- [ ] **Step 4: untrusted kind の DOM injection 防止を test にする（2〜5分）**
+
+  markup や quote に見える文字を含む CSS selector value / node kind を fixture にし、option の可視 text と value には同じ文字列が入るが、`img` / `script` / event handler 属性等の新しい DOM が生成されないことを確認する。選択後も投影更新は `data-kind` 属性だけで、外部 request が発生しないことを確認する。
+
+- [ ] **Step 5: model apply と picker の再同期を test にする（2〜5分）**
+
+  picker で変更後、モデル直接編集で別の候補 kind と候補外 kind を順に反映し、投影属性、computed style、picker の selected / disabled current option が毎回一致することを確認する。方向トグルの表示同期も同じ apply 後に維持されることを併記する。
+
+- [ ] **Step 6: 既存直接操作との共存 test を追加する（2〜5分）**
+
+  kind 変更後に代表的な node drag、edge endpoint rewire、field inline edit、list reorder を行い、submission model にすべての変更が共存することを確認する。`describeModelDiff()` には label / field / endpoint の意味差分だけが入り、kind と座標は入らないことを assertion にする。
+
+- [ ] **Step 7: clean submission の完全性を test にする（2〜5分）**
+
+  submission HTML に authored model script、graph、projection CSS、更新済み `data-kind` は残り、kind picker、direction button、graph / edge handles、CSP meta、`contenteditable`、`data-ark-harness-ui`、`ark-harness-*` class は残らないことを確認する。
+
+- [ ] **Step 8: 境界 E2E を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "kind ピッカー|kind 候補|モデル直接編集"
+  ```
+
+  Expected: PASS。候補なし、候補外 current kind、DOM injection 防止、model apply、既存編集共存、clean submission が Green。
+
+---
+
+## Task 5: round-trip と全回帰を検証する
+
+**Files:**
+
+- Verify: `packages/server/src/lib/diagram-harness.ts`
+- Verify: `packages/server/src/lib/diagram-harness.test.ts`
+- Verify: `packages/server/src/lib/diagram-diff.test.ts`
+- Verify: `e2e/diagram-harness.spec.ts`
+- Verify only: `packages/server/src/lib/diagram-model.test.ts`
+- Verify only: `packages/server/src/lib/diagram-file.test.ts`
+- Verify only: `packages/server/src/lib/diagram-reader.test.ts`
+
+- [ ] **Step 1: model parser の opaque kind 回帰を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run src/lib/diagram-model.test.ts
+  ```
+
+  Expected: PASS。`command` / `event` / `service` 等の任意文字列 kind が固定 enum なしで保持される。
+
+- [ ] **Step 2: model block round-trip を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run src/lib/diagram-file.test.ts
+  ```
+
+  Expected: PASS。`replaceModelBlock()` → `extractModel()` で更新後 `node.kind` と既存 ext / fields / edges / groups が保持される。
+
+- [ ] **Step 3: diagram delivery 回帰を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run src/lib/diagram-reader.test.ts
+  ```
+
+  Expected: PASS。配信時の CSP とハーネス注入、authored projection / `data-kind` が維持される。
+
+- [ ] **Step 4: server diagram unit suite を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run \
+    src/lib/diagram-harness.test.ts \
+    src/lib/diagram-model.test.ts \
+    src/lib/diagram-file.test.ts \
+    src/lib/diagram-reader.test.ts \
+    src/lib/diagram-diff.test.ts
+  ```
+
+  Expected: PASS。kind picker、opaque round-trip、非還流、CSP、注入サイズ guard が同時に Green。
+
+- [ ] **Step 5: diagram harness の Chromium 全回帰を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium
+  ```
+
+  Expected: PASS。kind に加え、graph layout、方向トグル、group、edge semantics / rewire、self-edge、node drag、inline edit、list reorder、model apply、authored samples がすべて Green。
+
+- [ ] **Step 6: 静的検査を実行する（2〜5分）**
+
+  Run: `pnpm check`
+
+  Expected: PASS。Biome と TypeScript project references が error 0件。
+
+- [ ] **Step 7: build を実行する（2〜5分）**
+
+  Run: `pnpm build`
+
+  Expected: PASS。server / web / desktop の既存 build が成功する。
+
+- [ ] **Step 8: scope と whitespace を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  git diff --name-only origin/main...HEAD
+  git diff --check origin/main...HEAD
+  ```
+
+  Expected: 実装差分は harness、harness unit、diff characterization、diagram E2E、本 plan に限定され、`DiagramPane.tsx`、`diagram-model.ts`、`diagram-file.ts`、production `diagram-diff.ts`、`packages/server/src/index.ts`、shared types、DB、skill / sample に変更がない。`git diff --check` は出力なし。
+
+---
+
+## Task 6: 実機で直接操作と保存を受け入れる
+
+**Files:**
+
+- Verify: `docs/diagrams/sample.diagram.html`
+- Verify: `packages/server/src/lib/diagram-harness.ts`
+- Verify only: `packages/web/src/components/DiagramPane.tsx:146-223`
+- Verify only: `packages/server/src/index.ts:2207-2342`
+
+- [ ] **Step 1: node 上の picker を操作する（2〜5分）**
+
+  PC session で `docs/diagrams/sample.diagram.html` を `board_open` し、node hover で picker が現れ、Tab / arrow key / Enter でも候補を選べることを確認する。kind を変えると色・アイコンが即時に切り替わり、node label や field edit を覆わないことを確認する。
+
+- [ ] **Step 2: graph geometry の追従を確認する（2〜5分）**
+
+  寸法の異なる kind へ切り替え、group boundary、edge line / marker / cardinality、endpoint handles が node 外周へ追従することを確認する。node drag と edge endpoint drag も picker と干渉しないことを確認する。
+
+- [ ] **Step 3: 変更を送って保存を確認する（2〜5分）**
+
+  「変更を送る」を押し、再読込後も選択した kind と投影 style が維持され、`.diagram.html` の model block に更新後 `node.kind`、authored projection に同期済み `data-kind` が残ることを確認する。一時 picker DOM / class はファイルに残らない。
+
+- [ ] **Step 4: 非還流を確認する（2〜5分）**
+
+  kind だけを変えた送信では ACK の `sent` が空で、会話へ「図を編集しました」が追加されないことを確認する。続けて field label または edge endpoint も変えた場合は、その既存意味差分だけが会話へ還流し、kind 名は混ざらないことを確認する。
+
+- [ ] **Step 5: P5 human gate を完了する（2〜5分）**
+
+  Expected: P5 human PASS。生 JSON を開かない kind 変更、即時 style / geometry 同期、model block 保存、非還流、graph / group / edge / list 編集との共存、外部通信なしを確認する。不具合があれば対応する acceptance を先に Red にしてから修正する。
+
+---
+
+## Human review / stop conditions
+
+- production `packages/server/src/lib/diagram-diff.ts` を変更して kind を自然文化・会話還流する案へ進む場合は、この plan の非還流境界を越える。kind は外部入力の opaque string であり文面注入対策も必要になるため、実装を止めて human security review と設計承認を受ける。
+- server enum、固定 palette、kind 用 DB column / migration、新規 Socket.IO event、React 側 picker が必要になった場合も、調査結果と異なるため実装を止めて scope を再承認する。DB schema 変更は本計画では不要である。
+- authored CSS 以外から候補を取るため新しい `model.ext` 設定を正式 contract にする場合は、authoring skill と sample の更新要否を human review で判断する。本計画は CSS selector 抽出だけで完了させる。
+- `<128KiB` guard を超えた場合は guard を緩和せず、helper の整理または UI 設計の縮小を行う。外部 script / stylesheet への分離は採用しない。
+
+---
+
+## 完了条件チェック
+
+- [ ] graph node 上の直接操作 picker が authored projection CSS の kind 候補を固定 enum なしで列挙する。
+- [ ] picker 選択で対象 `node.kind` が更新され、#226 の `syncNodeKinds()` により全対応投影の `data-kind` と色・アイコンが即時に変わる。
+- [ ] kind による node 寸法変更後も group、edge、endpoint handle の geometry が追従する。
+- [ ] 「変更を送る」後の model block と authored `data-kind` に更新値が保存され、再読込後も維持される。
+- [ ] kind 単独変更は既存 `describeModelDiff()` 契約どおり会話へ還流しない。
+- [ ] 候補・label は `textContent` / `value` / `setAttribute` だけで扱われ、`innerHTML`、外部 URL / font / stylesheet、外部 icon、dynamic fetch / import を使わない。
+- [ ] picker を含む一時 UI はすべて `data-ark-harness-ui` で除去され、authored model / projection / CSS は clean submission に残る。
+- [ ] 注入 HTML は `<128KiB`、marker は一意、既存 CSP / sandbox / MessageChannel 境界を維持する。
+- [ ] graph / group / edge / list、方向トグル、node / endpoint drag、inline edit、モデル直接編集が回帰していない。
+- [ ] DB schema、production diff、model parser、file writer、Socket.IO、`DiagramPane.tsx` を変更せず、Vitest、Chromium E2E、`pnpm check`、`pnpm build`、P5 human gate がすべて成功する。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -73,6 +73,7 @@ function diagramHtml(diagramModel: unknown = model): string {
       [data-kind="aggregate"] { --kind-color: #e0af68; --kind-bg: #332b1f; }
       [data-kind="entity"] { --kind-color: #7aa2f7; --kind-bg: #1f2a44; }
       [data-kind="event"] { --kind-color: #9ece6a; --kind-bg: #203222; }
+      .entity[data-kind="event"] { width: 280px; height: 260px; }
       [data-kind="aggregate"] .kind-icon::before { content: "◆"; }
       [data-kind="entity"] .kind-icon::before { content: "●"; }
       [data-kind="event"] .kind-icon::before { content: "⚡"; }
@@ -140,6 +141,54 @@ function invalidCoordinateHtml(): string {
       <section class="node" data-model-id="null_y">Null Y</section>
     </div>
     <section data-model-id="outside">Outside</section>
+  </body></html>`);
+}
+
+function kindCandidateHtml(): string {
+  const candidateModel = {
+    version: 1,
+    nodes: [{ id: "candidate", label: "Candidate", kind: "quoted" }],
+    edges: [],
+    groups: [],
+  };
+  return injectHarness(`<!doctype html><html><head><style>
+    [data-kind="quoted"] { color: red; }
+    [data-kind='single'], .variant[data-kind=unquoted] { color: green; }
+    [data-kind="quoted"] { border-color: red; }
+    @media (min-width: 0px) {
+      [data-kind="nested"] { color: blue; }
+    }
+    [data-kind="escaped\\26 kind"] { color: purple; }
+    .noise { --kind-like-text: "[data-kind=declaration]"; }
+    /* [data-kind=comment] */
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(candidateModel)}</script>
+    <div data-ark-container="graph">
+      <section data-model-id="candidate">Candidate</section>
+    </div>
+  </body></html>`);
+}
+
+function untrustedKindHtml(): string {
+  const boundaryModel = {
+    version: 1,
+    nodes: [
+      {
+        id: "unsafe",
+        label: 'Unsafe "Node" <img>',
+        kind: 'current"><img src=x onerror=alert(1)>',
+      },
+    ],
+    edges: [],
+    groups: [],
+  };
+  return injectHarness(`<!doctype html><html><head><style>
+    [data-kind="candidate\\22 ><script src=x>"] { color: rgb(1, 2, 3); }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(boundaryModel)}</script>
+    <div data-ark-container="graph">
+      <section data-model-id="unsafe">Unsafe Node</section>
+    </div>
   </body></html>`);
 }
 
@@ -1775,6 +1824,342 @@ test("node.kind を data-kind へ同期して色とアイコンを区別する",
   ).toHaveAttribute("contenteditable", "true");
 });
 
+test("kind 候補は authored CSS rule を宣言順かつ重複なしで収集する", async ({
+  page,
+}) => {
+  await page.setContent(kindCandidateHtml());
+
+  const picker = page.getByRole("combobox", {
+    name: /Candidate.*quoted/,
+  });
+  await expect(picker).toHaveCount(1);
+  expect(await picker.locator("option").allTextContents()).toEqual([
+    "quoted",
+    "single",
+    "unquoted",
+    "nested",
+    "escaped&kind",
+  ]);
+  await expect(picker.locator("option")).toHaveCount(5);
+  await expect(
+    picker.locator("option", { hasText: "declaration" })
+  ).toHaveCount(0);
+  await expect(picker.locator("option", { hasText: "comment" })).toHaveCount(0);
+});
+
+test("kind 候補が無い図ではピッカーを付けず既存編集 UI を維持する", async ({
+  page,
+}) => {
+  await page.setContent(invalidCoordinateHtml());
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  await expect(graph.locator(".ark-harness-kind-picker")).toHaveCount(0);
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(4);
+  await expect(
+    graph.locator('[data-model-id="valid_a"].ark-harness-editable')
+  ).toHaveAttribute("contenteditable", "true");
+});
+
+test("kind ピッカーは候補外の現在値を保持し候補選択時だけ更新する", async ({
+  page,
+}) => {
+  const boundaryModel = structuredClone(model);
+  boundaryModel.nodes[0].kind = "legacy-kind";
+  await openDiagram(page, boundaryModel);
+
+  const order = page.locator(
+    '[data-ark-container="graph"] > section[data-model-id="order"]'
+  );
+  const picker = order.locator("select.ark-harness-kind-select");
+  const current = picker.locator("option").first();
+  await expect(order).toHaveAttribute("data-kind", "legacy-kind");
+  await expect(picker).toHaveValue("legacy-kind");
+  await expect(current).toBeDisabled();
+  await expect(current).toHaveText("legacy-kind");
+  await expect(current).toHaveAttribute("value", "legacy-kind");
+  expect(await picker.locator("option").allTextContents()).toEqual([
+    "legacy-kind",
+    "aggregate",
+    "entity",
+    "event",
+  ]);
+
+  await picker.selectOption("entity");
+  await expect(order).toHaveAttribute("data-kind", "entity");
+  await expect(picker).toHaveValue("entity");
+  await expect(picker.locator("option")).toHaveCount(3);
+});
+
+test("kind ピッカーは untrusted 値を text と value だけで扱う", async ({
+  page,
+}) => {
+  const requests: string[] = [];
+  page.on("request", request => requests.push(request.url()));
+  await page.setContent(untrustedKindHtml());
+
+  const currentKind = 'current"><img src=x onerror=alert(1)>';
+  const candidateKind = 'candidate"><script src=x>';
+  const root = page.locator(
+    '[data-ark-container="graph"] > [data-model-id="unsafe"]'
+  );
+  const picker = root.locator("select.ark-harness-kind-select");
+  const options = picker.locator("option");
+  await expect(options).toHaveCount(2);
+  await expect(options.nth(0)).toBeDisabled();
+  await expect(options.nth(0)).toHaveText(currentKind);
+  await expect(options.nth(0)).toHaveAttribute("value", currentKind);
+  await expect(options.nth(1)).toHaveText(candidateKind);
+  await expect(options.nth(1)).toHaveAttribute("value", candidateKind);
+  await expect(
+    page.locator(
+      "img, script:not(#ark-diagram-model):not(#ark-diagram-harness), [onerror], [onload]"
+    )
+  ).toHaveCount(0);
+
+  await picker.selectOption(candidateKind);
+  await expect(root).toHaveAttribute("data-kind", candidateKind);
+  await expect(
+    page.locator(
+      "img, script:not(#ark-diagram-model):not(#ark-diagram-harness), [onerror], [onload]"
+    )
+  ).toHaveCount(0);
+  expect(requests).toEqual([]);
+});
+
+test("モデル直接編集後に kind ピッカーと方向表示を再同期する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  const order = page.locator(
+    '[data-ark-container="graph"] > section[data-model-id="order"]'
+  );
+  const picker = order.locator("select.ark-harness-kind-select");
+  const editButton = page.getByRole("button", {
+    name: "モデル JSON を直接編集する",
+  });
+
+  await picker.selectOption("event");
+  await expect(order).toHaveAttribute("data-kind", "event");
+
+  const candidateModel = structuredClone(model);
+  candidateModel.nodes[0].kind = "entity";
+  await editButton.click();
+  await page
+    .locator(".ark-harness-textarea")
+    .fill(JSON.stringify(candidateModel));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+  await expect(order).toHaveAttribute("data-kind", "entity");
+  await expect(picker).toHaveValue("entity");
+  await expect(picker).toHaveAccessibleName(/Order.*entity/);
+
+  const unknownModel = structuredClone(
+    candidateModel
+  ) as typeof candidateModel & {
+    ext?: { layout: { direction: string } };
+  };
+  unknownModel.nodes[0].kind = "custom-kind";
+  unknownModel.ext = { layout: { direction: "TB" } };
+  await editButton.click();
+  await page
+    .locator(".ark-harness-textarea")
+    .fill(JSON.stringify(unknownModel));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+  await expect(order).toHaveAttribute("data-kind", "custom-kind");
+  await expect(picker).toHaveValue("custom-kind");
+  await expect(picker).toHaveAccessibleName(/Order.*custom-kind/);
+  const current = picker.locator("option").first();
+  await expect(current).toBeDisabled();
+  await expect(current).toHaveText("custom-kind");
+  await expect(
+    page.getByRole("button", {
+      name: "方向: TB（現在 TB。LR に切り替える）",
+    })
+  ).toBeVisible();
+});
+
+test("kind ピッカーで CSS 候補を選び投影・geometry・保存へ同期する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  await connectSubmissionPort(page);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const order = graph.locator(':scope > section[data-model-id="order"]');
+  const user = graph.locator(':scope > section[data-model-id="user"]');
+  const orderPicker = order.locator("select.ark-harness-kind-select");
+  const userPicker = user.locator("select.ark-harness-kind-select");
+
+  await expect(orderPicker).toHaveCount(1);
+  await expect(userPicker).toHaveCount(1);
+  await expect(orderPicker).toHaveAccessibleName(/Order.*aggregate/);
+  await expect(userPicker).toHaveAccessibleName(/User.*entity/);
+  expect(await orderPicker.locator("option").allTextContents()).toEqual([
+    "aggregate",
+    "entity",
+    "event",
+  ]);
+  expect(await userPicker.locator("option").allTextContents()).toEqual([
+    "aggregate",
+    "entity",
+    "event",
+  ]);
+  await expect(
+    graph.locator(
+      '[data-ark-group] select, h2[data-model-id="order"] select, li select, .ark-harness-edge-layer select'
+    )
+  ).toHaveCount(0);
+  await expect(
+    page.locator('body > section[data-model-id="external"] select')
+  ).toHaveCount(0);
+
+  const beforeModel = structuredClone(model);
+  const beforeBox = await requiredBoundingBox(order);
+  const beforeStyle = await order.evaluate(element => {
+    const icon = element.querySelector(".kind-icon");
+    const style = getComputedStyle(element);
+    return {
+      backgroundColor: style.backgroundColor,
+      borderLeftColor: style.borderLeftColor,
+      icon: icon ? getComputedStyle(icon, "::before").content : "none",
+    };
+  });
+
+  await orderPicker.selectOption("event");
+
+  await expect(order).toHaveAttribute("data-kind", "event");
+  await expect(order.locator('h2[data-model-id="order"]')).toHaveAttribute(
+    "data-kind",
+    "event"
+  );
+  await expect(orderPicker).toHaveValue("event");
+  await expect(orderPicker).toHaveAccessibleName(/Order.*event/);
+  const afterStyle = await order.evaluate(element => {
+    const icon = element.querySelector(".kind-icon");
+    const style = getComputedStyle(element);
+    return {
+      backgroundColor: style.backgroundColor,
+      borderLeftColor: style.borderLeftColor,
+      icon: icon ? getComputedStyle(icon, "::before").content : "none",
+    };
+  });
+  expect(afterStyle.backgroundColor).not.toBe(beforeStyle.backgroundColor);
+  expect(afterStyle.borderLeftColor).not.toBe(beforeStyle.borderLeftColor);
+  expect(afterStyle.icon).not.toBe(beforeStyle.icon);
+
+  await expect
+    .poll(async () => {
+      const box = await order.boundingBox();
+      return box ? { width: box.width, height: box.height } : null;
+    })
+    .toEqual({ width: 280, height: 260 });
+  const afterBox = await requiredBoundingBox(order);
+  expect(afterBox.width).toBeGreaterThan(beforeBox.width);
+  expect(afterBox.height).toBeGreaterThan(beforeBox.height);
+
+  await expect
+    .poll(async () => {
+      const [groupBox, orderBox, userBox] = await Promise.all([
+        requiredBoundingBox(
+          graph.locator(
+            ':scope > [data-ark-group][data-model-id="ordering-context"]'
+          )
+        ),
+        requiredBoundingBox(order),
+        requiredBoundingBox(user),
+      ]);
+      return (
+        groupBox.x <= orderBox.x &&
+        groupBox.y <= orderBox.y &&
+        groupBox.x + groupBox.width >= orderBox.x + orderBox.width &&
+        groupBox.y + groupBox.height >= orderBox.y + orderBox.height &&
+        groupBox.x <= userBox.x &&
+        groupBox.y <= userBox.y &&
+        groupBox.x + groupBox.width >= userBox.x + userBox.width &&
+        groupBox.y + groupBox.height >= userBox.y + userBox.height
+      );
+    })
+    .toBe(true);
+  await expect
+    .poll(async () => {
+      const edge = await readEdge(page);
+      const handles = await graph
+        .locator('.ark-harness-edge-handle[data-ark-edge-id="e_order_user"]')
+        .evaluateAll(elements =>
+          elements.map(element => {
+            const rect = element.getBoundingClientRect();
+            return {
+              end: element.getAttribute("data-ark-edge-end"),
+              x: rect.x + rect.width / 2,
+              y: rect.y + rect.height / 2,
+            };
+          })
+        );
+      const from = handles.find(handle => handle.end === "from");
+      const to = handles.find(handle => handle.end === "to");
+      return Boolean(
+        from &&
+          to &&
+          Math.abs(from.x - edge.x1) < 1 &&
+          Math.abs(from.y - edge.y1) < 1 &&
+          Math.abs(to.x - edge.x2) < 1 &&
+          Math.abs(to.y - edge.y2) < 1 &&
+          edge.x1 >= afterBox.x &&
+          edge.x1 <= afterBox.x + afterBox.width &&
+          edge.y1 >= afterBox.y &&
+          edge.y1 <= afterBox.y + afterBox.height
+      );
+    })
+    .toBe(true);
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel; html: string };
+        }
+      ).arkHarnessSubmission
+  );
+  if (!submission) throw new Error("submission がありません");
+  expect(submission.model).toEqual({
+    ...beforeModel,
+    nodes: beforeModel.nodes.map(node =>
+      node.id === "order" ? { ...node, kind: "event" } : node
+    ),
+  });
+  expect(describeModelDiff(beforeModel, submission.model)).toEqual([]);
+  expect(submission.html).toContain('data-kind="event"');
+  expect(submission.html).toContain('id="ark-diagram-model"');
+  expect(submission.html).toContain('data-ark-container="graph"');
+  expect(submission.html).toContain('[data-kind="event"]');
+  expect(submission.html).not.toContain("ark-harness-kind-picker");
+  expect(submission.html).not.toContain("ark-harness-layout-direction");
+  expect(submission.html).not.toContain("ark-harness-graph-handle");
+  expect(submission.html).not.toContain("ark-harness-edge-handle");
+  expect(submission.html).not.toContain("Content-Security-Policy");
+  expect(submission.html).not.toContain("contenteditable");
+  expect(submission.html).not.toContain("<option");
+  expect(submission.html).not.toContain("data-ark-harness-ui");
+  expect(
+    await page.evaluate(cleanHtml => {
+      const parsed = new DOMParser().parseFromString(cleanHtml, "text/html");
+      return Array.from(parsed.querySelectorAll("[class]")).some(element =>
+        Array.from(element.classList).some(className =>
+          className.startsWith("ark-harness-")
+        )
+      );
+    }, submission.html)
+  ).toBe(false);
+});
+
 test("sample は複数 kind を色とアイコンで区別する", async ({ page }) => {
   await openSampleDiagram(page);
 
@@ -2425,13 +2810,21 @@ test("event storming sample は手動 timeline と flat group swimlane で配置
   }
 });
 
-test("node ドラッグと list 編集を送信 model と clean HTML に反映する", async ({
+test("kind 変更と node・edge・field・list 編集を同じ送信 model に反映する", async ({
   page,
 }) => {
   await openDiagram(page);
   await connectSubmissionPort(page);
 
   const order = page.locator('section[data-model-id="order"]');
+  await order.locator("select.ark-harness-kind-select").selectOption("event");
+  await expect(order).toHaveAttribute("data-kind", "event");
+  await page.evaluate(
+    () =>
+      new Promise<void>(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
   const handle = order.locator(".ark-harness-graph-handle");
   const beforeBox = await requiredBoundingBox(order);
   const beforeEdge = await readEdge(page);
@@ -2458,6 +2851,29 @@ test("node ドラッグと list 編集を送信 model と clean HTML に反映�
   expect(afterEdge.x1).toBeCloseTo(afterBox.x + afterBox.width, 0);
   expect(afterEdge.y1).toBeGreaterThanOrEqual(afterBox.y);
   expect(afterEdge.y1).toBeLessThanOrEqual(afterBox.y + afterBox.height);
+
+  const toHandle = page.locator(
+    '.ark-harness-edge-handle[data-ark-edge-id="e_order_user"][data-ark-edge-end="to"]'
+  );
+  const [toHandleBox, movedOrderBox] = await Promise.all([
+    requiredBoundingBox(toHandle),
+    requiredBoundingBox(order),
+  ]);
+  await page.mouse.move(
+    toHandleBox.x + toHandleBox.width / 2,
+    toHandleBox.y + toHandleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    movedOrderBox.x + movedOrderBox.width / 2,
+    movedOrderBox.y + movedOrderBox.height / 2,
+    { steps: 5 }
+  );
+  await expect(page.locator(".ark-harness-edge-drop-indicator")).toBeVisible();
+  await page.mouse.up();
+  await expect(
+    page.locator('path.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
+  ).toHaveCount(1);
 
   const status = page.locator('li[data-model-id="order_status"]');
   await expect(status.locator(".ark-harness-text")).toHaveAttribute(
@@ -2491,6 +2907,7 @@ test("node ドラッグと list 編集を送信 model と clean HTML に反映�
       nodes: [
         {
           id: "order",
+          kind: "event",
           ext: { x: 120, y: 110 },
           fields: [
             { id: "order_status", label: "state" },
@@ -2500,9 +2917,18 @@ test("node ドラッグと list 編集を送信 model と clean HTML に反映�
         { id: "user" },
         { id: "external" },
       ],
+      edges: [{ id: "e_order_user", from: "order", to: "order" }],
     },
   });
+  const submittedModel = (submission as { model: DiagramModel }).model;
+  expect(describeModelDiff(model, submittedModel)).toEqual([
+    "Order の status を state に変更",
+    "Order のフィールド順を state, id に変更",
+    "Order から User への関連「belongs to」を Order から Order への関連「belongs to」 に変更",
+  ]);
   const html = (submission as { html: string }).html;
+  expect(html).toContain('data-kind="event"');
+  expect(html).not.toContain("ark-harness-kind-picker");
   expect(html).not.toContain("ark-harness-edge-layer");
   expect(html).not.toContain("ark-harness-graph-handle");
   expect(html).not.toContain("--ark-harness-graph-x");

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1986,6 +1986,7 @@ test("kind ピッカーで CSS 候補を選び投影・geometry・保存へ同�
   const graph = page.locator('[data-ark-container="graph"]');
   const order = graph.locator(':scope > section[data-model-id="order"]');
   const user = graph.locator(':scope > section[data-model-id="user"]');
+  const orderPickerWrapper = order.locator(".ark-harness-kind-picker");
   const orderPicker = order.locator("select.ark-harness-kind-select");
   const userPicker = user.locator("select.ark-harness-kind-select");
 
@@ -2011,6 +2012,20 @@ test("kind ピッカーで CSS 候補を選び投影・geometry・保存へ同�
   await expect(
     page.locator('body > section[data-model-id="external"] select')
   ).toHaveCount(0);
+
+  await expect(orderPickerWrapper).toHaveCSS("opacity", "0");
+  const beforeHoverBox = await requiredBoundingBox(order);
+  await order.hover();
+  await expect(orderPickerWrapper).toHaveCSS("opacity", "1");
+  const [hoverBox, pickerBox, titleBox, dragHandleBox] = await Promise.all([
+    requiredBoundingBox(order),
+    requiredBoundingBox(orderPicker),
+    requiredBoundingBox(order.locator('h2[data-model-id="order"]')),
+    requiredBoundingBox(order.locator(".ark-harness-graph-handle")),
+  ]);
+  expect(hoverBox).toEqual(beforeHoverBox);
+  expect(boxesOverlap(pickerBox, titleBox)).toBe(false);
+  expect(boxesOverlap(pickerBox, dragHandleBox)).toBe(false);
 
   const beforeModel = structuredClone(model);
   const beforeBox = await requiredBoundingBox(order);

--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -371,6 +371,19 @@ describe("describeModelDiff（境界ケース）", () => {
     expect(describeModelDiff(model([before]), model([after]))).toEqual([]);
   });
 
+  it("kind 単独の変更は会話用意味差分に含めない", () => {
+    const before = {
+      ...order,
+      kind: "entity",
+    };
+    const after = {
+      ...order,
+      kind: "aggregate",
+    };
+
+    expect(describeModelDiff(model([before]), model([after]))).toEqual([]);
+  });
+
   it("node.ext の座標変更は意味差分に含めない", () => {
     const before = model([{ ...order, ext: { x: 40, y: 50 } }]);
     const after = model([{ ...order, ext: { x: 120, y: 110 } }]);

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -50,7 +50,7 @@ describe("injectHarness", () => {
     expect(out).toContain("ark-harness-layout-direction");
     expect(out).toContain("function syncLayoutDirectionButton(");
     expect(out).toContain("function toggleLayoutDirection(");
-    expect(out).toContain("現在のレイアウト方向は ");
+    expect(out).toContain('var label = visibleLabel + "（現在 "');
     expect(out).toContain(
       "if (!isRecordObject(state.model.ext)) state.model.ext = {};"
     );
@@ -83,6 +83,10 @@ describe("injectHarness", () => {
     expect(out).not.toContain("fetch(");
     expect(out).not.toContain("import(");
     expect(out).not.toContain("https://");
+    expect(out).not.toContain("innerHTML");
+    expect(out).not.toContain("insertAdjacentHTML");
+    expect(out).not.toContain("@font-face");
+    expect(out).not.toContain('rel="stylesheet"');
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
@@ -131,7 +135,40 @@ describe("injectHarness", () => {
     expect(out).toContain('typeof node.kind === "string"');
     expect(out).toContain('el.setAttribute("data-kind", node.kind)');
     expect(out).toContain('el.removeAttribute("data-kind")');
-    expect(out.match(/syncNodeKinds\(\);/g)).toHaveLength(2);
+    expect(out.match(/syncNodeKinds\(\);/g)).toHaveLength(3);
+    expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  });
+
+  it("authored CSS 由来の kind picker 契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain("function collectKindCandidates(");
+    expect(out).toContain("function collectKindRules(");
+    expect(out).toContain("function decodeCssEscapes(");
+    expect(out).toContain("style:not([data-ark-harness-ui])");
+    expect(out).toContain("rule.selectorText");
+    expect(out).toContain("new Set()");
+    expect(out).toContain("ark-harness-kind-picker");
+    expect(out).toContain('document.createElement("select")');
+    expect(out).toContain('document.createElement("option")');
+    expect(out).toContain("option.textContent = value");
+    expect(out).toContain("option.value = value");
+    expect(out).toContain("function syncKindPicker(");
+    expect(out).toContain("function updateNodeKind(");
+    expect(out).toContain("getNode(state.model, id)");
+    expect(out).toContain("kindCandidates.indexOf(value) === -1");
+    expect(out).toContain("node.kind = value");
+    expect(out).toContain("syncNodeKinds();");
+    expect(out).toContain("scheduleGraphRender(graph);");
+    expect(out).toContain('el.setAttribute("data-kind", node.kind)');
+    expect(out).not.toContain("aggregate");
+    expect(out).not.toContain("entity");
+    expect(out).not.toContain('value === "event"');
+    expect(out).not.toContain('kindCandidates = ["');
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 });

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -153,6 +153,12 @@ describe("injectHarness", () => {
     expect(out).toContain("rule.selectorText");
     expect(out).toContain("new Set()");
     expect(out).toContain("ark-harness-kind-picker");
+    expect(out).toContain("transform: translateY(calc(-100% - .25rem))");
+    expect(out).toContain("opacity: 0; pointer-events: none");
+    expect(out).toContain(
+      ".ark-harness-graph-node:focus-within > .ark-harness-kind-picker"
+    );
+    expect(out).toContain("opacity: 1; pointer-events: auto");
     expect(out).toContain('document.createElement("select")');
     expect(out).toContain('document.createElement("option")');
     expect(out).toContain("option.textContent = value");

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -98,6 +98,18 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-graph-node {
   position: absolute; left: var(--ark-harness-graph-x); top: var(--ark-harness-graph-y); z-index: 2;
 }
+.ark-harness-kind-picker {
+  position: absolute; top: .25rem; left: .25rem; z-index: 3; opacity: .35;
+  transition: opacity .12s ease;
+}
+.ark-harness-graph-node:hover > .ark-harness-kind-picker,
+.ark-harness-graph-node:focus-within > .ark-harness-kind-picker { opacity: 1; }
+.ark-harness-kind-select {
+  appearance: auto; max-width: 9rem; min-width: 4.5rem; padding: .18rem .25rem;
+  border: 1px solid rgba(100,116,139,.55); border-radius: 4px;
+  background: rgba(255,255,255,.94); color: #334155; font: 11px/1.2 sans-serif;
+  cursor: pointer;
+}
 .ark-harness-edge-layer {
   position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%;
   overflow: visible; pointer-events: none;
@@ -177,6 +189,8 @@ const HARNESS_JS = `(function () {
   var edgeDrag = null;
   var graphs = [];
   var graphSequence = 0;
+  var kindCandidates = [];
+  var kindPickers = [];
   var statusEl = null;
   var sendBtn = null;
   var layoutDirectionBtn = null;
@@ -217,6 +231,65 @@ const HARNESS_JS = `(function () {
       if (nodes[i].id === id) return nodes[i];
     }
     return null;
+  }
+
+  function decodeCssEscapes(value) {
+    return value.replace(/\\\\([0-9a-fA-F]{1,6}[ \\t\\r\\n\\f]?|[\\s\\S])/g, function (_, escaped) {
+      var hex = escaped.trim();
+      if (/^[0-9a-fA-F]{1,6}$/.test(hex)) {
+        var codePoint = parseInt(hex, 16);
+        if (codePoint === 0 || codePoint > 1114111 ||
+            (codePoint >= 55296 && codePoint <= 57343)) {
+          return "\\uFFFD";
+        }
+        return String.fromCodePoint(codePoint);
+      }
+      if (escaped === "\\n" || escaped === "\\r" || escaped === "\\f") return "";
+      return escaped;
+    });
+  }
+
+  function collectKindRules(rules, seen, values) {
+    if (!rules || values.length >= 128) return;
+    for (var i = 0; i < rules.length && values.length < 128; i++) {
+      var rule = rules[i];
+      if (typeof rule.selectorText === "string") {
+        var pattern = /\\[\\s*data-kind\\s*=\\s*(?:"((?:\\\\[\\s\\S]|[^"\\\\])*)"|'((?:\\\\[\\s\\S]|[^'\\\\])*)'|((?:\\\\[\\s\\S]|[^\\s\\]])+))\\s*\\]/gi;
+        var match = null;
+        while ((match = pattern.exec(rule.selectorText)) !== null &&
+               values.length < 128) {
+          var encoded = match[1] !== undefined ? match[1]
+            : match[2] !== undefined ? match[2] : match[3];
+          var value = decodeCssEscapes(encoded);
+          if (value && value.length <= 256 && !seen.has(value)) {
+            seen.add(value);
+            values.push(value);
+          }
+        }
+      }
+      var nested = null;
+      try {
+        nested = rule.cssRules;
+      } catch (_) {
+        nested = null;
+      }
+      if (nested) collectKindRules(nested, seen, values);
+    }
+  }
+
+  function collectKindCandidates() {
+    var seen = new Set();
+    var values = [];
+    document.querySelectorAll("style:not([data-ark-harness-ui])").forEach(function (style) {
+      var rules = null;
+      try {
+        rules = style.sheet && style.sheet.cssRules;
+      } catch (_) {
+        rules = null;
+      }
+      if (rules) collectKindRules(rules, seen, values);
+    });
+    return values;
   }
 
   function getGroup(model, id) {
@@ -1098,6 +1171,7 @@ const HARNESS_JS = `(function () {
       markerId: "ark-harness-arrow-" + graphSequence
     };
     nodesById.forEach(function (el, id) {
+      attachKindPicker(graph, el);
       attachGraphHandle(graph, el, modelNodesById.get(id));
     });
     if (typeof ResizeObserver !== "undefined") {
@@ -1204,6 +1278,88 @@ const HARNESS_JS = `(function () {
         el.removeAttribute("data-kind");
       }
     });
+  }
+
+  function createKindOption(value) {
+    var option = document.createElement("option");
+    option.textContent = value;
+    option.value = value;
+    markUi(option);
+    return option;
+  }
+
+  function syncKindPicker(picker) {
+    var id = picker.root.getAttribute("data-model-id");
+    var node = id && getNode(state.model, id);
+    if (!node) {
+      picker.select.disabled = true;
+      return;
+    }
+    picker.select.disabled = false;
+    var current = typeof node.kind === "string" ? node.kind : "";
+    if (kindCandidates.indexOf(current) === -1) {
+      if (!picker.currentOption) {
+        picker.currentOption = createKindOption(current);
+        picker.currentOption.disabled = true;
+        picker.select.insertBefore(picker.currentOption, picker.select.firstChild);
+      } else {
+        picker.currentOption.textContent = current || "kind なし";
+        picker.currentOption.value = current;
+      }
+    } else if (picker.currentOption) {
+      picker.currentOption.remove();
+      picker.currentOption = null;
+    }
+    picker.select.value = current;
+    var name = (typeof node.label === "string" && node.label) || node.id;
+    var currentLabel = current || "なし";
+    var label = name + " の kind（現在 " + currentLabel + "）";
+    picker.select.setAttribute("aria-label", label);
+    picker.select.title = label;
+  }
+
+  function syncKindPickers() {
+    kindPickers.forEach(function (picker) { syncKindPicker(picker); });
+  }
+
+  function updateNodeKind(graph, root, value) {
+    var id = root.getAttribute("data-model-id");
+    if (!id || kindCandidates.indexOf(value) === -1) return;
+    var node = getNode(state.model, id);
+    if (!node) return;
+    node.kind = value;
+    syncNodeKinds();
+    syncKindPickers();
+    scheduleGraphRender(graph);
+  }
+
+  function attachKindPicker(graph, root) {
+    if (kindCandidates.length === 0) return;
+    var wrapper = document.createElement("span");
+    wrapper.className = "ark-harness-kind-picker";
+    markUi(wrapper);
+    var select = document.createElement("select");
+    select.className = "ark-harness-kind-select";
+    markUi(select);
+    kindCandidates.forEach(function (value) {
+      select.appendChild(createKindOption(value));
+    });
+    var picker = {
+      root: root,
+      select: select,
+      currentOption: null
+    };
+    ["pointerdown", "click", "keydown"].forEach(function (type) {
+      select.addEventListener(type, function (event) { event.stopPropagation(); });
+    });
+    select.addEventListener("change", function (event) {
+      event.stopPropagation();
+      updateNodeKind(graph, root, select.value);
+    });
+    wrapper.appendChild(select);
+    root.appendChild(wrapper);
+    kindPickers.push(picker);
+    syncKindPicker(picker);
   }
 
   function markUi(el) {
@@ -1494,6 +1650,7 @@ const HARNESS_JS = `(function () {
         if (!Array.isArray(parsed.groups)) parsed.groups = [];
         state.model = parsed;
         syncNodeKinds();
+        syncKindPickers();
         syncLayoutDirectionButton();
         graphs.forEach(function (graph) { scheduleGraphRender(graph); });
         error.style.display = "none";
@@ -1566,6 +1723,7 @@ const HARNESS_JS = `(function () {
       if (!model) return;
       state.model = model;
       syncNodeKinds();
+      kindCandidates = collectKindCandidates();
       buildToolbar();
       initEditing();
       initGraphs();

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -99,11 +99,14 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   position: absolute; left: var(--ark-harness-graph-x); top: var(--ark-harness-graph-y); z-index: 2;
 }
 .ark-harness-kind-picker {
-  position: absolute; top: .25rem; left: .25rem; z-index: 3; opacity: .35;
-  transition: opacity .12s ease;
+  position: absolute; top: 0; right: .25rem; z-index: 4;
+  transform: translateY(calc(-100% - .25rem));
+  opacity: 0; pointer-events: none; transition: opacity .12s ease;
 }
 .ark-harness-graph-node:hover > .ark-harness-kind-picker,
-.ark-harness-graph-node:focus-within > .ark-harness-kind-picker { opacity: 1; }
+.ark-harness-graph-node:focus-within > .ark-harness-kind-picker {
+  opacity: 1; pointer-events: auto;
+}
 .ark-harness-kind-select {
   appearance: auto; max-width: 9rem; min-width: 4.5rem; padding: .18rem .25rem;
   border: 1px solid rgba(100,116,139,.55); border-radius: 4px;


### PR DESCRIPTION
## 概要

グラフノード上の**直接操作 UI（kind ピッカー）**を追加する。生 JSON を開かずに、ノード上で kind を直接選べる（[[feedback-diagram-direct-manipulation]] で求められた「常用操作は直接操作へ」の一環・編集UX #241）。

## 実装

- ノード上に native `<select>` の kind ピッカーを出し、その図の **authored CSS の `[data-kind=…]` から候補を diagram-local allowlist 化**して選ばせる（server enum / 固定 palette を作らない）
- 選択で `node.kind` を更新 → **#226 `syncNodeKinds()`** で全投影の `data-kind` を同期 → `scheduleGraphRender()` で group / edge / handle の geometry 追従 → 既存「変更を送る」（`diagram:submit`）で保存
- **配置**: picker はノード**上辺の外側（右寄せ）**。通常時は透明・非表示、hover / `:focus-within` で表示し、**ノード内容（title/label/fields）を覆わない・寸法も変えない**。右上の drag handle と非衝突
- **非還流**: kind 単独変更は model にのみ保存、会話へは還流しない（`describeModelDiff` は kind を無視・production `diagram-diff.ts` 不変）
- **セキュリティ**: `createElement`/`textContent`/`setAttribute` のみ・外部リソースなし・一時UIは `data-ark-harness-ui`（`buildSubmissionHtml` が除去）・**<128KiB guard 維持**
- **DB スキーマ変更なし**。スコープは `diagram-harness.ts` + テスト + e2e に限定（`DiagramPane.tsx` / model / file / production diff / Socket.IO / shared 型 不変）

## 検証

- server unit（vitest）: PASS・**Chromium E2E 37 tests PASS**（候補表示・直接変更・即時 style/geometry 同期・保存・clean HTML・非還流・既存編集共存・**picker 非重複/寸法不変**）
- `pnpm check`（biome + tsc）: PASS ・ `pnpm build`: PASS
- **実機プレビューで動作確認済み**（配置の被りも解消を確認）

## 進め方

`/flow-loop` 経由の自走 run。設計承認（P2.5）・実機動作確認・マージ承認、いずれも取得済み。

Closes #241
