### PR TITLE
feat(diagram): edge カーディナリティ・方向の直接操作コントロール (#242)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-issue-242.md
+++ b/docs/superpowers/plans/2026-07-23-issue-242.md
@@ -1,0 +1,480 @@
+# issue-242: edge cardinality / direction 直接操作コントロール Implementation Plan
+
+> **実装担当者向け:** 各チェック項目を Red → Green → Refactor の順で進めること。各 Step は 2〜5 分で完了できる粒度にしている。
+
+**Goal:** graph edge の始点・終点付近から cardinality、edge 中点付近から direction を生 JSON なしで選び、`edge.ext.from_card` / `to_card` / `direction` と crow's foot・矢印を即時同期して、既存の「変更を送る」で model block に保存する。
+
+**Issue:** 242 (GitHub Issue 紐付けあり)
+
+**Architecture:** `diagram-harness.ts` の graph ごとの生成 UI に、edge id で key 管理する3つの native `<select>`（始点 cardinality、終点 cardinality、direction）を追加する。選択肢は #229 と同じ固定 allowlist だけから `createElement()` / `textContent` で作り、変更時は現在の `state.model` から edge を引き直して record 形状の `edge.ext` に対象 key だけを保存する。その後 `scheduleGraphRender()` を通じて既存の `edgeDirection()` / `edgeCardinality()` / `applyEdgeMarkers()` / `appendEdgeCardinality()` を再利用し、矢印と inline SVG の crow's foot を次 frame で再投影する。コントロールは edge path の 20% / 50% / 80% 付近を基点に、edge label・両 endpoint handle・node・他 control と重ならない候補位置へ配置し、edge の透明 hit path の hover または control の focus で表示する。すべて `data-ark-harness-ui` の一時 UI とし、保存と非還流は既存 MessageChannel / `diagram:submit` / `describeModelDiff()` の境界を変更しない。
+
+**Tech Stack:** TypeScript / injected vanilla DOM・CSS・inline SVG / Vitest / Playwright
+
+---
+
+## 調査結果と設計判断
+
+- #229 は `edge.ext.from_card` / `to_card` を `one` / `many` / `zero-or-one` / `one-or-many` / `zero-or-many` の5値、`edge.ext.direction` を `forward` / `reverse` / `both` / `none` の4値として投影する。未知 direction は `forward`、未知 cardinality は記号なしへ正規化し、`edge.ext.type` は authored CSS 用の opaque string のまま扱う。本 Issue ではこの意味論を増やさず、同じ allowlist を読取・選択・更新の唯一の正にする。
+- 現在の `renderGraph()` は edge main、`applyEdgeMarkers()`、`appendEdgeCardinality()`、label を毎 frame 作り直した後、`syncEdgeHandles()` で endpoint handle を edge id + end の key で再利用する。select の focus を再描画で失わないよう、edge control も SVG 内へ毎回作り直さず `graph.edgeControlsById` で DOM を保持し、geometry と選択状態だけを同期する。
+- #229 の endpoint handle は graph の専用 handle layer（z-index 3）にあり、`edgeDrag` と `graphDrag` を排他にして `edge.from` / `edge.to` だけを変更する。cardinality control は handle 自体へ埋め込まず、同じ layer 内の別 wrapper と衝突回避配置にして、既存 pointer capture と張り替え hit target を保つ。
+- #241 は native control を対象要素の hover / focus で表示し、選択時に現在の model entry を id から引き直し、allowlist を再検証してから `setAttribute` と graph 再描画へ進む直接操作パターンである。edge control もこの構造を踏襲する。特に、最初の配置を修正して node 内容の外へ移した教訓を受け、edge label・endpoint handle・node 内容を覆わないことを geometry test で必須にする。
+- #240 のレイアウト方向ボタンは `model.ext.layout.direction` の LR / TB を切り替える toolbar UI であり、本 Issue の `edge.ext.direction` とは別物である。既存ボタンの文言・動作・model path は変更せず、edge direction は対象 edge 上の4値 select だけで扱う。
+- `buildSubmissionHtml()` は `[data-ark-harness-ui]`、`ark-harness-*` class、graph / group の一時 geometry、CSP meta、`contenteditable` を既に除去する。edge control wrapper、select、option、透明 hit path、必要な hover bridge はすべて `markUi()` し、この汎用 cleanup に任せる。authored HTML に edge control の投影を保存しない。
+- `handleSubmit()` は `state.model` と clean HTML を MessageChannel で送り、server の既存 `parseDiagramModel()` / `replaceModelBlock()` が model block を保存する。`edge.ext` は既存 parser が opaque record として保持するので、model schema、file writer、Socket.IO payload、`DiagramPane.tsx` の変更は不要である。
+- production `diagram-diff.ts` の `diffEdges()` は同一 edge id の `from` / `to` / `label` だけを見る。既存 `diagram-diff.test.ts` には「`edge.ext` 単独変更は `[]`」「`edge.ext` と endpoint の同時変更は endpoint 差分だけ」という契約がすでにある。これを #242 の3 field 名で明示的に維持し、production `diagram-diff.ts` は変更しない。
+- cardinality が欠損または未知の場合、記号を勝手に補わず、select に安全な disabled placeholder（例: `未設定`）を表示する。direction 欠損時は既存投影どおり effective value の `forward` を表示し、明示的な未知値では disabled placeholder（例: `不正値・表示は forward`）を選択状態にして、`forward` 自体も直接選び直せるようにする。表示同期だけでは model を書き換えず、ユーザーが allowlist 値を選んだ時だけ対象 key を更新する。
+- 更新時は `CARDINALITY_VALUES.indexOf(value)` / `DIRECTION_VALUES.indexOf(value)` で再検証する。`edge.ext` が record なら `type` と未知 key を保持し、対象の `from_card` / `to_card` / `direction` だけを変更する。欠損または array / primitive なら `{}` を作って選択 key だけを入れる。
+- 表示用の値は固定の日本語・Unicode label（`1`、`N`、`0..1`、`1..N`、`0..N`、`→`、`←`、`↔`、`矢印なし`）と canonical value を併記する。edge label は信頼せず、accessible name / `title` へ `setAttribute` するだけにし、HTML 文字列や selector へ連結しない。
+- edge main と同じ geometry の透明な wide-stroke hit path を SVG に追加し、node より背面のまま `pointer-events: stroke` だけを有効にする。hover で該当 edge の control group を active にし、hit path から select へポインターが移る短い間は遅延 close、control hover / `:focus-within` 中は表示を維持する。hidden 時は pointer event を奪わず、Tab focus では native select 自身の focus により表示する。
+- control の anchor は SVG main の `getTotalLength()` / `getPointAtLength()` で line と self-loop path を同じ方法で求める。始点 cardinality は 20%、direction は 50%、終点 cardinality は 80% を基準とし、接線から法線を計算する。法線の両側と接線方向の小さなずらしを決定的な順で試し、実測した edge label、両 endpoint handle、graph node、先に配置済み control と最低6pxの gap を確保する。候補が尽きた場合も edge 外接矩形の上側 / 下側へ退避し、重なったまま採用しない。
+- `select` の `pointerdown` / `click` / `keydown` は propagation を止め、endpoint drag、node drag、inline edit、list reorder を開始させない。変更後の `scheduleGraphRender(graph)` では既存 SVG projection と handle geometry に加え control の value / accessible name / position を再同期する。
+- 外部 URL、image、font、stylesheet、icon library、外部 `<use href>`、`fetch()`、dynamic `import()`、Worker / blob URL は追加しない。記号は既存 inline SVG と Unicode だけを使い、`innerHTML` / `insertAdjacentHTML` は禁止する。
+- 実装差分は `packages/server/src/lib/diagram-harness.ts`、`packages/server/src/lib/diagram-harness.test.ts`、`packages/server/src/lib/diagram-diff.test.ts`、`e2e/diagram-harness.spec.ts`、本 plan に限定する。`edge.type` GUI、レイアウト方向 UI、kind picker、node 追加削除、sample / skill、React、shared types、server submit handler、DB は変更しない。
+- DB schema 変更は不要である。実装中に migration、column、永続化 API の追加が必要だと判明した場合は本計画の信頼境界を越えるため、作業を止めて human review と再承認を受ける。
+- `diagram-harness.test.ts` の注入後 HTML `<128KiB` guard、marker 一意性、外部リソース禁止 assertion は維持する。上限超過時は guard を緩和せず、重複 helper / CSS / label 定義を整理する。
+- 以下のコマンドは実装時の Red / Green 確認用である。この plan 作成時は production code と test code を変更せず、テストも実行しない。
+
+---
+
+## Task 1: edge 直接操作の主要 acceptance を先に Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts:323-403,1092-1572`
+- Reference: `packages/server/src/lib/diagram-harness.ts:651-807,857-1069,1130-1201`
+- Reference: `packages/server/src/lib/diagram-diff.ts:127-165`
+
+- [ ] **Step 1: edge fixture の期待値を3 control 用に整理する（2〜5分）**
+
+  既存 `edgeSemanticsModel` の `e_order_owner` を使い、期待 allowlist と表示 label を test 内の readonly table にする。`type: "belongs-to"` と未知 ext key を一つ fixture に残し、control 操作後も非対象 key が保持されることを後続 test で確認できるようにする。
+
+- [ ] **Step 2: edge ごとに3つの native select がある Red test を追加する（2〜5分）**
+
+  `e_order_owner` に始点 cardinality、終点 cardinality、direction の3 select があり、accessible name に edge label・役割・現在値が含まれることを assertion にする。各 option の `value` が5値 / 5値 / 4値 allowlist と完全一致し、`type` select とレイアウト LR / TB option がないことも固定する。
+
+- [ ] **Step 3: control の hover / focus 表示を Red test にする（2〜5分）**
+
+  初期状態では control group が opacity 0 かつ pointer event を取らず、対象 edge の透明 hit path を hover すると3 control が表示されることを確認する。ポインターを select へ移しても表示を維持し、別 edge へ移動すると元の group が閉じること、Tab focus / `focus()` でも表示されることを assertion にする。
+
+- [ ] **Step 4: cardinality 選択の即時投影を Red test にする（2〜5分）**
+
+  モデル直接編集 panel を開かず、始点を `one` → `zero-or-one`、終点を `zero-or-many` → `one-or-many` に選ぶ。対応する `.ark-harness-edge-cardinality` の `data-ark-edge-cardinality` と circle / line 数が次 frame で変わり、反対側と edge main の from / to / label / type は変わらないことを確認する。
+
+- [ ] **Step 5: direction 選択の即時投影を Red test にする（2〜5分）**
+
+  direction select を `reverse` → `both` → `none` → `forward` と選び、`data-ark-edge-direction` と `marker-start` / `marker-end` の有無が #229 の4値契約どおり即時変化することを確認する。toolbar の「方向: LR/TB」は変わらないことも assertion にする。
+
+- [ ] **Step 6: 保存と非還流を Red test にする（2〜5分）**
+
+  cardinality と direction を変更して「変更を送る」を押し、submission model の対象 edge の `ext` だけが新値になり、`type` / 未知 key と他 edge が保持されることを確認する。`describeModelDiff(initialModel, submission.model)` は `[]`、clean HTML には model script / authored graph が残り、control / hit path / option / `data-ark-harness-ui` は残らないことを固定する。
+
+- [ ] **Step 7: 主要 acceptance の Red を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "edge control|edge cardinality|edge direction"
+  ```
+
+  Expected: FAIL。現状は edge 上に native select と hover hit path がないため、最初の control assertion で失敗する。
+
+---
+
+## Task 2: allowlist と非還流の server contract を Red で固定する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.test.ts:35-109`
+- Modify: `packages/server/src/lib/diagram-diff.test.ts:246-307`
+- Do not modify: `packages/server/src/lib/diagram-diff.ts`
+
+- [ ] **Step 1: harness の3 control 契約 assertion を追加する（2〜5分）**
+
+  注入 HTML に cardinality / direction の allowlist 定数、edge id で再解決する update helper、`edge.ext` record 補完、`scheduleGraphRender(graph)`、native `select` / `option`、`textContent`、`data-ark-harness-ui` が含まれることを assertion にする。
+
+- [ ] **Step 2: 既存投影 helper と allowlist の共有を assertion にする（2〜5分）**
+
+  `edgeCardinality()` / `edgeDirection()` が control と同じ allowlist helper を参照し、変更後の描画が既存 `applyEdgeMarkers()` / `appendEdgeCardinality()` を通る契約を文字列 assertion で固定する。別の cardinality enum や2つ目の marker renderer を許さない。
+
+- [ ] **Step 3: UI security contract を assertion にする（2〜5分）**
+
+  `innerHTML` / `insertAdjacentHTML` / `fetch(` / `import(` / `https://` / `@font-face` / 外部 stylesheet がない既存 assertion を維持し、option 作成が `createElement("option")` と `textContent` / `value`、属性反映が `setAttribute` だけであることを追加する。
+
+- [ ] **Step 4: edge.ext 非還流 test を #242 の3 field に絞る（2〜5分）**
+
+  既存「`edge.ext` だけの変更」case を、`from_card` / `to_card` / `direction` がすべて変わっても `describeModelDiff()` が `[]` になる内容として明示する。`type` 変更を混ぜず、今回の直接操作だけの契約を読み取れる test 名にする。
+
+- [ ] **Step 5: endpoint と ext の同時変更 test を維持する（2〜5分）**
+
+  既存 case を `to` 張り替え + 3つの `edge.ext` 変更へ揃え、結果が endpoint の関連変更文1件だけで cardinality / direction の文字列を含まないことを確認する。production `diagram-diff.ts` は触らない。
+
+- [ ] **Step 6: server contract の Red /既存 Green を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test -- \
+    src/lib/diagram-harness.test.ts src/lib/diagram-diff.test.ts
+  ```
+
+  Expected: `diagram-harness.test.ts` の新しい control assertion は FAIL。`diagram-diff.test.ts` は production diff 不変のまま PASS。
+
+---
+
+## Task 3: allowlist を読取・表示・更新で共有する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:188-200,651-669`
+- Test: `packages/server/src/lib/diagram-harness.test.ts`
+
+- [ ] **Step 1: canonical value と表示 label を定義する（2〜5分）**
+
+  HARNESS JS 内に cardinality 5値と direction 4値の配列を一度だけ定義し、表示用 label table を固定文字列で併置する。値の配列を更新 validation、option 作成、`edgeCardinality()` / `edgeDirection()` の正規化で共有する。
+
+- [ ] **Step 2: 既存 read helper を共有 allowlist へ寄せる（2〜5分）**
+
+  `edgeCardinality(edge, end)` は対応 key の値が cardinality 配列に含まれる時だけ返し、それ以外は `null`。`edgeDirection(edge)` は direction 配列に含まれる時だけ返し、それ以外は従来どおり `forward` にする。`edgeType()` は変更しない。
+
+- [ ] **Step 3: edge.ext を安全に更新する helper を作る（2〜5分）**
+
+  `(graph, edgeId, property, value)` を受け、property と value の組合せを allowlist で再検証し、`getEdge(state.model, edgeId)` で現 edge を引き直す。record の ext は spread / 再構築せずその場で対象 key だけを更新し、欠損・不正 ext だけ `{}` に置換する。
+
+- [ ] **Step 4: 更新後の再描画だけを接続する（2〜5分）**
+
+  helper の成功時だけ `scheduleGraphRender(graph)` を呼ぶ。DOM marker を直接書き換える別経路は作らず、既存 `renderGraph()` → `applyEdgeMarkers()` / `appendEdgeCardinality()` に即時投影を一元化する。
+
+- [ ] **Step 5: harness contract を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test -- src/lib/diagram-harness.test.ts
+  ```
+
+  Expected: 共有 allowlist と安全な model update の assertion が PASS。UI DOM の未実装 assertion は引き続き Red でよい。
+
+---
+
+## Task 4: keyed native control DOM と選択状態同期を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:998-1069,1130-1175,1368-1390`
+- Test: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: graph state に edge control map を追加する（2〜5分）**
+
+  `wireGraph()` の graph object に `edgeControlsById: new Map()` を追加する。既存 `handleLayer` を control の親として再利用し、新しい authored container や React portal は作らない。
+
+- [ ] **Step 2: option factory を安全に実装する（2〜5分）**
+
+  `document.createElement("option")` で canonical `value` と固定 label を `textContent` に設定し、`markUi()` する。cardinality の欠損 / 不正値用 disabled placeholder も固定 text だけで作り、未知値を HTML として表示しない。
+
+- [ ] **Step 3: edge control group を生成する（2〜5分）**
+
+  edge id ごとに `div.ark-harness-edge-controls` を1つ作り、その中に role を data 属性で識別する3つの native select を置く。wrapper、select、option をすべて `markUi()` し、`data-ark-edge-id` と control role は `setAttribute` で設定する。
+
+- [ ] **Step 4: input event の干渉を止める（2〜5分）**
+
+  各 select の `pointerdown` / `click` / `keydown` で propagation を止める。`change` では select の data role と value を読み、Task 3 の update helper を呼ぶだけにして endpoint / graph drag state を触らない。
+
+- [ ] **Step 5: 現在 model から select を同期する（2〜5分）**
+
+  `syncEdgeControl()` は edge id から現在の edge を引き直し、始点 / 終点 cardinality と effective direction を value、accessible name、`title` へ同期する。edge が消えた場合は disabled にし、stale cleanup で後から除去できる状態にする。
+
+- [ ] **Step 6: create / reuse / stale removal を実装する（2〜5分）**
+
+  `syncEdgeControls(graph, edges)` で geometry がある edge だけを active key とし、未作成 group は生成、既存 group は DOM を再利用、削除・graph 外参照 edge の stale group は remove + map delete する。select focus 中の通常再描画では node を置換しない。
+
+- [ ] **Step 7: DOM と選択肢の E2E を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "edge ごとに3つ"
+  ```
+
+  Expected: PASS。各 edge の3 control と完全一致 allowlist が role / accessible name で取得できる。
+
+---
+
+## Task 5: edge hover / focus と非重複配置を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:101-157,642-649,671-724,857-911`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: edge label と hit path を edge id で識別可能にする（2〜5分）**
+
+  `appendGraphLabel()` に edge id を渡して生成 text に `data-ark-edge-id` を付ける。main と同じ line / path geometry の `.ark-harness-edge-hit-target` を追加し、透明 wide stroke と `pointer-events: stroke` を明示する。main の marker / authored type selector は変更しない。
+
+- [ ] **Step 2: hover active state を接続する（2〜5分）**
+
+  hit path の `pointerenter` で対応 control group に active class、`pointerleave` で短い close timer を設定する。group の `pointerenter` では timer を解除し、`pointerleave` では hit path と `:focus-within` を再確認して閉じる。edge 再描画や stale removal 時は timer を破棄する。
+
+- [ ] **Step 3: focus だけでも見える CSS を追加する（2〜5分）**
+
+  group は通常 `opacity: 0; pointer-events: none`、active または `:focus-within` で `opacity: 1` にし、各 select だけ `pointer-events: auto` にする。`display:none` / `visibility:hidden` は使わず、Tab focus 可能な native control を維持する。
+
+- [ ] **Step 4: path 上の3 anchor を求める（2〜5分）**
+
+  edge main の total length と前後の微小点から 20% / 50% / 80% の点・接線・法線を求める helper を追加する。line と self-loop path を分岐した別計算にせず、length が0または非有限なら control を安全に非表示にする。
+
+- [ ] **Step 5: control の実測矩形を取得する（2〜5分）**
+
+  opacity 0 のまま select の bounding box を測り、graph container 座標へ正規化する。edge label、2 endpoint handle、graph 内 node、配置済み sibling control の矩形を blocker として集め、6px gap を加えた overlap 判定 helper を作る。
+
+- [ ] **Step 6: 決定的な候補探索を実装する（2〜5分）**
+
+  anchor ごとに法線の正負、距離2段階、接線方向のずらしを固定順で試し、blocker と重ならない最初の位置を `style.left` / `style.top` で設定する。始点 / direction / 終点の順で配置して相互重複も避ける。
+
+- [ ] **Step 7: fallback も重なりを許さないようにする（2〜5分）**
+
+  通常候補が埋まる短 edge では edge 外接矩形の上側・下側の control strip 候補を追加する。そこでも blocker と重なる場合は control を誤位置に出さず、その edge group を一時非表示にして model /描画を壊さない。
+
+- [ ] **Step 8: hover / focus /配置 E2E を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "hover|focus|重ならない"
+  ```
+
+  Expected: PASS。control が edge hover と keyboard focus で現れ、edge label、両 endpoint handle、3 node の bounding box と重ならない。
+
+---
+
+## Task 6: 変更を既存 SVG 投影へ即時反映する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:857-905,1041-1069,1650-1670`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: render 順序を main → label → handle → control にする（2〜5分）**
+
+  edge SVG を描いた後に `syncEdgeHandles()`、続けて `syncEdgeControls()` を呼ぶ。control 配置時に新しい label と現在の handle geometry を実測でき、既存 handle の keyed reuse と pointer capture を壊さない順序にする。
+
+- [ ] **Step 2: cardinality change を Green にする（2〜5分）**
+
+  始点 / 終点 select の change 後、対象 edge の該当 `edge.ext` key、crow's foot の data 属性、circle / line primitive 数が同期するようにする。反対 endpoint の value、`edge.type`、core field は維持する。
+
+- [ ] **Step 3: direction change を Green にする（2〜5分）**
+
+  direction select の4値を順に変更し、既存 `applyEdgeMarkers()` が marker-start / marker-end を更新することを確認する。edge main を手作業で mutate せず、再描画後の control value / accessible name も維持する。
+
+- [ ] **Step 4: model JSON 再適用後の同期を追加する（2〜5分）**
+
+  既存「反映」で `state.model` が置き換わった後の graph render から control を同期する。追加 edge は control 作成、削除 edge は stale removal、cardinality / direction / ext 不正形状は placeholder / fallback へ反映し、古い closure の edge object は使わない。
+
+- [ ] **Step 5: model 変更中の focus / drag 安全性を確認する（2〜5分）**
+
+  active control の edge がモデル直接編集で削除された場合は group と timer を除去し、例外を出さない。endpoint drag 中は control 操作を開始せず、control focus 中は graph / endpoint drag が始まらないことを E2E に追加する。
+
+- [ ] **Step 6: 即時投影 E2E を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "edge cardinality|edge direction|モデル直接編集後の edge control"
+  ```
+
+  Expected: PASS。選択、model 再適用、edge 削除のすべてで projection と control が一致し、page error がない。
+
+---
+
+## Task 7: allowlist 境界・安全な DOM・clean submission を固める
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts:323-403,1092-1572`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts:67-109`
+- Reference: `packages/server/src/lib/diagram-harness.ts:1554-1597`
+
+- [ ] **Step 1: 欠損 / unknown cardinality の test を追加する（2〜5分）**
+
+  `from_card` 欠損、`to_card: "<img ...>"` の edge を開き、記号が出ず disabled placeholder が選択され、DOM に img / script / event handler が生成されないことを確認する。allowlist の値を選ぶとその endpoint だけ正常化されることを assertion にする。
+
+- [ ] **Step 2: unknown direction fallback の test を追加する（2〜5分）**
+
+  `direction: "<script ...>"` でも edge は #229 どおり forward marker になり、select は disabled placeholder で「不正値・表示は forward」を示し、外部 request や要素生成がないことを確認する。表示だけで model の未知値を変更せず、`forward` を含む allowlist 値の選択後だけ model が正規化されることを確認する。
+
+- [ ] **Step 3: ext 保存時の非対象 key 保持を追加する（2〜5分）**
+
+  `type`、nested な未知 key、既存反対 endpoint の cardinality を持つ edge で1 control だけ変更し、submission model が対象 key 以外を deep equal で保持することを確認する。
+
+- [ ] **Step 4: clean HTML の除去対象を網羅する（2〜5分）**
+
+  submission HTML に edge control group / select / option / hit path / hover class / timer 用属性 / `data-ark-harness-ui` / `ark-harness-*` class がないことを DOMParser でも確認する。authored graph、model script、node / field / group 投影、authored style は残す。
+
+- [ ] **Step 5: marker 一意性・外部リソース禁止・サイズ guard を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test -- src/lib/diagram-harness.test.ts
+  ```
+
+  Expected: PASS。注入 marker は1個、危険 API / 外部 resource は0、注入後 HTML は `<128KiB`。
+
+- [ ] **Step 6: security / submission E2E を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "allowlist|clean submission|unknown"
+  ```
+
+  Expected: PASS。不正値は executable DOM や外部通信にならず、保存値は control allowlist だけになる。
+
+---
+
+## Task 8: endpoint 張り替えと既存編集の共存を回帰 test にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts:1253-1572,2828-2952`
+- Modify: `packages/server/src/lib/diagram-diff.test.ts:246-307`
+- Do not modify: `packages/server/src/lib/diagram-diff.ts`
+
+- [ ] **Step 1: control 変更後の endpoint drag を test する（2〜5分）**
+
+  `e_order_owner` の cardinality / direction を control で変更した後、既存 to handle を `account` へ張り替える。新 endpoint 外周へ main、crow's foot、handle、control が追従し、変更済み `edge.ext` が保持されることを確認する。
+
+- [ ] **Step 2: endpoint drag 中の control 非干渉を test する（2〜5分）**
+
+  handle pointerdown 中は preview / drop indicator が従来どおり出て、control が pointer capture を奪わないことを確認する。invalid drop / pointercancel では core endpoint も ext も変更しない。
+
+- [ ] **Step 3: self-edge の control 配置と更新を test する（2〜5分）**
+
+  始点 / 終点が同じ self-loop でも3 control が取得でき、path 上の別 anchor に配置され、label / 2 handle / node と重ならないことを確認する。cardinality 5値と direction 4値の代表変更が既存 self-loop SVG に反映されることも確認する。
+
+- [ ] **Step 4: kind / layout / group geometry との共存を test する（2〜5分）**
+
+  kind picker で node 寸法を変え、layout 方向を切り替え、node drag した後も control が再配置され、edge label / handle / node を覆わないことを polling で確認する。既存 kind select と layout button の option / model path は変えない。
+
+- [ ] **Step 5: field / list / group 編集との同時 submission を test する（2〜5分）**
+
+  既存の複合編集 test に edge cardinality / direction 操作を加え、field label、list reorder、group label、kind、node 座標、endpoint、edge.ext が同じ submission model に共存することを確認する。
+
+- [ ] **Step 6: 非還流と endpoint 還流を同じ assertion にする（2〜5分）**
+
+  ext だけの段階では `describeModelDiff()` が `[]`、endpoint も張り替えた最終 model では関連変更文だけになることを確認する。会話用文面に `one` / `many` / `both` 等が混ざらないことを明示する。
+
+- [ ] **Step 7: targeted regression を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "edge|kind 変更と node・edge"
+  ```
+
+  Expected: PASS。#229 の endpoint drag と #241 の直接操作を含む既存 edge 系 test がすべて Green。
+
+---
+
+## Task 9: scope と品質 gate を完了する
+
+**Files:**
+
+- Verify only: `packages/server/src/lib/diagram-harness.ts`
+- Verify only: `packages/server/src/lib/diagram-harness.test.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.test.ts`
+- Verify only: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: production diff が不変なことを確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  git diff -- packages/server/src/lib/diagram-diff.ts
+  ```
+
+  Expected: 出力なし。cardinality / direction の自然文化や会話還流処理を追加していない。
+
+- [ ] **Step 2: server Vitest を全件実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test
+  ```
+
+  Expected: PASS。diagram harness、diff、model parse、file round-trip を含む server test が Green。
+
+- [ ] **Step 3: diagram harness E2E を全件実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium
+  ```
+
+  Expected: PASS。graph / kind / group / list、layout direction、edge semantics / drag / controls の全 test が Green。
+
+- [ ] **Step 4: static check を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm check
+  ```
+
+  Expected: PASS。Biome と TypeScript に error がない。
+
+- [ ] **Step 5: production build を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm build
+  ```
+
+  Expected: PASS。server / web の既存 build に新しい依存や CSP 違反がない。
+
+- [ ] **Step 6: 変更ファイル scope を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  git diff --name-only
+  ```
+
+  Expected: production / test 差分は `diagram-harness.ts`、`diagram-harness.test.ts`、`diagram-diff.test.ts`、`diagram-harness.spec.ts` と本 plan のみ。DB migration、React、shared types、sample、skill、production diff は含まない。
+
+---
+
+## Human review / stop conditions
+
+- DB schema、migration、永続化 column、新規 API が必要になった場合は実装を止める。`edge.ext` の既存 model block 保存で完結する調査結果と矛盾するため、人間の設計レビューと scope 再承認が必須である。
+- production `packages/server/src/lib/diagram-diff.ts` を変更して cardinality / direction を会話へ還流する案へ進む場合は実装を止める。Issue の非還流契約に反し、外部入力を自然文へ入れる追加 security review も必要になる。
+- `edge.type` editor、edge 追加削除、layout LR / TB、kind picker、node CRUD を同じ UI に含める必要が出た場合は別 Issue として切り分け、本実装へ混ぜない。
+- control のため authored HTML / CSS contract、model schema、Socket.IO message、`DiagramPane.tsx` の変更が必要になった場合は実装を止める。ハーネス一時 UI と既存 submit 経路だけで完了させる。
+- `<128KiB` guard を超えた場合は上限を緩和せず、重複する label table、geometry helper、CSS を整理する。外部 script / stylesheet / icon library への分離は採用しない。
+- すべての collision candidate が塞がる fixture で control を表示できない場合、node や edge label を覆う fallback は採用しない。候補探索または graph 余白の扱いを人間レビューし、被りのない設計を承認してから進める。
+
+---
+
+## 完了条件チェック
+
+- [ ] 各 edge に始点 / 終点 cardinality 5値と direction 4値を直接選べる native control があり、生 JSON を開かず操作できる。
+- [ ] 選択可能値と model 保存値は allowlist のみで、欠損・未知値を executable DOM や選択候補として扱わない。
+- [ ] 選択直後に既存 `applyEdgeMarkers()` / `appendEdgeCardinality()` 経路で矢印と crow's foot が再描画される。
+- [ ] control は edge hover / control focus で表示され、edge label、両 endpoint handle、node 内容、他 control と重ならない。
+- [ ] endpoint handle の pointer drag、invalid drop、pointercancel、self-edge が従来どおり動き、`from` / `to` の変更だけは会話へ還流する。
+- [ ] 「変更を送る」後の model block に更新済み `edge.ext.from_card` / `to_card` / `direction` が保存され、`type` と未知 ext key が保持される。
+- [ ] cardinality / direction の `edge.ext` 単独変更は `describeModelDiff()` で `[]`、endpoint と同時変更した場合は endpoint / label の既存意味差分だけになる。
+- [ ] control、option、hit path、hover bridge は `data-ark-harness-ui` で clean HTML から除去され、authored graph / model / CSS は残る。
+- [ ] DOM は `createElement` / `createElementNS` / `textContent` / `setAttribute` だけで構築し、`innerHTML`、外部 URL / font / stylesheet / icon / script、dynamic fetch / import を使わない。
+- [ ] 注入後 HTML `<128KiB`、marker 一意性、既存 CSP / sandbox / MessageChannel 境界を維持する。
+- [ ] graph / kind / group / list / field 編集、layout direction、node drag、model 直接編集が回帰していない。
+- [ ] DB schema、production diff、model parser、file writer、Socket.IO、React / `DiagramPane.tsx` を変更せず、Vitest、Chromium E2E、`pnpm check`、`pnpm build` がすべて成功する。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -357,6 +357,7 @@ const edgeSemanticsModel = {
         to_card: "zero-or-many",
         direction: "forward",
         type: "belongs-to",
+        custom: { retained: true },
       },
     },
     {
@@ -368,6 +369,29 @@ const edgeSemanticsModel = {
   ],
   groups: [],
 };
+
+const edgeControlOptions = {
+  from: [
+    ["one", "1"],
+    ["many", "N"],
+    ["zero-or-one", "0..1"],
+    ["one-or-many", "1..N"],
+    ["zero-or-many", "0..N"],
+  ],
+  to: [
+    ["one", "1"],
+    ["many", "N"],
+    ["zero-or-one", "0..1"],
+    ["one-or-many", "1..N"],
+    ["zero-or-many", "0..N"],
+  ],
+  direction: [
+    ["forward", "→"],
+    ["reverse", "←"],
+    ["both", "↔"],
+    ["none", "矢印なし"],
+  ],
+} as const;
 
 function edgeSemanticsHtml(diagramModel: unknown = edgeSemanticsModel): string {
   return injectHarness(`<!doctype html><html><head><style>
@@ -1095,7 +1119,7 @@ test("cardinality・方向・type を edge SVG に安全に投影する", async 
   const errors = await openEdgeSemanticsDiagram(page);
   const graph = page.locator('[data-ark-container="graph"]');
   const edge = graph.locator(
-    'line[data-ark-edge-id="e_order_owner"], path[data-ark-edge-id="e_order_owner"]'
+    '.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
   );
   const fromCardinality = graph.locator(
     '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"][data-ark-edge-cardinality="one"]'
@@ -1157,7 +1181,7 @@ test("cardinality・方向・type を edge SVG に安全に投影する", async 
   await page.reload();
   await page.setContent(edgeSemanticsHtml());
   const legacyEdge = page.locator(
-    'line[data-ark-edge-id="e_account_user"], path[data-ark-edge-id="e_account_user"]'
+    '.ark-harness-edge-main[data-ark-edge-id="e_account_user"]'
   );
   await expect(legacyEdge).toHaveAttribute(
     "data-ark-edge-direction",
@@ -1165,6 +1189,372 @@ test("cardinality・方向・type を edge SVG に安全に投影する", async 
   );
   await expect(legacyEdge).toHaveAttribute("marker-end", /url\(.+\)/);
   await expect(page.locator("text", { hasText: "legacy edge" })).toBeVisible();
+  expect(errors).toEqual([]);
+});
+
+test("edge ごとに3つの native edge control と allowlist を表示する", async ({
+  page,
+}) => {
+  const errors = await openEdgeSemanticsDiagram(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const controls = graph.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
+  );
+
+  await expect(controls.locator("select")).toHaveCount(3);
+  for (const [role, name, expected] of [
+    ["from-card", /owned by.*始点 cardinality.*one/, edgeControlOptions.from],
+    [
+      "to-card",
+      /owned by.*終点 cardinality.*zero-or-many/,
+      edgeControlOptions.to,
+    ],
+    ["direction", /owned by.*direction.*forward/, edgeControlOptions.direction],
+  ] as const) {
+    const select = controls.locator(`select[data-ark-edge-control="${role}"]`);
+    await expect(select).toHaveAttribute("aria-label", name);
+    expect(
+      await select.locator("option").evaluateAll(options =>
+        options.map(option => ({
+          value: (option as HTMLOptionElement).value,
+          text: option.textContent,
+        }))
+      )
+    ).toEqual(
+      expected.map(([value, label]) => ({
+        value,
+        text: `${label} (${value})`,
+      }))
+    );
+  }
+  await expect(
+    controls.locator('select[data-ark-edge-control="type"]')
+  ).toHaveCount(0);
+  await expect(
+    controls.locator('option[value="LR"], option[value="TB"]')
+  ).toHaveCount(0);
+  expect(errors).toEqual([]);
+});
+
+test("edge control は hover・focus で表示され6px gapで重ならない", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const controls = graph.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
+  );
+  const hitTarget = graph.locator(
+    '.ark-harness-edge-hit-target[data-ark-edge-id="e_order_owner"]'
+  );
+
+  await expect(controls).toHaveCSS("opacity", "0");
+  await expect(controls).toHaveCSS("pointer-events", "none");
+  await hitTarget.hover({ force: true });
+  await expect(controls).toHaveCSS("opacity", "1");
+  await controls.locator("select").first().hover();
+  await expect(controls).toHaveCSS("opacity", "1");
+
+  const secondHitTarget = graph.locator(
+    '.ark-harness-edge-hit-target[data-ark-edge-id="e_account_user"]'
+  );
+  await secondHitTarget.hover({ force: true });
+  await expect(controls).toHaveCSS("opacity", "0");
+  await controls.locator("select").first().focus();
+  await expect(controls).toHaveCSS("opacity", "1");
+
+  const blockers = [
+    graph.locator(
+      'text[data-ark-edge-id="e_order_owner"].ark-harness-edge-label'
+    ),
+    graph.locator(
+      '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"]'
+    ),
+    graph.locator(
+      '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]'
+    ),
+    graph.locator('.ark-harness-graph-node[data-model-id="order"]'),
+    graph.locator('.ark-harness-graph-node[data-model-id="user"]'),
+    graph.locator('.ark-harness-graph-node[data-model-id="account"]'),
+  ];
+  const controlBoxes = await controls.locator("select").evaluateAll(elements =>
+    elements.map(element => {
+      const rect = element.getBoundingClientRect();
+      return {
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+      };
+    })
+  );
+  const blockerBoxes = await Promise.all(
+    blockers.map(async blocker => {
+      const box = await requiredBoundingBox(blocker);
+      return {
+        left: box.x,
+        top: box.y,
+        right: box.x + box.width,
+        bottom: box.y + box.height,
+      };
+    })
+  );
+  for (let index = 0; index < controlBoxes.length; index += 1) {
+    const control = controlBoxes[index];
+    for (const blocker of [...blockerBoxes, ...controlBoxes.slice(0, index)]) {
+      expect(
+        control.right + 6 <= blocker.left ||
+          blocker.right + 6 <= control.left ||
+          control.bottom + 6 <= blocker.top ||
+          blocker.bottom + 6 <= control.top
+      ).toBe(true);
+    }
+  }
+});
+
+test("edge cardinality・edge direction control を即時投影し非還流で保存する", async ({
+  page,
+}) => {
+  const initialModel = structuredClone(edgeSemanticsModel);
+  const errors = await openEdgeSemanticsDiagram(page, initialModel);
+  await connectSubmissionPort(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const controls = graph.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
+  );
+  const main = graph.locator(
+    '.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
+  );
+  const layoutButton = page.getByRole("button", { name: /方向: LR/ });
+
+  await controls
+    .locator('select[data-ark-edge-control="from-card"]')
+    .selectOption("zero-or-one");
+  await controls
+    .locator('select[data-ark-edge-control="to-card"]')
+    .selectOption("one-or-many");
+  const fromCard = graph.locator(
+    '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"][data-ark-edge-cardinality="zero-or-one"]'
+  );
+  const toCard = graph.locator(
+    '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"][data-ark-edge-cardinality="one-or-many"]'
+  );
+  await expect(fromCard.locator("circle")).toHaveCount(1);
+  await expect(fromCard.locator("line")).toHaveCount(1);
+  await expect(toCard.locator("circle")).toHaveCount(0);
+  await expect(toCard.locator("line")).toHaveCount(4);
+
+  for (const [direction, markerStart, markerEnd] of [
+    ["reverse", true, false],
+    ["both", true, true],
+    ["none", false, false],
+    ["forward", false, true],
+  ] as const) {
+    await controls
+      .locator('select[data-ark-edge-control="direction"]')
+      .selectOption(direction);
+    await expect(main).toHaveAttribute("data-ark-edge-direction", direction);
+    if (markerStart) {
+      await expect(main).toHaveAttribute("marker-start", /url\(.+\)/);
+    } else {
+      await expect(main).not.toHaveAttribute("marker-start", /.+/);
+    }
+    if (markerEnd) {
+      await expect(main).toHaveAttribute("marker-end", /url\(.+\)/);
+    } else {
+      await expect(main).not.toHaveAttribute("marker-end", /.+/);
+    }
+    await expect(layoutButton).toHaveAttribute("aria-label", /方向: LR/);
+  }
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: {
+            model: typeof edgeSemanticsModel;
+            html: string;
+          };
+        }
+      ).arkHarnessSubmission
+  );
+  if (!submission) throw new Error("submission がありません");
+  const submittedEdge = submission.model.edges.find(
+    edge => edge.id === "e_order_owner"
+  );
+  expect(submittedEdge).toMatchObject({
+    from: "order",
+    to: "user",
+    label: "owned by",
+    ext: {
+      from_card: "zero-or-one",
+      to_card: "one-or-many",
+      direction: "forward",
+      type: "belongs-to",
+      custom: { retained: true },
+    },
+  });
+  expect(submission.model.edges[1]).toEqual(initialModel.edges[1]);
+  expect(describeModelDiff(initialModel, submission.model)).toEqual([]);
+  expect(submission.html).not.toMatch(
+    /ark-harness-edge-controls|ark-harness-edge-hit-target|data-ark-harness-ui|<select|<option/
+  );
+  expect(submission.html).toContain('id="ark-diagram-model"');
+  expect(submission.html).toContain('data-ark-container="graph"');
+  expect(errors).toEqual([]);
+});
+
+test("unknown edge ext は allowlist placeholder と forward fallback で安全に扱う", async ({
+  page,
+}) => {
+  const requests: string[] = [];
+  page.on("request", request => requests.push(request.url()));
+  const hostileModel = structuredClone(edgeSemanticsModel);
+  const hostileExt = hostileModel.edges[0].ext as Record<string, unknown>;
+  delete hostileExt.from_card;
+  hostileExt.to_card =
+    '<img src="https://example.invalid/x" onerror="alert(1)">';
+  hostileExt.direction = '<script src="https://example.invalid/x.js">';
+  const errors = await openEdgeSemanticsDiagram(page, hostileModel);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const controls = graph.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
+  );
+  const main = graph.locator(
+    '.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
+  );
+  const fromSelect = controls.locator(
+    'select[data-ark-edge-control="from-card"]'
+  );
+  const toSelect = controls.locator('select[data-ark-edge-control="to-card"]');
+  const directionSelect = controls.locator(
+    'select[data-ark-edge-control="direction"]'
+  );
+
+  await expect(fromSelect.locator("option:checked")).toBeDisabled();
+  await expect(fromSelect.locator("option:checked")).toHaveText("未設定");
+  await expect(toSelect.locator("option:checked")).toBeDisabled();
+  await expect(toSelect.locator("option:checked")).toHaveText("不正値");
+  await expect(directionSelect.locator("option:checked")).toBeDisabled();
+  await expect(directionSelect.locator("option:checked")).toHaveText(
+    "不正値・表示は forward"
+  );
+  await expect(main).toHaveAttribute("data-ark-edge-direction", "forward");
+  await expect(main).not.toHaveAttribute("marker-start", /.+/);
+  await expect(main).toHaveAttribute("marker-end", /url\(.+\)/);
+  await expect(
+    graph.locator(
+      '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"]'
+    )
+  ).toHaveCount(0);
+  await expect(graph.locator("img")).toHaveCount(0);
+  await expect(graph.locator("script")).toHaveCount(0);
+  expect(
+    await controls
+      .locator("*")
+      .evaluateAll(elements =>
+        elements.some(element =>
+          [...element.attributes].some(attribute =>
+            attribute.name.toLowerCase().startsWith("on")
+          )
+        )
+      )
+  ).toBe(false);
+  expect(requests.filter(url => url.startsWith("http"))).toEqual([]);
+
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  const beforeNormalization = JSON.parse(
+    await page.locator(".ark-harness-textarea").inputValue()
+  ) as { edges: Array<{ ext: Record<string, unknown> }> };
+  expect(beforeNormalization.edges[0].ext).toMatchObject({
+    to_card: hostileExt.to_card,
+    direction: hostileExt.direction,
+  });
+  expect(beforeNormalization.edges[0].ext).not.toHaveProperty("from_card");
+  await page.getByRole("button", { name: "閉じる", exact: true }).click();
+
+  await fromSelect.selectOption("one");
+  await toSelect.selectOption("many");
+  await directionSelect.selectOption("forward");
+  await expect(fromSelect.locator("option")).toHaveCount(5);
+  await expect(toSelect.locator("option")).toHaveCount(5);
+  await expect(directionSelect.locator("option")).toHaveCount(4);
+  await expect(
+    graph.locator(
+      '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"][data-ark-edge-cardinality="one"]'
+    )
+  ).toHaveCount(1);
+  await expect(
+    graph.locator(
+      '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"][data-ark-edge-cardinality="many"]'
+    )
+  ).toHaveCount(1);
+  expect(errors).toEqual([]);
+});
+
+test("モデル直接編集後の edge control を current model と同期して stale group を除去する", async ({
+  page,
+}) => {
+  const errors = await openEdgeSemanticsDiagram(page);
+  const graph = page.locator('[data-ark-container="graph"]');
+  const ownerControls = graph.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
+  );
+  await ownerControls
+    .locator('select[data-ark-edge-control="direction"]')
+    .focus();
+
+  const nextModel = structuredClone(edgeSemanticsModel);
+  nextModel.edges = [
+    {
+      id: "e_account_user",
+      from: "order",
+      to: "account",
+      label: "legacy edge",
+      ext: {
+        from_card: "many",
+        to_card: "one",
+        direction: "both",
+        type: "legacy",
+        custom: { retained: true },
+      },
+    },
+  ];
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .evaluate(element => (element as HTMLButtonElement).click());
+  await page.locator(".ark-harness-textarea").fill(JSON.stringify(nextModel));
+  await page
+    .getByRole("button", { name: "反映", exact: true })
+    .evaluate(element => (element as HTMLButtonElement).click());
+
+  await expect(ownerControls).toHaveCount(0);
+  const legacyControls = graph.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_account_user"]'
+  );
+  await expect(
+    legacyControls.locator('select[data-ark-edge-control="from-card"]')
+  ).toHaveValue("many");
+  await expect(
+    legacyControls.locator('select[data-ark-edge-control="to-card"]')
+  ).toHaveValue("one");
+  await expect(
+    legacyControls.locator('select[data-ark-edge-control="direction"]')
+  ).toHaveValue("both");
+  await expect(
+    graph.locator('.ark-harness-edge-main[data-ark-edge-id="e_account_user"]')
+  ).toHaveAttribute("data-ark-edge-direction", "both");
   expect(errors).toEqual([]);
 });
 
