### PR TITLE
fix(flow-loop): active_scope を現プロジェクトの run に限定（クロスプロジェクト汚染防止）

### DIFF
--- a/.claude/skills/flow-loop/lib/loop.sh
+++ b/.claude/skills/flow-loop/lib/loop.sh
@@ -156,18 +156,47 @@ flow_loop_unlock() {
   rm -rf "$FLOW_LOOP_LOCK" 2>/dev/null || true
 }
 
-# アクティブ run の scope_key 一覧 (progress の phase != done)。WIP 算出・走査の起点。
-# glob 展開はシェル依存 (zsh は no-match で全体がエラーになる) のため find で列挙する。
+# 現在のプロジェクト (repo) の git-common-dir。run の所属判定に使う。
+# CLAUDE_PROJECT_DIR (loop 起動元) を基準に解決。repo 外なら空 (= 絞り込み無効)。
+flow_loop_self_repo() {
+  git -C "${CLAUDE_PROJECT_DIR:-$PWD}" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true
+}
+
+# run が現在のプロジェクトに属するか (別プロジェクトの run を掴まないためのフィルタ)。
+# 判定は run の context.worktree_path の git-common-dir と self_repo の一致で行う。
+#   - self_repo 空 (repo 外で起動)        → 真 (絞り込みしない = 旧挙動)
+#   - context / worktree が解決できない    → 真 (permissive。active run は通常 worktree を持つ)
+#   - worktree が別 repo                   → 偽 (掴まない)
+# flow state は /tmp 共有のため、このフィルタが無いと他プロジェクトの run まで wip 算入・
+# 走査・前進してしまう (クロスプロジェクト汚染。別 repo の PR を CI 判定/マージしかねない)。
+_flow_loop_run_in_self_repo() {
+  local key="$1" self_repo="$2" ctx wt run_repo
+  [ -n "$self_repo" ] || return 0
+  ctx="$FLOW_LOOP_RUNS_DIR/flow-context-$key.json"
+  [ -f "$ctx" ] || return 0
+  wt="$(jq -r '.worktree_path // empty' "$ctx" 2>/dev/null)" || return 0
+  { [ -n "$wt" ] && [ -d "$wt" ]; } || return 0
+  run_repo="$(git -C "$wt" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || return 0
+  [ -n "$run_repo" ] || return 0
+  [ "$run_repo" = "$self_repo" ]
+}
+
+# アクティブ run の scope_key 一覧 (progress の phase != done・かつ現プロジェクト所属)。
+# WIP 算出・走査の起点。glob 展開はシェル依存 (zsh は no-match で全体がエラーになる) のため find で列挙する。
 flow_loop_active_scope_keys() {
   [ -d "$FLOW_LOOP_RUNS_DIR" ] || return 0
-  local f phase key
+  local f phase key self_repo
+  self_repo="$(flow_loop_self_repo)"
   while IFS= read -r f; do
     [ -n "$f" ] || continue
     phase="$(jq -r '.phase // empty' "$f" 2>/dev/null)" || continue
     if [ -z "$phase" ] || [ "$phase" = "done" ]; then continue; fi
     key="${f##*/flow-progress-}"
     key="${key%.json}"
-    [ -n "$key" ] && printf '%s\n' "$key"
+    [ -n "$key" ] || continue
+    # 別プロジェクトの run (worktree が別 repo) は掴まない。
+    _flow_loop_run_in_self_repo "$key" "$self_repo" || continue
+    printf '%s\n' "$key"
   done < <(find "$FLOW_LOOP_RUNS_DIR" -maxdepth 1 -name 'flow-progress-*.json' -type f 2>/dev/null)
   return 0
 }

--- a/.claude/skills/flow-loop/tests/test-loop.sh
+++ b/.claude/skills/flow-loop/tests/test-loop.sh
@@ -131,6 +131,23 @@ printf '{"phase":"done","ticket":"issue-2"}' > "$TMP_RUNS/flow-progress-issue-2.
 assert_eq "phase=done は active に数えない" "1" "$(flow_loop_active_count)"
 assert_eq "active_scope_keys は scope_key を返す" "issue-1" "$(flow_loop_active_scope_keys)"
 
+# --- クロスプロジェクト分離 (別 repo の run を掴まない) ---
+# flow state は /tmp 共有なので、active_scope は「現プロジェクト所属の run」だけを返すべき。
+# 別 repo の worktree を持つ run を掴むと、別プロジェクトの PR を CI 判定/マージしかねない。
+REPO_A="$TMP_RUNS/repo-a"; REPO_B="$TMP_RUNS/repo-b"
+git init -q "$REPO_A"; git init -q "$REPO_B"
+printf '{"phase":"P3"}' > "$TMP_RUNS/flow-progress-run-a.json"
+printf '{"worktree_path":"%s"}' "$REPO_A" > "$TMP_RUNS/flow-context-run-a.json"
+printf '{"phase":"P3"}' > "$TMP_RUNS/flow-progress-run-b.json"
+printf '{"worktree_path":"%s"}' "$REPO_B" > "$TMP_RUNS/flow-context-run-b.json"
+# 現プロジェクト = repo-a。run-a (同 repo) と context 無しの issue-1 (permissive) は出て、
+# run-b (別 repo) は出ない。
+_scope="$(CLAUDE_PROJECT_DIR="$REPO_A" flow_loop_active_scope_keys | sort | tr '\n' ',')"
+assert_eq "別 repo の run は active_scope に出ない (現 repo + permissive のみ)" "issue-1,run-a," "$_scope"
+# 後片付け (以降の active 系テストに影響させない)
+rm -f "$TMP_RUNS/flow-progress-run-a.json" "$TMP_RUNS/flow-context-run-a.json" \
+      "$TMP_RUNS/flow-progress-run-b.json" "$TMP_RUNS/flow-context-run-b.json"
+
 # --- 稼働時間帯 ---
 flow_loop_update '.active_hours = ""'
 assert_rc "active_hours 空は常時可" 0 'flow_loop_within_active_hours'


### PR DESCRIPTION
## 概要

flow-loop の run 走査を**現在のプロジェクトの run に限定**し、クロスプロジェクト汚染を防ぐ。

## 不具合

flow の run state は `/tmp` 共有（`/tmp/flow-progress-*.json`）。`flow_loop_active_scope_keys` は `/tmp` の全 `flow-progress-*.json` を列挙するため、**別プロジェクトの run まで**掴んでいた。

実害:
- 別プロジェクトの run が **wip_limit を消費**（本来 2 並列できるのに 1 本しか回せない）
- **もっと危険**: tick の STEP 3 が別プロジェクトの run（例: P7）を処理しようとして `(cd <別 repo の worktree> && check_cr_action_state)` を実行 → 条件次第で **別 repo の PR を CI 判定・前進・マージしかねない**

## 修正

`flow_loop_active_scope_keys` に、run の `context.worktree_path` の git-common-dir が**現プロジェクト**（`CLAUDE_PROJECT_DIR` の git-common-dir）と一致する run だけを返すフィルタを追加。

- `self_repo` 空（repo 外で起動）→ permissive（絞り込みしない＝旧挙動）
- context / worktree が解決できない → permissive（active run は通常 worktree を持つ）
- worktree が別 repo → **除外**
- `--path-format=absolute --git-common-dir` 比較なので linked worktree / symlink 経由でも同一 repo を正しく識別

## 検証

- `bash .claude/skills/flow-loop/tests/test-loop.sh` → **58/58 PASS**（別 repo の run を掴まない回帰テストを追加）
- `bash -n` OK
- **codex レビュー: APPROVE**（根本原因妥当・permissive 妥当・副作用なし・指摘なし）

## レビュー体制

Claude が実装、codex がレビュー（実装者 ≠ レビュアー）。関連: #219（/tmp state のユーザーdir 移行）のプロジェクト分離版。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * フローの実行状況を確認する際、現在のプロジェクトに属する実行のみを対象にするよう改善しました。
  * 別プロジェクトや別ワークツリーの実行を誤って検出・処理する問題を防止しました。

* **テスト**
  * プロジェクト間の実行が適切に分離されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->