@@ -1201,8 +1591,79 @@ test("カーディナリティ 5 語彙を self-loop にも投影する", async 
     await expect(main).toHaveAttribute("marker-end", /url\(.+\)/);
     await expect(primitive.locator("line")).toHaveCount(lineCount);
     await expect(primitive.locator("circle")).toHaveCount(circleCount);
+    await expect(
+      page.locator(
+        '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"] select[data-ark-edge-control="from-card"]'
+      )
+    ).toHaveValue(cardinality);
   }
 
+  const graph = page.locator('[data-ark-container="graph"]');
+  const controls = graph.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
+  );
+  await expect(controls.locator("select")).toHaveCount(3);
+  await controls
+    .locator('select[data-ark-edge-control="to-card"]')
+    .selectOption("one-or-many");
+  await controls
+    .locator('select[data-ark-edge-control="direction"]')
+    .selectOption("none");
+  await expect(
+    graph.locator(
+      '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"][data-ark-edge-cardinality="one-or-many"]'
+    )
+  ).toHaveCount(1);
+  await expect(
+    graph.locator(
+      'path.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
+    )
+  ).toHaveAttribute("data-ark-edge-direction", "none");
+  await expect(
+    graph.locator(
+      'path.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
+    )
+  ).not.toHaveAttribute("marker-start", /.+/);
+  await expect(
+    graph.locator(
+      'path.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
+    )
+  ).not.toHaveAttribute("marker-end", /.+/);
+  expect(
+    await graph.evaluate(container => {
+      const selects = [
+        ...container.querySelectorAll(
+          '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"] select'
+        ),
+      ];
+      const blockers = [
+        container.querySelector(
+          'text.ark-harness-edge-label[data-ark-edge-id="e_order_owner"]'
+        ),
+        ...container.querySelectorAll(
+          '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"]'
+        ),
+        container.querySelector(
+          '.ark-harness-graph-node[data-model-id="order"]'
+        ),
+      ].filter((element): element is Element => element !== null);
+      const separated = (left: Element, right: Element) => {
+        const a = left.getBoundingClientRect();
+        const b = right.getBoundingClientRect();
+        return (
+          a.right + 6 <= b.left ||
+          b.right + 6 <= a.left ||
+          a.bottom + 6 <= b.top ||
+          b.bottom + 6 <= a.top
+        );
+      };
+      return selects.every(
+        (select, index) =>
+          blockers.every(blocker => separated(select, blocker)) &&
+          selects.slice(0, index).every(other => separated(select, other))
+      );
+    })
+  ).toBe(true);
   expect(errors).toEqual([]);
 });
 
@@ -1254,6 +1715,18 @@ test("edge 終点を張り替えて記号と clean HTML を同期する", async 
   await openEdgeSemanticsDiagram(page);
   await connectSubmissionPort(page);
   const graph = page.locator('[data-ark-container="graph"]');
+  const controls = graph.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
+  );
+  await controls
+    .locator('select[data-ark-edge-control="from-card"]')
+    .selectOption("zero-or-one");
+  await controls
+    .locator('select[data-ark-edge-control="to-card"]')
+    .selectOption("one-or-many");
+  await controls
+    .locator('select[data-ark-edge-control="direction"]')
+    .selectOption("both");
   const account = graph.locator('[data-model-id="account"]').first();
   const toHandle = graph.locator(
     '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]'
@@ -1292,7 +1765,7 @@ test("edge 終点を張り替えて記号と clean HTML を同期する", async 
   expect(after.y2).toBeLessThan(accountBox.y + accountBox.height + 2);
 
   const movedCardinality = graph.locator(
-    '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"][data-ark-edge-cardinality="zero-or-many"]'
+    '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"][data-ark-edge-cardinality="one-or-many"]'
   );
   const movedHandle = graph.locator(
     '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]'
@@ -1333,12 +1806,22 @@ test("edge 終点を張り替えて記号と clean HTML を同期する", async 
     from: "order",
     to: "account",
     ext: {
-      from_card: "one",
-      to_card: "zero-or-many",
-      direction: "forward",
+      from_card: "zero-or-one",
+      to_card: "one-or-many",
+      direction: "both",
       type: "belongs-to",
+      custom: { retained: true },
     },
   });
+  const submittedModel = (submission as { model: typeof edgeSemanticsModel })
+    .model;
+  const diff = describeModelDiff(edgeSemanticsModel, submittedModel);
+  expect(diff).toEqual([
+    "Order から User への関連「owned by」を Order から Account への関連「owned by」 に変更",
+  ]);
+  expect(diff.join("\n")).not.toMatch(
+    /one|many|zero-or-one|one-or-many|zero-or-many|forward|reverse|both|none/
+  );
 
   const html = (submission as { html: string }).html;
   expect(html).not.toContain("ark-harness-edge-handle-layer");
@@ -1346,6 +1829,11 @@ test("edge 終点を張り替えて記号と clean HTML を同期する", async 
   expect(html).not.toContain("ark-harness-edge-preview");
   expect(html).not.toContain("ark-harness-edge-drop-indicator");
   expect(html).not.toContain("ark-harness-edge-cardinality");
+  expect(html).not.toContain("ark-harness-edge-controls");
+  expect(html).not.toContain("ark-harness-edge-hit-target");
+  expect(html).not.toContain("<select");
+  expect(html).not.toContain("<option");
+  expect(html).not.toContain("data-ark-harness-ui");
   expect(html).toContain('data-ark-container="graph"');
   expect(html).toContain('data-model-id="account"');
   expect(html).toContain('data-model-id="account_id"');
@@ -1416,8 +1904,8 @@ test("edge 始点の張り替えと self-edge を同じ handle 機構で扱う",
   await page.goto("about:blank");
   const selfEdgeStartModel = structuredClone(edgeSemanticsModel);
   selfEdgeStartModel.edges[0].from = "account";
+  selfEdgeStartModel.edges[0].to = "account";
   await openEdgeSemanticsDiagram(page, selfEdgeStartModel);
-  await dragEndToAccount("to");
   await expect(
     graph.locator(
       'path.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
@@ -2840,6 +3328,28 @@ test("kind 変更と node・edge・field・list 編集を同じ送信 model に�
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       })
   );
+  const edgeControls = page.locator(
+    '.ark-harness-edge-controls[data-ark-edge-id="e_order_user"]'
+  );
+  await edgeControls
+    .locator('select[data-ark-edge-control="from-card"]')
+    .selectOption("zero-or-many");
+  await edgeControls
+    .locator('select[data-ark-edge-control="to-card"]')
+    .selectOption("one");
+  await edgeControls
+    .locator('select[data-ark-edge-control="direction"]')
+    .selectOption("both");
+  const layoutDirection = page.getByRole("button", { name: /方向: LR/ });
+  await layoutDirection.click();
+  await page.getByRole("button", { name: /方向: TB/ }).click();
+  await expect(layoutDirection).toHaveAttribute("aria-label", /方向: LR/);
+  await page.evaluate(
+    () =>
+      new Promise<void>(resolve => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      })
+  );
   const handle = order.locator(".ark-harness-graph-handle");
   const beforeBox = await requiredBoundingBox(order);
   const beforeEdge = await readEdge(page);
@@ -2932,7 +3442,18 @@ test("kind 変更と node・edge・field・list 編集を同じ送信 model に�
         { id: "user" },
         { id: "external" },
       ],
-      edges: [{ id: "e_order_user", from: "order", to: "order" }],
+      edges: [
+        {
+          id: "e_order_user",
+          from: "order",
+          to: "order",
+          ext: {
+            from_card: "zero-or-many",
+            to_card: "one",
+            direction: "both",
+          },
+        },
+      ],
     },
   });
   const submittedModel = (submission as { model: DiagramModel }).model;

--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -243,7 +243,7 @@ describe("describeModelDiff（境界ケース）", () => {
     ]);
   });
 
-  it("edge.ext だけの変更は意味差分に含めない", () => {
+  it("edge cardinality・direction だけの変更は意味差分に含めない", () => {
     const user = { id: "user", label: "User" };
     const nodes = [order, user];
     const before = model(nodes, [
@@ -270,7 +270,7 @@ describe("describeModelDiff（境界ケース）", () => {
           from_card: "zero-or-one",
           to_card: "one-or-many",
           direction: "both",
-          type: "identifying",
+          type: "belongs-to",
         },
       },
     ]);
@@ -278,7 +278,7 @@ describe("describeModelDiff（境界ケース）", () => {
     expect(describeModelDiff(before, after)).toEqual([]);
   });
 
-  it("edge.ext と端点を同時に変えても端点の意味差分だけを述べる", () => {
+  it("edge cardinality・direction と端点を同時に変えても端点だけを述べる", () => {
     const user = { id: "user", label: "User" };
     const account = { id: "account", label: "Account" };
     const nodes = [order, user, account];
@@ -288,7 +288,12 @@ describe("describeModelDiff（境界ケース）", () => {
         from: "order",
         to: "user",
         label: "belongs to",
-        ext: { direction: "forward", type: "belongs-to" },
+        ext: {
+          from_card: "one",
+          to_card: "zero-or-many",
+          direction: "forward",
+          type: "belongs-to",
+        },
       },
     ]);
     const after = model(nodes, [
@@ -297,13 +302,22 @@ describe("describeModelDiff（境界ケース）", () => {
         from: "order",
         to: "account",
         label: "belongs to",
-        ext: { direction: "both", type: "identifying" },
+        ext: {
+          from_card: "zero-or-one",
+          to_card: "one-or-many",
+          direction: "both",
+          type: "belongs-to",
+        },
       },
     ]);
 
-    expect(describeModelDiff(before, after)).toEqual([
+    const diff = describeModelDiff(before, after);
+    expect(diff).toEqual([
       "Order から User への関連「belongs to」を Order から Account への関連「belongs to」 に変更",
     ]);
+    expect(diff.join("\n")).not.toMatch(
+      /one|many|zero-or-one|one-or-many|zero-or-many|forward|reverse|both|none/
+    );
   });
 
   it("削除されるノードとそれを参照するedgeが同時に消えたとき、edge文の主語はbefore側のノードlabelを使う", () => {

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -108,6 +108,65 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
+  it("edge cardinality・direction control の安全な更新契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain("var CARDINALITY_VALUES = [");
+    expect(out).toContain("var DIRECTION_VALUES = [");
+    expect(out).toContain("function updateEdgeExt(");
+    expect(out).toContain("getEdge(state.model, edgeId)");
+    expect(out).toContain("if (!isRecordObject(edge.ext)) edge.ext = {};");
+    expect(out).toContain("scheduleGraphRender(graph);");
+    expect(out).toContain('document.createElement("select")');
+    expect(out).toContain('document.createElement("option")');
+    expect(out).toContain("option.textContent =");
+    expect(out).toContain("markUi(option)");
+    expect(out).toContain("function syncEdgeControls(");
+    expect(out).toContain("edgeControlsById: new Map()");
+    expect(out).toContain("data-ark-harness-ui");
+  });
+
+  it("edge control と SVG 投影が同じ allowlist・描画経路を共有する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain("CARDINALITY_VALUES.indexOf(value)");
+    expect(out).toContain("DIRECTION_VALUES.indexOf(direction)");
+    expect(out).toContain("function edgeCardinality(");
+    expect(out).toContain("function edgeDirection(");
+    expect(out).toContain("applyEdgeMarkers(main, graph.markerId, direction)");
+    expect(out).toContain("appendEdgeCardinality(");
+    expect(out.match(/var CARDINALITY_VALUES = \[/g)).toHaveLength(1);
+    expect(out.match(/var DIRECTION_VALUES = \[/g)).toHaveLength(1);
+  });
+
+  it("edge control option を固定文字列と安全な DOM API だけで作る", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain('document.createElement("option")');
+    expect(out).toContain("option.textContent =");
+    expect(out).toContain("option.value =");
+    expect(out).toContain('option.setAttribute("disabled", "")');
+    expect(out).not.toContain("innerHTML");
+    expect(out).not.toContain("insertAdjacentHTML");
+    expect(out).not.toContain("fetch(");
+    expect(out).not.toContain("import(");
+    expect(out).not.toContain("https://");
+    expect(out).not.toContain("@font-face");
+    expect(out).not.toContain('rel="stylesheet"');
+  });
+
   it("group projection と geometry 同期の契約を注入する", () => {
     const out = injectHarness(
       page(

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -130,6 +130,9 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   fill: #475569; font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
   font-size: 12px; text-anchor: middle; dominant-baseline: central;
 }
+.ark-harness-edge-hit-target {
+  stroke: transparent !important; stroke-width: 18 !important; pointer-events: stroke;
+}
 .ark-harness-edge-handle-layer {
   position: absolute; inset: 0; z-index: 3; pointer-events: none;
 }
@@ -138,6 +141,31 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   width: 18px; height: 18px; padding: 0; border: 2px solid #0ea5b7; border-radius: 999px;
   background: #fff; color: #0e7490; cursor: crosshair; line-height: 14px; font-size: 9px;
   pointer-events: auto; touch-action: none;
+}
+.ark-harness-edge-controls {
+  position: absolute; inset: 0; z-index: 4; opacity: 0; pointer-events: none;
+  transition: opacity .1s ease;
+}
+.ark-harness-edge-controls.ark-harness-edge-controls-active,
+.ark-harness-edge-controls:focus-within {
+  opacity: 1;
+}
+.ark-harness-edge-control {
+  position: absolute; transform: translate(-50%, -50%); box-sizing: border-box;
+  width: 108px; min-width: 0; padding: 2px 3px;
+  border: 1px solid rgba(100,116,139,.65); border-radius: 4px;
+  background: rgba(255,255,255,.97); color: #334155; font: 10px/1.2 sans-serif;
+  pointer-events: none;
+}
+.ark-harness-edge-controls.ark-harness-edge-controls-active .ark-harness-edge-control,
+.ark-harness-edge-controls:focus-within .ark-harness-edge-control {
+  pointer-events: auto;
+}
+.ark-harness-edge-controls-unavailable {
+  opacity: 0 !important; pointer-events: none !important;
+}
+.ark-harness-edge-controls-unavailable .ark-harness-edge-control {
+  pointer-events: none !important;
 }
 .ark-harness-edge-preview {
   position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; pointer-events: none;
@@ -177,6 +205,23 @@ const HARNESS_JS = `(function () {
     "--ark-harness-graph-min-width",
     "--ark-harness-graph-min-height"
   ];
+  var CARDINALITY_VALUES = [
+    "one", "many", "zero-or-one", "one-or-many", "zero-or-many"
+  ];
+  var DIRECTION_VALUES = ["forward", "reverse", "both", "none"];
+  var CARDINALITY_LABELS = {
+    "one": "1",
+    "many": "N",
+    "zero-or-one": "0..1",
+    "one-or-many": "1..N",
+    "zero-or-many": "0..N"
+  };
+  var DIRECTION_LABELS = {
+    "forward": "\\u2192",
+    "reverse": "\\u2190",
+    "both": "\\u2194",
+    "none": "\\u77E2\\u5370\\u306A\\u3057"
+  };
 
   var BLOCK_TAGS = {
     DIV: 1, UL: 1, OL: 1, LI: 1, TABLE: 1, THEAD: 1, TBODY: 1, TR: 1, TD: 1, TH: 1,
@@ -639,9 +684,12 @@ const HARNESS_JS = `(function () {
     svg.appendChild(defs);
   }
 
-  function appendGraphLabel(svg, label, x, y) {
+  function appendGraphLabel(svg, edge, x, y) {
+    var label = edge && edge.label;
     if (typeof label !== "string" || label.length === 0) return;
     var text = svgElement("text");
+    text.classList.add("ark-harness-edge-label");
+    text.setAttribute("data-ark-edge-id", edge.id);
     text.setAttribute("x", String(x));
     text.setAttribute("y", String(y));
     text.textContent = label;
@@ -651,21 +699,31 @@ const HARNESS_JS = `(function () {
   function edgeDirection(edge) {
     if (!edge || !isRecordObject(edge.ext)) return "forward";
     var direction = edge.ext.direction;
-    return direction === "reverse" || direction === "both" || direction === "none"
-      ? direction
-      : "forward";
+    return DIRECTION_VALUES.indexOf(direction) !== -1 ? direction : "forward";
   }
 
   function edgeCardinality(edge, end) {
     if (!edge || !isRecordObject(edge.ext)) return null;
     var value = edge.ext[end === "from" ? "from_card" : "to_card"];
-    return value === "one" || value === "many" || value === "zero-or-one" ||
-      value === "one-or-many" || value === "zero-or-many" ? value : null;
+    return CARDINALITY_VALUES.indexOf(value) !== -1 ? value : null;
   }
 
   function edgeType(edge) {
     if (!edge || !isRecordObject(edge.ext)) return null;
     return typeof edge.ext.type === "string" ? edge.ext.type : null;
+  }
+
+  function updateEdgeExt(graph, edgeId, property, value) {
+    var cardinalityProperty = property === "from_card" || property === "to_card";
+    var valid = cardinalityProperty
+      ? CARDINALITY_VALUES.indexOf(value) !== -1
+      : property === "direction" && DIRECTION_VALUES.indexOf(value) !== -1;
+    if (!valid) return;
+    var edge = getEdge(state.model, edgeId);
+    if (!edge) return;
+    if (!isRecordObject(edge.ext)) edge.ext = {};
+    edge.ext[property] = value;
+    scheduleGraphRender(graph);
   }
 
   function edgeGeometry(graph, edge) {
@@ -739,6 +797,32 @@ const HARNESS_JS = `(function () {
     if (direction === "forward" || direction === "both") {
       main.setAttribute("marker-end", marker);
     }
+  }
+
+  function setEdgeShapeGeometry(element, geometry) {
+    if (geometry.kind === "path") {
+      element.setAttribute("d", geometry.path);
+    } else {
+      element.setAttribute("x1", String(geometry.from.x));
+      element.setAttribute("y1", String(geometry.from.y));
+      element.setAttribute("x2", String(geometry.to.x));
+      element.setAttribute("y2", String(geometry.to.y));
+    }
+  }
+
+  function appendEdgeHitTarget(graph, edge, geometry) {
+    var hitTarget = svgElement(geometry.kind);
+    hitTarget.classList.add("ark-harness-edge-hit-target");
+    hitTarget.setAttribute("data-ark-edge-id", edge.id);
+    setEdgeShapeGeometry(hitTarget, geometry);
+    markUi(hitTarget);
+    hitTarget.addEventListener("pointerenter", function () {
+      activateEdgeControls(graph, edge.id);
+    });
+    hitTarget.addEventListener("pointerleave", function () {
+      scheduleEdgeControlsClose(graph, edge.id);
+    });
+    graph.svg.appendChild(hitTarget);
   }
 
   function appendCardinalityLine(group, a, b) {
@@ -862,6 +946,7 @@ const HARNESS_JS = `(function () {
     appendGraphMarker(graph.svg, graph.markerId);
 
     graph.edgeGeometryById.clear();
+    graph.edgeMainById.clear();
     var edges = state.model && state.model.edges ? state.model.edges : [];
     edges.forEach(function (edge) {
       var geometry = edgeGeometry(graph, edge);
@@ -870,16 +955,10 @@ const HARNESS_JS = `(function () {
       var direction = edgeDirection(edge);
       var main = svgElement(geometry.kind);
       setEdgeProjectionAttributes(main, edge, direction);
-      if (geometry.kind === "path") {
-        main.setAttribute("d", geometry.path);
-      } else {
-        main.setAttribute("x1", String(geometry.from.x));
-        main.setAttribute("y1", String(geometry.from.y));
-        main.setAttribute("x2", String(geometry.to.x));
-        main.setAttribute("y2", String(geometry.to.y));
-      }
+      setEdgeShapeGeometry(main, geometry);
       applyEdgeMarkers(main, graph.markerId, direction);
       graph.svg.appendChild(main);
+      graph.edgeMainById.set(edge.id, main);
       appendEdgeCardinality(
         graph.svg,
         edge,
@@ -894,9 +973,11 @@ const HARNESS_JS = `(function () {
         geometry.to,
         edgeCardinality(edge, "to")
       );
-      appendGraphLabel(graph.svg, edge.label, geometry.label.x, geometry.label.y);
+      appendGraphLabel(graph.svg, edge, geometry.label.x, geometry.label.y);
+      appendEdgeHitTarget(graph, edge, geometry);
     });
     syncEdgeHandles(graph, edges);
+    syncEdgeControls(graph, edges);
   }
 
   function scheduleGraphRender(graph) {
@@ -974,13 +1055,23 @@ const HARNESS_JS = `(function () {
     );
   }
 
+  function edgeDropCandidateAtPointer(drag, event) {
+    var candidate = findEdgeDropCandidate(drag.graph, event.clientX, event.clientY);
+    if (candidate || !drag.candidateId) return candidate;
+    var nodeEl = drag.graph.nodesById.get(drag.candidateId);
+    if (!nodeEl || !getNode(state.model, drag.candidateId)) return null;
+    var rect = nodeEl.getBoundingClientRect();
+    return event.clientX >= rect.left && event.clientX <= rect.right &&
+      event.clientY >= rect.top && event.clientY <= rect.bottom
+      ? { id: drag.candidateId, el: nodeEl }
+      : null;
+  }
+
   function finishEdgeDrag(event, commit) {
     if (!edgeDrag) return;
     if (event && event.pointerId !== edgeDrag.pointerId) return;
     var drag = edgeDrag;
-    var candidate = commit && event
-      ? findEdgeDropCandidate(drag.graph, event.clientX, event.clientY)
-      : null;
+    var candidate = commit && event ? edgeDropCandidateAtPointer(drag, event) : null;
     edgeDrag = null;
     if (commit && candidate) {
       var currentEdge = getEdge(state.model, drag.edgeId);
@@ -1065,6 +1156,337 @@ const HARNESS_JS = `(function () {
       if (activeKeys.has(key)) return;
       if (handle.parentNode) handle.parentNode.removeChild(handle);
       graph.edgeHandlesByKey.delete(key);
+    });
+  }
+
+  function createEdgeOption(value, label) {
+    var option = document.createElement("option");
+    option.value = value;
+    option.textContent = label + " (" + value + ")";
+    markUi(option);
+    return option;
+  }
+
+  function createEdgePlaceholder(text) {
+    var option = document.createElement("option");
+    option.value = "__ark_invalid__";
+    option.textContent = text;
+    option.setAttribute("disabled", "");
+    markUi(option);
+    return option;
+  }
+
+  function edgeControlProperty(role) {
+    if (role === "from-card") return "from_card";
+    if (role === "to-card") return "to_card";
+    return role === "direction" ? "direction" : null;
+  }
+
+  function createEdgeSelect(graph, edgeId, role) {
+    var select = document.createElement("select");
+    select.className = "ark-harness-edge-control";
+    select.setAttribute("data-ark-edge-control", role);
+    markUi(select);
+    var values = role === "direction" ? DIRECTION_VALUES : CARDINALITY_VALUES;
+    var labels = role === "direction" ? DIRECTION_LABELS : CARDINALITY_LABELS;
+    values.forEach(function (value) {
+      select.appendChild(createEdgeOption(value, labels[value]));
+    });
+    ["pointerdown", "click", "keydown"].forEach(function (type) {
+      select.addEventListener(type, function (event) { event.stopPropagation(); });
+    });
+    select.addEventListener("focus", function () {
+      activateEdgeControls(graph, edgeId);
+    });
+    select.addEventListener("change", function (event) {
+      event.stopPropagation();
+      var property = edgeControlProperty(select.getAttribute("data-ark-edge-control"));
+      if (property) updateEdgeExt(graph, edgeId, property, select.value);
+    });
+    return select;
+  }
+
+  function createEdgeControls(graph, edge) {
+    var root = document.createElement("div");
+    root.className = "ark-harness-edge-controls";
+    root.setAttribute("data-ark-edge-id", edge.id);
+    markUi(root);
+    var controls = {
+      root: root,
+      selects: {},
+      placeholders: {},
+      closeTimer: null
+    };
+    ["from-card", "direction", "to-card"].forEach(function (role) {
+      var select = createEdgeSelect(graph, edge.id, role);
+      controls.selects[role] = select;
+      root.appendChild(select);
+    });
+    root.addEventListener("pointerenter", function () {
+      activateEdgeControls(graph, edge.id);
+    });
+    root.addEventListener("pointerleave", function () {
+      scheduleEdgeControlsClose(graph, edge.id);
+    });
+    graph.handleLayer.appendChild(root);
+    return controls;
+  }
+
+  function clearEdgeControlsClose(controls) {
+    if (controls.closeTimer === null) return;
+    window.clearTimeout(controls.closeTimer);
+    controls.closeTimer = null;
+  }
+
+  function edgeControlsEngaged(controls) {
+    if (controls.root.contains(document.activeElement)) return true;
+    var roles = ["from-card", "direction", "to-card"];
+    for (var i = 0; i < roles.length; i++) {
+      if (controls.selects[roles[i]].matches(":hover")) return true;
+    }
+    return false;
+  }
+
+  function activateEdgeControls(graph, edgeId) {
+    graph.edgeControlsById.forEach(function (controls, currentId) {
+      clearEdgeControlsClose(controls);
+      if (currentId === edgeId) {
+        controls.root.classList.add("ark-harness-edge-controls-active");
+      } else {
+        controls.root.classList.remove("ark-harness-edge-controls-active");
+      }
+    });
+  }
+
+  function scheduleEdgeControlsClose(graph, edgeId) {
+    var controls = graph.edgeControlsById.get(edgeId);
+    if (!controls) return;
+    clearEdgeControlsClose(controls);
+    controls.closeTimer = window.setTimeout(function () {
+      controls.closeTimer = null;
+      if (!edgeControlsEngaged(controls)) {
+        controls.root.classList.remove("ark-harness-edge-controls-active");
+      }
+    }, 100);
+  }
+
+  function syncEdgeSelect(controls, role, edge) {
+    var select = controls.selects[role];
+    var property = edgeControlProperty(role);
+    var raw = isRecordObject(edge.ext) ? edge.ext[property] : undefined;
+    var allowed = role === "direction"
+      ? DIRECTION_VALUES.indexOf(raw) !== -1
+      : CARDINALITY_VALUES.indexOf(raw) !== -1;
+    var missingDirection = role === "direction" && raw === undefined;
+    var current = allowed ? raw : missingDirection ? "forward" : null;
+    var placeholderText = raw === undefined
+      ? "\\u672A\\u8A2D\\u5B9A"
+      : role === "direction"
+        ? "\\u4E0D\\u6B63\\u5024\\u30FB\\u8868\\u793A\\u306F forward"
+        : "\\u4E0D\\u6B63\\u5024";
+    if (current === null) {
+      if (!controls.placeholders[role]) {
+        controls.placeholders[role] = createEdgePlaceholder(placeholderText);
+        select.insertBefore(controls.placeholders[role], select.firstChild);
+      } else {
+        controls.placeholders[role].textContent = placeholderText;
+      }
+      select.value = "__ark_invalid__";
+    } else {
+      if (controls.placeholders[role]) {
+        controls.placeholders[role].remove();
+        controls.placeholders[role] = null;
+      }
+      select.value = current;
+    }
+    select.disabled = false;
+    var name = (typeof edge.label === "string" && edge.label) || edge.id;
+    var roleLabel = role === "from-card"
+      ? "\\u59CB\\u70B9 cardinality"
+      : role === "to-card"
+        ? "\\u7D42\\u70B9 cardinality"
+        : "direction";
+    var currentLabel = current === null ? placeholderText : current;
+    var label = name + " \\u306E" + roleLabel + "\\uFF08\\u73FE\\u5728 " + currentLabel + "\\uFF09";
+    select.setAttribute("aria-label", label);
+    select.setAttribute("title", label);
+  }
+
+  function domRectangle(element, containerRect) {
+    var rect = element.getBoundingClientRect();
+    return {
+      x: rect.left - containerRect.left,
+      y: rect.top - containerRect.top,
+      width: rect.width,
+      height: rect.height
+    };
+  }
+
+  function findEdgeLabel(graph, edgeId) {
+    var labels = graph.svg.querySelectorAll(".ark-harness-edge-label");
+    for (var i = 0; i < labels.length; i++) {
+      if (labels[i].getAttribute("data-ark-edge-id") === edgeId) return labels[i];
+    }
+    return null;
+  }
+
+  function edgeControlBlockers(graph, edgeId, containerRect) {
+    var blockers = [];
+    var label = findEdgeLabel(graph, edgeId);
+    if (label) blockers.push(domRectangle(label, containerRect));
+    ["from", "to"].forEach(function (end) {
+      var handle = graph.edgeHandlesByKey.get(edgeId + ":" + end);
+      if (handle) blockers.push(domRectangle(handle, containerRect));
+    });
+    graph.nodesById.forEach(function (node) {
+      blockers.push(domRectangle(node, containerRect));
+    });
+    return blockers;
+  }
+
+  function edgePathAnchor(main, fraction) {
+    var length = main.getTotalLength();
+    if (!Number.isFinite(length) || length <= 0) return null;
+    var offset = Math.max(0.5, Math.min(2, length / 20));
+    var distance = length * fraction;
+    var before = main.getPointAtLength(Math.max(0, distance - offset));
+    var after = main.getPointAtLength(Math.min(length, distance + offset));
+    var dx = after.x - before.x;
+    var dy = after.y - before.y;
+    var tangentLength = Math.sqrt(dx * dx + dy * dy);
+    if (!Number.isFinite(tangentLength) || tangentLength <= 0) return null;
+    var point = main.getPointAtLength(distance);
+    return {
+      x: point.x,
+      y: point.y,
+      tx: dx / tangentLength,
+      ty: dy / tangentLength
+    };
+  }
+
+  function controlRectangle(center, size) {
+    return {
+      x: center.x - size.width / 2,
+      y: center.y - size.height / 2,
+      width: size.width,
+      height: size.height
+    };
+  }
+
+  function placeEdgeSelect(select, anchor, blockers, edgeBox) {
+    var measured = select.getBoundingClientRect();
+    var size = { width: measured.width, height: measured.height };
+    if (!Number.isFinite(size.width) || !Number.isFinite(size.height) ||
+        size.width <= 0 || size.height <= 0) return null;
+    var nx = -anchor.ty;
+    var ny = anchor.tx;
+    var distances = [32, 56, 84, 112, 140, 168, 196];
+    var shifts = [0, -48, 48, -96, 96, -144, 144];
+    for (var i = 0; i < distances.length; i++) {
+      for (var signIndex = 0; signIndex < 2; signIndex++) {
+        var sign = signIndex === 0 ? 1 : -1;
+        for (var j = 0; j < shifts.length; j++) {
+          var center = {
+            x: anchor.x + nx * distances[i] * sign + anchor.tx * shifts[j],
+            y: anchor.y + ny * distances[i] * sign + anchor.ty * shifts[j]
+          };
+          var candidate = controlRectangle(center, size);
+          var blocked = blockers.some(function (blocker) {
+            return rectanglesCollide(candidate, blocker, 6);
+          });
+          if (blocked) continue;
+          select.style.left = center.x + "px";
+          select.style.top = center.y + "px";
+          return candidate;
+        }
+      }
+    }
+    var fallbackXs = [
+      edgeBox.x + edgeBox.width / 2,
+      edgeBox.x,
+      edgeBox.x + edgeBox.width,
+      edgeBox.x - size.width - 6,
+      edgeBox.x + edgeBox.width + size.width + 6
+    ];
+    for (var row = 0; row < 6; row++) {
+      for (var sideIndex = 0; sideIndex < 2; sideIndex++) {
+        for (var xIndex = 0; xIndex < fallbackXs.length; xIndex++) {
+          var fallbackCenter = {
+            x: fallbackXs[xIndex],
+            y: sideIndex === 0
+              ? edgeBox.y - size.height / 2 - 6 - row * (size.height + 6)
+              : edgeBox.y + edgeBox.height + size.height / 2 + 6 +
+                row * (size.height + 6)
+          };
+          var fallback = controlRectangle(fallbackCenter, size);
+          var fallbackBlocked = blockers.some(function (blocker) {
+            return rectanglesCollide(fallback, blocker, 6);
+          });
+          if (fallbackBlocked) continue;
+          select.style.left = fallbackCenter.x + "px";
+          select.style.top = fallbackCenter.y + "px";
+          return fallback;
+        }
+      }
+    }
+    return null;
+  }
+
+  function positionEdgeControls(graph, edge, controls) {
+    var main = graph.edgeMainById.get(edge.id);
+    if (!main) {
+      controls.root.classList.add("ark-harness-edge-controls-unavailable");
+      ["from-card", "direction", "to-card"].forEach(function (role) {
+        controls.selects[role].disabled = true;
+      });
+      return;
+    }
+    var containerRect = graph.container.getBoundingClientRect();
+    var blockers = edgeControlBlockers(graph, edge.id, containerRect);
+    var edgeBox = domRectangle(main, containerRect);
+    var placements = [
+      { role: "from-card", fraction: 0.2 },
+      { role: "direction", fraction: 0.5 },
+      { role: "to-card", fraction: 0.8 }
+    ];
+    for (var i = 0; i < placements.length; i++) {
+      var placement = placements[i];
+      var anchor = edgePathAnchor(main, placement.fraction);
+      var rectangle = anchor &&
+        placeEdgeSelect(controls.selects[placement.role], anchor, blockers, edgeBox);
+      if (!rectangle) {
+        controls.root.classList.add("ark-harness-edge-controls-unavailable");
+        ["from-card", "direction", "to-card"].forEach(function (role) {
+          controls.selects[role].disabled = true;
+        });
+        return;
+      }
+      blockers.push(rectangle);
+    }
+    controls.root.classList.remove("ark-harness-edge-controls-unavailable");
+  }
+
+  function syncEdgeControls(graph, edges) {
+    var activeIds = new Set();
+    edges.forEach(function (edge) {
+      if (!graph.edgeGeometryById.has(edge.id)) return;
+      activeIds.add(edge.id);
+      var controls = graph.edgeControlsById.get(edge.id);
+      if (!controls) {
+        controls = createEdgeControls(graph, edge);
+        graph.edgeControlsById.set(edge.id, controls);
+      }
+      controls.root.setAttribute("data-ark-edge-id", edge.id);
+      syncEdgeSelect(controls, "from-card", edge);
+      syncEdgeSelect(controls, "direction", edge);
+      syncEdgeSelect(controls, "to-card", edge);
+      positionEdgeControls(graph, edge, controls);
+    });
+    graph.edgeControlsById.forEach(function (controls, edgeId) {
+      if (activeIds.has(edgeId)) return;
+      clearEdgeControlsClose(controls);
+      if (controls.root.parentNode) controls.root.parentNode.removeChild(controls.root);
+      graph.edgeControlsById.delete(edgeId);
     });
   }
 
@@ -1165,8 +1587,10 @@ const HARNESS_JS = `(function () {
       groupsById: groupsById,
       svg: svg,
       edgeGeometryById: new Map(),
+      edgeMainById: new Map(),
       handleLayer: handleLayer,
       edgeHandlesByKey: new Map(),
+      edgeControlsById: new Map(),
       positionsById: new Map(),
       layoutExtent: { width: null, height: null },
       resizeObserver: null,


### PR DESCRIPTION
## 概要

graph の **edge 上に直接操作コントロール**を追加する（編集UX 直接操作レイヤ：#240 方向トグル・#241 kind ピッカーに続く）。生 JSON を開かず、edge の cardinality（多重度）と direction（向き）を直接選べる。

## 実装

- edge ごとに **3つの native `<select>`**（始点 cardinality / 終点 cardinality / direction）。候補は **#229 と同じ単一 allowlist**（5値 / 5値 / 4値）を読取・表示・更新で共有（別 enum を作らない）
- 選択で `edge.ext.from_card`/`to_card`/`direction` を更新 → 既存 `applyEdgeMarkers()`/`appendEdgeCardinality()` 経路で **crow's foot・矢印を即時再描画**
- **配置**: hover/`:focus-within` 表示・edge label / endpoint handle / node と **6px gap で非重複**・上下 fallback（#241 の被り教訓）
- **非還流**: edge.ext 単独変更は会話へ還流しない（`describeModelDiff` は from/to/label のみ・production `diagram-diff.ts` 不変）。端点張り替えは従来どおり還流
- **セキュリティ**: allowlist + `createElement`/`textContent`/`setAttribute` のみ・悪意値（`<img>`/`<script>`）は disabled placeholder で無害化・inline SVG・**<128KiB guard 維持**・一時UIは `data-ark-harness-ui`
- **DB スキーマ変更なし**。スコープは `diagram-harness.ts` + テスト + e2e に限定

## 検証

- server: **24 files / 416 tests PASS** ・ Chromium **E2E 42/42 PASS**
- `pnpm check`（biome + tsc）: PASS ・ `pnpm build`: PASS ・ <128KiB / marker 一意 / 外部リソース禁止: PASS
- **実機プレビューで動作確認済み**（3コントロール表示・被りなし・即時再描画・保存・非還流）

## 進め方

`/flow-loop`→`/flow-x --async-gates` の自走 run。設計承認（P2.5）・実機動作確認・マージ承認、いずれも取得済み。

Closes #242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - エッジの始点・終点のカーディナリティと方向を、JSONを直接編集せず選択式UIで変更できるようになりました。
  - 変更内容が図に即時反映され、エッジの再接続後も設定が保持されます。
  - エッジ操作時の表示や配置を改善し、関連要素との重なりを抑制しました。

- **改善**
  - 不正または未対応の値を安全に扱い、許可された選択肢のみ保存されます。
  - 保存時には編集用UIが除去され、不要な表示情報が提出内容に含まれないようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->