### PR TITLE
feat(diagram): ノード・edge の追加/削除（パレット・ドラッグ作成・削除） (#243)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-issue-243.md
+++ b/docs/superpowers/plans/2026-07-23-issue-243.md
@@ -1,0 +1,643 @@
+# Issue #243: ノード・edge の追加/削除 Implementation Plan
+
+> **実装担当者向け:** 各チェック項目を Red → Green → Refactor の順で進めること。各 Step は 2〜5 分で完了できる粒度にしている。
+
+**Goal:** graph 上の安全なパレットと直接操作だけで node を追加・削除し、node 間 drag で edge を追加、edge 自体または端点から削除できるようにする。構造変更を clean HTML と model block に保存し、既存 `describeModelDiff()` の node / edge add・remove 文として会話へ還流する。
+
+**Issue:** [#243](https://github.com/ignission/claude-code-ark/issues/243)
+
+**Architecture:** `packages/server/src/lib/diagram-harness.ts` が注入する vanilla DOM ハーネス内に、graph 選択・kind 選択・「+ ノード」を持つ toolbar palette、node ごとの edge 作成 handle / 削除 button、edge ごとの透明 hit target / 削除 button を追加する。新規 node は model entry と、保存対象になる最小の authored-style projection root を同時に作り、`node.ext.x/y` に既存 node・edge label・handle と衝突しない有限整数座標を保存する。新規 edge は #229 の `edgeDrag` / `findEdgeDropCandidate()` / preview / drop indicator を create mode に一般化し、commit 時に実在 node id を再検証して model へ追加する。node 削除は node とそれを参照する全 edge、全 `groups[].nodes` 参照を一回の操作で除去する。全 ID は label やユーザー入力を使わない opaque 値とし、node / field / edge / group 全体の予約集合で衝突を防ぐ。保存・422 validation・ファイル置換・会話送信は既存 MessageChannel → `diagram:submit` → `parseDiagramModel()` → `replaceModelBlock()` → `describeModelDiff()` をそのまま使う。
+
+**Tech Stack:** TypeScript / injected vanilla DOM・CSS・inline SVG / Vitest / Playwright
+
+---
+
+## 調査結果
+
+- #224 で `data-ark-container="graph"` が opt-in graph root になり、model node id と一致する最初の `[data-model-id]` root を `graph.nodesById` に登録している。`layoutGraph()` は有限な `node.ext.x` / `ext.y` を manual 座標として保持し、それ以外を auto layout する。drag は整数座標を `Math.max(0, …)` で保存し、edge / group / min extent を同じ render frame で追従させる。
+- #224 の graph state は `nodesById`、`groupsById`、`positionsById`、`edgeGeometryById`、`edgeHandlesByKey`、`ResizeObserver` を container ごとに持つ。新規 node を reload なしで表示するには model だけでなく、この state、DOM、observer、kind picker、graph drag handle、inline label edit を同じ登録 helper から更新する必要がある。
+- #229 は `edgeDrag` を1件だけ持ち、edge endpoint handle の pointer capture、`findEdgeDropCandidate()`、preview line、drop indicator、`syncEdgeHandles()` の id + end key reuse、pointerup 時の現 edge 再取得を実装済みである。create と rewire の drag state を mode で分ければ、drop 判定と cleanup を共用できる。
+- `parseDiagramModel()` は node / field / edge / group の id を1つの `seen` set で検証する。したがって node id と edge id は同種内だけでなく全 model id に対して一意でなければならない。`edge.from` / `edge.to` と `groups[].nodes` は実在 node id でなければ 422 になる。self-edge は既存 test と renderer が許容する。
+- #241 は CSSOM から得た diagram-local kind allowlist、現在 model entry の id 再解決、native control、`createElement()` / `textContent` / `setAttribute()`、`data-ark-harness-ui` cleanup という直接操作パターンを確立した。kind picker を node 内から node 外上部へ移した経緯があり、機能だけでなく実測 bounding box の非重複 test が必要である。
+- #242 の計画は edge control を edge id で key 管理し、hover / focus、透明 hit path、geometry に基づく候補探索、label / endpoint handle / node との非重複、stale cleanup を行う方針である。本 Issue の edge delete affordance も同じ基盤形にし、将来 #242 が3 select を同じ layer へ追加できる構造にする。
+- `buildSubmissionHtml()` は `[data-ark-harness-ui]`、`ark-harness-*` class、graph / group の一時 style、CSP meta、`contenteditable` を除去する。palette、button、hit target、preview、indicator は必ず一時 UI として除去する一方、新規 node の projection root と label leaf は semantic projection なので `data-ark-harness-ui` を付けず clean HTML に残す必要がある。
+- production `diagram-diff.ts` の `diffNodes()` は新規 id を `${label} を追加`、消えた id を `${label} を削除` とし、`diffEdges()` は新規・削除 edge を node label で関連文にする。node と参照 edge の同時削除も before model の node label を使って2文にできる既存 test がある。構造変更の還流に production diff の変更は不要である。
+- kind / `node.ext` / `edge.ext` / top-level layout は既存どおり非還流であり、label / field / endpoint は既存どおり還流する。node / edge add・remove をこの id ベース契約に乗せれば、見た目変更との区別を保てる。
+- server の `diagram:submit` は受信 model を `parseDiagramModel()` で検証してから clean HTML の model block を `replaceModelBlock()` で置換し、その後だけ `describeModelDiff()` の固定文を会話へ送る。Socket.IO payload、`DiagramPane`、shared types、DB schema を増やす必要はない。
+- GitHub 上の #243 には追加コメントはなく、2026-07-23 時点の本文は本計画の入力と一致している。
+
+---
+
+## 設計判断と不変条件
+
+### ID
+
+- 初期 model を読み込んだ直後に node / field / edge / group の全 id を `reservedModelIds` へ登録する。削除した id もセッション中は予約解除せず、「削除して同じ id を再追加」が rename / rewire と誤認されることを防ぐ。
+- `generateUniqueModelId(prefix)` は `crypto.randomUUID()`、次に `crypto.getRandomValues()`、最後にセッション内単調 counter を使う。`node-…` / `edge-…` の prefix は固定し、label、kind、edge endpoint、入力文字列を id 材料にしない。
+- candidate は予約集合との衝突を毎回検査し、成功時に即予約する。規定回数で生成できなければ status に固定エラーを出し、model / DOM を一切変更しない。乱数だけを「衝突しない根拠」にしない。
+
+### node 追加と projection
+
+- toolbar palette は graph が1個ならその graph、複数なら DOM 順の固定 label を持つ「配置先」select で対象 graph を選ぶ。kind select は #241 の authored CSS 由来 allowlistだけを選択可能にし、候補が無い図では固定の「kind なし」を選べる。自由入力や server 固定 enum は追加しない。
+- node model の初期値は `{ id, label: "新しいノード", ext: { x, y } }` とし、kind 選択時だけ `kind` を付ける。fields、group membership、図種固有 `ext` は推測しない。
+- permanent projection は allowlist 済み `article` / `section` / `div` のいずれかと `span` label leaf を `createElement()` で作る。選択 kind と同じ既存 node root、無ければ同 graph の先頭 node rootから authored class token だけをコピーし、`ark-harness-*` token はコピーしない。root と label leaf の `data-model-id`、root の `data-kind` は `setAttribute()`、label は `textContent` で設定する。
+- 新規 semantic projection に `data-ark-harness-ui` は付けない。graph node class、picker、drag / create / delete handle、editable class は従来どおり一時 UI とし、submission cleanup 後は authored class + `data-model-id` + `data-kind` + label text だけが残る。
+- 座標は現在の `positionsById`、node 実測矩形、edge label、endpoint handle、visible affordance の graph-local bounding box を blocker として扱う。LR は右方向、TB は下方向を第一候補にし、padding / rankSpacing / nodeSpacing を使った決定的候補列を走査する。候補が埋まる場合は blocker 全体の右または下へ退避し、有限・非負整数の `ext.x/y` を必ず得てから model / DOM を commit する。
+- node 登録処理は初期 `wireGraph()` と新規追加で共有する。`nodesById` / `positionsById`、ResizeObserver、kind picker、graph drag handle、edge-create handle、node-delete button、inline label edit を一箇所で接続し、重複 listener を作らない。
+
+### node 削除
+
+- node 削除は対象 id を現在の `state.model` から再取得してから行う。`state.model.nodes` から node、`state.model.edges` から `from === id || to === id` の全 edge、全 `groups[].nodes` から id を同一 synchronous operation で除去する。
+- group 自体は削除せず、空 group も残す。新規 node を既存 group へ自動所属させない。group の追加・削除・任意 membership 編集は別 Issue とし、本 Issue が行う membership 変更は node 削除に伴う参照整合性 cleanup のみとする。
+- 同じ node が複数 graph や graph 外に投影されていても stale HTML を残さないよう、untrusted id を selector へ連結せず全 `[data-model-id]` を列挙して属性値を比較し、同 id の最上位 projection root を除去する。各 graph map / observer / picker / node affordance も解除する。
+- 対象 node / incident edge に関係する active drag、selection、pointer capture を先に cancel し、その後すべての graph を再描画する。途中で不整合 model を外へ送れる event loop の隙間を作らない。
+
+### edge 追加
+
+- 既存 `edgeDrag` を `{ mode: "rewire", edgeId, end, … }` と `{ mode: "create", sourceId, … }` の discriminated state にする。preview / indicator / pointer capture / window-level pointerup・cancel cleanup は共通化する。
+- node の edge-create handle から pointerdown し、source node 外周を preview 始点にする。drop 時は `findEdgeDropCandidate()` で同じ graph の target を求め、source / target の双方が現在の model と `graph.nodesById` に存在することを再検証する。target と source が同じ場合も有効な self-edge とする。
+- create commit でだけ予約済み unique edge id を生成し、`{ id, from: sourceId, to: targetId }` を `state.model.edges` に追加する。label、direction、cardinality、type は推測しない。同じ endpoint pair の parallel edge は model が禁止していないため id で区別し、勝手に既存 edge へ統合しない。
+- graph 外、削除済み node、pointercancel、Escape、drop candidate なしでは model を変更しない。rewire mode は現行どおり既存 edge を id で引き直し、今回の refactor で endpoint 張り替えの意味差分を壊さない。
+
+### edge 削除
+
+- edge main と同じ geometry の透明 wide-stroke hit target を一時 SVG として作り、edge id を `setAttribute()` する。hover / focus / click で該当 edge を選択し、keyed delete button と endpoint handle の Delete / Backspace のどちらからでも edge 全体を削除できるようにする。
+- `removeEdge(edgeId)` は現在 model から edge を再取得し、存在するときだけ `state.model.edges` を filter する。active rewire drag / selected edge を解除し、全 graph を schedule render して `syncEdgeHandles()` と delete control map の stale entry を除去する。
+- edge delete button は label 中点へ重ねない。path 上の複数 fraction と法線両側を固定順で試し、edge label、両 endpoint handle、node、node affordance、既配置 edge delete button と gap を取る。通常候補が無ければ blocker 全体の安全な外側へ置き、重なった位置には出さない。
+
+### UI 配置・安全性・accessibility
+
+- palette は既存 fixed toolbar 内に置き、body bottom padding を palette 高に追従させる。graph 内 node / edge / label / handle の上へ fixed panel を増設しない。
+- node の edge-create / delete は1つの affordance rail にまとめ、node 外周の上・左・右・下候補を実測する。既存 kind picker と graph drag handle を blocker に含め、#241 の被りを再発させない。hover と `:focus-within` の両方で表示し、native button の accessible name に node label と操作を含める。
+- preview は node より背面の専用 SVG layerへ置き、source / target の node 外周で終端する。drop indicator は node 内容を塗りつぶさず、透明背景の外側 ring とする。edge drag 中は衝突する node control を隠し、preview / ring は pointer event を取らない。
+- palette、rail、button、hit target、preview、indicator、option を含む一時 UI はすべて `markUi()` で `data-ark-harness-ui` を持つ。記号は Unicode または既存 inline SVG のみとし、外部 image / font / stylesheet / icon / `<use href>` を追加しない。
+- model / label / kind / id は信頼しない。DOM は `createElement()` / `createElementNS()`、`textContent`、`setAttribute()` と既存 style property API だけで組み立て、`innerHTML` / `outerHTML` 代入 / `insertAdjacentHTML` / untrusted selector interpolation / dynamic script を使わない。
+- native select / button の pointerdown / click / keydown は必要な範囲で propagation を止め、graph drag、endpoint rewire、inline edit、list reorder を起動させない。Escape は drag cancel、Delete / Backspace は focus 中の削除対象だけへ作用し、contenteditable 入力中は横取りしない。
+
+### 保存・還流・変更境界
+
+- `buildSubmissionHtml()`、MessageChannel payload、server `diagram:submit`、`parseDiagramModel()`、`replaceModelBlock()` を変更しない。新規 node projection が clean HTML に残り、一時 CRUD UI が既存汎用 cleanup で消えることを e2e で固定する。
+- production `packages/server/src/lib/diagram-diff.ts` は変更しない。`diagram-diff.test.ts` に node / edge add・remove、cascade、self-edge、既存 field / label / endpoint との共存を追加し、既存契約だけで Green になることを確認する。
+- 実装中に production diff の変更が必要と判明した場合は、会話へ送る意味文と prompt-injection 境界を変える大きな判断なので作業を止め、**人間レビュー必須**として再設計する。
+- DB schema / migration、model schema、diagram file helper、`DiagramPane`、Socket.IO、shared type を変更しない。いずれかが必要と判明した場合も本 Issue の信頼境界外なので、**人間レビュー必須**として作業を止める。
+- 実装差分は本 plan を除き `packages/server/src/lib/diagram-harness.ts`、`packages/server/src/lib/diagram-harness.test.ts`、`packages/server/src/lib/diagram-diff.test.ts`、`e2e/diagram-harness.spec.ts` に限定する。
+- 注入後 HTML の既存 `<128KiB` guard を緩和しない。上限を超えた場合は定数 table、geometry helper、drag cleanup、control factory の重複を整理する。
+
+---
+
+## Task 1: CRUD acceptance を E2E で先に Red にする
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+- Reference: `packages/server/src/lib/diagram-harness.ts:188-229,857-1201,1264-1383,1554-1721`
+- Reference: `packages/server/src/lib/diagram-diff.ts:104-165`
+
+- [ ] **Step 1: CRUD 用 graph fixture を追加する（2〜5分）**
+
+  kind CSS、manual / auto node、self-edge、通常 edge、2 graph、node を含む group、graph 外 duplicate projection を持つ fixture を追加する。id / label に HTML 記号を含む境界用 node も置き、安全性 test を後から同じ fixture で書けるようにする。
+
+- [ ] **Step 2: palette の Red test を追加する（2〜5分）**
+
+  toolbar に配置先 select、CSS allowlist だけを持つ kind select、「+ ノード」button があり、自由入力、group 追加、edge kind / cardinality UI が無いことを assertion にする。
+
+- [ ] **Step 3: node 追加 model / projection の Red test を追加する（2〜5分）**
+
+  kind を選んで node を追加し、固定 label、opaque id、選択 kind、有限整数 `ext.x/y` を持つ model entryと、同じ id / kind / label の graph projection が即時に1件増えることを確認する。
+
+- [ ] **Step 4: node 非重複座標の Red test を追加する（2〜5分）**
+
+  LR / TB、manual / auto 混在 fixture の双方で追加し、新規 node bounding box が全既存 node、edge label、endpoint handle と gap 付きで重ならず、graph min extent 内に収まることを確認する。
+
+- [ ] **Step 5: node projection の再編集 Red test を追加する（2〜5分）**
+
+  追加直後の label を inline editし、kind picker、graph drag、edge-create / delete affordance が既存 node と同様に付くことを確認する。drag 後は同じ node の `ext.x/y` だけが変わることも固定する。
+
+- [ ] **Step 6: node cascade 削除の Red test を追加する（2〜5分）**
+
+  group member かつ複数 edge / self-edge の endpoint である node を「−」から削除し、node、incident edge、全 group member 参照、全 projection が同時に消える一方、group object と非 incident edge は残ることを確認する。
+
+- [ ] **Step 7: node 間 drag edge 追加の Red test を追加する（2〜5分）**
+
+  source node の create handle から target node へ pointer dragし、新規 edge が opaque unique id、実在 `from` / `to`、ext / label なしで追加され、SVG main と両 endpoint handle が即時に現れることを確認する。
+
+- [ ] **Step 8: self-edge 追加の Red test を追加する（2〜5分）**
+
+  source と同じ node へ dropし、`from === to` の edge が追加され cubic path と2 endpoint handle で描画されることを確認する。
+
+- [ ] **Step 9: invalid drop / cancel の Red test を追加する（2〜5分）**
+
+  graph 背景、別 graph、graph 外 projection、pointercancel、Escape では edge 数と予約済み model が変わらず、preview / indicator / pointer capture が残らないことを確認する。
+
+- [ ] **Step 10: edge 削除の Red test を追加する（2〜5分）**
+
+  edge hover / focus で delete affordance を表示して削除する case と、endpoint handle focus 中の Delete で削除する case を分ける。対象 edge の main / label / handles / controls だけが消え、node と他 edge は残ることを確認する。
+
+- [ ] **Step 11: clean submission と意味差分の Red test を追加する（2〜5分）**
+
+  node add、edge add、edge delete、cascade node delete、既存 field rename を同一 session で行って「変更を送る」を押す。submission model が valid な最終構造になり、新規 node projection は HTML に残る一方、palette / rail / button / hit target / preview / indicator / `data-ark-harness-ui` は残らないことを確認する。`describeModelDiff(initial, submission.model)` に構造変更と field rename だけが現れ、座標 / kind は現れないことも assertion にする。
+
+- [ ] **Step 12: acceptance の Red を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "node CRUD|edge CRUD|構造変更"
+  ```
+
+  Expected: FAIL。現状は node palette、node create/delete、edge create/delete affordance が無いため最初の palette assertion で失敗する。
+
+---
+
+## Task 2: server contract と diff 還流を Red / Green で固定する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Modify: `packages/server/src/lib/diagram-diff.test.ts`
+- Do not modify: `packages/server/src/lib/diagram-diff.ts`
+
+- [ ] **Step 1: CRUD 注入契約の Red test を追加する（2〜5分）**
+
+  injected HTML に unique id reservation、node palette、node registration / removal、edge create mode、edge removal、group reference cleanup、keyed control sync が含まれることを文字列 assertion で固定する。
+
+- [ ] **Step 2: 安全な DOM API 契約の Red test を追加する（2〜5分）**
+
+  新規 semantic projection と全 control が `createElement` / `createElementNS`、`textContent`、`setAttribute` を使うことを確認する。既存の `innerHTML`、`insertAdjacentHTML`、`fetch(`、`import(`、`https://`、外部 font / stylesheet 不在 assertion を維持する。
+
+- [ ] **Step 3: 全 model id 横断の予約契約を Red にする（2〜5分）**
+
+  node / fields / edges / groups の id を収集し、削除後も予約集合から消さず、candidate を予約集合で再検査する helper の存在を assertion にする。label / kind から id を組み立てる文字列が無いことも確認する。
+
+- [ ] **Step 4: node add/remove の diff test を補強する（2〜5分）**
+
+  kind / ext 付き node 追加が node 追加文1件だけになる case、node 削除が node 削除文1件だけになる case を追加する。production diff 不変で Green になることを確認する。
+
+- [ ] **Step 5: edge add/remove/self-edge の diff test を追加する（2〜5分）**
+
+  label なし edge 追加、label 付き edge 削除、self-edge 追加・削除を別 case にし、node label を使った既存文面を完全一致で固定する。
+
+- [ ] **Step 6: cascade と既存編集の diff test を追加する（2〜5分）**
+
+  node + incident edges の同時削除で node 文が先、edge 文が後になること、node / edge add・remove と field label / edge endpoint 変更が共存しても全意味差分が欠落しないことを確認する。kind / ext / layout は引き続き出ないことも同じ case で固定する。
+
+- [ ] **Step 7: production diff 無変更で Green を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test -- \
+    src/lib/diagram-diff.test.ts src/lib/diagram-harness.test.ts
+  ```
+
+  Expected: `diagram-diff.test.ts` は production `diagram-diff.ts` 無変更で PASS。`diagram-harness.test.ts` の新規 CRUD assertion は未実装のため FAIL。
+
+---
+
+## Task 3: 一意 ID 予約と palette を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:188-229,276-292,1618-1721`
+- Test: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: model id 収集 helper を実装する（2〜5分）**
+
+  node、各 node.fields、edge、group の文字列 id を1つの set へ収集する。model load 後に `reservedModelIds` を初期化し、model 直接編集の反映時は新規 id を追加するが既予約 id は消さない。
+
+- [ ] **Step 2: unique opaque id generator を実装する（2〜5分）**
+
+  prefix + UUID / random bytes / counter candidate を作り、予約集合との照合と即時予約を行う。規定回数失敗時は null を返し、呼び出し側が固定 status error で中止できるようにする。
+
+- [ ] **Step 3: graph 選択肢を作る（2〜5分）**
+
+  DOM 順の graph に固定の表示番号を与え、toolbar の配置先 native select を `createElement()` / `textContent` / `setAttribute()` で作る。graph が1件でも accessible name を持たせ、model / authored label を HTML 化しない。
+
+- [ ] **Step 4: kind 選択肢を #241 allowlist から作る（2〜5分）**
+
+  `kindCandidates` を再利用して native option を作り、0件時だけ固定の「kind なし」option を出す。change / click / keydown が graph drag や edit に伝播しないようにする。
+
+- [ ] **Step 5: palette button と status を接続する（2〜5分）**
+
+  「+ ノード」button を既存 layout direction button と model editor の間に置き、選択 graph / kind を node add entry point へ渡す。未解決 graph や id 生成失敗時は partial mutation せず status だけ更新する。
+
+- [ ] **Step 6: palette CSS と bottom padding を追加する（2〜5分）**
+
+  toolbar 内で wrap 可能な小さい control group とし、狭幅でも send button を隠さない。実測 toolbar 高に body bottom padding を合わせ、fixed palette が graph 内容へ重ならないようにする。
+
+- [ ] **Step 7: palette contract を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test -- src/lib/diagram-harness.test.ts
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "node palette"
+  ```
+
+  Expected: palette、allowlist、unique id helper の test は PASS。node 作成本体を期待する test は引き続き Red。
+
+---
+
+## Task 4: permanent node projection と衝突しない追加を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:327-617,1073-1201,1264-1366,1427-1452`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: projection template metadata を安全に読む（2〜5分）**
+
+  選択 kind と一致する既存 graph node、無ければ先頭 graph nodeから allowlist 済み tag と authored class token を得る。`ark-harness-*` class、style、event attribute、子 DOM はコピーしない。
+
+- [ ] **Step 2: semantic projection factory を実装する（2〜5分）**
+
+  root と label `span` を新規作成し、id / kind / class / label を安全な DOM API だけで設定する。root / label に `data-ark-harness-ui` を付けないことを helper 境界で明確にする。
+
+- [ ] **Step 3: graph node 登録 helper を抽出する（2〜5分）**
+
+  初期 `wireGraph()` の node class付与、map 登録、kind picker、graph drag handle、ResizeObserver 登録を `registerGraphNode()` へまとめる。初期化と動的追加の双方をこの helper へ通す。
+
+- [ ] **Step 4: 動的 label edit を接続する（2〜5分）**
+
+  新規 label leaf だけを `wireEditableLeaf()` へ渡し、model label を即時更新する。list row control や field 追加 button は作らず、node fields を暗黙に追加しない。
+
+- [ ] **Step 5: placement blocker 収集を実装する（2〜5分）**
+
+  graph-local node、edge label、endpoint handle、visible control の bounding box を正規化する。UI 自身や別 graph の要素を混ぜず、finite size の box だけを返す。
+
+- [ ] **Step 6: LR / TB 候補探索を実装する（2〜5分）**
+
+  新規 root を安全な仮位置で測定し、layout direction、padding、spacing から候補を走査する。gap 付き rectangle intersection が無い最初の非負整数 x/y を返し、無ければ blocker 全体の右 / 下へ退避する。
+
+- [ ] **Step 7: model + DOM の commit 順を実装する（2〜5分）**
+
+  id、projection、測定、座標の全準備が成功してから node entry を model へ pushし、root を container へ append、register、render する。途中失敗では仮 DOM と予約以外を残さず、invalid node を送れないようにする。
+
+- [ ] **Step 8: node add と inline edit を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "node CRUD.*追加|node CRUD.*編集"
+  ```
+
+  Expected: model / projection / kind / coordinate / inline edit / graph drag の追加 test が PASS。
+
+- [ ] **Step 9: LR / TB 非重複 test を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "node CRUD.*重ならない"
+  ```
+
+  Expected: manual / auto 混在でも新規 node が blocker と重ならず、有限 manual 座標を得る。
+
+---
+
+## Task 5: node affordance と参照整合な削除を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:810-905,1073-1201,1264-1366`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: node affordance rail factory を作る（2〜5分）**
+
+  edge-create handle と「−」delete button を native button として同じ marked wrapper に入れる。node id は data attribute に置き、handler は click / pointerdown 時に model を再取得する。
+
+- [ ] **Step 2: rail の表示と event 分離を実装する（2〜5分）**
+
+  node hover / focus-within で表示し、rail 操作は kind picker、graph drag、inline editを開始させない。accessible name / title は `textContent` / `setAttribute` で node label を安全に含める。
+
+- [ ] **Step 3: rail の非重複候補探索を実装する（2〜5分）**
+
+  node 外周候補を kind picker、graph handle、node、edge label、endpoint handle、他 rail に対して測る。通常候補が無い場合は blocker union 外側へ安全に退避し、重なった位置を採用しない。
+
+- [ ] **Step 4: graph node unregister helper を実装する（2〜5分）**
+
+  map、position、observer、picker、rail、active graph drag を安全に解除する。DOM が既に無い / model が既に変わった場合も例外を投げない idempotent cleanup にする。
+
+- [ ] **Step 5: cascade model cleanup を実装する（2〜5分）**
+
+  node、incident edge、全 group member参照を synchronous に filter する。空 group と group metadata は保持し、非 incident edge / field / ext を変更しない。
+
+- [ ] **Step 6: 全 projection と全 graph state を清掃する（2〜5分）**
+
+  `[data-model-id]` の属性値比較で同 id の最上位 projection を求め、graph 内外・複数 graph の stale projection を除去する。untrusted id を CSS selector 文字列へ挿入しない。
+
+- [ ] **Step 7: active drag / selection cleanup を接続する（2〜5分）**
+
+  対象 node または incident edge を参照する create / rewire drag を cancelし、pointer captureと previewを解放する。全 graph を renderして edge handle / group geometryを同期する。
+
+- [ ] **Step 8: node cascade delete を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "node CRUD.*削除|参照整合"
+  ```
+
+  Expected: node / incident edges / group refs / projections が同時に消え、submission model は 422 要因を持たない。
+
+---
+
+## Task 6: #229 edge drag を create / rewire 共通基盤へ一般化する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:913-1069`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: edgeDrag state に mode を導入する（2〜5分）**
+
+  rewire に `edgeId/end`、create に `sourceId` を持たせ、共通 pointer / graph / handle / preview / indicator state と分離する。既存 endpoint handler を rewire constructor へ移す。
+
+- [ ] **Step 2: preview layer factory を共通化する（2〜5分）**
+
+  node 背面の専用 marked SVG layerに preview path を作り、rewire / create の開始 endpoint を graph-local 座標で設定する。render 中に消えず、drag 終了時に必ず除去されるようにする。
+
+- [ ] **Step 3: create drag start を node handleへ接続する（2〜5分）**
+
+  pointerdown 時に source id / node / geometry を再検証し、node 外周の開始点を求めて pointer capture する。graphDrag / edgeDrag との排他は既存条件を維持する。
+
+- [ ] **Step 4: candidate と drop ring を共通化する（2〜5分）**
+
+  `findEdgeDropCandidate()` を再利用し、source と同じ node を除外しない。indicator は target node border の外側 ring、preview 終点は target 外周として、node 内容 / handle を覆わない。
+
+- [ ] **Step 5: create commit validation を実装する（2〜5分）**
+
+  pointerup の瞬間に source / target が同 graph map と現在 model に存在することを再確認する。成功時だけ unique edge id を予約し、最小 edge objectを pushする。
+
+- [ ] **Step 6: rewire commit を既存挙動のまま接続する（2〜5分）**
+
+  rewire は現在 edge を id で引き直し、対象 endpoint だけを candidate id へ変える。stale edge / node では no-op にし、既存 endpoint 意味差分を保つ。
+
+- [ ] **Step 7: Escape / cancel / window pointerup cleanup を統一する（2〜5分）**
+
+  mode に関係なく preview、ring、active class、pointer captureを一度だけ解除する。失敗 / cancel時は予約 id と model edgeを作らない。
+
+- [ ] **Step 8: edge create / self-edge / invalid drop を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "edge CRUD.*追加|self-edge|invalid drop"
+  ```
+
+  Expected: 通常 edge と self-edge は追加され、graph 外 / cancel は no-op。既存 rewire test も PASS。
+
+---
+
+## Task 7: edge hit target と削除 affordance を実装する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts:642-649,671-905,998-1069,1130-1175`
+- Test: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: edge label / main / hit target を id で揃える（2〜5分）**
+
+  label に edge id を付け、main geometry と同じ透明 wide-stroke path / lineを作る。hit target は一時 UI、main は既存 authored CSS selector契約を維持する。
+
+- [ ] **Step 2: edge selection state を接続する（2〜5分）**
+
+  hit target の hover / focus / click で edge id を選択し、mainへ選択 classを同期する。別 edge 選択、edge 消失、drag 開始で stale selectionを解除する。
+
+- [ ] **Step 3: keyed delete control map を graph stateへ追加する（2〜5分）**
+
+  edge id ごとの wrapper / buttonを作成・再利用し、renderごとに model と accessible nameを同期する。消えた edge / geometryなし edgeは DOM remove + map deleteする。
+
+- [ ] **Step 4: edge delete control の geometry を実装する（2〜5分）**
+
+  path の複数 fraction / 法線候補を測り、label、endpoint handle、node、node rail、他 edge controlと重ならない座標を選ぶ。self-edgeも path length APIで同じ処理へ通す。
+
+- [ ] **Step 5: removeEdge を実装する（2〜5分）**
+
+  edge idを現在 modelから再取得して filterし、active rewire、selection、controlを解除して全 graphをrenderする。node / group /他 edgeは変更しない。
+
+- [ ] **Step 6: button と keyboard delete を接続する（2〜5分）**
+
+  delete button click、focused hit target / endpoint handle の Delete / Backspaceを `removeEdge()` へ接続する。contenteditable / select内の key event は横取りしない。
+
+- [ ] **Step 7: edge delete と stale cleanup を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "edge CRUD.*削除|stale edge"
+  ```
+
+  Expected: hover / focus / endpoint の全経路で対象 edgeだけが消え、control / handle mapに stale entryが残らない。
+
+---
+
+## Task 8: UI 非重複・security・cleanup を固定する
+
+**Files:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Modify: `e2e/diagram-harness.spec.ts`
+
+- [ ] **Step 1: 共通 rectangle / gap helper を整理する（2〜5分）**
+
+  node placement、node rail、edge deleteで重複している graph-local rectangle、inflate、intersection、unionを共通 helperへ寄せる。非有限 boxは無視し、候補順を決定的にする。
+
+- [ ] **Step 2: palette / rail / edge control の bounding-box test を追加する（2〜5分）**
+
+  paletteが toolbar外へはみ出さず graph semantic elementと重ならないこと、railがnode / kind picker / graph handle / edge label / endpoint handleと重ならないこと、edge deleteが同じ blocker群と重ならないことを gap付きで確認する。
+
+- [ ] **Step 3: preview / indicator の視覚境界 test を追加する（2〜5分）**
+
+  previewの source / target endpointがnode外周にありnode内部へ入らないこと、preview layerがnodeより背面であること、drop ringの背景が透明でnode border外にあることをcomputed styleとgeometryで固定する。
+
+- [ ] **Step 4: untrusted label / kind / id の E2E を追加する（2〜5分）**
+
+  HTML記号を含む既存 label / kindをpalette accessible name、new projection、delete controlへ流しても要素数が増えずscript / image / handlerが生成されないことを確認する。programmatic allowlist外 kindもnode addへ通らないことを固定する。
+
+- [ ] **Step 5: clean HTML の semantic / temporary 境界を確認する（2〜5分）**
+
+  新規 root / label / authored class / data-model-id / data-kindは残り、全 CRUD UI、hit target、preview、ring、runtime style、`ark-harness-*` class、`contenteditable`、CSP metaは残らないことを確認する。
+
+- [ ] **Step 6: `<128KiB` と外部リソース禁止を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test -- src/lib/diagram-harness.test.ts
+  ```
+
+  Expected: marker一意性、DOM API、外部リソース禁止、CRUD contract、注入後 `<128KiB` がすべて PASS。guard は変更しない。
+
+- [ ] **Step 7: UI geometry / security E2E を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "CRUD UI|重ならない|untrusted|clean submission"
+  ```
+
+  Expected: 全 affordance が blockerを覆わず、untrusted値はtext / attributeとしてだけ扱われ、temporary UIはsubmissionから消える。
+
+---
+
+## Task 9: 構造変更の保存・還流と既存操作の共存を統合検証する
+
+**Files:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+- Modify: `packages/server/src/lib/diagram-diff.test.ts`
+- Do not modify: production `packages/server/src/lib/diagram-diff.ts`
+
+- [ ] **Step 1: add → edit → connect → rewire → delete scenario を追加する（2〜5分）**
+
+  node追加、label edit、drag移動、edge追加、endpoint張り替え、edge削除、別node cascade削除を順に行い、各 frameのmodel / projection / handle countを確認する。
+
+- [ ] **Step 2: field / kind / layout / CRUD 共存 scenario を追加する（2〜5分）**
+
+  field inline edit / add / reorder、kind picker、LR↔TB、node / edge CRUDを同一diagramで行う。各操作のmodel pathが互いを上書きしないことを確認する。
+
+- [ ] **Step 3: submission model の参照整合性を assertion にする（2〜5分）**
+
+  全 edge endpointが最終 nodes setに存在し、全 group memberがnodes setに存在し、node / field / edge / group idが全体で一意であることをtest内helperで検証する。
+
+- [ ] **Step 4: 意味差分の順序と非還流を assertion にする（2〜5分）**
+
+  `describeModelDiff(initial, final)` が node add/remove、edge add/remove、label / field / endpoint変更を返し、kind、座標、layout、edge.extを返さないことを完全一致で確認する。
+
+- [ ] **Step 5: production diff 無変更を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  git diff -- packages/server/src/lib/diagram-diff.ts
+  ```
+
+  Expected: no output。差分がある場合は実装を続けず、人間レビューへ戻す。
+
+- [ ] **Step 6: focused server tests を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test -- \
+    src/lib/diagram-harness.test.ts src/lib/diagram-diff.test.ts
+  ```
+
+  Expected: PASS。
+
+- [ ] **Step 7: focused E2E を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "node CRUD|edge CRUD|構造変更"
+  ```
+
+  Expected: PASS。
+
+---
+
+## Task 10: 全回帰・変更境界・手動 acceptance を確認する
+
+**Files:**
+
+- Verify only
+
+- [ ] **Step 1: diagram harness E2E 全件を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium
+  ```
+
+  Expected: PASS。graph layout、方向toggle、group、kind picker、edge semantics / rewire、self-edge、node drag、inline edit、list reorder、model direct edit、authored samplesを含む全件がGreen。
+
+- [ ] **Step 2: server test suite を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server test
+  ```
+
+  Expected: PASS。model validator、diagram file round-trip、diff、harnessを含めて回帰なし。
+
+- [ ] **Step 3: type / format check を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm check
+  ```
+
+  Expected: PASS。
+
+- [ ] **Step 4: 変更ファイル境界を確認する（2〜5分）**
+
+  Run:
+
+  ```bash
+  git status --short
+  git diff --stat
+  git diff -- \
+    packages/server/src/lib/diagram-model.ts \
+    packages/server/src/lib/diagram-file.ts \
+    packages/server/src/lib/diagram-diff.ts \
+    packages/server/src/index.ts \
+    packages/shared \
+    packages/web \
+    packages/desktop
+  ```
+
+  Expected: production対象外 pathは no output。planを除く変更は `diagram-harness.ts`、2つのserver test、diagram harness e2eだけ。
+
+- [ ] **Step 5: 実ブラウザで node CRUD を確認する（2〜5分）**
+
+  代表的な `.diagram.html` を開き、kind選択→node追加→label編集→drag→node削除を行う。palette / rail / picker / handleがnode内容や互いを覆わず、追加nodeが既存nodeと重ならないことを確認する。
+
+- [ ] **Step 6: 実ブラウザで edge CRUD を確認する（2〜5分）**
+
+  通常 edge、self-edge、別nodeへのdrag追加、endpoint rewire、edge hover削除、endpoint keyboard削除を行う。preview / ringが内容を覆わず、cancel後に一時UIが残らないことを確認する。
+
+- [ ] **Step 7: 「変更を送る」後の保存と会話還流を確認する（2〜5分）**
+
+  node / edge add・removeを送信し、再読込後も新規node projectionとmodel構造が残ること、削除projectionが戻らないこと、会話にnode /関連の追加・削除文が届くことを確認する。座標 / kindだけの変更では会話送信が増えないことも確認する。
+
+- [ ] **Step 8: 422 回避を実ブラウザで確認する（2〜5分）**
+
+  group memberかつ複数edge endpointのnodeを削除して送信し、成功することを確認する。保存modelの全edge endpoint / group memberが実在nodeを指すことを確認する。
+
+- [ ] **Step 9: size / scope gate を最終確認する（2〜5分）**
+
+  `<128KiB` guard、外部resource禁止、DB schema不変、production diff不変を再確認する。いずれかを満たせない場合はguardやscopeを緩めず、人間レビューへ戻す。
+
+---
+
+## 完了条件チェックリスト
+
+- [ ] palette /「+ ノード」で配置先 graph と diagram-local kindを選び、opaque unique idと非重複 `ext.x/y` を持つnodeを追加できる。
+- [ ] 新規nodeはmodelとpermanent projectionの両方へ追加され、inline label edit、kind picker、drag、edge create、deleteが既存nodeと同様に使える。
+- [ ] node削除時にincident edgeと全group member参照が同時に除去され、422になるdangling referenceが残らない。group CRUD自体は追加していない。
+- [ ] node間dragで通常edgeとself-edgeを作成でき、`from` / `to` はcommit時点の実在node idを指す。invalid drop / cancelはno-op。
+- [ ] edge hover / focusの削除buttonとendpoint keyboard操作で対象edgeを削除でき、他node / edgeを変更しない。
+- [ ] node / edge idはlabel・kind・ユーザー入力から作られず、node / field / edge / group横断の予約集合で衝突しない。削除idを同一sessionで再利用しない。
+- [ ] palette、+/−、preview、drop indicator、hit targetはsemantic node / edge / label / handleと重なって内容を覆わず、keyboardでも操作できる。
+- [ ] DOM生成は`createElement` / `createElementNS`、`textContent`、`setAttribute`と既存style APIだけを使い、`innerHTML`、外部resource、dynamic codeを使わない。
+- [ ] temporary UIはすべて`data-ark-harness-ui`でclean submissionから消え、新規semantic node projectionは残る。
+- [ ] 「変更を送る」後のmodel blockに構造変更が保存され、全edge endpoint / group memberがvalidである。
+- [ ] node / edge add・removeは既存`describeModelDiff()`から会話へ還流し、kind / ext / layoutは非還流、既存field / label / endpoint編集は引き続き還流する。
+- [ ] production `diagram-diff.ts`、model / file、server submit handler、DiagramPane、Socket.IO、shared types、DB schemaを変更していない。
+- [ ] `diagram-harness.test.ts` / `diagram-diff.test.ts` / `diagram-harness.spec.ts` と全server回帰がGreenで、注入後HTMLの`<128KiB` guardを維持している。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -478,7 +478,7 @@ function crudDiagramHtml(diagramModel: DiagramModel = crudModel): string {
     [data-kind="event"] { border-left: 4px solid #16a34a; }
   </style></head><body>
     <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
-    <div class="crud-graph" data-ark-container="graph">
+    <div class="crud-graph" data-ark-container="graph" data-model-id="crud-a">
       <section data-ark-group data-model-id="crud-group">CRUD group</section>
       <section class="crud-node" data-model-id="crud-a">A unsafe node</section>
       <section class="crud-node" data-model-id="crud-b">B</section>
@@ -655,6 +655,7 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
 
   await palette.getByLabel("配置先").selectOption("0");
   await palette.getByLabel("kind").selectOption("event");
+  const initialEdgeCount = (await readCurrentModel(page)).edges.length;
   await palette.getByRole("button", { name: "ノードを追加" }).click();
 
   const firstGraph = page.locator('[data-ark-container="graph"]').first();
@@ -669,6 +670,7 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
   expect(added?.id).not.toContain("新しいノード");
   expect(Number.isInteger((added?.ext as { x?: number })?.x)).toBe(true);
   expect(Number.isInteger((added?.ext as { y?: number })?.y)).toBe(true);
+  expect(current.edges).toHaveLength(initialEdgeCount);
   if (!added) throw new Error("追加 node がありません");
 
   const projection = firstGraph
@@ -715,10 +717,13 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
   expect(errors).toEqual([]);
 });
 
-test("node CRUD: node 削除で incident edge・group 参照・全 projection を同期除去する", async ({
+test("node CRUD: node 削除を対象 projection・incident edge・group 参照だけに限定する", async ({
   page,
 }) => {
   await page.setContent(crudDiagramHtml());
+  await connectSubmissionPort(page);
+  const graphs = page.locator('[data-ark-container="graph"]');
+  await expect(graphs).toHaveCount(2);
   const node = page
     .locator('[data-ark-container="graph"]')
     .first()
@@ -754,7 +759,21 @@ test("node CRUD: node 削除で incident edge・group 参照・全 projection �
   await page.mouse.down();
   await page.mouse.up();
 
-  await expect(page.locator('[data-model-id="crud-a"]')).toHaveCount(0);
+  await expect(graphs).toHaveCount(2);
+  await expect(graphs.first()).toHaveAttribute("data-model-id", "crud-a");
+  await expect(
+    graphs.first().locator(':scope > [data-model-id="crud-a"]')
+  ).toHaveCount(0);
+  await expect(page.locator('aside[data-model-id="crud-a"]')).toHaveCount(0);
+  await expect(
+    graphs.first().locator(':scope > [data-model-id="crud-b"]')
+  ).toHaveCount(1);
+  await expect(
+    graphs.first().locator(':scope > [data-model-id="crud-d"]')
+  ).toHaveCount(1);
+  await expect(
+    graphs.nth(1).locator(':scope > [data-model-id="crud-other"]')
+  ).toHaveCount(1);
   await expect(page.locator('[data-ark-edge-id="crud-ab"]')).toHaveCount(0);
   await expect(page.locator('[data-ark-edge-id="crud-aa"]')).toHaveCount(0);
   await expect(
@@ -766,9 +785,35 @@ test("node CRUD: node 削除で incident edge・group 参照・全 projection �
   expect(current.groups).toEqual([
     { id: "crud-group", label: "CRUD group", nodes: ["crud-b"] },
   ]);
+  expect(describeModelDiff(crudModel, current)).toEqual([
+    'A <unsafe "node"> を削除',
+    'A <unsafe "node"> から B への関連「A to B」を削除',
+    'A <unsafe "node"> から A <unsafe "node"> への関連を削除',
+  ]);
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel; html: string };
+        }
+      ).arkHarnessSubmission
+  );
+  expect(submission?.model).toEqual(current);
+  expect(submission?.html).toContain('data-ark-container="graph"');
+  expect(submission?.html).toContain('data-model-id="crud-b"');
+  expect(submission?.html).toContain('id="ark-diagram-model"');
 });
 
-test("edge CRUD: node handle から通常 edge と self-edge を追加し invalid drop を無視する", async ({
+test("edge CRUD: click・微小移動・source drop を無視し明確な drag だけで edge を追加する", async ({
   page,
 }) => {
   await page.setContent(crudDiagramHtml());
@@ -803,6 +848,38 @@ test("edge CRUD: node handle から通常 edge と self-edge を追加し invali
   };
 
   const initialCount = (await readCurrentModel(page)).edges.length;
+  await source.hover();
+  const createHandle = source.locator(".ark-harness-node-create");
+  await createHandle.click();
+  expect((await readCurrentModel(page)).edges).toHaveLength(initialCount);
+
+  let handleBox = await requiredBoundingBox(createHandle);
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2 + 3,
+    handleBox.y + handleBox.height / 2 + 2
+  );
+  await page.mouse.up();
+  expect((await readCurrentModel(page)).edges).toHaveLength(initialCount);
+
+  handleBox = await requiredBoundingBox(createHandle);
+  const sourceBox = await requiredBoundingBox(source);
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width / 2,
+    sourceBox.y + sourceBox.height / 2
+  );
+  await page.mouse.up();
+  expect((await readCurrentModel(page)).edges).toHaveLength(initialCount);
+
   await dragCreate(target);
   await expect
     .poll(async () => (await readCurrentModel(page)).edges.length)
@@ -819,7 +896,25 @@ test("edge CRUD: node handle から通常 edge と self-edge を追加し invali
     graph.locator(`.ark-harness-edge-handle[data-ark-edge-id="${normal?.id}"]`)
   ).toHaveCount(2);
 
-  await dragCreate(source);
+  await source.hover();
+  handleBox = await requiredBoundingBox(createHandle);
+  const graphBox = await requiredBoundingBox(graph);
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    graphBox.x + graphBox.width - 20,
+    graphBox.y + graphBox.height - 20,
+    { steps: 4 }
+  );
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width / 2,
+    sourceBox.y + sourceBox.height / 2,
+    { steps: 4 }
+  );
+  await page.mouse.up();
   current = await readCurrentModel(page);
   const self = current.edges.find(
     edge => edge.from === "crud-b" && edge.to === "crud-b"
@@ -861,6 +956,13 @@ test("edge CRUD: hit target button と endpoint keyboard で対象 edge だけ�
   await page.mouse.up();
   await expect(graph.locator('[data-ark-edge-id="crud-ab"]')).toHaveCount(0);
   await expect(graph.locator('[data-model-id="crud-a"]').first()).toBeVisible();
+  await expect(page.locator('[data-ark-container="graph"]')).toHaveCount(2);
+  const afterSingleDelete = await readCurrentModel(page);
+  expect(describeModelDiff(crudModel, afterSingleDelete)).toEqual([
+    'A <unsafe "node"> から B への関連「A to B」を削除',
+  ]);
+  expect(afterSingleDelete.nodes).toEqual(crudModel.nodes);
+  expect(afterSingleDelete.groups).toEqual(crudModel.groups);
 
   const endpoint = graph.locator(
     '.ark-harness-edge-handle[data-ark-edge-id="crud-bd"][data-ark-edge-end="to"]'

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -480,12 +480,12 @@ function crudDiagramHtml(diagramModel: DiagramModel = crudModel): string {
     <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
     <div class="crud-graph" data-ark-container="graph" data-model-id="crud-a">
       <section data-ark-group data-model-id="crud-group">CRUD group</section>
-      <section class="crud-node" data-model-id="crud-a">A unsafe node</section>
-      <section class="crud-node" data-model-id="crud-b">B</section>
-      <section class="crud-node" data-model-id="crud-d">D</section>
+      <section class="crud-node" data-model-id="crud-a"><span data-model-id="crud-a">A unsafe node</span></section>
+      <section class="crud-node" data-model-id="crud-b"><span data-model-id="crud-b">B</span></section>
+      <section class="crud-node" data-model-id="crud-d"><span data-model-id="crud-d">D</span></section>
     </div>
     <div class="crud-graph" data-ark-container="graph">
-      <section class="crud-node" data-model-id="crud-other">Other graph</section>
+      <section class="crud-node" data-model-id="crud-other"><span data-model-id="crud-other">Other graph</span></section>
     </div>
     <aside data-model-id="crud-a">duplicate projection</aside>
   </body></html>`);
@@ -684,7 +684,7 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
   await expect(projection.locator(".ark-harness-kind-picker")).toHaveCount(1);
   await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(1);
   await expect(projection.locator(".ark-harness-node-create")).toHaveCount(1);
-  await expect(projection.locator(".ark-harness-node-delete")).toHaveCount(1);
+  await expect(projection.locator(".ark-harness-node-delete")).toHaveCount(0);
 
   const newBox = await requiredBoundingBox(projection);
   const oldBoxes = await firstGraph
@@ -729,35 +729,14 @@ test("node CRUD: node 削除を対象 projection・incident edge・group 参照�
     .first()
     .locator('[data-model-id="crud-a"]')
     .first();
-  await node.hover();
-  await expect(node.locator(".ark-harness-node-delete")).toHaveAttribute(
-    "aria-label",
-    'A <unsafe "node"> を削除'
-  );
+  await expect(page.locator(".ark-harness-node-delete")).toHaveCount(0);
+  await expect(page.locator(".ark-harness-edge-delete")).toHaveCount(0);
+  await expect(page.locator(".ark-harness-edge-hit")).toHaveCount(0);
   await expect(page.locator("img, script[src], [onerror]")).toHaveCount(0);
-  const nodeBox = await requiredBoundingBox(node);
-  const deleteButton = node.locator(".ark-harness-node-delete");
-  const deleteBox = await requiredBoundingBox(deleteButton);
-  await page.mouse.move(
-    nodeBox.x + nodeBox.width / 2,
-    nodeBox.y + nodeBox.height / 2
-  );
-  await page.mouse.move(
-    deleteBox.x + deleteBox.width / 2,
-    deleteBox.y + deleteBox.height / 2,
-    { steps: 8 }
-  );
-  await page.waitForTimeout(160);
-  await expect(node.locator(".ark-harness-node-rail")).toHaveCSS(
-    "opacity",
-    "1"
-  );
-  await expect(node.locator(".ark-harness-node-rail")).toHaveCSS(
-    "pointer-events",
-    "auto"
-  );
-  await page.mouse.down();
-  await page.mouse.up();
+  await node.focus();
+  await expect(node).toBeFocused();
+  await expect(node).toHaveClass(/ark-harness-node-selected/);
+  await page.keyboard.press("Delete");
 
   await expect(graphs).toHaveCount(2);
   await expect(graphs.first()).toHaveAttribute("data-model-id", "crud-a");
@@ -811,6 +790,27 @@ test("node CRUD: node 削除を対象 projection・incident edge・group 参照�
   expect(submission?.html).toContain('data-ark-container="graph"');
   expect(submission?.html).toContain('data-model-id="crud-b"');
   expect(submission?.html).toContain('id="ark-diagram-model"');
+});
+
+test("node CRUD: contenteditable 編集中の Delete は node 削除に使わない", async ({
+  page,
+}) => {
+  await page.setContent(crudDiagramHtml());
+  const node = page
+    .locator('[data-ark-container="graph"]')
+    .first()
+    .locator('[data-model-id="crud-a"]')
+    .first();
+  const editable = node.locator('span[data-model-id="crud-a"]');
+
+  await editable.focus();
+  await expect(editable).toBeFocused();
+  await page.keyboard.press("Delete");
+
+  await expect(node).toBeAttached();
+  expect(
+    (await readCurrentModel(page)).nodes.some(entry => entry.id === "crud-a")
+  ).toBe(true);
 });
 
 test("edge CRUD: click・微小移動・source drop を無視し明確な drag だけで edge を追加する", async ({
@@ -933,26 +933,36 @@ test("edge CRUD: click・微小移動・source drop を無視し明確な drag �
   );
 });
 
-test("edge CRUD: hit target button と endpoint keyboard で対象 edge だけを削除する", async ({
+test("edge CRUD: endpoint を空き領域へ drag して対象 edge だけを削除する", async ({
   page,
 }) => {
   await page.setContent(crudDiagramHtml());
   const graph = page.locator('[data-ark-container="graph"]').first();
-  const button = graph.locator(
-    '.ark-harness-edge-delete[data-ark-edge-id="crud-ab"]'
+  const endpoint = graph.locator(
+    '.ark-harness-edge-handle[data-ark-edge-id="crud-ab"][data-ark-edge-end="to"]'
   );
-  const edge = await readNamedEdge(page, "crud-ab");
-  await page.mouse.move((edge.x1 + edge.x2) / 2, (edge.y1 + edge.y2) / 2);
-  await expect(button).toBeVisible();
-  const buttonBox = await requiredBoundingBox(button);
+  const [handleBox, graphBox] = await Promise.all([
+    requiredBoundingBox(endpoint),
+    requiredBoundingBox(graph),
+  ]);
   await page.mouse.move(
-    buttonBox.x + buttonBox.width / 2,
-    buttonBox.y + buttonBox.height / 2,
-    { steps: 8 }
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
   );
-  await page.waitForTimeout(160);
-  await expect(button).toBeVisible();
   await page.mouse.down();
+  await page.mouse.move(
+    graphBox.x + graphBox.width - 20,
+    graphBox.y + graphBox.height - 24,
+    { steps: 5 }
+  );
+  await expect(endpoint).toHaveClass(/ark-harness-edge-delete-pending/);
+  await expect(endpoint).toHaveAttribute("aria-label", "離すと edge を削除");
+  await expect(
+    graph.locator('.ark-harness-edge-main[data-ark-edge-id="crud-ab"]')
+  ).toHaveClass(/ark-harness-edge-delete-pending/);
+  await expect(graph.locator(".ark-harness-edge-drop-indicator")).toHaveCount(
+    0
+  );
   await page.mouse.up();
   await expect(graph.locator('[data-ark-edge-id="crud-ab"]')).toHaveCount(0);
   await expect(graph.locator('[data-model-id="crud-a"]').first()).toBeVisible();
@@ -963,15 +973,9 @@ test("edge CRUD: hit target button と endpoint keyboard で対象 edge だけ�
   ]);
   expect(afterSingleDelete.nodes).toEqual(crudModel.nodes);
   expect(afterSingleDelete.groups).toEqual(crudModel.groups);
-
-  const endpoint = graph.locator(
-    '.ark-harness-edge-handle[data-ark-edge-id="crud-bd"][data-ark-edge-end="to"]'
-  );
-  await endpoint.focus();
-  await endpoint.press("Delete");
-  await expect(graph.locator('[data-ark-edge-id="crud-bd"]')).toHaveCount(0);
-  expect((await readCurrentModel(page)).edges.map(edge => edge.id)).toEqual([
+  expect(afterSingleDelete.edges.map(edge => edge.id)).toEqual([
     "crud-aa",
+    "crud-bd",
   ]);
 });
 
@@ -1956,43 +1960,50 @@ test("端点 drag 中の model 直接削除でも stale edge を更新しない"
   expect(errors).toEqual([]);
 });
 
-test("edge 端点の invalid drop と pointercancel は model を変更しない", async ({
+test("edge 端点 drag の Escape と pointercancel は model を変更しない", async ({
   page,
 }) => {
   await openEdgeSemanticsDiagram(page);
   await connectSubmissionPort(page);
   const graph = page.locator('[data-ark-container="graph"]');
   const graphBox = await requiredBoundingBox(graph);
-  const outside = page.locator('body > [data-model-id="outside"]');
-  const outsideBox = await requiredBoundingBox(outside);
   const handleSelector =
     '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]';
 
-  for (const target of [
-    { x: graphBox.x + 820, y: graphBox.y + 30 },
-    {
-      x: outsideBox.x + outsideBox.width / 2,
-      y: outsideBox.y + outsideBox.height / 2,
-    },
-  ]) {
-    const handleBox = await requiredBoundingBox(graph.locator(handleSelector));
-    await page.mouse.move(
-      handleBox.x + handleBox.width / 2,
-      handleBox.y + handleBox.height / 2
-    );
-    await page.mouse.down();
-    await page.mouse.move(target.x, target.y, { steps: 3 });
-    await page.mouse.up();
-  }
-
-  const handle = graph.locator(handleSelector);
-  const cancelBox = await requiredBoundingBox(handle);
+  let handle = graph.locator(handleSelector);
+  let handleBox = await requiredBoundingBox(handle);
   await page.mouse.move(
-    cancelBox.x + cancelBox.width / 2,
-    cancelBox.y + cancelBox.height / 2
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
   );
   await page.mouse.down();
-  await page.mouse.move(graphBox.x + 700, graphBox.y + 400);
+  await page.mouse.move(
+    graphBox.x + graphBox.width - 20,
+    graphBox.y + graphBox.height - 20,
+    { steps: 3 }
+  );
+  await expect(handle).toHaveClass(/ark-harness-edge-delete-pending/);
+  await page.keyboard.press("Escape");
+  await page.mouse.up();
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
+  expect(
+    (await readCurrentModel(page)).edges.find(
+      edge => edge.id === "e_order_owner"
+    )
+  ).toMatchObject({ from: "order", to: "user" });
+
+  handle = graph.locator(handleSelector);
+  handleBox = await requiredBoundingBox(handle);
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    graphBox.x + graphBox.width - 20,
+    graphBox.y + graphBox.height - 20
+  );
+  await expect(handle).toHaveClass(/ark-harness-edge-delete-pending/);
   await handle.dispatchEvent("pointercancel", { pointerId: 1 });
   await page.mouse.up();
 

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -519,6 +519,7 @@ async function readEdge(page: Page) {
 async function readNamedEdge(page: Page, edgeId: string) {
   return page
     .locator('[data-ark-container="graph"]')
+    .first()
     .evaluate((graph, expectedEdgeId) => {
       const edge = Array.from(
         graph.querySelectorAll("line[data-ark-edge-id], path[data-ark-edge-id]")
@@ -729,7 +730,29 @@ test("node CRUD: node 削除で incident edge・group 参照・全 projection �
     'A <unsafe "node"> を削除'
   );
   await expect(page.locator("img, script[src], [onerror]")).toHaveCount(0);
-  await node.locator(".ark-harness-node-delete").click();
+  const nodeBox = await requiredBoundingBox(node);
+  const deleteButton = node.locator(".ark-harness-node-delete");
+  const deleteBox = await requiredBoundingBox(deleteButton);
+  await page.mouse.move(
+    nodeBox.x + nodeBox.width / 2,
+    nodeBox.y + nodeBox.height / 2
+  );
+  await page.mouse.move(
+    deleteBox.x + deleteBox.width / 2,
+    deleteBox.y + deleteBox.height / 2,
+    { steps: 8 }
+  );
+  await page.waitForTimeout(160);
+  await expect(node.locator(".ark-harness-node-rail")).toHaveCSS(
+    "opacity",
+    "1"
+  );
+  await expect(node.locator(".ark-harness-node-rail")).toHaveCSS(
+    "pointer-events",
+    "auto"
+  );
+  await page.mouse.down();
+  await page.mouse.up();
 
   await expect(page.locator('[data-model-id="crud-a"]')).toHaveCount(0);
   await expect(page.locator('[data-ark-edge-id="crud-ab"]')).toHaveCount(0);
@@ -820,15 +843,22 @@ test("edge CRUD: hit target button と endpoint keyboard で対象 edge だけ�
 }) => {
   await page.setContent(crudDiagramHtml());
   const graph = page.locator('[data-ark-container="graph"]').first();
-  const hit = graph.locator(
-    '.ark-harness-edge-hit[data-ark-edge-id="crud-ab"]'
-  );
-  await hit.focus();
   const button = graph.locator(
     '.ark-harness-edge-delete[data-ark-edge-id="crud-ab"]'
   );
+  const edge = await readNamedEdge(page, "crud-ab");
+  await page.mouse.move((edge.x1 + edge.x2) / 2, (edge.y1 + edge.y2) / 2);
   await expect(button).toBeVisible();
-  await button.click();
+  const buttonBox = await requiredBoundingBox(button);
+  await page.mouse.move(
+    buttonBox.x + buttonBox.width / 2,
+    buttonBox.y + buttonBox.height / 2,
+    { steps: 8 }
+  );
+  await page.waitForTimeout(160);
+  await expect(button).toBeVisible();
+  await page.mouse.down();
+  await page.mouse.up();
   await expect(graph.locator('[data-ark-edge-id="crud-ab"]')).toHaveCount(0);
   await expect(graph.locator('[data-model-id="crud-a"]').first()).toBeVisible();
 

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -433,6 +433,73 @@ async function connectSubmissionPort(page: Page) {
   ).toBeEnabled();
 }
 
+const crudModel: DiagramModel = {
+  version: 1,
+  nodes: [
+    {
+      id: "crud-a",
+      label: 'A <unsafe "node">',
+      kind: "entity",
+      ext: { x: 30, y: 50 },
+    },
+    { id: "crud-b", label: "B", kind: "entity", ext: { x: 280, y: 50 } },
+    { id: "crud-d", label: "D", kind: "event" },
+    {
+      id: "crud-other",
+      label: "Other graph",
+      kind: "entity",
+      ext: { x: 30, y: 30 },
+    },
+  ],
+  edges: [
+    { id: "crud-ab", from: "crud-a", to: "crud-b", label: "A to B" },
+    { id: "crud-aa", from: "crud-a", to: "crud-a" },
+    { id: "crud-bd", from: "crud-b", to: "crud-d" },
+  ],
+  groups: [
+    { id: "crud-group", label: "CRUD group", nodes: ["crud-a", "crud-b"] },
+  ],
+  ext: {
+    layout: {
+      direction: "LR",
+      rankSpacing: 72,
+      nodeSpacing: 32,
+      padding: 20,
+    },
+  },
+};
+
+function crudDiagramHtml(diagramModel: DiagramModel = crudModel): string {
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .crud-graph { width: 760px; min-height: 420px; background: #f8fafc; }
+    .crud-node { box-sizing: border-box; width: 150px; min-height: 72px; padding: 12px; border: 1px solid #64748b; background: white; }
+    [data-kind="entity"] { border-left: 4px solid #2563eb; }
+    [data-kind="event"] { border-left: 4px solid #16a34a; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
+    <div class="crud-graph" data-ark-container="graph">
+      <section data-ark-group data-model-id="crud-group">CRUD group</section>
+      <section class="crud-node" data-model-id="crud-a">A unsafe node</section>
+      <section class="crud-node" data-model-id="crud-b">B</section>
+      <section class="crud-node" data-model-id="crud-d">D</section>
+    </div>
+    <div class="crud-graph" data-ark-container="graph">
+      <section class="crud-node" data-model-id="crud-other">Other graph</section>
+    </div>
+    <aside data-model-id="crud-a">duplicate projection</aside>
+  </body></html>`);
+}
+
+async function readCurrentModel(page: Page): Promise<DiagramModel> {
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  const value = await page.locator(".ark-harness-textarea").inputValue();
+  await page.getByRole("button", { name: "閉じる", exact: true }).click();
+  return JSON.parse(value) as DiagramModel;
+}
+
 async function readEdge(page: Page) {
   return page
     .locator('.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
@@ -568,6 +635,258 @@ function expectNoOverlaps(
   }
 }
 
+test("node CRUD: palette から安全な projection を重ならず追加して再編集できる", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
+  await page.setContent(crudDiagramHtml());
+
+  const palette = page.locator(".ark-harness-node-palette");
+  await expect(palette.getByLabel("配置先")).toHaveText(/graph 1/);
+  await expect(palette.getByLabel("kind")).toHaveText(/entity/);
+  await expect(palette.getByLabel("kind").locator("option")).toHaveText([
+    "entity",
+    "event",
+  ]);
+  await expect(palette.locator("input")).toHaveCount(0);
+  await expect(palette.getByText(/group|cardinality/i)).toHaveCount(0);
+
+  await palette.getByLabel("配置先").selectOption("0");
+  await palette.getByLabel("kind").selectOption("event");
+  await palette.getByRole("button", { name: "ノードを追加" }).click();
+
+  const firstGraph = page.locator('[data-ark-container="graph"]').first();
+  await expect(firstGraph.locator(".ark-harness-graph-node")).toHaveCount(4);
+  const current = await readCurrentModel(page);
+  const added = current.nodes.find(
+    node => !crudModel.nodes.some(old => old.id === node.id)
+  );
+  expect(added).toBeDefined();
+  expect(added).toMatchObject({ label: "新しいノード", kind: "event" });
+  expect(added?.id).toMatch(/^node-/);
+  expect(added?.id).not.toContain("新しいノード");
+  expect(Number.isInteger((added?.ext as { x?: number })?.x)).toBe(true);
+  expect(Number.isInteger((added?.ext as { y?: number })?.y)).toBe(true);
+  if (!added) throw new Error("追加 node がありません");
+
+  const projection = firstGraph
+    .locator(`[data-model-id="${added.id}"]`)
+    .first();
+  await expect(projection).toHaveAttribute("data-kind", "event");
+  await expect(projection).toHaveClass(/crud-node/);
+  await expect(
+    projection.locator(`span[data-model-id="${added.id}"]`)
+  ).toHaveText("新しいノード");
+  await expect(projection.locator(".ark-harness-kind-picker")).toHaveCount(1);
+  await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(1);
+  await expect(projection.locator(".ark-harness-node-create")).toHaveCount(1);
+  await expect(projection.locator(".ark-harness-node-delete")).toHaveCount(1);
+
+  const newBox = await requiredBoundingBox(projection);
+  const oldBoxes = await firstGraph
+    .locator(".ark-harness-graph-node")
+    .evaluateAll(
+      (elements, addedId) =>
+        elements
+          .filter(element => element.getAttribute("data-model-id") !== addedId)
+          .map(element => {
+            const rect = element.getBoundingClientRect();
+            return {
+              x: rect.x,
+              y: rect.y,
+              width: rect.width,
+              height: rect.height,
+            };
+          }),
+      added.id
+    );
+  for (const oldBox of oldBoxes)
+    expect(boxesOverlap(newBox, oldBox, 8)).toBe(false);
+
+  await projection
+    .locator(`span[data-model-id="${added.id}"]`)
+    .fill("追加済み");
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
+      ?.label
+  ).toBe("追加済み");
+  expect(errors).toEqual([]);
+});
+
+test("node CRUD: node 削除で incident edge・group 参照・全 projection を同期除去する", async ({
+  page,
+}) => {
+  await page.setContent(crudDiagramHtml());
+  const node = page
+    .locator('[data-ark-container="graph"]')
+    .first()
+    .locator('[data-model-id="crud-a"]')
+    .first();
+  await node.hover();
+  await expect(node.locator(".ark-harness-node-delete")).toHaveAttribute(
+    "aria-label",
+    'A <unsafe "node"> を削除'
+  );
+  await expect(page.locator("img, script[src], [onerror]")).toHaveCount(0);
+  await node.locator(".ark-harness-node-delete").click();
+
+  await expect(page.locator('[data-model-id="crud-a"]')).toHaveCount(0);
+  await expect(page.locator('[data-ark-edge-id="crud-ab"]')).toHaveCount(0);
+  await expect(page.locator('[data-ark-edge-id="crud-aa"]')).toHaveCount(0);
+  await expect(
+    page.locator('.ark-harness-edge-main[data-ark-edge-id="crud-bd"]')
+  ).toHaveCount(1);
+  const current = await readCurrentModel(page);
+  expect(current.nodes.some(entry => entry.id === "crud-a")).toBe(false);
+  expect(current.edges.map(edge => edge.id)).toEqual(["crud-bd"]);
+  expect(current.groups).toEqual([
+    { id: "crud-group", label: "CRUD group", nodes: ["crud-b"] },
+  ]);
+});
+
+test("edge CRUD: node handle から通常 edge と self-edge を追加し invalid drop を無視する", async ({
+  page,
+}) => {
+  await page.setContent(crudDiagramHtml());
+  const graph = page.locator('[data-ark-container="graph"]').first();
+  const source = graph.locator('[data-model-id="crud-b"]').first();
+  const target = graph.locator('[data-model-id="crud-d"]').first();
+  const otherGraphTarget = page
+    .locator('[data-ark-container="graph"]')
+    .nth(1)
+    .locator('[data-model-id="crud-other"]')
+    .first();
+
+  const dragCreate = async (drop: Locator) => {
+    await source.hover();
+    const handleBox = await requiredBoundingBox(
+      source.locator(".ark-harness-node-create")
+    );
+    const dropBox = await requiredBoundingBox(drop);
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2,
+      handleBox.y + handleBox.height / 2
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      dropBox.x + dropBox.width / 2,
+      dropBox.y + dropBox.height / 2,
+      {
+        steps: 5,
+      }
+    );
+    await page.mouse.up();
+  };
+
+  const initialCount = (await readCurrentModel(page)).edges.length;
+  await dragCreate(target);
+  await expect
+    .poll(async () => (await readCurrentModel(page)).edges.length)
+    .toBe(initialCount + 1);
+  let current = await readCurrentModel(page);
+  const normal = current.edges.find(
+    edge => !crudModel.edges.some(old => old.id === edge.id)
+  );
+  expect(normal).toMatchObject({ from: "crud-b", to: "crud-d" });
+  expect(normal?.id).toMatch(/^edge-/);
+  expect(normal).not.toHaveProperty("label");
+  expect(normal).not.toHaveProperty("ext");
+  await expect(
+    graph.locator(`.ark-harness-edge-handle[data-ark-edge-id="${normal?.id}"]`)
+  ).toHaveCount(2);
+
+  await dragCreate(source);
+  current = await readCurrentModel(page);
+  const self = current.edges.find(
+    edge => edge.from === "crud-b" && edge.to === "crud-b"
+  );
+  expect(self).toBeDefined();
+  await expect(
+    graph.locator(`path.ark-harness-edge-main[data-ark-edge-id="${self?.id}"]`)
+  ).toHaveCount(1);
+
+  const beforeInvalid = current.edges.length;
+  await dragCreate(otherGraphTarget);
+  expect((await readCurrentModel(page)).edges).toHaveLength(beforeInvalid);
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
+  await expect(graph.locator(".ark-harness-edge-drop-indicator")).toHaveCount(
+    0
+  );
+});
+
+test("edge CRUD: hit target button と endpoint keyboard で対象 edge だけを削除する", async ({
+  page,
+}) => {
+  await page.setContent(crudDiagramHtml());
+  const graph = page.locator('[data-ark-container="graph"]').first();
+  const hit = graph.locator(
+    '.ark-harness-edge-hit[data-ark-edge-id="crud-ab"]'
+  );
+  await hit.focus();
+  const button = graph.locator(
+    '.ark-harness-edge-delete[data-ark-edge-id="crud-ab"]'
+  );
+  await expect(button).toBeVisible();
+  await button.click();
+  await expect(graph.locator('[data-ark-edge-id="crud-ab"]')).toHaveCount(0);
+  await expect(graph.locator('[data-model-id="crud-a"]').first()).toBeVisible();
+
+  const endpoint = graph.locator(
+    '.ark-harness-edge-handle[data-ark-edge-id="crud-bd"][data-ark-edge-end="to"]'
+  );
+  await endpoint.focus();
+  await endpoint.press("Delete");
+  await expect(graph.locator('[data-ark-edge-id="crud-bd"]')).toHaveCount(0);
+  expect((await readCurrentModel(page)).edges.map(edge => edge.id)).toEqual([
+    "crud-aa",
+  ]);
+});
+
+test("構造変更: clean submission は semantic node を残し CRUD UI と見た目差分を除く", async ({
+  page,
+}) => {
+  await page.setContent(crudDiagramHtml());
+  await connectSubmissionPort(page);
+  await page.locator(".ark-harness-palette-kind-select").selectOption("event");
+  await page.getByRole("button", { name: "ノードを追加" }).click();
+  const current = await readCurrentModel(page);
+  const added = current.nodes.find(
+    node => !crudModel.nodes.some(old => old.id === node.id)
+  );
+  if (!added) throw new Error("追加 node がありません");
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel; html: string };
+        }
+      ).arkHarnessSubmission
+  );
+  if (!submission) throw new Error("submission がありません");
+  expect(submission.html).toContain(`data-model-id="${added.id}"`);
+  expect(submission.html).toContain('data-kind="event"');
+  expect(submission.html).toContain("新しいノード");
+  expect(submission.html).not.toContain("data-ark-harness-ui");
+  expect(submission.html).not.toContain("ark-harness-node-palette");
+  expect(submission.html).not.toContain("ark-harness-node-rail");
+  expect(submission.html).not.toContain("ark-harness-edge-hit");
+  expect(submission.html).not.toContain("--ark-harness-graph-x");
+  expect(describeModelDiff(crudModel, submission.model)).toEqual([
+    "新しいノード を追加",
+  ]);
+});
+
 test("レイアウト方向を LR から TB へ切り替えて再配置・保存する", async ({
   page,
 }) => {
@@ -598,7 +917,7 @@ test("レイアウト方向を LR から TB へ切り替えて再配置・保存
     await toolbar
       .locator("button")
       .evaluateAll(buttons => buttons.map(button => button.textContent))
-  ).toEqual(["方向: LR", "モデルを直接編集", "変更を送る"]);
+  ).toEqual(["方向: LR", "+ ノード", "モデルを直接編集", "変更を送る"]);
   expect(
     await directionButton.evaluate(
       (button, editButton) =>
@@ -1095,7 +1414,7 @@ test("cardinality・方向・type を edge SVG に安全に投影する", async 
   const errors = await openEdgeSemanticsDiagram(page);
   const graph = page.locator('[data-ark-container="graph"]');
   const edge = graph.locator(
-    'line[data-ark-edge-id="e_order_owner"], path[data-ark-edge-id="e_order_owner"]'
+    '.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
   );
   const fromCardinality = graph.locator(
     '.ark-harness-edge-cardinality[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"][data-ark-edge-cardinality="one"]'
@@ -1157,7 +1476,7 @@ test("cardinality・方向・type を edge SVG に安全に投影する", async 
   await page.reload();
   await page.setContent(edgeSemanticsHtml());
   const legacyEdge = page.locator(
-    'line[data-ark-edge-id="e_account_user"], path[data-ark-edge-id="e_account_user"]'
+    '.ark-harness-edge-main[data-ark-edge-id="e_account_user"]'
   );
   await expect(legacyEdge).toHaveAttribute(
     "data-ark-edge-direction",

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -738,7 +738,16 @@ test("node CRUD: node 削除を対象 projection・incident edge・group 参照�
   await expect(page.locator(".ark-harness-edge-delete")).toHaveCount(0);
   await expect(page.locator(".ark-harness-edge-hit")).toHaveCount(0);
   await expect(page.locator("img, script[src], [onerror]")).toHaveCount(0);
-  await node.focus();
+  await node.hover();
+  await expect(
+    graphs
+      .first()
+      .locator(
+        '.ark-harness-node-connectors[data-ark-node-id="crud-a"] .ark-harness-node-anchor'
+      )
+      .first()
+  ).toHaveCSS("pointer-events", "auto");
+  await node.click({ position: { x: 10, y: 36 } });
   await expect(node).toBeFocused();
   await expect(node).toHaveClass(/ark-harness-node-selected/);
   await page.keyboard.press("Delete");
@@ -1079,13 +1088,34 @@ test("edge CRUD: endpoint を空き領域へ drag して対象 edge だけを削
 }) => {
   await page.setContent(crudDiagramHtml());
   const graph = page.locator('[data-ark-container="graph"]').first();
+  const endpointNode = graph.locator('[data-model-id="crud-b"]').first();
   const endpoint = graph.locator(
     '.ark-harness-edge-handle[data-ark-edge-id="crud-ab"][data-ark-edge-end="to"]'
   );
+  const overlappingAnchor = graph.locator(
+    '.ark-harness-node-connectors[data-ark-node-id="crud-b"] ' +
+      '.ark-harness-node-anchor[data-ark-anchor-position="left"]'
+  );
+  await endpointNode.hover();
+  await expect(overlappingAnchor).toHaveCSS("pointer-events", "auto");
   const [handleBox, graphBox] = await Promise.all([
     requiredBoundingBox(endpoint),
     requiredBoundingBox(graph),
   ]);
+  const hitTarget = await page.evaluate(
+    ({ x, y }) => {
+      const target = document.elementFromPoint(x, y);
+      return {
+        edgeId: target?.getAttribute("data-ark-edge-id"),
+        edgeEnd: target?.getAttribute("data-ark-edge-end"),
+      };
+    },
+    {
+      x: handleBox.x + handleBox.width / 2,
+      y: handleBox.y + handleBox.height / 2,
+    }
+  );
+  expect(hitTarget).toEqual({ edgeId: "crud-ab", edgeEnd: "to" });
   await page.mouse.move(
     handleBox.x + handleBox.width / 2,
     handleBox.y + handleBox.height / 2

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -683,7 +683,12 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
   ).toHaveText("新しいノード");
   await expect(projection.locator(".ark-harness-kind-picker")).toHaveCount(1);
   await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(1);
-  await expect(projection.locator(".ark-harness-node-create")).toHaveCount(1);
+  await expect(
+    firstGraph.locator(
+      `.ark-harness-node-connectors[data-ark-node-id="${added.id}"] .ark-harness-node-anchor`
+    )
+  ).toHaveCount(8);
+  await expect(projection.locator(".ark-harness-node-create")).toHaveCount(0);
   await expect(projection.locator(".ark-harness-node-delete")).toHaveCount(0);
 
   const newBox = await requiredBoundingBox(projection);
@@ -813,12 +818,126 @@ test("node CRUD: contenteditable 編集中の Delete は node 削除に使わな
   ).toBe(true);
 });
 
-test("edge CRUD: click・微小移動・source drop を無視し明確な drag だけで edge を追加する", async ({
+test("edge CRUD: hover でノード周縁の8接続点を予測可能な位置に表示する", async ({
   page,
 }) => {
   await page.setContent(crudDiagramHtml());
   const graph = page.locator('[data-ark-container="graph"]').first();
   const source = graph.locator('[data-model-id="crud-b"]').first();
+  const connectors = graph.locator(
+    '.ark-harness-node-connectors[data-ark-node-id="crud-b"]'
+  );
+  const anchors = connectors.locator(".ark-harness-node-anchor");
+
+  await expect(anchors).toHaveCount(8);
+  await expect(source.locator(".ark-harness-node-create")).toHaveCount(0);
+  await expect(source.locator(".ark-harness-node-rail")).toHaveCount(0);
+  await expect(connectors).toHaveCSS("opacity", "0");
+  await expect(anchors.first()).toHaveCSS("opacity", "1");
+  await expect(anchors.first()).toHaveCSS("pointer-events", "none");
+
+  await source.hover();
+  for (let index = 0; index < 8; index += 1) {
+    await expect(anchors.nth(index)).toBeVisible();
+    await expect(anchors.nth(index)).toHaveCSS("pointer-events", "auto");
+  }
+
+  const geometry = await graph.evaluate(element => {
+    const node = element.querySelector<HTMLElement>(
+      '[data-model-id="crud-b"].ark-harness-graph-node'
+    );
+    const connectors = element.querySelector<HTMLElement>(
+      '.ark-harness-node-connectors[data-ark-node-id="crud-b"]'
+    );
+    if (!node || !connectors) throw new Error("接続点 geometry がありません");
+    const nodeRect = node.getBoundingClientRect();
+    return Array.from(
+      connectors.querySelectorAll<HTMLElement>(".ark-harness-node-anchor")
+    ).map(anchor => {
+      const rect = anchor.getBoundingClientRect();
+      return {
+        position: anchor.getAttribute("data-ark-anchor-position"),
+        xRatio: Number(anchor.getAttribute("data-ark-anchor-x")),
+        yRatio: Number(anchor.getAttribute("data-ark-anchor-y")),
+        centerX: rect.left + rect.width / 2,
+        centerY: rect.top + rect.height / 2,
+        expectedX:
+          nodeRect.left +
+          nodeRect.width * Number(anchor.getAttribute("data-ark-anchor-x")),
+        expectedY:
+          nodeRect.top +
+          nodeRect.height * Number(anchor.getAttribute("data-ark-anchor-y")),
+      };
+    });
+  });
+  expect(geometry.map(anchor => anchor.position)).toEqual([
+    "top-left",
+    "top",
+    "top-right",
+    "right",
+    "bottom-right",
+    "bottom",
+    "bottom-left",
+    "left",
+  ]);
+  expect(
+    geometry.filter(
+      anchor =>
+        (anchor.xRatio === 0 || anchor.xRatio === 0.5 || anchor.xRatio === 1) &&
+        (anchor.yRatio === 0 || anchor.yRatio === 0.5 || anchor.yRatio === 1) &&
+        (anchor.xRatio !== 0.5 || anchor.yRatio !== 0.5)
+    )
+  ).toHaveLength(8);
+  for (const anchor of geometry) {
+    expect(anchor.centerX).toBeCloseTo(anchor.expectedX, 1);
+    expect(anchor.centerY).toBeCloseTo(anchor.expectedY, 1);
+  }
+
+  const rightBox = await requiredBoundingBox(
+    connectors.locator(
+      '.ark-harness-node-anchor[data-ark-anchor-position="right"]'
+    )
+  );
+  await page.mouse.move(
+    rightBox.x + rightBox.width / 2,
+    rightBox.y + rightBox.height / 2
+  );
+  await page.mouse.down();
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(1);
+  const previewStart = await graph.evaluate(element => {
+    const node = element.querySelector<HTMLElement>(
+      '[data-model-id="crud-b"].ark-harness-graph-node'
+    );
+    const line = element.querySelector<SVGLineElement>(
+      ".ark-harness-edge-preview line"
+    );
+    if (!node || !line) throw new Error("preview geometry がありません");
+    const svgRect = line.ownerSVGElement?.getBoundingClientRect();
+    if (!svgRect) throw new Error("preview SVG geometry がありません");
+    const nodeRect = node.getBoundingClientRect();
+    return {
+      x: svgRect.left + Number(line.getAttribute("x1")),
+      y: svgRect.top + Number(line.getAttribute("y1")),
+      expectedX: nodeRect.right,
+      expectedY: nodeRect.top + nodeRect.height / 2,
+    };
+  });
+  expect(previewStart.x).toBeCloseTo(previewStart.expectedX, 1);
+  expect(previewStart.y).toBeCloseTo(previewStart.expectedY, 1);
+  await page.keyboard.press("Escape");
+  await page.mouse.up();
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
+});
+
+test("edge CRUD: click・微小移動・source drop・Escape を無視し明確な anchor drag だけで edge を追加する", async ({
+  page,
+}) => {
+  await page.setContent(crudDiagramHtml());
+  const graph = page.locator('[data-ark-container="graph"]').first();
+  const source = graph.locator('[data-model-id="crud-b"]').first();
+  const sourceConnectors = graph.locator(
+    '.ark-harness-node-connectors[data-ark-node-id="crud-b"]'
+  );
   const target = graph.locator('[data-model-id="crud-d"]').first();
   const otherGraphTarget = page
     .locator('[data-ark-container="graph"]')
@@ -829,7 +948,9 @@ test("edge CRUD: click・微小移動・source drop を無視し明確な drag �
   const dragCreate = async (drop: Locator) => {
     await source.hover();
     const handleBox = await requiredBoundingBox(
-      source.locator(".ark-harness-node-create")
+      sourceConnectors.locator(
+        '.ark-harness-node-anchor[data-ark-anchor-position="bottom"]'
+      )
     );
     const dropBox = await requiredBoundingBox(drop);
     await page.mouse.move(
@@ -849,11 +970,13 @@ test("edge CRUD: click・微小移動・source drop を無視し明確な drag �
 
   const initialCount = (await readCurrentModel(page)).edges.length;
   await source.hover();
-  const createHandle = source.locator(".ark-harness-node-create");
-  await createHandle.click();
+  const createAnchor = sourceConnectors.locator(
+    '.ark-harness-node-anchor[data-ark-anchor-position="bottom"]'
+  );
+  await createAnchor.click();
   expect((await readCurrentModel(page)).edges).toHaveLength(initialCount);
 
-  let handleBox = await requiredBoundingBox(createHandle);
+  let handleBox = await requiredBoundingBox(createAnchor);
   await page.mouse.move(
     handleBox.x + handleBox.width / 2,
     handleBox.y + handleBox.height / 2
@@ -866,7 +989,7 @@ test("edge CRUD: click・微小移動・source drop を無視し明確な drag �
   await page.mouse.up();
   expect((await readCurrentModel(page)).edges).toHaveLength(initialCount);
 
-  handleBox = await requiredBoundingBox(createHandle);
+  handleBox = await requiredBoundingBox(createAnchor);
   const sourceBox = await requiredBoundingBox(source);
   await page.mouse.move(
     handleBox.x + handleBox.width / 2,
@@ -879,6 +1002,24 @@ test("edge CRUD: click・微小移動・source drop を無視し明確な drag �
   );
   await page.mouse.up();
   expect((await readCurrentModel(page)).edges).toHaveLength(initialCount);
+
+  handleBox = await requiredBoundingBox(createAnchor);
+  const targetBox = await requiredBoundingBox(target);
+  await page.mouse.move(
+    handleBox.x + handleBox.width / 2,
+    handleBox.y + handleBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 4 }
+  );
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(1);
+  await page.keyboard.press("Escape");
+  await page.mouse.up();
+  expect((await readCurrentModel(page)).edges).toHaveLength(initialCount);
+  await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
 
   await dragCreate(target);
   await expect
@@ -897,7 +1038,7 @@ test("edge CRUD: click・微小移動・source drop を無視し明確な drag �
   ).toHaveCount(2);
 
   await source.hover();
-  handleBox = await requiredBoundingBox(createHandle);
+  handleBox = await requiredBoundingBox(createAnchor);
   const graphBox = await requiredBoundingBox(graph);
   await page.mouse.move(
     handleBox.x + handleBox.width / 2,
@@ -1015,7 +1156,8 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   expect(submission.html).toContain("新しいノード");
   expect(submission.html).not.toContain("data-ark-harness-ui");
   expect(submission.html).not.toContain("ark-harness-node-palette");
-  expect(submission.html).not.toContain("ark-harness-node-rail");
+  expect(submission.html).not.toContain("ark-harness-node-connectors");
+  expect(submission.html).not.toContain("ark-harness-node-anchor");
   expect(submission.html).not.toContain("ark-harness-edge-hit");
   expect(submission.html).not.toContain("--ark-harness-graph-x");
   expect(describeModelDiff(crudModel, submission.model)).toEqual([

--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -558,3 +558,87 @@ describe("describeModelDiff（label の無害化 / プロンプト注入対策�
     expect(field.label).toBe(label);
   });
 });
+
+describe("describeModelDiff（node / edge CRUD）", () => {
+  const base: DiagramModel = {
+    version: 1,
+    nodes: [
+      { id: "a", label: "A", fields: [{ id: "a_name", label: "name" }] },
+      { id: "b", label: "B" },
+    ],
+    edges: [{ id: "ab", from: "a", to: "b", label: "uses" }],
+    groups: [],
+  };
+
+  it("kind / ext 付き node の追加と削除だけを既存文面で述べる", () => {
+    const added: DiagramModel = {
+      ...base,
+      nodes: [
+        ...base.nodes,
+        { id: "c", label: "C", kind: "event", ext: { x: 10, y: 20 } },
+      ],
+      ext: { layout: { direction: "TB" } },
+    };
+    expect(describeModelDiff(base, added)).toEqual(["C を追加"]);
+    expect(describeModelDiff(added, base)).toEqual(["C を削除"]);
+  });
+
+  it("label 無し edge と label 付き edge、self-edge の追加削除を述べる", () => {
+    const edges: DiagramModel = {
+      ...base,
+      edges: [
+        ...base.edges,
+        { id: "ba", from: "b", to: "a" },
+        { id: "aa", from: "a", to: "a" },
+      ],
+    };
+    expect(describeModelDiff(base, edges)).toEqual([
+      "B から A への関連を追加",
+      "A から A への関連を追加",
+    ]);
+    expect(describeModelDiff(edges, base)).toEqual([
+      "B から A への関連を削除",
+      "A から A への関連を削除",
+    ]);
+  });
+
+  it("cascade 削除は node 文の後に incident edge 文を返す", () => {
+    const after: DiagramModel = {
+      ...base,
+      nodes: [base.nodes[1]],
+      edges: [],
+    };
+    expect(describeModelDiff(base, after)).toEqual([
+      "A を削除",
+      "A から B への関連「uses」を削除",
+    ]);
+  });
+
+  it("CRUD と既存 field / endpoint 編集が共存し見た目変更を返さない", () => {
+    const after: DiagramModel = {
+      version: 1,
+      nodes: [
+        {
+          ...base.nodes[0],
+          fields: [{ id: "a_name", label: "display name" }],
+          kind: "aggregate",
+          ext: { x: 100, y: 200 },
+        },
+        { id: "c", label: "C" },
+      ],
+      edges: [
+        { id: "ab", from: "a", to: "c", label: "uses", ext: { type: "async" } },
+        { id: "ca", from: "c", to: "a" },
+      ],
+      groups: [],
+      ext: { layout: { direction: "TB" } },
+    };
+    expect(describeModelDiff(base, after)).toEqual([
+      "A の name を display name に変更",
+      "C を追加",
+      "B を削除",
+      "A から B への関連「uses」を A から C への関連「uses」 に変更",
+      "C から A への関連を追加",
+    ]);
+  });
+});

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -198,6 +198,14 @@ describe("injectHarness", () => {
     expect(out).toContain("var EDGE_DRAG_MIN_DISTANCE = 8");
     expect(out).toContain("drag.didDrag");
     expect(out).toContain("drag.leftSource");
+    expect(out).toContain("ark-harness-node-connectors");
+    expect(out).toContain("ark-harness-node-anchor");
+    expect(out).toContain("function nodeAnchorPoint(");
+    expect(out).toContain("function attachNodeConnectors(");
+    expect(out).toContain('["top-left", 0, 0]');
+    expect(out).toContain('["bottom-right", 1, 1]');
+    expect(out).not.toContain("ark-harness-node-create");
+    expect(out).not.toContain("ark-harness-node-rail");
     expect(out).toContain("function removeEdge(");
     expect(out).toContain("function setEdgeDeletePending(");
     expect(out).toContain('drag.mode === "rewire" && !candidate');

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -200,6 +200,9 @@ describe("injectHarness", () => {
     expect(out).toContain("drag.leftSource");
     expect(out).toContain("ark-harness-node-connectors");
     expect(out).toContain("ark-harness-node-anchor");
+    expect(out).toContain(
+      "position: absolute; transform: translate(-50%, -50%); z-index: 5"
+    );
     expect(out).toContain("function nodeAnchorPoint(");
     expect(out).toContain("function attachNodeConnectors(");
     expect(out).toContain('["top-left", 0, 0]');
@@ -211,6 +214,10 @@ describe("injectHarness", () => {
     expect(out).toContain('drag.mode === "rewire" && !candidate');
     expect(out).toContain("離すと edge を削除");
     expect(out).toContain("function setSelectedNode(");
+    expect(out).toContain('root.addEventListener("pointerdown"');
+    expect(out).toContain("editableControl.getBoundingClientRect()");
+    expect(out).toContain("event.preventDefault()");
+    expect(out).toContain("root.focus({ preventScroll: true })");
     expect(out).toContain("function handleNodeDeleteKey(");
     expect(out).toContain('event.key !== "Delete"');
     expect(out).toContain('event.key !== "Backspace"');

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -177,4 +177,51 @@ describe("injectHarness", () => {
     expect(out).not.toContain('kindCandidates = ["');
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
+
+  it("node / edge CRUD と参照整合性の契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain("reservedModelIds");
+    expect(out).toContain("function collectModelIds(");
+    expect(out).toContain("function generateUniqueModelId(");
+    expect(out).toContain("ark-harness-node-palette");
+    expect(out).toContain("function registerGraphNode(");
+    expect(out).toContain("function addNode(");
+    expect(out).toContain("function removeNode(");
+    expect(out).toContain("group.nodes = group.nodes.filter");
+    expect(out).toContain('mode: "create"');
+    expect(out).toContain('mode: "rewire"');
+    expect(out).toContain("function removeEdge(");
+    expect(out).toContain("edgeDeleteControlsById");
+    expect(out).toContain("function syncEdgeDeleteControls(");
+  });
+
+  it("CRUD DOM を安全な API だけで生成し全 model id を予約する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain('document.createElement("article")');
+    expect(out).toContain('document.createElement("span")');
+    expect(out).toContain(
+      'document.createElementNS("http://www.w3.org/2000/svg"'
+    );
+    expect(out).toContain('root.setAttribute("data-model-id", node.id)');
+    expect(out).toContain("label.textContent = node.label");
+    expect(out).toContain("(node.fields || []).forEach");
+    expect(out).toContain("(model.edges || []).forEach");
+    expect(out).toContain("(model.groups || []).forEach");
+    expect(out).toContain("reservedModelIds.has(candidate)");
+    expect(out).not.toContain("innerHTML");
+    expect(out).not.toContain("insertAdjacentHTML");
+    expect(out).not.toContain("fetch(");
+    expect(out).not.toContain("import(");
+    expect(out).not.toContain("https://");
+  });
 });

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -195,6 +195,9 @@ describe("injectHarness", () => {
     expect(out).toContain("group.nodes = group.nodes.filter");
     expect(out).toContain('mode: "create"');
     expect(out).toContain('mode: "rewire"');
+    expect(out).toContain("var EDGE_DRAG_MIN_DISTANCE = 8");
+    expect(out).toContain("drag.didDrag");
+    expect(out).toContain("drag.leftSource");
     expect(out).toContain("function removeEdge(");
     expect(out).toContain("edgeDeleteControlsById");
     expect(out).toContain("function syncEdgeDeleteControls(");
@@ -203,6 +206,10 @@ describe("injectHarness", () => {
     expect(out).toContain("function scheduleEdgeDeleteClose(");
     expect(out).toContain("ark-harness-node-affordance-open");
     expect(out).toContain('controller.root.matches(":focus-within")');
+    expect(out).toContain(
+      "root.closest('[data-ark-container=\"graph\"]') === graph.container"
+    );
+    expect(out).toContain('element.hasAttribute("data-ark-container")');
   });
 
   it("CRUD DOM を安全な API だけで生成し全 model id を予約する", () => {

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -199,11 +199,20 @@ describe("injectHarness", () => {
     expect(out).toContain("drag.didDrag");
     expect(out).toContain("drag.leftSource");
     expect(out).toContain("function removeEdge(");
-    expect(out).toContain("edgeDeleteControlsById");
-    expect(out).toContain("function syncEdgeDeleteControls(");
+    expect(out).toContain("function setEdgeDeletePending(");
+    expect(out).toContain('drag.mode === "rewire" && !candidate');
+    expect(out).toContain("離すと edge を削除");
+    expect(out).toContain("function setSelectedNode(");
+    expect(out).toContain("function handleNodeDeleteKey(");
+    expect(out).toContain('event.key !== "Delete"');
+    expect(out).toContain('event.key !== "Backspace"');
+    expect(out).toContain("target.isContentEditable");
+    expect(out).not.toContain("ark-harness-node-delete");
+    expect(out).not.toContain("ark-harness-edge-delete-visible");
+    expect(out).not.toContain("ark-harness-edge-hit");
+    expect(out).not.toContain("function syncEdgeDeleteControls(");
     expect(out).toContain("var AFFORDANCE_CLOSE_DELAY = 120");
     expect(out).toContain("function scheduleNodeAffordanceClose(");
-    expect(out).toContain("function scheduleEdgeDeleteClose(");
     expect(out).toContain("ark-harness-node-affordance-open");
     expect(out).toContain('controller.root.matches(":focus-within")');
     expect(out).toContain(

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -198,6 +198,11 @@ describe("injectHarness", () => {
     expect(out).toContain("function removeEdge(");
     expect(out).toContain("edgeDeleteControlsById");
     expect(out).toContain("function syncEdgeDeleteControls(");
+    expect(out).toContain("var AFFORDANCE_CLOSE_DELAY = 120");
+    expect(out).toContain("function scheduleNodeAffordanceClose(");
+    expect(out).toContain("function scheduleEdgeDeleteClose(");
+    expect(out).toContain("ark-harness-node-affordance-open");
+    expect(out).toContain('controller.root.matches(":focus-within")');
   });
 
   it("CRUD DOM を安全な API だけで生成し全 model id を予約する", () => {

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -153,22 +153,26 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   background: #fff; color: #0e7490; cursor: crosshair; line-height: 14px; font-size: 9px;
   pointer-events: auto; touch-action: none;
 }
-.ark-harness-node-rail {
-  position: absolute; z-index: 5; display: flex; gap: 4px; padding: 2px;
-  border: 1px solid rgba(100,116,139,.55); border-radius: 999px;
-  background: rgba(255,255,255,.96); opacity: 0; pointer-events: none;
+.ark-harness-node-connectors {
+  position: absolute; inset: 0; z-index: 4; opacity: 0; pointer-events: none;
+  transition: opacity .12s ease;
 }
-.ark-harness-graph-node:hover > .ark-harness-node-rail,
-.ark-harness-graph-node.ark-harness-node-affordance-open > .ark-harness-node-rail,
-.ark-harness-graph-node:focus-within > .ark-harness-node-rail {
-  opacity: 1; pointer-events: auto;
+.ark-harness-node-anchor {
+  position: absolute; width: 12px; height: 12px; padding: 0;
+  transform: translate(-50%, -50%); border: 2px solid #0ea5b7; border-radius: 999px;
+  background: #fff; color: #0e7490; font: 9px/8px sans-serif;
+  cursor: crosshair; touch-action: none; pointer-events: none;
 }
-.ark-harness-node-create {
-  width: 24px; height: 24px; padding: 0; border-radius: 999px;
-  border: 1px solid #94a3b8; background: #fff; color: #0e7490;
-  cursor: crosshair; touch-action: none;
+.ark-harness-node-connectors.ark-harness-node-connectors-visible {
+  opacity: 1;
 }
-.ark-harness-edge-dragging .ark-harness-node-rail { opacity: 0; pointer-events: none; }
+.ark-harness-node-connectors.ark-harness-node-connectors-visible > .ark-harness-node-anchor {
+  pointer-events: auto;
+}
+.ark-harness-edge-dragging .ark-harness-node-connectors {
+  opacity: 0; pointer-events: none;
+}
+.ark-harness-edge-dragging .ark-harness-node-anchor { pointer-events: none !important; }
 .ark-harness-edge-preview {
   position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; pointer-events: none;
 }
@@ -1016,7 +1020,7 @@ const HARNESS_JS = `(function () {
       appendGraphLabel(graph.svg, edge.id, edge.label, geometry.label.x, geometry.label.y);
     });
     syncEdgeHandles(graph, edges);
-    syncNodeRails(graph);
+    syncNodeConnectors(graph);
   }
 
   function scheduleGraphRender(graph) {
@@ -1093,20 +1097,20 @@ const HARNESS_JS = `(function () {
       markUi(drag.indicator);
       drag.graph.handleLayer.appendChild(drag.indicator);
     }
-    var containerRect = drag.graph.container.getBoundingClientRect();
+    var layerRect = drag.graph.handleLayer.getBoundingClientRect();
     var nodeRect = candidate.el.getBoundingClientRect();
-    drag.indicator.style.left = nodeRect.left - containerRect.left - 4 + "px";
-    drag.indicator.style.top = nodeRect.top - containerRect.top - 4 + "px";
+    drag.indicator.style.left = nodeRect.left - layerRect.left - 4 + "px";
+    drag.indicator.style.top = nodeRect.top - layerRect.top - 4 + "px";
     drag.indicator.style.width = nodeRect.width + 8 + "px";
     drag.indicator.style.height = nodeRect.height + 8 + "px";
     drag.candidateId = candidate.id;
   }
 
   function nodeBoundaryPoint(graph, nodeEl, towardX, towardY) {
-    var containerRect = graph.container.getBoundingClientRect();
+    var previewRect = graph.previewLayer.getBoundingClientRect();
     var rect = nodeEl.getBoundingClientRect();
-    var cx = rect.left + rect.width / 2 - containerRect.left;
-    var cy = rect.top + rect.height / 2 - containerRect.top;
+    var cx = rect.left + rect.width / 2 - previewRect.left;
+    var cy = rect.top + rect.height / 2 - previewRect.top;
     var dx = towardX - cx;
     var dy = towardY - cy;
     var length = Math.sqrt(dx * dx + dy * dy) || 1;
@@ -1123,7 +1127,7 @@ const HARNESS_JS = `(function () {
   function updateEdgeDrag(event) {
     if (!edgeDrag || event.pointerId !== edgeDrag.pointerId) return;
     var drag = edgeDrag;
-    var containerRect = drag.graph.container.getBoundingClientRect();
+    var previewRect = drag.graph.previewLayer.getBoundingClientRect();
     var candidate = findEdgeDropCandidate(drag.graph, event.clientX, event.clientY);
     var dx = event.clientX - drag.startClientX;
     var dy = event.clientY - drag.startClientY;
@@ -1142,8 +1146,8 @@ const HARNESS_JS = `(function () {
           Number(drag.previewLine.getAttribute("y1"))
         )
       : {
-          x: event.clientX - containerRect.left,
-          y: event.clientY - containerRect.top
+          x: event.clientX - previewRect.left,
+          y: event.clientY - previewRect.top
         };
     drag.previewLine.setAttribute("x2", String(end.x));
     drag.previewLine.setAttribute("y2", String(end.y));
@@ -1352,108 +1356,52 @@ const HARNESS_JS = `(function () {
     el.appendChild(handle);
   }
 
-  function positionNodeRail(graph, id) {
-    var nodeEl = graph.nodesById.get(id);
-    var rail = graph.nodeRailsById.get(id);
-    if (!nodeEl || !rail) return;
-    var nodeRect = nodeEl.getBoundingClientRect();
-    var railWidth = rail.offsetWidth || 56;
-    var railHeight = rail.offsetHeight || 28;
-    var candidates = [
-      { x: (nodeRect.width - railWidth) / 2, y: nodeRect.height + 8 },
-      { x: -railWidth - 8, y: (nodeRect.height - railHeight) / 2 },
-      { x: nodeRect.width + 8, y: (nodeRect.height - railHeight) / 2 },
-      { x: (nodeRect.width - railWidth) / 2, y: -railHeight - 8 }
-    ];
-    var containerRect = graph.container.getBoundingClientRect();
-    var nodeX = nodeRect.left - containerRect.left;
-    var nodeY = nodeRect.top - containerRect.top;
-    var blockers = [];
-    graph.nodesById.forEach(function (other, otherId) {
-      if (otherId === id) return;
-      var rect = graphLocalRect(graph, other);
-      if (rect) blockers.push(rect);
-    });
-    graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(function (label) {
-      var rect = graphLocalRect(graph, label);
-      if (rect) blockers.push(rect);
-    });
-    graph.edgeHandlesByKey.forEach(function (handle) {
-      var rect = graphLocalRect(graph, handle);
-      if (rect) blockers.push(rect);
-    });
-    graph.nodeRailsById.forEach(function (other, otherId) {
-      if (otherId === id) return;
-      var rect = graphLocalRect(graph, other);
-      if (rect) blockers.push(rect);
-    });
-    [".ark-harness-kind-picker", ".ark-harness-graph-handle"].forEach(function (selector) {
-      var control = nodeEl.querySelector(selector);
-      var rect = control && graphLocalRect(graph, control);
-      if (rect) blockers.push(rect);
-    });
-    var chosen = null;
-    for (var i = 0; i < candidates.length; i++) {
-      var candidateRect = {
-        x: nodeX + candidates[i].x,
-        y: nodeY + candidates[i].y,
-        width: railWidth,
-        height: railHeight
-      };
-      if (candidateRect.x < 0 || candidateRect.y < 0) continue;
-      if (!blockers.some(function (blocker) {
-        return rectanglesCollide(candidateRect, blocker, 6);
-      })) {
-        chosen = candidates[i];
-        break;
-      }
-    }
-    if (!chosen) {
-      var right = nodeRect.width + 12;
-      blockers.forEach(function (blocker) {
-        right = Math.max(right, blocker.x + blocker.width - nodeX + 12);
-      });
-      chosen = { x: right, y: 0 };
-    }
-    rail.style.left = Math.round(chosen.x) + "px";
-    rail.style.top = Math.round(chosen.y) + "px";
-  }
-
-  function syncNodeRails(graph) {
-    graph.nodeRailsById.forEach(function (rail, id) {
+  function syncNodeConnectors(graph) {
+    graph.nodeConnectorsById.forEach(function (connectors, id) {
       var node = getNode(state.model, id);
-      if (node) {
-        var name = (typeof node.label === "string" && node.label) || node.id;
-        var create = rail.querySelector(".ark-harness-node-create");
-        if (create) {
-          create.setAttribute("aria-label", name + " から edge を作成");
-          create.title = name + " から edge を作成";
-        }
-      }
-      positionNodeRail(graph, id);
+      if (!node) return;
+      var name = (typeof node.label === "string" && node.label) || node.id;
+      connectors.querySelectorAll(".ark-harness-node-anchor").forEach(function (anchor) {
+        var position = anchor.getAttribute("data-ark-anchor-position") || "";
+        var label = name + " の" + position + "接続点から edge を作成";
+        anchor.setAttribute("aria-label", label);
+        anchor.title = label;
+        var point = nodeAnchorPoint(
+          graph.nodesById.get(id),
+          anchor,
+          connectors
+        );
+        anchor.style.left = point.x + "px";
+        anchor.style.top = point.y + "px";
+      });
     });
   }
 
-  function startCreateEdgeDrag(graph, nodeEl, handle, event) {
+  function nodeAnchorPoint(nodeEl, anchor, reference) {
+    var referenceRect = reference.getBoundingClientRect();
+    var nodeRect = nodeEl.getBoundingClientRect();
+    var xRatio = Number(anchor.getAttribute("data-ark-anchor-x"));
+    var yRatio = Number(anchor.getAttribute("data-ark-anchor-y"));
+    return {
+      x: nodeRect.left - referenceRect.left + nodeRect.width * xRatio,
+      y: nodeRect.top - referenceRect.top + nodeRect.height * yRatio
+    };
+  }
+
+  function startCreateEdgeDrag(graph, nodeEl, anchor, event) {
     if (graphDrag || edgeDrag) return;
     var sourceId = nodeEl.getAttribute("data-model-id");
     if (!sourceId || !getNode(state.model, sourceId) ||
         graph.nodesById.get(sourceId) !== nodeEl) return;
     event.preventDefault();
     event.stopPropagation();
-    handle.setPointerCapture(event.pointerId);
-    var containerRect = graph.container.getBoundingClientRect();
-    var start = nodeBoundaryPoint(
-      graph,
-      nodeEl,
-      event.clientX - containerRect.left + 1,
-      event.clientY - containerRect.top
-    );
+    anchor.setPointerCapture(event.pointerId);
+    var start = nodeAnchorPoint(nodeEl, anchor, graph.previewLayer);
     var previewUi = createEdgePreview(graph, start);
     edgeDrag = {
       mode: "create",
       pointerId: event.pointerId,
-      handle: handle,
+      handle: anchor,
       graph: graph,
       sourceId: sourceId,
       startClientX: event.clientX,
@@ -1467,34 +1415,50 @@ const HARNESS_JS = `(function () {
     };
   }
 
-  function attachNodeRail(graph, root) {
+  function attachNodeConnectors(graph, root) {
     var id = root.getAttribute("data-model-id");
-    if (!id || graph.nodeRailsById.has(id)) return;
+    if (!id || graph.nodeConnectorsById.has(id)) return;
     var node = getNode(state.model, id);
     if (!node) return;
-    var rail = document.createElement("span");
-    rail.className = "ark-harness-node-rail";
-    rail.setAttribute("data-ark-node-id", id);
-    markUi(rail);
+    var connectors = document.createElement("span");
+    connectors.className = "ark-harness-node-connectors";
+    connectors.setAttribute("data-ark-node-id", id);
+    markUi(connectors);
     var name = (typeof node.label === "string" && node.label) || node.id;
-    var create = createButton(
-      "+",
-      "ark-harness-node-create",
-      name + " から edge を作成"
-    );
-    create.setAttribute("data-ark-node-id", id);
+    var positions = [
+      ["top-left", 0, 0],
+      ["top", 0.5, 0],
+      ["top-right", 1, 0],
+      ["right", 1, 0.5],
+      ["bottom-right", 1, 1],
+      ["bottom", 0.5, 1],
+      ["bottom-left", 0, 1],
+      ["left", 0, 0.5]
+    ];
     ["pointerdown", "click", "keydown"].forEach(function (type) {
-      rail.addEventListener(type, function (event) { event.stopPropagation(); });
+      connectors.addEventListener(type, function (event) { event.stopPropagation(); });
     });
-    create.addEventListener("pointerdown", function (event) {
-      startCreateEdgeDrag(graph, root, create, event);
+    positions.forEach(function (position) {
+      var label = name + " の" + position[0] + "接続点から edge を作成";
+      var anchor = createButton("\\u2022", "ark-harness-node-anchor", label);
+      anchor.setAttribute("data-ark-node-id", id);
+      anchor.setAttribute("data-ark-anchor-position", String(position[0]));
+      anchor.setAttribute("data-ark-anchor-x", String(position[1]));
+      anchor.setAttribute("data-ark-anchor-y", String(position[2]));
+      anchor.addEventListener("pointerdown", function (event) {
+        startCreateEdgeDrag(graph, root, anchor, event);
+      });
+      anchor.addEventListener("pointermove", updateEdgeDrag);
+      anchor.addEventListener("pointerup", function (event) {
+        finishEdgeDrag(event, true);
+      });
+      anchor.addEventListener("pointercancel", function (event) {
+        finishEdgeDrag(event, false);
+      });
+      connectors.appendChild(anchor);
     });
-    create.addEventListener("pointermove", updateEdgeDrag);
-    create.addEventListener("pointerup", function (event) { finishEdgeDrag(event, true); });
-    create.addEventListener("pointercancel", function (event) { finishEdgeDrag(event, false); });
-    rail.appendChild(create);
-    root.appendChild(rail);
-    graph.nodeRailsById.set(id, rail);
+    graph.handleLayer.appendChild(connectors);
+    graph.nodeConnectorsById.set(id, connectors);
   }
 
   function clearNodeAffordanceClose(controller) {
@@ -1506,6 +1470,7 @@ const HARNESS_JS = `(function () {
   function openNodeAffordance(controller) {
     clearNodeAffordanceClose(controller);
     controller.root.classList.add("ark-harness-node-affordance-open");
+    controller.connectors.classList.add("ark-harness-node-connectors-visible");
   }
 
   function scheduleNodeAffordanceClose(controller) {
@@ -1513,13 +1478,18 @@ const HARNESS_JS = `(function () {
     controller.closeTimer = window.setTimeout(function () {
       controller.closeTimer = null;
       if (controller.root.matches(":hover") ||
-          controller.root.matches(":focus-within")) return;
+          controller.root.matches(":focus-within") ||
+          controller.connectors.matches(":hover") ||
+          controller.connectors.matches(":focus-within")) return;
       controller.root.classList.remove("ark-harness-node-affordance-open");
+      controller.connectors.classList.remove("ark-harness-node-connectors-visible");
     }, AFFORDANCE_CLOSE_DELAY);
   }
 
   function attachNodeAffordanceHover(graph, root, id) {
-    var controller = { root: root, closeTimer: null };
+    var connectors = graph.nodeConnectorsById.get(id);
+    if (!connectors) return;
+    var controller = { root: root, connectors: connectors, closeTimer: null };
     ["pointerenter", "focusin"].forEach(function (type) {
       root.addEventListener(type, function () {
         openNodeAffordance(controller);
@@ -1530,9 +1500,13 @@ const HARNESS_JS = `(function () {
         scheduleNodeAffordanceClose(controller);
       });
     });
-    root.querySelectorAll(
-      ".ark-harness-kind-picker, .ark-harness-graph-handle, .ark-harness-node-rail"
-    ).forEach(function (affordance) {
+    var affordances = [
+      root.querySelector(".ark-harness-kind-picker"),
+      root.querySelector(".ark-harness-graph-handle"),
+      connectors
+    ];
+    affordances.forEach(function (affordance) {
+      if (!affordance) return;
       affordance.addEventListener("pointerenter", function () {
         openNodeAffordance(controller);
       });
@@ -1571,7 +1545,7 @@ const HARNESS_JS = `(function () {
     attachNodeSelection(root, node.id);
     attachKindPicker(graph, root);
     attachGraphHandle(graph, root, node);
-    attachNodeRail(graph, root);
+    attachNodeConnectors(graph, root);
     attachNodeAffordanceHover(graph, root, node.id);
     if (graph.resizeObserver) graph.resizeObserver.observe(root);
     return true;
@@ -1582,9 +1556,9 @@ const HARNESS_JS = `(function () {
     if (root && graph.resizeObserver) graph.resizeObserver.unobserve(root);
     graph.nodesById.delete(id);
     graph.positionsById.delete(id);
-    var rail = graph.nodeRailsById.get(id);
-    if (rail) rail.remove();
-    graph.nodeRailsById.delete(id);
+    var connectors = graph.nodeConnectorsById.get(id);
+    if (connectors) connectors.remove();
+    graph.nodeConnectorsById.delete(id);
     var affordance = graph.nodeAffordancesById.get(id);
     clearNodeAffordanceClose(affordance);
     graph.nodeAffordancesById.delete(id);
@@ -1713,7 +1687,6 @@ const HARNESS_JS = `(function () {
     graph.nodesById.forEach(add);
     graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(add);
     graph.edgeHandlesByKey.forEach(add);
-    graph.nodeRailsById.forEach(add);
     graph.nodesById.forEach(function (nodeRoot) {
       nodeRoot.querySelectorAll(
         ".ark-harness-kind-picker, .ark-harness-graph-handle"
@@ -1844,7 +1817,7 @@ const HARNESS_JS = `(function () {
       handleLayer: handleLayer,
       previewLayer: previewLayer,
       edgeHandlesByKey: new Map(),
-      nodeRailsById: new Map(),
+      nodeConnectorsById: new Map(),
       nodeAffordancesById: new Map(),
       positionsById: new Map(),
       layoutExtent: { width: null, height: null },

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -140,11 +140,6 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   fill: #475569; font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
   font-size: 12px; text-anchor: middle; dominant-baseline: central;
 }
-.ark-harness-edge-hit {
-  fill: none; stroke: transparent !important; stroke-width: 18 !important;
-  pointer-events: stroke; cursor: pointer;
-}
-.ark-harness-edge-main.ark-harness-edge-selected { stroke: #0ea5b7; stroke-width: 2.5; }
 .ark-harness-edge-handle-layer {
   position: absolute; inset: 0; z-index: 3; pointer-events: none;
 }
@@ -158,14 +153,6 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   background: #fff; color: #0e7490; cursor: crosshair; line-height: 14px; font-size: 9px;
   pointer-events: auto; touch-action: none;
 }
-.ark-harness-edge-delete {
-  position: absolute; transform: translate(-50%, -50%); z-index: 5;
-  width: 24px; height: 24px; padding: 0; border: 1px solid #ef4444;
-  border-radius: 999px; background: #fff; color: #b91c1c; cursor: pointer;
-  pointer-events: none; opacity: 0;
-}
-.ark-harness-edge-delete.ark-harness-edge-delete-visible,
-.ark-harness-edge-delete:focus { opacity: 1; pointer-events: auto; }
 .ark-harness-node-rail {
   position: absolute; z-index: 5; display: flex; gap: 4px; padding: 2px;
   border: 1px solid rgba(100,116,139,.55); border-radius: 999px;
@@ -176,18 +163,27 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-graph-node:focus-within > .ark-harness-node-rail {
   opacity: 1; pointer-events: auto;
 }
-.ark-harness-node-create, .ark-harness-node-delete {
+.ark-harness-node-create {
   width: 24px; height: 24px; padding: 0; border-radius: 999px;
   border: 1px solid #94a3b8; background: #fff; color: #0e7490;
   cursor: crosshair; touch-action: none;
 }
-.ark-harness-node-delete { color: #b91c1c; cursor: pointer; }
 .ark-harness-edge-dragging .ark-harness-node-rail { opacity: 0; pointer-events: none; }
 .ark-harness-edge-preview {
   position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; pointer-events: none;
 }
 .ark-harness-edge-preview line {
   stroke: #0ea5b7; stroke-width: 2; stroke-dasharray: 5 4;
+}
+.ark-harness-edge-delete-pending { cursor: not-allowed !important; }
+.ark-harness-edge-main.ark-harness-edge-delete-pending {
+  opacity: .28; stroke-width: 1;
+}
+.ark-harness-edge-preview.ark-harness-edge-delete-pending line {
+  stroke: #dc2626; stroke-width: 1; stroke-dasharray: 2 5; opacity: .55;
+}
+.ark-harness-edge-handle.ark-harness-edge-delete-pending {
+  border-color: #dc2626; background: #fee2e2; color: #b91c1c;
 }
 .ark-harness-edge-drop-indicator {
   position: absolute; box-sizing: border-box; border: 2px solid #0ea5b7;
@@ -197,6 +193,9 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   position: absolute; top: .25rem; right: .25rem; z-index: 3;
   border: 1px solid rgba(100,116,139,.45); border-radius: 4px; background: rgba(255,255,255,.9);
   color: #64748b; cursor: grab; line-height: 1; padding: .25rem; touch-action: none;
+}
+.ark-harness-graph-node.ark-harness-node-selected {
+  outline: 2px solid #0ea5b7; outline-offset: 3px;
 }
 .ark-harness-graph-dragging { z-index: 3; }
 body { padding-bottom: var(--ark-harness-toolbar-height, 3.4rem) !important; }
@@ -242,7 +241,7 @@ const HARNESS_JS = `(function () {
   var kindPickers = [];
   var reservedModelIds = new Set();
   var generatedIdCounter = 0;
-  var selectedEdgeId = null;
+  var selectedNodeId = null;
   var statusEl = null;
   var sendBtn = null;
   var layoutDirectionBtn = null;
@@ -840,24 +839,6 @@ const HARNESS_JS = `(function () {
     }
   }
 
-  function setSelectedEdge(edgeId) {
-    selectedEdgeId = edgeId && getEdge(state.model, edgeId) ? edgeId : null;
-    graphs.forEach(function (graph) {
-      graph.svg.querySelectorAll(".ark-harness-edge-main").forEach(function (main) {
-        main.classList.toggle(
-          "ark-harness-edge-selected",
-          main.getAttribute("data-ark-edge-id") === selectedEdgeId
-        );
-      });
-      graph.edgeDeleteControlsById.forEach(function (control, id) {
-        control.wrapper.classList.toggle(
-          "ark-harness-edge-delete-visible",
-          id === selectedEdgeId
-        );
-      });
-    });
-  }
-
   function removeEdge(edgeId) {
     var edge = getEdge(state.model, edgeId);
     if (!edge) return;
@@ -867,21 +848,13 @@ const HARNESS_JS = `(function () {
     state.model.edges = state.model.edges.filter(function (entry) {
       return entry.id !== edgeId;
     });
-    if (selectedEdgeId === edgeId) selectedEdgeId = null;
     graphs.forEach(function (graph) { scheduleGraphRender(graph); });
   }
 
   function isEditableControlTarget(target) {
     if (!target || !target.closest) return false;
-    return !!target.closest('[contenteditable="true"], input, textarea, select');
-  }
-
-  function handleEdgeDeleteKey(event, edgeId) {
-    if ((event.key !== "Delete" && event.key !== "Backspace") ||
-        isEditableControlTarget(event.target)) return;
-    event.preventDefault();
-    event.stopPropagation();
-    removeEdge(edgeId);
+    return !!target.isContentEditable ||
+      !!target.closest('[contenteditable="true"], input, textarea, select, button');
   }
 
   function applyEdgeMarkers(main, markerId, direction) {
@@ -1026,29 +999,6 @@ const HARNESS_JS = `(function () {
       setEdgeGeometryAttributes(main, geometry);
       applyEdgeMarkers(main, graph.markerId, direction);
       graph.svg.appendChild(main);
-      var hit = svgElement(geometry.kind);
-      hit.classList.add("ark-harness-edge-hit");
-      hit.setAttribute("data-ark-edge-id", edge.id);
-      hit.setAttribute("tabindex", "0");
-      hit.setAttribute("role", "button");
-      var edgeName = (typeof edge.label === "string" && edge.label) || edge.id;
-      hit.setAttribute("aria-label", edgeName + " を選択");
-      setEdgeGeometryAttributes(hit, geometry);
-      markUi(hit);
-      ["pointerenter", "focus", "click"].forEach(function (type) {
-        hit.addEventListener(type, function (event) {
-          event.stopPropagation();
-          activateEdgeDeleteControl(graph, edge.id);
-        });
-      });
-      ["pointerleave", "blur"].forEach(function (type) {
-        hit.addEventListener(type, function () {
-          scheduleEdgeDeleteClose(graph, edge.id);
-        });
-      });
-      hit.addEventListener("keydown", function (event) {
-        handleEdgeDeleteKey(event, edge.id);
-      });
       appendEdgeCardinality(
         graph.svg,
         edge,
@@ -1064,12 +1014,9 @@ const HARNESS_JS = `(function () {
         edgeCardinality(edge, "to")
       );
       appendGraphLabel(graph.svg, edge.id, edge.label, geometry.label.x, geometry.label.y);
-      graph.svg.appendChild(hit);
     });
     syncEdgeHandles(graph, edges);
     syncNodeRails(graph);
-    syncEdgeDeleteControls(graph, edges);
-    setSelectedEdge(selectedEdgeId);
   }
 
   function scheduleGraphRender(graph) {
@@ -1101,6 +1048,7 @@ const HARNESS_JS = `(function () {
   }
 
   function removeEdgeDragUi(drag) {
+    setEdgeDeletePending(drag, false);
     if (drag.preview && drag.preview.parentNode) drag.preview.parentNode.removeChild(drag.preview);
     if (drag.indicator && drag.indicator.parentNode) {
       drag.indicator.parentNode.removeChild(drag.indicator);
@@ -1110,6 +1058,24 @@ const HARNESS_JS = `(function () {
     drag.indicator = null;
     drag.candidateId = null;
     drag.graph.container.classList.remove("ark-harness-edge-dragging");
+  }
+
+  function setEdgeDeletePending(drag, pending) {
+    if (drag.mode !== "rewire") return;
+    drag.graph.container.classList.toggle("ark-harness-edge-delete-pending", pending);
+    drag.preview.classList.toggle("ark-harness-edge-delete-pending", pending);
+    drag.handle.classList.toggle("ark-harness-edge-delete-pending", pending);
+    drag.handle.textContent = pending ? "\\u00D7" : "";
+    drag.handle.setAttribute(
+      "aria-label",
+      pending ? "離すと edge を削除" : drag.handleLabel
+    );
+    drag.handle.title = pending ? "離すと edge を削除" : drag.handleLabel;
+    drag.graph.svg.querySelectorAll(".ark-harness-edge-main").forEach(function (main) {
+      if (main.getAttribute("data-ark-edge-id") === drag.edgeId) {
+        main.classList.toggle("ark-harness-edge-delete-pending", pending);
+      }
+    });
   }
 
   function updateEdgeDropIndicator(drag, candidate) {
@@ -1182,6 +1148,10 @@ const HARNESS_JS = `(function () {
     drag.previewLine.setAttribute("x2", String(end.x));
     drag.previewLine.setAttribute("y2", String(end.y));
     updateEdgeDropIndicator(drag, candidate);
+    setEdgeDeletePending(
+      drag,
+      drag.mode === "rewire" && drag.didDrag && !candidate
+    );
   }
 
   function finishEdgeDrag(event, commit) {
@@ -1195,7 +1165,9 @@ const HARNESS_JS = `(function () {
     var explicitSelfDrop = drag.mode !== "create" ||
       candidate && candidate.id !== drag.sourceId ||
       drag.leftSource;
-    if (commit && drag.didDrag && candidate && explicitSelfDrop) {
+    if (commit && drag.didDrag && drag.mode === "rewire" && !candidate) {
+      removeEdge(drag.edgeId);
+    } else if (commit && drag.didDrag && candidate && explicitSelfDrop) {
       if (drag.mode === "rewire") {
         var currentEdge = getEdge(state.model, drag.edgeId);
         if (currentEdge && getNode(state.model, candidate.id) &&
@@ -1264,6 +1236,7 @@ const HARNESS_JS = `(function () {
         startClientY: event.clientY,
         didDrag: false,
         leftSource: false,
+        handleLabel: handle.getAttribute("aria-label") || "",
         preview: previewUi.preview,
         previewLine: previewUi.line,
         indicator: null,
@@ -1273,9 +1246,6 @@ const HARNESS_JS = `(function () {
     handle.addEventListener("pointermove", updateEdgeDrag);
     handle.addEventListener("pointerup", function (event) { finishEdgeDrag(event, true); });
     handle.addEventListener("pointercancel", function (event) { finishEdgeDrag(event, false); });
-    handle.addEventListener("keydown", function (event) {
-      handleEdgeDeleteKey(event, handle.getAttribute("data-ark-edge-id"));
-    });
     graph.handleLayer.appendChild(handle);
     return handle;
   }
@@ -1297,7 +1267,8 @@ const HARNESS_JS = `(function () {
         handle.setAttribute("data-ark-edge-end", end);
         var name = (typeof edge.label === "string" && edge.label) || edge.id;
         var endLabel = end === "from" ? "始点" : "終点";
-        var ariaLabel = name + " の" + endLabel + "をドラッグして張り替え";
+        var ariaLabel = name + " の" + endLabel +
+          "をドラッグして張り替え、空き領域で削除";
         handle.setAttribute("aria-label", ariaLabel);
         handle.title = ariaLabel;
         positionEdgeHandle(handle, geometry[end]);
@@ -1320,155 +1291,6 @@ const HARNESS_JS = `(function () {
       width: rect.width,
       height: rect.height
     };
-  }
-
-  function edgeDeleteBlockers(graph, ownWrapper) {
-    var blockers = [];
-    var add = function (element) {
-      if (element === ownWrapper || !element.isConnected) return;
-      var rect = graphLocalRect(graph, element);
-      if (rect && rect.width >= 0 && rect.height >= 0) blockers.push(rect);
-    };
-    graph.nodesById.forEach(add);
-    graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(add);
-    graph.edgeHandlesByKey.forEach(add);
-    graph.nodeRailsById.forEach(function (rail) { add(rail); });
-    graph.edgeDeleteControlsById.forEach(function (control) { add(control.wrapper); });
-    return blockers;
-  }
-
-  function positionEdgeDeleteControl(graph, control, geometry) {
-    var width = control.wrapper.offsetWidth || 24;
-    var height = control.wrapper.offsetHeight || 24;
-    var nx = -geometry.from.ty;
-    var ny = geometry.from.tx;
-    var candidates = [];
-    var fractions = [0.35, 0.65, 0.2, 0.8];
-    fractions.forEach(function (fraction) {
-      var base = geometry.kind === "line"
-        ? {
-            x: geometry.from.x + (geometry.to.x - geometry.from.x) * fraction,
-            y: geometry.from.y + (geometry.to.y - geometry.from.y) * fraction
-          }
-        : geometry.label;
-      [34, -34, 50, -50].forEach(function (offset) {
-        candidates.push({
-          x: base.x + nx * offset - width / 2,
-          y: base.y + ny * offset - height / 2
-        });
-      });
-    });
-    var blockers = edgeDeleteBlockers(graph, control.wrapper);
-    var chosen = null;
-    for (var i = 0; i < candidates.length; i++) {
-      var rectangle = {
-        x: candidates[i].x,
-        y: candidates[i].y,
-        width: width,
-        height: height
-      };
-      if (rectangle.x < 0 || rectangle.y < 0) continue;
-      var collision = blockers.some(function (blocker) {
-        return rectanglesCollide(rectangle, blocker, 6);
-      });
-      if (!collision) {
-        chosen = candidates[i];
-        break;
-      }
-    }
-    if (!chosen) {
-      var right = readLayoutConfig(state.model).padding;
-      blockers.forEach(function (blocker) {
-        right = Math.max(right, blocker.x + blocker.width + 12);
-      });
-      chosen = { x: right, y: readLayoutConfig(state.model).padding };
-    }
-    control.wrapper.style.left = chosen.x + width / 2 + "px";
-    control.wrapper.style.top = chosen.y + height / 2 + "px";
-  }
-
-  function createEdgeDeleteControl(graph, edge) {
-    var name = (typeof edge.label === "string" && edge.label) || edge.id;
-    var button = createButton(
-      "\\u2212",
-      "ark-harness-edge-delete",
-      name + " を削除"
-    );
-    button.setAttribute("data-ark-edge-id", edge.id);
-    ["pointerdown", "click", "keydown"].forEach(function (type) {
-      button.addEventListener(type, function (event) { event.stopPropagation(); });
-    });
-    ["pointerenter", "focus"].forEach(function (type) {
-      button.addEventListener(type, function () {
-        activateEdgeDeleteControl(
-          graph,
-          button.getAttribute("data-ark-edge-id")
-        );
-      });
-    });
-    ["pointerleave", "blur"].forEach(function (type) {
-      button.addEventListener(type, function () {
-        scheduleEdgeDeleteClose(
-          graph,
-          button.getAttribute("data-ark-edge-id")
-        );
-      });
-    });
-    button.addEventListener("click", function () {
-      removeEdge(button.getAttribute("data-ark-edge-id"));
-    });
-    graph.handleLayer.appendChild(button);
-    return { wrapper: button, button: button, closeTimer: null };
-  }
-
-  function clearEdgeDeleteClose(control) {
-    if (!control || control.closeTimer === null) return;
-    window.clearTimeout(control.closeTimer);
-    control.closeTimer = null;
-  }
-
-  function activateEdgeDeleteControl(graph, edgeId) {
-    graph.edgeDeleteControlsById.forEach(function (control) {
-      clearEdgeDeleteClose(control);
-    });
-    setSelectedEdge(edgeId);
-  }
-
-  function scheduleEdgeDeleteClose(graph, edgeId) {
-    var control = graph.edgeDeleteControlsById.get(edgeId);
-    if (!control) return;
-    clearEdgeDeleteClose(control);
-    control.closeTimer = window.setTimeout(function () {
-      control.closeTimer = null;
-      if (control.wrapper.matches(":hover") ||
-          control.wrapper.contains(document.activeElement)) return;
-      if (selectedEdgeId === edgeId) setSelectedEdge(null);
-    }, AFFORDANCE_CLOSE_DELAY);
-  }
-
-  function syncEdgeDeleteControls(graph, edges) {
-    var activeIds = new Set();
-    edges.forEach(function (edge) {
-      var geometry = graph.edgeGeometryById.get(edge.id);
-      if (!geometry) return;
-      activeIds.add(edge.id);
-      var control = graph.edgeDeleteControlsById.get(edge.id);
-      if (!control) {
-        control = createEdgeDeleteControl(graph, edge);
-        graph.edgeDeleteControlsById.set(edge.id, control);
-      }
-      control.button.setAttribute("data-ark-edge-id", edge.id);
-      var name = (typeof edge.label === "string" && edge.label) || edge.id;
-      control.button.setAttribute("aria-label", name + " を削除");
-      control.button.title = name + " を削除";
-      positionEdgeDeleteControl(graph, control, geometry);
-    });
-    graph.edgeDeleteControlsById.forEach(function (control, id) {
-      if (activeIds.has(id)) return;
-      clearEdgeDeleteClose(control);
-      control.wrapper.remove();
-      graph.edgeDeleteControlsById.delete(id);
-    });
   }
 
   function finishGraphDrag(event) {
@@ -1603,14 +1425,9 @@ const HARNESS_JS = `(function () {
       if (node) {
         var name = (typeof node.label === "string" && node.label) || node.id;
         var create = rail.querySelector(".ark-harness-node-create");
-        var remove = rail.querySelector(".ark-harness-node-delete");
         if (create) {
           create.setAttribute("aria-label", name + " から edge を作成");
           create.title = name + " から edge を作成";
-        }
-        if (remove) {
-          remove.setAttribute("aria-label", name + " を削除");
-          remove.title = name + " を削除";
         }
       }
       positionNodeRail(graph, id);
@@ -1665,13 +1482,7 @@ const HARNESS_JS = `(function () {
       "ark-harness-node-create",
       name + " から edge を作成"
     );
-    var remove = createButton(
-      "\\u2212",
-      "ark-harness-node-delete",
-      name + " を削除"
-    );
     create.setAttribute("data-ark-node-id", id);
-    remove.setAttribute("data-ark-node-id", id);
     ["pointerdown", "click", "keydown"].forEach(function (type) {
       rail.addEventListener(type, function (event) { event.stopPropagation(); });
     });
@@ -1681,11 +1492,7 @@ const HARNESS_JS = `(function () {
     create.addEventListener("pointermove", updateEdgeDrag);
     create.addEventListener("pointerup", function (event) { finishEdgeDrag(event, true); });
     create.addEventListener("pointercancel", function (event) { finishEdgeDrag(event, false); });
-    remove.addEventListener("click", function () {
-      removeNode(remove.getAttribute("data-ark-node-id"));
-    });
     rail.appendChild(create);
-    rail.appendChild(remove);
     root.appendChild(rail);
     graph.nodeRailsById.set(id, rail);
   }
@@ -1736,10 +1543,32 @@ const HARNESS_JS = `(function () {
     graph.nodeAffordancesById.set(id, controller);
   }
 
+  function setSelectedNode(id) {
+    selectedNodeId = id && getNode(state.model, id) ? id : null;
+    graphs.forEach(function (graph) {
+      graph.nodesById.forEach(function (root, nodeId) {
+        root.classList.toggle(
+          "ark-harness-node-selected",
+          nodeId === selectedNodeId
+        );
+      });
+    });
+  }
+
+  function attachNodeSelection(root, id) {
+    if (!root.hasAttribute("tabindex")) {
+      root.setAttribute("tabindex", "0");
+      root.classList.add("ark-harness-node-tabindex-added");
+    }
+    root.addEventListener("click", function () { setSelectedNode(id); });
+    root.addEventListener("focusin", function () { setSelectedNode(id); });
+  }
+
   function registerGraphNode(graph, root, node) {
     if (!node || typeof node.id !== "string" || graph.nodesById.has(node.id)) return false;
     graph.nodesById.set(node.id, root);
     root.classList.add("ark-harness-graph-node");
+    attachNodeSelection(root, node.id);
     attachKindPicker(graph, root);
     attachGraphHandle(graph, root, node);
     attachNodeRail(graph, root);
@@ -1805,7 +1634,7 @@ const HARNESS_JS = `(function () {
       (edgeDrag.mode === "create" && edgeDrag.sourceId === id) ||
       (edgeDrag.mode === "rewire" && incidentIds.has(edgeDrag.edgeId))
     )) finishEdgeDrag(null, false);
-    if (selectedEdgeId && incidentIds.has(selectedEdgeId)) selectedEdgeId = null;
+    if (selectedNodeId === id) selectedNodeId = null;
 
     state.model.nodes = state.model.nodes.filter(function (entry) {
       return entry.id !== id;
@@ -1820,6 +1649,15 @@ const HARNESS_JS = `(function () {
     graphs.forEach(function (graph) { unregisterGraphNode(graph, id); });
     projections.forEach(function (element) { element.remove(); });
     graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+  }
+
+  function handleNodeDeleteKey(event) {
+    if ((event.key !== "Delete" && event.key !== "Backspace") ||
+        !selectedNodeId || graphDrag || edgeDrag ||
+        isEditableControlTarget(event.target)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    removeNode(selectedNodeId);
   }
 
   function authoredClassName(root) {
@@ -1876,7 +1714,6 @@ const HARNESS_JS = `(function () {
     graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(add);
     graph.edgeHandlesByKey.forEach(add);
     graph.nodeRailsById.forEach(add);
-    graph.edgeDeleteControlsById.forEach(function (control) { add(control.wrapper); });
     graph.nodesById.forEach(function (nodeRoot) {
       nodeRoot.querySelectorAll(
         ".ark-harness-kind-picker, .ark-harness-graph-handle"
@@ -2007,7 +1844,6 @@ const HARNESS_JS = `(function () {
       handleLayer: handleLayer,
       previewLayer: previewLayer,
       edgeHandlesByKey: new Map(),
-      edgeDeleteControlsById: new Map(),
       nodeRailsById: new Map(),
       nodeAffordancesById: new Map(),
       positionsById: new Map(),
@@ -2042,7 +1878,12 @@ const HARNESS_JS = `(function () {
       finishEdgeDrag(event, false);
     });
     window.addEventListener("keydown", function (event) {
-      if (event.key === "Escape") finishEdgeDrag(null, false);
+      if (event.key === "Escape") {
+        if (edgeDrag) event.preventDefault();
+        finishEdgeDrag(null, false);
+        return;
+      }
+      handleNodeDeleteKey(event);
     });
   }
 
@@ -2389,6 +2230,9 @@ const HARNESS_JS = `(function () {
     editableEls.forEach(function (el) {
       if (isInsideHarnessUi(el)) return;
       if (el.hasAttribute("data-ark-group")) return;
+      if (getNode(model, el.getAttribute("data-model-id")) &&
+          el.closest('[data-ark-container="graph"]') &&
+          el.querySelector("[data-model-id]")) return;
       if (!isLeaf(el)) return;
       var rowInfo = null;
       if (el.tagName === "LI" && el.parentElement) {
@@ -2436,6 +2280,9 @@ const HARNESS_JS = `(function () {
     });
     clone.querySelectorAll("[contenteditable]").forEach(function (el) {
       el.removeAttribute("contenteditable");
+    });
+    clone.querySelectorAll(".ark-harness-node-tabindex-added").forEach(function (el) {
+      el.removeAttribute("tabindex");
     });
     clone.querySelectorAll('meta[http-equiv="Content-Security-Policy" i]').forEach(function (el) {
       if (el.parentNode) el.parentNode.removeChild(el);

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -222,6 +222,7 @@ const HARNESS_JS = `(function () {
     "--ark-harness-graph-min-height"
   ];
   var AFFORDANCE_CLOSE_DELAY = 120;
+  var EDGE_DRAG_MIN_DISTANCE = 8;
 
   var BLOCK_TAGS = {
     DIV: 1, UL: 1, OL: 1, LI: 1, TABLE: 1, THEAD: 1, TBODY: 1, TR: 1, TD: 1, TH: 1,
@@ -1158,6 +1159,15 @@ const HARNESS_JS = `(function () {
     var drag = edgeDrag;
     var containerRect = drag.graph.container.getBoundingClientRect();
     var candidate = findEdgeDropCandidate(drag.graph, event.clientX, event.clientY);
+    var dx = event.clientX - drag.startClientX;
+    var dy = event.clientY - drag.startClientY;
+    if (dx * dx + dy * dy >= EDGE_DRAG_MIN_DISTANCE * EDGE_DRAG_MIN_DISTANCE) {
+      drag.didDrag = true;
+    }
+    if (drag.didDrag && drag.mode === "create" &&
+        (!candidate || candidate.id !== drag.sourceId)) {
+      drag.leftSource = true;
+    }
     var end = candidate
       ? nodeBoundaryPoint(
           drag.graph,
@@ -1182,7 +1192,10 @@ const HARNESS_JS = `(function () {
       ? findEdgeDropCandidate(drag.graph, event.clientX, event.clientY)
       : null;
     edgeDrag = null;
-    if (commit && candidate) {
+    var explicitSelfDrop = drag.mode !== "create" ||
+      candidate && candidate.id !== drag.sourceId ||
+      drag.leftSource;
+    if (commit && drag.didDrag && candidate && explicitSelfDrop) {
       if (drag.mode === "rewire") {
         var currentEdge = getEdge(state.model, drag.edgeId);
         if (currentEdge && getNode(state.model, candidate.id) &&
@@ -1247,6 +1260,10 @@ const HARNESS_JS = `(function () {
         graph: graph,
         edgeId: currentEdge.id,
         end: end,
+        startClientX: event.clientX,
+        startClientY: event.clientY,
+        didDrag: false,
+        leftSource: false,
         preview: previewUi.preview,
         previewLine: previewUi.line,
         indicator: null,
@@ -1622,6 +1639,10 @@ const HARNESS_JS = `(function () {
       handle: handle,
       graph: graph,
       sourceId: sourceId,
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      didDrag: false,
+      leftSource: false,
       preview: previewUi.preview,
       previewLine: previewUi.line,
       indicator: null,
@@ -1752,6 +1773,30 @@ const HARNESS_JS = `(function () {
   function removeNode(id) {
     var node = getNode(state.model, id);
     if (!node) return;
+    var projections = [];
+    graphs.forEach(function (graph) {
+      var root = graph.nodesById.get(id);
+      if (root && root !== graph.container &&
+          root.closest('[data-ark-container="graph"]') === graph.container) {
+        projections.push(root);
+      }
+    });
+    document.querySelectorAll("[data-model-id]").forEach(function (element) {
+      if (element.getAttribute("data-model-id") !== id ||
+          isInsideHarnessUi(element) ||
+          element.closest('[data-ark-container="graph"]') ||
+          element.hasAttribute("data-ark-container") ||
+          element.hasAttribute("data-ark-group")) return;
+      var ancestor = element.parentElement;
+      while (ancestor && ancestor !== document.body) {
+        if (ancestor.getAttribute &&
+            ancestor.getAttribute("data-model-id") === id &&
+            !ancestor.hasAttribute("data-ark-container") &&
+            !ancestor.hasAttribute("data-ark-group")) return;
+        ancestor = ancestor.parentElement;
+      }
+      projections.push(element);
+    });
     var incidentIds = new Set();
     state.model.edges.forEach(function (edge) {
       if (edge.from === id || edge.to === id) incidentIds.add(edge.id);
@@ -1773,18 +1818,6 @@ const HARNESS_JS = `(function () {
       group.nodes = group.nodes.filter(function (nodeId) { return nodeId !== id; });
     });
     graphs.forEach(function (graph) { unregisterGraphNode(graph, id); });
-
-    var projections = [];
-    document.querySelectorAll("[data-model-id]").forEach(function (element) {
-      if (element.getAttribute("data-model-id") !== id || isInsideHarnessUi(element)) return;
-      var ancestor = element.parentElement;
-      while (ancestor && ancestor !== document.body) {
-        if (ancestor.getAttribute &&
-            ancestor.getAttribute("data-model-id") === id) return;
-        ancestor = ancestor.parentElement;
-      }
-      projections.push(element);
-    });
     projections.forEach(function (element) { element.remove(); });
     graphs.forEach(function (graph) { scheduleGraphRender(graph); });
   }

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -148,7 +148,7 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   overflow: visible; pointer-events: none;
 }
 .ark-harness-edge-handle {
-  position: absolute; transform: translate(-50%, -50%); z-index: 3;
+  position: absolute; transform: translate(-50%, -50%); z-index: 5;
   width: 18px; height: 18px; padding: 0; border: 2px solid #0ea5b7; border-radius: 999px;
   background: #fff; color: #0e7490; cursor: crosshair; line-height: 14px; font-size: 9px;
   pointer-events: auto; touch-action: none;
@@ -1534,6 +1534,19 @@ const HARNESS_JS = `(function () {
       root.setAttribute("tabindex", "0");
       root.classList.add("ark-harness-node-tabindex-added");
     }
+    root.addEventListener("pointerdown", function (event) {
+      if (event.button !== 0 || isInsideHarnessUi(event.target)) return;
+      var editableControl = event.target && event.target.closest &&
+        event.target.closest('[contenteditable="true"], input, textarea, select, button');
+      if (editableControl) {
+        var editableRect = editableControl.getBoundingClientRect();
+        if (event.clientX >= editableRect.left && event.clientX <= editableRect.right &&
+            event.clientY >= editableRect.top && event.clientY <= editableRect.bottom) return;
+      }
+      event.preventDefault();
+      setSelectedNode(id);
+      root.focus({ preventScroll: true });
+    });
     root.addEventListener("click", function () { setSelectedNode(id); });
     root.addEventListener("focusin", function () { setSelectedNode(id); });
   }

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -52,6 +52,15 @@ const HARNESS_STYLE = `<style data-ark-harness-ui="1">
 .ark-harness-btn:hover { background: #232732; }
 .ark-harness-btn:disabled { opacity: .45; cursor: not-allowed; }
 .ark-harness-layout-direction { min-width: 5.5rem; }
+.ark-harness-node-palette {
+  display: flex; align-items: center; flex-wrap: wrap; gap: .35rem;
+  padding: .2rem .35rem; border: 1px solid #2a2f3a; border-radius: 6px;
+}
+.ark-harness-palette-label { display: flex; align-items: center; gap: .25rem; color: #aab1c1; }
+.ark-harness-palette-select {
+  appearance: auto; max-width: 9rem; padding: .2rem .3rem;
+  border: 1px solid #333947; border-radius: 4px; background: #1b1e27; color: #e6e8ee;
+}
 .ark-harness-btn-primary { background: #0ea5b7; border-color: #0ea5b7; color: #05201f; font-weight: 600; }
 .ark-harness-btn-primary:hover { background: #14b8c9; }
 .ark-harness-btn-primary:disabled { background: #1b1e27; border-color: #333947; color: #8b93a7; }
@@ -130,8 +139,17 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   fill: #475569; font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Noto Sans JP", sans-serif;
   font-size: 12px; text-anchor: middle; dominant-baseline: central;
 }
+.ark-harness-edge-hit {
+  fill: none; stroke: transparent !important; stroke-width: 18 !important;
+  pointer-events: stroke; cursor: pointer;
+}
+.ark-harness-edge-main.ark-harness-edge-selected { stroke: #0ea5b7; stroke-width: 2.5; }
 .ark-harness-edge-handle-layer {
   position: absolute; inset: 0; z-index: 3; pointer-events: none;
+}
+.ark-harness-edge-preview-layer {
+  position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%;
+  overflow: visible; pointer-events: none;
 }
 .ark-harness-edge-handle {
   position: absolute; transform: translate(-50%, -50%); z-index: 3;
@@ -139,6 +157,30 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   background: #fff; color: #0e7490; cursor: crosshair; line-height: 14px; font-size: 9px;
   pointer-events: auto; touch-action: none;
 }
+.ark-harness-edge-delete {
+  position: absolute; transform: translate(-50%, -50%); z-index: 5;
+  width: 24px; height: 24px; padding: 0; border: 1px solid #ef4444;
+  border-radius: 999px; background: #fff; color: #b91c1c; cursor: pointer;
+  pointer-events: auto; opacity: 0;
+}
+.ark-harness-edge-delete.ark-harness-edge-delete-visible,
+.ark-harness-edge-delete:focus { opacity: 1; }
+.ark-harness-node-rail {
+  position: absolute; z-index: 5; display: flex; gap: 4px; padding: 2px;
+  border: 1px solid rgba(100,116,139,.55); border-radius: 999px;
+  background: rgba(255,255,255,.96); opacity: 0; pointer-events: none;
+}
+.ark-harness-graph-node:hover > .ark-harness-node-rail,
+.ark-harness-graph-node:focus-within > .ark-harness-node-rail {
+  opacity: 1; pointer-events: auto;
+}
+.ark-harness-node-create, .ark-harness-node-delete {
+  width: 24px; height: 24px; padding: 0; border-radius: 999px;
+  border: 1px solid #94a3b8; background: #fff; color: #0e7490;
+  cursor: crosshair; touch-action: none;
+}
+.ark-harness-node-delete { color: #b91c1c; cursor: pointer; }
+.ark-harness-edge-dragging .ark-harness-node-rail { opacity: 0; pointer-events: none; }
 .ark-harness-edge-preview {
   position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; pointer-events: none;
 }
@@ -147,7 +189,7 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 }
 .ark-harness-edge-drop-indicator {
   position: absolute; box-sizing: border-box; border: 2px solid #0ea5b7;
-  border-radius: 6px; background: rgba(14,165,183,.1); pointer-events: none;
+  border-radius: 8px; background: transparent; pointer-events: none;
 }
 .ark-harness-graph-handle {
   position: absolute; top: .25rem; right: .25rem; z-index: 3;
@@ -155,7 +197,7 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   color: #64748b; cursor: grab; line-height: 1; padding: .25rem; touch-action: none;
 }
 .ark-harness-graph-dragging { z-index: 3; }
-body { padding-bottom: 3.4rem !important; }
+body { padding-bottom: var(--ark-harness-toolbar-height, 3.4rem) !important; }
 </style>`;
 
 /**
@@ -194,6 +236,9 @@ const HARNESS_JS = `(function () {
   var graphSequence = 0;
   var kindCandidates = [];
   var kindPickers = [];
+  var reservedModelIds = new Set();
+  var generatedIdCounter = 0;
+  var selectedEdgeId = null;
   var statusEl = null;
   var sendBtn = null;
   var layoutDirectionBtn = null;
@@ -202,11 +247,59 @@ const HARNESS_JS = `(function () {
     return v !== null && typeof v === "object" && !Array.isArray(v);
   }
 
-  function cryptoRandomId() {
+  function collectModelIds(model) {
+    var ids = new Set();
+    var reserve = function (entry) {
+      if (entry && typeof entry.id === "string") ids.add(entry.id);
+    };
+    (model.nodes || []).forEach(function (node) {
+      reserve(node);
+      (node.fields || []).forEach(reserve);
+    });
+    (model.edges || []).forEach(reserve);
+    (model.groups || []).forEach(reserve);
+    return ids;
+  }
+
+  function reserveCurrentModelIds() {
+    collectModelIds(state.model || {}).forEach(function (id) {
+      reservedModelIds.add(id);
+    });
+  }
+
+  function randomOpaquePart() {
     if (window.crypto && typeof window.crypto.randomUUID === "function") {
-      return window.crypto.randomUUID();
+      try {
+        return window.crypto.randomUUID();
+      } catch (_) {
+        // getRandomValues fallback へ進む
+      }
     }
-    return Math.random().toString(36).slice(2) + Date.now().toString(36);
+    if (window.crypto && typeof window.crypto.getRandomValues === "function") {
+      try {
+        var bytes = new Uint8Array(16);
+        window.crypto.getRandomValues(bytes);
+        var encoded = "";
+        for (var i = 0; i < bytes.length; i++) {
+          encoded += bytes[i].toString(16).padStart(2, "0");
+        }
+        return encoded;
+      } catch (_) {
+        // counter fallback へ進む
+      }
+    }
+    generatedIdCounter += 1;
+    return "session-" + generatedIdCounter;
+  }
+
+  function generateUniqueModelId(prefix) {
+    for (var attempt = 0; attempt < 32; attempt++) {
+      var candidate = prefix + "-" + randomOpaquePart();
+      if (reservedModelIds.has(candidate)) continue;
+      reservedModelIds.add(candidate);
+      return candidate;
+    }
+    return null;
   }
 
   function loadModel() {
@@ -639,9 +732,10 @@ const HARNESS_JS = `(function () {
     svg.appendChild(defs);
   }
 
-  function appendGraphLabel(svg, label, x, y) {
+  function appendGraphLabel(svg, edgeId, label, x, y) {
     if (typeof label !== "string" || label.length === 0) return;
     var text = svgElement("text");
+    text.setAttribute("data-ark-edge-id", edgeId);
     text.setAttribute("x", String(x));
     text.setAttribute("y", String(y));
     text.textContent = label;
@@ -729,6 +823,61 @@ const HARNESS_JS = `(function () {
     main.setAttribute("data-ark-edge-direction", direction);
     var type = edgeType(edge);
     if (type !== null) main.setAttribute("data-ark-edge-type", type);
+  }
+
+  function setEdgeGeometryAttributes(element, geometry) {
+    if (geometry.kind === "path") {
+      element.setAttribute("d", geometry.path);
+    } else {
+      element.setAttribute("x1", String(geometry.from.x));
+      element.setAttribute("y1", String(geometry.from.y));
+      element.setAttribute("x2", String(geometry.to.x));
+      element.setAttribute("y2", String(geometry.to.y));
+    }
+  }
+
+  function setSelectedEdge(edgeId) {
+    selectedEdgeId = edgeId && getEdge(state.model, edgeId) ? edgeId : null;
+    graphs.forEach(function (graph) {
+      graph.svg.querySelectorAll(".ark-harness-edge-main").forEach(function (main) {
+        main.classList.toggle(
+          "ark-harness-edge-selected",
+          main.getAttribute("data-ark-edge-id") === selectedEdgeId
+        );
+      });
+      graph.edgeDeleteControlsById.forEach(function (control, id) {
+        control.wrapper.classList.toggle(
+          "ark-harness-edge-delete-visible",
+          id === selectedEdgeId
+        );
+      });
+    });
+  }
+
+  function removeEdge(edgeId) {
+    var edge = getEdge(state.model, edgeId);
+    if (!edge) return;
+    if (edgeDrag && edgeDrag.mode === "rewire" && edgeDrag.edgeId === edgeId) {
+      finishEdgeDrag(null, false);
+    }
+    state.model.edges = state.model.edges.filter(function (entry) {
+      return entry.id !== edgeId;
+    });
+    if (selectedEdgeId === edgeId) selectedEdgeId = null;
+    graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+  }
+
+  function isEditableControlTarget(target) {
+    if (!target || !target.closest) return false;
+    return !!target.closest('[contenteditable="true"], input, textarea, select');
+  }
+
+  function handleEdgeDeleteKey(event, edgeId) {
+    if ((event.key !== "Delete" && event.key !== "Backspace") ||
+        isEditableControlTarget(event.target)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    removeEdge(edgeId);
   }
 
   function applyEdgeMarkers(main, markerId, direction) {
@@ -870,16 +1019,27 @@ const HARNESS_JS = `(function () {
       var direction = edgeDirection(edge);
       var main = svgElement(geometry.kind);
       setEdgeProjectionAttributes(main, edge, direction);
-      if (geometry.kind === "path") {
-        main.setAttribute("d", geometry.path);
-      } else {
-        main.setAttribute("x1", String(geometry.from.x));
-        main.setAttribute("y1", String(geometry.from.y));
-        main.setAttribute("x2", String(geometry.to.x));
-        main.setAttribute("y2", String(geometry.to.y));
-      }
+      setEdgeGeometryAttributes(main, geometry);
       applyEdgeMarkers(main, graph.markerId, direction);
       graph.svg.appendChild(main);
+      var hit = svgElement(geometry.kind);
+      hit.classList.add("ark-harness-edge-hit");
+      hit.setAttribute("data-ark-edge-id", edge.id);
+      hit.setAttribute("tabindex", "0");
+      hit.setAttribute("role", "button");
+      var edgeName = (typeof edge.label === "string" && edge.label) || edge.id;
+      hit.setAttribute("aria-label", edgeName + " を選択");
+      setEdgeGeometryAttributes(hit, geometry);
+      markUi(hit);
+      ["pointerenter", "focus", "click"].forEach(function (type) {
+        hit.addEventListener(type, function (event) {
+          event.stopPropagation();
+          setSelectedEdge(edge.id);
+        });
+      });
+      hit.addEventListener("keydown", function (event) {
+        handleEdgeDeleteKey(event, edge.id);
+      });
       appendEdgeCardinality(
         graph.svg,
         edge,
@@ -894,9 +1054,13 @@ const HARNESS_JS = `(function () {
         geometry.to,
         edgeCardinality(edge, "to")
       );
-      appendGraphLabel(graph.svg, edge.label, geometry.label.x, geometry.label.y);
+      appendGraphLabel(graph.svg, edge.id, edge.label, geometry.label.x, geometry.label.y);
+      graph.svg.appendChild(hit);
     });
     syncEdgeHandles(graph, edges);
+    syncNodeRails(graph);
+    syncEdgeDeleteControls(graph, edges);
+    setSelectedEdge(selectedEdgeId);
   }
 
   function scheduleGraphRender(graph) {
@@ -936,6 +1100,7 @@ const HARNESS_JS = `(function () {
     drag.previewLine = null;
     drag.indicator = null;
     drag.candidateId = null;
+    drag.graph.container.classList.remove("ark-harness-edge-dragging");
   }
 
   function updateEdgeDropIndicator(drag, candidate) {
@@ -955,23 +1120,50 @@ const HARNESS_JS = `(function () {
     }
     var containerRect = drag.graph.container.getBoundingClientRect();
     var nodeRect = candidate.el.getBoundingClientRect();
-    drag.indicator.style.left = nodeRect.left - containerRect.left + "px";
-    drag.indicator.style.top = nodeRect.top - containerRect.top + "px";
-    drag.indicator.style.width = nodeRect.width + "px";
-    drag.indicator.style.height = nodeRect.height + "px";
+    drag.indicator.style.left = nodeRect.left - containerRect.left - 4 + "px";
+    drag.indicator.style.top = nodeRect.top - containerRect.top - 4 + "px";
+    drag.indicator.style.width = nodeRect.width + 8 + "px";
+    drag.indicator.style.height = nodeRect.height + 8 + "px";
     drag.candidateId = candidate.id;
+  }
+
+  function nodeBoundaryPoint(graph, nodeEl, towardX, towardY) {
+    var containerRect = graph.container.getBoundingClientRect();
+    var rect = nodeEl.getBoundingClientRect();
+    var cx = rect.left + rect.width / 2 - containerRect.left;
+    var cy = rect.top + rect.height / 2 - containerRect.top;
+    var dx = towardX - cx;
+    var dy = towardY - cy;
+    var length = Math.sqrt(dx * dx + dy * dy) || 1;
+    var ux = dx / length;
+    var uy = dy / length;
+    var radius = Math.min(
+      Math.abs(ux) > 0 ? rect.width / 2 / Math.abs(ux) : Infinity,
+      Math.abs(uy) > 0 ? rect.height / 2 / Math.abs(uy) : Infinity
+    );
+    if (!finiteNumber(radius)) radius = 0;
+    return { x: cx + ux * radius, y: cy + uy * radius };
   }
 
   function updateEdgeDrag(event) {
     if (!edgeDrag || event.pointerId !== edgeDrag.pointerId) return;
     var drag = edgeDrag;
     var containerRect = drag.graph.container.getBoundingClientRect();
-    drag.previewLine.setAttribute("x2", String(event.clientX - containerRect.left));
-    drag.previewLine.setAttribute("y2", String(event.clientY - containerRect.top));
-    updateEdgeDropIndicator(
-      drag,
-      findEdgeDropCandidate(drag.graph, event.clientX, event.clientY)
-    );
+    var candidate = findEdgeDropCandidate(drag.graph, event.clientX, event.clientY);
+    var end = candidate
+      ? nodeBoundaryPoint(
+          drag.graph,
+          candidate.el,
+          Number(drag.previewLine.getAttribute("x1")),
+          Number(drag.previewLine.getAttribute("y1"))
+        )
+      : {
+          x: event.clientX - containerRect.left,
+          y: event.clientY - containerRect.top
+        };
+    drag.previewLine.setAttribute("x2", String(end.x));
+    drag.previewLine.setAttribute("y2", String(end.y));
+    updateEdgeDropIndicator(drag, candidate);
   }
 
   function finishEdgeDrag(event, commit) {
@@ -983,16 +1175,46 @@ const HARNESS_JS = `(function () {
       : null;
     edgeDrag = null;
     if (commit && candidate) {
-      var currentEdge = getEdge(state.model, drag.edgeId);
-      if (currentEdge && drag.graph.positionsById.has(candidate.id)) {
-        currentEdge[drag.end] = candidate.id;
+      if (drag.mode === "rewire") {
+        var currentEdge = getEdge(state.model, drag.edgeId);
+        if (currentEdge && getNode(state.model, candidate.id) &&
+            drag.graph.nodesById.has(candidate.id)) {
+          currentEdge[drag.end] = candidate.id;
+        }
+      } else {
+        var source = getNode(state.model, drag.sourceId);
+        var target = getNode(state.model, candidate.id);
+        if (source && target && drag.graph.nodesById.has(source.id) &&
+            drag.graph.nodesById.has(target.id)) {
+          var edgeId = generateUniqueModelId("edge");
+          if (edgeId) {
+            state.model.edges.push({ id: edgeId, from: source.id, to: target.id });
+          } else {
+            updateStatus(!!submitPort, "一意な ID を生成できませんでした");
+          }
+        }
       }
     }
     removeEdgeDragUi(drag);
     if (drag.handle.hasPointerCapture(drag.pointerId)) {
       drag.handle.releasePointerCapture(drag.pointerId);
     }
-    scheduleGraphRender(drag.graph);
+    graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+  }
+
+  function createEdgePreview(graph, start) {
+    var preview = svgElement("svg");
+    preview.classList.add("ark-harness-edge-preview");
+    markUi(preview);
+    var line = svgElement("line");
+    line.setAttribute("x1", String(start.x));
+    line.setAttribute("y1", String(start.y));
+    line.setAttribute("x2", String(start.x));
+    line.setAttribute("y2", String(start.y));
+    preview.appendChild(line);
+    graph.previewLayer.appendChild(preview);
+    graph.container.classList.add("ark-harness-edge-dragging");
+    return { preview: preview, line: line };
   }
 
   function createEdgeHandle(graph, edge, end) {
@@ -1009,24 +1231,16 @@ const HARNESS_JS = `(function () {
       event.stopPropagation();
       handle.setPointerCapture(event.pointerId);
 
-      var preview = svgElement("svg");
-      preview.classList.add("ark-harness-edge-preview");
-      markUi(preview);
-      var line = svgElement("line");
-      line.setAttribute("x1", String(endpoint.x));
-      line.setAttribute("y1", String(endpoint.y));
-      line.setAttribute("x2", String(endpoint.x));
-      line.setAttribute("y2", String(endpoint.y));
-      preview.appendChild(line);
-      graph.handleLayer.insertBefore(preview, graph.handleLayer.firstChild);
+      var previewUi = createEdgePreview(graph, endpoint);
       edgeDrag = {
+        mode: "rewire",
         pointerId: event.pointerId,
         handle: handle,
         graph: graph,
         edgeId: currentEdge.id,
         end: end,
-        preview: preview,
-        previewLine: line,
+        preview: previewUi.preview,
+        previewLine: previewUi.line,
         indicator: null,
         candidateId: null
       };
@@ -1034,6 +1248,9 @@ const HARNESS_JS = `(function () {
     handle.addEventListener("pointermove", updateEdgeDrag);
     handle.addEventListener("pointerup", function (event) { finishEdgeDrag(event, true); });
     handle.addEventListener("pointercancel", function (event) { finishEdgeDrag(event, false); });
+    handle.addEventListener("keydown", function (event) {
+      handleEdgeDeleteKey(event, handle.getAttribute("data-ark-edge-id"));
+    });
     graph.handleLayer.appendChild(handle);
     return handle;
   }
@@ -1065,6 +1282,125 @@ const HARNESS_JS = `(function () {
       if (activeKeys.has(key)) return;
       if (handle.parentNode) handle.parentNode.removeChild(handle);
       graph.edgeHandlesByKey.delete(key);
+    });
+  }
+
+  function graphLocalRect(graph, element) {
+    var rect = element.getBoundingClientRect();
+    var containerRect = graph.container.getBoundingClientRect();
+    if (!finiteNumber(rect.width) || !finiteNumber(rect.height)) return null;
+    return {
+      x: rect.left - containerRect.left,
+      y: rect.top - containerRect.top,
+      width: rect.width,
+      height: rect.height
+    };
+  }
+
+  function edgeDeleteBlockers(graph, ownWrapper) {
+    var blockers = [];
+    var add = function (element) {
+      if (element === ownWrapper || !element.isConnected) return;
+      var rect = graphLocalRect(graph, element);
+      if (rect && rect.width >= 0 && rect.height >= 0) blockers.push(rect);
+    };
+    graph.nodesById.forEach(add);
+    graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(add);
+    graph.edgeHandlesByKey.forEach(add);
+    graph.nodeRailsById.forEach(function (rail) { add(rail); });
+    graph.edgeDeleteControlsById.forEach(function (control) { add(control.wrapper); });
+    return blockers;
+  }
+
+  function positionEdgeDeleteControl(graph, control, geometry) {
+    var width = control.wrapper.offsetWidth || 24;
+    var height = control.wrapper.offsetHeight || 24;
+    var nx = -geometry.from.ty;
+    var ny = geometry.from.tx;
+    var candidates = [];
+    var fractions = [0.35, 0.65, 0.2, 0.8];
+    fractions.forEach(function (fraction) {
+      var base = geometry.kind === "line"
+        ? {
+            x: geometry.from.x + (geometry.to.x - geometry.from.x) * fraction,
+            y: geometry.from.y + (geometry.to.y - geometry.from.y) * fraction
+          }
+        : geometry.label;
+      [34, -34, 50, -50].forEach(function (offset) {
+        candidates.push({
+          x: base.x + nx * offset - width / 2,
+          y: base.y + ny * offset - height / 2
+        });
+      });
+    });
+    var blockers = edgeDeleteBlockers(graph, control.wrapper);
+    var chosen = null;
+    for (var i = 0; i < candidates.length; i++) {
+      var rectangle = {
+        x: candidates[i].x,
+        y: candidates[i].y,
+        width: width,
+        height: height
+      };
+      if (rectangle.x < 0 || rectangle.y < 0) continue;
+      var collision = blockers.some(function (blocker) {
+        return rectanglesCollide(rectangle, blocker, 6);
+      });
+      if (!collision) {
+        chosen = candidates[i];
+        break;
+      }
+    }
+    if (!chosen) {
+      var right = readLayoutConfig(state.model).padding;
+      blockers.forEach(function (blocker) {
+        right = Math.max(right, blocker.x + blocker.width + 12);
+      });
+      chosen = { x: right, y: readLayoutConfig(state.model).padding };
+    }
+    control.wrapper.style.left = chosen.x + width / 2 + "px";
+    control.wrapper.style.top = chosen.y + height / 2 + "px";
+  }
+
+  function createEdgeDeleteControl(graph, edge) {
+    var name = (typeof edge.label === "string" && edge.label) || edge.id;
+    var button = createButton(
+      "\\u2212",
+      "ark-harness-edge-delete",
+      name + " を削除"
+    );
+    button.setAttribute("data-ark-edge-id", edge.id);
+    ["pointerdown", "click", "keydown"].forEach(function (type) {
+      button.addEventListener(type, function (event) { event.stopPropagation(); });
+    });
+    button.addEventListener("click", function () {
+      removeEdge(button.getAttribute("data-ark-edge-id"));
+    });
+    graph.handleLayer.appendChild(button);
+    return { wrapper: button, button: button };
+  }
+
+  function syncEdgeDeleteControls(graph, edges) {
+    var activeIds = new Set();
+    edges.forEach(function (edge) {
+      var geometry = graph.edgeGeometryById.get(edge.id);
+      if (!geometry) return;
+      activeIds.add(edge.id);
+      var control = graph.edgeDeleteControlsById.get(edge.id);
+      if (!control) {
+        control = createEdgeDeleteControl(graph, edge);
+        graph.edgeDeleteControlsById.set(edge.id, control);
+      }
+      control.button.setAttribute("data-ark-edge-id", edge.id);
+      var name = (typeof edge.label === "string" && edge.label) || edge.id;
+      control.button.setAttribute("aria-label", name + " を削除");
+      control.button.title = name + " を削除";
+      positionEdgeDeleteControl(graph, control, geometry);
+    });
+    graph.edgeDeleteControlsById.forEach(function (control, id) {
+      if (activeIds.has(id)) return;
+      control.wrapper.remove();
+      graph.edgeDeleteControlsById.delete(id);
     });
   }
 
@@ -1127,9 +1463,376 @@ const HARNESS_JS = `(function () {
     el.appendChild(handle);
   }
 
+  function positionNodeRail(graph, id) {
+    var nodeEl = graph.nodesById.get(id);
+    var rail = graph.nodeRailsById.get(id);
+    if (!nodeEl || !rail) return;
+    var nodeRect = nodeEl.getBoundingClientRect();
+    var railWidth = rail.offsetWidth || 56;
+    var railHeight = rail.offsetHeight || 28;
+    var candidates = [
+      { x: (nodeRect.width - railWidth) / 2, y: nodeRect.height + 8 },
+      { x: -railWidth - 8, y: (nodeRect.height - railHeight) / 2 },
+      { x: nodeRect.width + 8, y: (nodeRect.height - railHeight) / 2 },
+      { x: (nodeRect.width - railWidth) / 2, y: -railHeight - 8 }
+    ];
+    var containerRect = graph.container.getBoundingClientRect();
+    var nodeX = nodeRect.left - containerRect.left;
+    var nodeY = nodeRect.top - containerRect.top;
+    var blockers = [];
+    graph.nodesById.forEach(function (other, otherId) {
+      if (otherId === id) return;
+      var rect = graphLocalRect(graph, other);
+      if (rect) blockers.push(rect);
+    });
+    graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(function (label) {
+      var rect = graphLocalRect(graph, label);
+      if (rect) blockers.push(rect);
+    });
+    graph.edgeHandlesByKey.forEach(function (handle) {
+      var rect = graphLocalRect(graph, handle);
+      if (rect) blockers.push(rect);
+    });
+    graph.nodeRailsById.forEach(function (other, otherId) {
+      if (otherId === id) return;
+      var rect = graphLocalRect(graph, other);
+      if (rect) blockers.push(rect);
+    });
+    [".ark-harness-kind-picker", ".ark-harness-graph-handle"].forEach(function (selector) {
+      var control = nodeEl.querySelector(selector);
+      var rect = control && graphLocalRect(graph, control);
+      if (rect) blockers.push(rect);
+    });
+    var chosen = null;
+    for (var i = 0; i < candidates.length; i++) {
+      var candidateRect = {
+        x: nodeX + candidates[i].x,
+        y: nodeY + candidates[i].y,
+        width: railWidth,
+        height: railHeight
+      };
+      if (candidateRect.x < 0 || candidateRect.y < 0) continue;
+      if (!blockers.some(function (blocker) {
+        return rectanglesCollide(candidateRect, blocker, 6);
+      })) {
+        chosen = candidates[i];
+        break;
+      }
+    }
+    if (!chosen) {
+      var right = nodeRect.width + 12;
+      blockers.forEach(function (blocker) {
+        right = Math.max(right, blocker.x + blocker.width - nodeX + 12);
+      });
+      chosen = { x: right, y: 0 };
+    }
+    rail.style.left = Math.round(chosen.x) + "px";
+    rail.style.top = Math.round(chosen.y) + "px";
+  }
+
+  function syncNodeRails(graph) {
+    graph.nodeRailsById.forEach(function (rail, id) {
+      var node = getNode(state.model, id);
+      if (node) {
+        var name = (typeof node.label === "string" && node.label) || node.id;
+        var create = rail.querySelector(".ark-harness-node-create");
+        var remove = rail.querySelector(".ark-harness-node-delete");
+        if (create) {
+          create.setAttribute("aria-label", name + " から edge を作成");
+          create.title = name + " から edge を作成";
+        }
+        if (remove) {
+          remove.setAttribute("aria-label", name + " を削除");
+          remove.title = name + " を削除";
+        }
+      }
+      positionNodeRail(graph, id);
+    });
+  }
+
+  function startCreateEdgeDrag(graph, nodeEl, handle, event) {
+    if (graphDrag || edgeDrag) return;
+    var sourceId = nodeEl.getAttribute("data-model-id");
+    if (!sourceId || !getNode(state.model, sourceId) ||
+        graph.nodesById.get(sourceId) !== nodeEl) return;
+    event.preventDefault();
+    event.stopPropagation();
+    handle.setPointerCapture(event.pointerId);
+    var containerRect = graph.container.getBoundingClientRect();
+    var start = nodeBoundaryPoint(
+      graph,
+      nodeEl,
+      event.clientX - containerRect.left + 1,
+      event.clientY - containerRect.top
+    );
+    var previewUi = createEdgePreview(graph, start);
+    edgeDrag = {
+      mode: "create",
+      pointerId: event.pointerId,
+      handle: handle,
+      graph: graph,
+      sourceId: sourceId,
+      preview: previewUi.preview,
+      previewLine: previewUi.line,
+      indicator: null,
+      candidateId: null
+    };
+  }
+
+  function attachNodeRail(graph, root) {
+    var id = root.getAttribute("data-model-id");
+    if (!id || graph.nodeRailsById.has(id)) return;
+    var node = getNode(state.model, id);
+    if (!node) return;
+    var rail = document.createElement("span");
+    rail.className = "ark-harness-node-rail";
+    rail.setAttribute("data-ark-node-id", id);
+    markUi(rail);
+    var name = (typeof node.label === "string" && node.label) || node.id;
+    var create = createButton(
+      "+",
+      "ark-harness-node-create",
+      name + " から edge を作成"
+    );
+    var remove = createButton(
+      "\\u2212",
+      "ark-harness-node-delete",
+      name + " を削除"
+    );
+    create.setAttribute("data-ark-node-id", id);
+    remove.setAttribute("data-ark-node-id", id);
+    ["pointerdown", "click", "keydown"].forEach(function (type) {
+      rail.addEventListener(type, function (event) { event.stopPropagation(); });
+    });
+    create.addEventListener("pointerdown", function (event) {
+      startCreateEdgeDrag(graph, root, create, event);
+    });
+    create.addEventListener("pointermove", updateEdgeDrag);
+    create.addEventListener("pointerup", function (event) { finishEdgeDrag(event, true); });
+    create.addEventListener("pointercancel", function (event) { finishEdgeDrag(event, false); });
+    remove.addEventListener("click", function () {
+      removeNode(remove.getAttribute("data-ark-node-id"));
+    });
+    rail.appendChild(create);
+    rail.appendChild(remove);
+    root.appendChild(rail);
+    graph.nodeRailsById.set(id, rail);
+  }
+
+  function registerGraphNode(graph, root, node) {
+    if (!node || typeof node.id !== "string" || graph.nodesById.has(node.id)) return false;
+    graph.nodesById.set(node.id, root);
+    root.classList.add("ark-harness-graph-node");
+    attachKindPicker(graph, root);
+    attachGraphHandle(graph, root, node);
+    attachNodeRail(graph, root);
+    if (graph.resizeObserver) graph.resizeObserver.observe(root);
+    return true;
+  }
+
+  function unregisterGraphNode(graph, id) {
+    var root = graph.nodesById.get(id);
+    if (root && graph.resizeObserver) graph.resizeObserver.unobserve(root);
+    graph.nodesById.delete(id);
+    graph.positionsById.delete(id);
+    var rail = graph.nodeRailsById.get(id);
+    if (rail) rail.remove();
+    graph.nodeRailsById.delete(id);
+    kindPickers = kindPickers.filter(function (picker) {
+      if (picker.root !== root) return true;
+      if (picker.select.parentNode) picker.select.parentNode.remove();
+      return false;
+    });
+    if (graphDrag && graphDrag.graph === graph &&
+        graphDrag.el.getAttribute("data-model-id") === id) {
+      finishGraphDrag(null);
+    }
+  }
+
+  function removeNode(id) {
+    var node = getNode(state.model, id);
+    if (!node) return;
+    var incidentIds = new Set();
+    state.model.edges.forEach(function (edge) {
+      if (edge.from === id || edge.to === id) incidentIds.add(edge.id);
+    });
+    if (edgeDrag && (
+      (edgeDrag.mode === "create" && edgeDrag.sourceId === id) ||
+      (edgeDrag.mode === "rewire" && incidentIds.has(edgeDrag.edgeId))
+    )) finishEdgeDrag(null, false);
+    if (selectedEdgeId && incidentIds.has(selectedEdgeId)) selectedEdgeId = null;
+
+    state.model.nodes = state.model.nodes.filter(function (entry) {
+      return entry.id !== id;
+    });
+    state.model.edges = state.model.edges.filter(function (edge) {
+      return edge.from !== id && edge.to !== id;
+    });
+    state.model.groups.forEach(function (group) {
+      if (!Array.isArray(group.nodes)) return;
+      group.nodes = group.nodes.filter(function (nodeId) { return nodeId !== id; });
+    });
+    graphs.forEach(function (graph) { unregisterGraphNode(graph, id); });
+
+    var projections = [];
+    document.querySelectorAll("[data-model-id]").forEach(function (element) {
+      if (element.getAttribute("data-model-id") !== id || isInsideHarnessUi(element)) return;
+      var ancestor = element.parentElement;
+      while (ancestor && ancestor !== document.body) {
+        if (ancestor.getAttribute &&
+            ancestor.getAttribute("data-model-id") === id) return;
+        ancestor = ancestor.parentElement;
+      }
+      projections.push(element);
+    });
+    projections.forEach(function (element) { element.remove(); });
+    graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+  }
+
+  function authoredClassName(root) {
+    var kept = [];
+    root.classList.forEach(function (token) {
+      if (token.indexOf("ark-harness-") !== 0) kept.push(token);
+    });
+    return kept.join(" ");
+  }
+
+  function projectionTemplate(graph, kind) {
+    var template = null;
+    graph.nodesById.forEach(function (root, id) {
+      if (template) return;
+      var node = getNode(state.model, id);
+      if (kind && node && node.kind === kind) template = root;
+    });
+    if (!template) {
+      graph.nodesById.forEach(function (root) {
+        if (!template) template = root;
+      });
+    }
+    var tag = template && /^(ARTICLE|SECTION|DIV)$/.test(template.tagName)
+      ? template.tagName.toLowerCase()
+      : "article";
+    return { tag: tag, className: template ? authoredClassName(template) : "" };
+  }
+
+  function createNodeProjection(graph, node) {
+    var template = projectionTemplate(graph, node.kind || "");
+    var root = template.tag === "section"
+      ? document.createElement("section")
+      : template.tag === "div"
+        ? document.createElement("div")
+        : document.createElement("article");
+    var label = document.createElement("span");
+    root.setAttribute("data-model-id", node.id);
+    label.setAttribute("data-model-id", node.id);
+    if (node.kind) root.setAttribute("data-kind", node.kind);
+    if (template.className) root.className = template.className;
+    label.textContent = node.label;
+    root.appendChild(label);
+    return { root: root, label: label };
+  }
+
+  function nodePlacementBlockers(graph, excluded) {
+    var blockers = [];
+    var add = function (element) {
+      if (element === excluded || !element.isConnected) return;
+      var rect = graphLocalRect(graph, element);
+      if (rect && rect.width > 0 && rect.height > 0) blockers.push(rect);
+    };
+    graph.nodesById.forEach(add);
+    graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(add);
+    graph.edgeHandlesByKey.forEach(add);
+    graph.nodeRailsById.forEach(add);
+    graph.edgeDeleteControlsById.forEach(function (control) { add(control.wrapper); });
+    graph.nodesById.forEach(function (nodeRoot) {
+      nodeRoot.querySelectorAll(
+        ".ark-harness-kind-picker, .ark-harness-graph-handle"
+      ).forEach(add);
+    });
+    return blockers;
+  }
+
+  function findNodePlacement(graph, root) {
+    var config = readLayoutConfig(state.model);
+    var rect = root.getBoundingClientRect();
+    var width = rect.width || 160;
+    var height = rect.height || 64;
+    var blockers = nodePlacementBlockers(graph, root);
+    var maximumRight = config.padding;
+    var maximumBottom = config.padding;
+    blockers.forEach(function (blocker) {
+      maximumRight = Math.max(maximumRight, blocker.x + blocker.width);
+      maximumBottom = Math.max(maximumBottom, blocker.y + blocker.height);
+    });
+    var candidates = [];
+    for (var i = 0; i < blockers.length + 8; i++) {
+      candidates.push(config.direction === "TB"
+        ? {
+            x: config.padding + i * (width + config.nodeSpacing),
+            y: maximumBottom + config.rankSpacing
+          }
+        : {
+            x: maximumRight + config.rankSpacing,
+            y: config.padding + i * (height + config.nodeSpacing)
+          });
+    }
+    for (var j = 0; j < candidates.length; j++) {
+      var candidate = {
+        x: Math.max(0, Math.round(candidates[j].x)),
+        y: Math.max(0, Math.round(candidates[j].y)),
+        width: width,
+        height: height
+      };
+      if (!blockers.some(function (blocker) {
+        return rectanglesCollide(candidate, blocker, config.nodeSpacing);
+      })) return { x: candidate.x, y: candidate.y };
+    }
+    return config.direction === "TB"
+      ? { x: Math.round(maximumRight + config.nodeSpacing), y: Math.round(maximumBottom + config.rankSpacing) }
+      : { x: Math.round(maximumRight + config.rankSpacing), y: Math.round(maximumBottom + config.nodeSpacing) };
+  }
+
+  function addNode(graph, kind) {
+    if (!graph || graphs.indexOf(graph) === -1) {
+      updateStatus(!!submitPort, "配置先 graph を解決できませんでした");
+      return;
+    }
+    if (kind && kindCandidates.indexOf(kind) === -1) return;
+    var id = generateUniqueModelId("node");
+    if (!id) {
+      updateStatus(!!submitPort, "一意な ID を生成できませんでした");
+      return;
+    }
+    var node = { id: id, label: "新しいノード", ext: { x: 0, y: 0 } };
+    if (kind) node.kind = kind;
+    var projection = createNodeProjection(graph, node);
+    graph.container.appendChild(projection.root);
+    projection.root.classList.add("ark-harness-graph-node");
+    projection.root.style.setProperty("--ark-harness-graph-x", "0px");
+    projection.root.style.setProperty("--ark-harness-graph-y", "0px");
+    try {
+      var position = findNodePlacement(graph, projection.root);
+      node.ext.x = position.x;
+      node.ext.y = position.y;
+      state.model.nodes.push(node);
+      if (!registerGraphNode(graph, projection.root, node)) {
+        throw new Error("node registration failed");
+      }
+      wireEditableLeaf(projection.label, null);
+      graphs.forEach(function (entry) { scheduleGraphRender(entry); });
+    } catch (error) {
+      state.model.nodes = state.model.nodes.filter(function (entry) {
+        return entry.id !== id;
+      });
+      unregisterGraphNode(graph, id);
+      projection.root.remove();
+      updateStatus(!!submitPort, "ノードを追加できませんでした");
+    }
+  }
+
   function wireGraph(container) {
     var nodesById = new Map();
-    var modelNodesById = new Map();
+    var nodeCandidates = [];
     var groupsById = new Map();
     var groupCandidates = container.querySelectorAll("[data-ark-group][data-model-id]");
     groupCandidates.forEach(function (el) {
@@ -1146,14 +1849,17 @@ const HARNESS_JS = `(function () {
       var node = getNode(state.model, id);
       if (!node) return;
       nodesById.set(id, el);
-      modelNodesById.set(id, node);
-      el.classList.add("ark-harness-graph-node");
+      nodeCandidates.push({ root: el, node: node });
     });
 
     var svg = svgElement("svg");
     svg.classList.add("ark-harness-edge-layer");
     markUi(svg);
     container.appendChild(svg);
+    var previewLayer = document.createElement("div");
+    previewLayer.classList.add("ark-harness-edge-preview-layer");
+    markUi(previewLayer);
+    container.appendChild(previewLayer);
     var handleLayer = document.createElement("div");
     handleLayer.className = "ark-harness-edge-handle-layer";
     markUi(handleLayer);
@@ -1166,21 +1872,24 @@ const HARNESS_JS = `(function () {
       svg: svg,
       edgeGeometryById: new Map(),
       handleLayer: handleLayer,
+      previewLayer: previewLayer,
       edgeHandlesByKey: new Map(),
+      edgeDeleteControlsById: new Map(),
+      nodeRailsById: new Map(),
       positionsById: new Map(),
       layoutExtent: { width: null, height: null },
       resizeObserver: null,
       scheduled: false,
       markerId: "ark-harness-arrow-" + graphSequence
     };
-    nodesById.forEach(function (el, id) {
-      attachKindPicker(graph, el);
-      attachGraphHandle(graph, el, modelNodesById.get(id));
+    nodesById.clear();
+    nodeCandidates.forEach(function (candidate) {
+      registerGraphNode(graph, candidate.root, candidate.node);
     });
     if (typeof ResizeObserver !== "undefined") {
       graph.resizeObserver = new ResizeObserver(function () { scheduleGraphRender(graph); });
       graph.resizeObserver.observe(container);
-      nodesById.forEach(function (el) { graph.resizeObserver.observe(el); });
+      graph.nodesById.forEach(function (el) { graph.resizeObserver.observe(el); });
     }
     scheduleGraphRender(graph);
     return graph;
@@ -1197,6 +1906,9 @@ const HARNESS_JS = `(function () {
     });
     window.addEventListener("pointercancel", function (event) {
       finishEdgeDrag(event, false);
+    });
+    window.addEventListener("keydown", function (event) {
+      if (event.key === "Escape") finishEdgeDrag(null, false);
     });
   }
 
@@ -1478,7 +2190,11 @@ const HARNESS_JS = `(function () {
   function addField(listEl, ownerNodeId) {
     var node = getNode(state.model, ownerNodeId);
     if (!node) return;
-    var id = cryptoRandomId();
+    var id = generateUniqueModelId("field");
+    if (!id) {
+      updateStatus(!!submitPort, "一意な ID を生成できませんでした");
+      return;
+    }
     var field = { id: id, label: "新しい項目" };
     if (!node.fields) node.fields = [];
     node.fields.push(field);
@@ -1557,6 +2273,10 @@ const HARNESS_JS = `(function () {
     clone.querySelectorAll("[data-ark-harness-ui]").forEach(function (el) {
       if (el.parentNode) el.parentNode.removeChild(el);
     });
+    if (clone.body) {
+      clone.body.style.removeProperty("--ark-harness-toolbar-height");
+      if (clone.body.style.length === 0) clone.body.removeAttribute("style");
+    }
     clone.querySelectorAll(".ark-harness-graph-node").forEach(function (el) {
       el.style.removeProperty("--ark-harness-graph-x");
       el.style.removeProperty("--ark-harness-graph-y");
@@ -1651,7 +2371,9 @@ const HARNESS_JS = `(function () {
         if (!Array.isArray(parsed.nodes)) throw new Error("nodes は配列である必要があります");
         if (!Array.isArray(parsed.edges)) parsed.edges = [];
         if (!Array.isArray(parsed.groups)) parsed.groups = [];
+        finishEdgeDrag(null, false);
         state.model = parsed;
+        reserveCurrentModelIds();
         syncNodeKinds();
         syncKindPickers();
         syncLayoutDirectionButton();
@@ -1672,6 +2394,82 @@ const HARNESS_JS = `(function () {
     return panel;
   }
 
+  function createPaletteSelect(labelText, className) {
+    var label = document.createElement("label");
+    label.className = "ark-harness-palette-label";
+    markUi(label);
+    var text = document.createElement("span");
+    text.textContent = labelText;
+    markUi(text);
+    var select = document.createElement("select");
+    select.className = "ark-harness-palette-select " + className;
+    select.setAttribute("aria-label", labelText);
+    markUi(select);
+    ["pointerdown", "click", "keydown"].forEach(function (type) {
+      select.addEventListener(type, function (event) { event.stopPropagation(); });
+    });
+    label.appendChild(text);
+    label.appendChild(select);
+    return { label: label, select: select };
+  }
+
+  function buildNodePalette() {
+    var palette = document.createElement("div");
+    palette.className = "ark-harness-node-palette";
+    markUi(palette);
+    var graphChoice = createPaletteSelect("配置先", "ark-harness-graph-select");
+    document.querySelectorAll('[data-ark-container="graph"]').forEach(function (_, index) {
+      var option = document.createElement("option");
+      option.value = String(index);
+      option.textContent = "graph " + (index + 1);
+      markUi(option);
+      graphChoice.select.appendChild(option);
+    });
+    var kindChoice = createPaletteSelect("kind", "ark-harness-palette-kind-select");
+    if (kindCandidates.length === 0) {
+      var none = document.createElement("option");
+      none.value = "";
+      none.textContent = "kind なし";
+      markUi(none);
+      kindChoice.select.appendChild(none);
+    } else {
+      kindCandidates.forEach(function (value) {
+        kindChoice.select.appendChild(createKindOption(value));
+      });
+    }
+    var add = createButton(
+      "+ ノード",
+      "ark-harness-btn ark-harness-btn-secondary ark-harness-add-node",
+      "ノードを追加"
+    );
+    add.addEventListener("click", function () {
+      var graphIndex = Number(graphChoice.select.value);
+      var graph = Number.isInteger(graphIndex) ? graphs[graphIndex] : null;
+      var kind = kindChoice.select.value;
+      if (kind && kindCandidates.indexOf(kind) === -1) return;
+      addNode(graph, kind);
+    });
+    palette.appendChild(graphChoice.label);
+    palette.appendChild(kindChoice.label);
+    palette.appendChild(add);
+    return palette;
+  }
+
+  function syncToolbarHeight(bar) {
+    var update = function () {
+      var height = Math.ceil(bar.getBoundingClientRect().height);
+      if (height > 0) {
+        document.body.style.setProperty("--ark-harness-toolbar-height", height + "px");
+      }
+    };
+    update();
+    window.requestAnimationFrame(update);
+    if (typeof ResizeObserver !== "undefined") {
+      var observer = new ResizeObserver(update);
+      observer.observe(bar);
+    }
+  }
+
   function buildToolbar() {
     var bar = document.createElement("div");
     bar.className = "ark-harness-toolbar";
@@ -1682,6 +2480,7 @@ const HARNESS_JS = `(function () {
       syncLayoutDirectionButton();
       layoutDirectionBtn.addEventListener("click", toggleLayoutDirection);
       bar.appendChild(layoutDirectionBtn);
+      bar.appendChild(buildNodePalette());
     }
 
     var editModelBtn = createButton("モデルを直接編集", "ark-harness-btn ark-harness-btn-secondary", "モデル JSON を直接編集する");
@@ -1707,6 +2506,7 @@ const HARNESS_JS = `(function () {
 
     document.body.appendChild(panel);
     document.body.appendChild(bar);
+    syncToolbarHeight(bar);
 
     editModelBtn.addEventListener("click", function () {
       var opening = panel.style.display !== "flex";
@@ -1725,6 +2525,7 @@ const HARNESS_JS = `(function () {
       var model = loadModel();
       if (!model) return;
       state.model = model;
+      reservedModelIds = collectModelIds(model);
       syncNodeKinds();
       kindCandidates = collectKindCandidates();
       buildToolbar();

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -113,6 +113,7 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   opacity: 0; pointer-events: none; transition: opacity .12s ease;
 }
 .ark-harness-graph-node:hover > .ark-harness-kind-picker,
+.ark-harness-graph-node.ark-harness-node-affordance-open > .ark-harness-kind-picker,
 .ark-harness-graph-node:focus-within > .ark-harness-kind-picker {
   opacity: 1; pointer-events: auto;
 }
@@ -161,16 +162,17 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   position: absolute; transform: translate(-50%, -50%); z-index: 5;
   width: 24px; height: 24px; padding: 0; border: 1px solid #ef4444;
   border-radius: 999px; background: #fff; color: #b91c1c; cursor: pointer;
-  pointer-events: auto; opacity: 0;
+  pointer-events: none; opacity: 0;
 }
 .ark-harness-edge-delete.ark-harness-edge-delete-visible,
-.ark-harness-edge-delete:focus { opacity: 1; }
+.ark-harness-edge-delete:focus { opacity: 1; pointer-events: auto; }
 .ark-harness-node-rail {
   position: absolute; z-index: 5; display: flex; gap: 4px; padding: 2px;
   border: 1px solid rgba(100,116,139,.55); border-radius: 999px;
   background: rgba(255,255,255,.96); opacity: 0; pointer-events: none;
 }
 .ark-harness-graph-node:hover > .ark-harness-node-rail,
+.ark-harness-graph-node.ark-harness-node-affordance-open > .ark-harness-node-rail,
 .ark-harness-graph-node:focus-within > .ark-harness-node-rail {
   opacity: 1; pointer-events: auto;
 }
@@ -219,6 +221,7 @@ const HARNESS_JS = `(function () {
     "--ark-harness-graph-min-width",
     "--ark-harness-graph-min-height"
   ];
+  var AFFORDANCE_CLOSE_DELAY = 120;
 
   var BLOCK_TAGS = {
     DIV: 1, UL: 1, OL: 1, LI: 1, TABLE: 1, THEAD: 1, TBODY: 1, TR: 1, TD: 1, TH: 1,
@@ -1034,7 +1037,12 @@ const HARNESS_JS = `(function () {
       ["pointerenter", "focus", "click"].forEach(function (type) {
         hit.addEventListener(type, function (event) {
           event.stopPropagation();
-          setSelectedEdge(edge.id);
+          activateEdgeDeleteControl(graph, edge.id);
+        });
+      });
+      ["pointerleave", "blur"].forEach(function (type) {
+        hit.addEventListener(type, function () {
+          scheduleEdgeDeleteClose(graph, edge.id);
         });
       });
       hit.addEventListener("keydown", function (event) {
@@ -1373,11 +1381,52 @@ const HARNESS_JS = `(function () {
     ["pointerdown", "click", "keydown"].forEach(function (type) {
       button.addEventListener(type, function (event) { event.stopPropagation(); });
     });
+    ["pointerenter", "focus"].forEach(function (type) {
+      button.addEventListener(type, function () {
+        activateEdgeDeleteControl(
+          graph,
+          button.getAttribute("data-ark-edge-id")
+        );
+      });
+    });
+    ["pointerleave", "blur"].forEach(function (type) {
+      button.addEventListener(type, function () {
+        scheduleEdgeDeleteClose(
+          graph,
+          button.getAttribute("data-ark-edge-id")
+        );
+      });
+    });
     button.addEventListener("click", function () {
       removeEdge(button.getAttribute("data-ark-edge-id"));
     });
     graph.handleLayer.appendChild(button);
-    return { wrapper: button, button: button };
+    return { wrapper: button, button: button, closeTimer: null };
+  }
+
+  function clearEdgeDeleteClose(control) {
+    if (!control || control.closeTimer === null) return;
+    window.clearTimeout(control.closeTimer);
+    control.closeTimer = null;
+  }
+
+  function activateEdgeDeleteControl(graph, edgeId) {
+    graph.edgeDeleteControlsById.forEach(function (control) {
+      clearEdgeDeleteClose(control);
+    });
+    setSelectedEdge(edgeId);
+  }
+
+  function scheduleEdgeDeleteClose(graph, edgeId) {
+    var control = graph.edgeDeleteControlsById.get(edgeId);
+    if (!control) return;
+    clearEdgeDeleteClose(control);
+    control.closeTimer = window.setTimeout(function () {
+      control.closeTimer = null;
+      if (control.wrapper.matches(":hover") ||
+          control.wrapper.contains(document.activeElement)) return;
+      if (selectedEdgeId === edgeId) setSelectedEdge(null);
+    }, AFFORDANCE_CLOSE_DELAY);
   }
 
   function syncEdgeDeleteControls(graph, edges) {
@@ -1399,6 +1448,7 @@ const HARNESS_JS = `(function () {
     });
     graph.edgeDeleteControlsById.forEach(function (control, id) {
       if (activeIds.has(id)) return;
+      clearEdgeDeleteClose(control);
       control.wrapper.remove();
       graph.edgeDeleteControlsById.delete(id);
     });
@@ -1619,6 +1669,52 @@ const HARNESS_JS = `(function () {
     graph.nodeRailsById.set(id, rail);
   }
 
+  function clearNodeAffordanceClose(controller) {
+    if (!controller || controller.closeTimer === null) return;
+    window.clearTimeout(controller.closeTimer);
+    controller.closeTimer = null;
+  }
+
+  function openNodeAffordance(controller) {
+    clearNodeAffordanceClose(controller);
+    controller.root.classList.add("ark-harness-node-affordance-open");
+  }
+
+  function scheduleNodeAffordanceClose(controller) {
+    clearNodeAffordanceClose(controller);
+    controller.closeTimer = window.setTimeout(function () {
+      controller.closeTimer = null;
+      if (controller.root.matches(":hover") ||
+          controller.root.matches(":focus-within")) return;
+      controller.root.classList.remove("ark-harness-node-affordance-open");
+    }, AFFORDANCE_CLOSE_DELAY);
+  }
+
+  function attachNodeAffordanceHover(graph, root, id) {
+    var controller = { root: root, closeTimer: null };
+    ["pointerenter", "focusin"].forEach(function (type) {
+      root.addEventListener(type, function () {
+        openNodeAffordance(controller);
+      });
+    });
+    ["pointerleave", "focusout"].forEach(function (type) {
+      root.addEventListener(type, function () {
+        scheduleNodeAffordanceClose(controller);
+      });
+    });
+    root.querySelectorAll(
+      ".ark-harness-kind-picker, .ark-harness-graph-handle, .ark-harness-node-rail"
+    ).forEach(function (affordance) {
+      affordance.addEventListener("pointerenter", function () {
+        openNodeAffordance(controller);
+      });
+      affordance.addEventListener("pointerleave", function () {
+        scheduleNodeAffordanceClose(controller);
+      });
+    });
+    graph.nodeAffordancesById.set(id, controller);
+  }
+
   function registerGraphNode(graph, root, node) {
     if (!node || typeof node.id !== "string" || graph.nodesById.has(node.id)) return false;
     graph.nodesById.set(node.id, root);
@@ -1626,6 +1722,7 @@ const HARNESS_JS = `(function () {
     attachKindPicker(graph, root);
     attachGraphHandle(graph, root, node);
     attachNodeRail(graph, root);
+    attachNodeAffordanceHover(graph, root, node.id);
     if (graph.resizeObserver) graph.resizeObserver.observe(root);
     return true;
   }
@@ -1638,6 +1735,9 @@ const HARNESS_JS = `(function () {
     var rail = graph.nodeRailsById.get(id);
     if (rail) rail.remove();
     graph.nodeRailsById.delete(id);
+    var affordance = graph.nodeAffordancesById.get(id);
+    clearNodeAffordanceClose(affordance);
+    graph.nodeAffordancesById.delete(id);
     kindPickers = kindPickers.filter(function (picker) {
       if (picker.root !== root) return true;
       if (picker.select.parentNode) picker.select.parentNode.remove();
@@ -1876,6 +1976,7 @@ const HARNESS_JS = `(function () {
       edgeHandlesByKey: new Map(),
       edgeDeleteControlsById: new Map(),
       nodeRailsById: new Map(),
+      nodeAffordancesById: new Map(),
       positionsById: new Map(),
       layoutExtent: { width: null, height: null },
       resizeObserver: null,


### PR DESCRIPTION
## 概要

graph 上でノード/edge を**追加・削除**する直接操作を追加する（編集UX 直接操作レイヤの完結：#240 方向トグル・#241 kind ピッカー・#242 edge コントロールに続く）。**ドラッグ主体**の操作モデル（実機フィードバックで反復）。

## 操作モデル（実機検証で確定）

- **ノード追加**: toolbar パレット（配置先 graph + kind allowlist + 「+ ノード」）。座標は既存要素と非重複、id は `crypto` で安全生成
- **edge 作成**: **draw.io 風の接続アンカー** ―― ノード hover で**周縁（4辺中点＋4隅の8点）にアンカー**を表示し、そこからドラッグ → target ノードで drop で作成（8px 閾値・self-edge・invalid drop/Escape は無効）
- **edge 削除**: **端点をノード外の空きへドラッグ**して離すと削除（薄赤＋×で予告）。ノードへ drop は #229 rewire、Escape は復元
- **node 削除**: ノード本体クリックで選択 → **Delete / Backspace**（contenteditable 編集中は無効）。node と incident edge・`groups[].nodes` 参照を同期除去（参照整合性・422 回避）
- **還流**: 追加・削除は**構造変更なので会話へ還流**（既存 `describeModelDiff`・production `diagram-diff.ts` 不変）。kind/ext は非還流
- **セキュリティ**: `createElement`/`textContent`/`setAttribute` のみ・id/label に HTML 記号があっても安全・新規 node projection は clean HTML に残し一時UIは `data-ark-harness-ui` で除去・**<128KiB guard 維持**（94.5KB）
- **DB スキーマ変更なし**。スコープは `diagram-harness.ts` + テスト + e2e に限定

## 実機で潰した UX（プレビュー反復）

- 追加系 UI の hover gap（掴む前に消える）→ 遅延 close
- クリックで self-edge / 削除で全消し → 8px 閾値・削除範囲の厳密化
- +/− ボタン → **ドラッグ主体**へ（端点外し削除・Delete キー削除）
- create handle が hover 位置とズレる → **周縁アンカー方式**（draw.io 風）
- アンカーが削除操作を横取り → endpoint 前面化・本体クリックで選択

## 検証

- server: **419 tests PASS** ・ Chromium **E2E 44 PASS**
- `pnpm check` / `pnpm build`: PASS ・ <128KiB / 外部リソース禁止 / marker 一意: PASS
- **実機プレビューで動作確認済み**

Closes #243


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ノードの追加・削除、エッジの作成・削除・再接続に対応しました。
  - ノード間のドラッグ操作、接続プレビュー、キャンセル操作を改善しました。
  - ノード追加用パレットと、選択・削除操作を追加しました。
  - ノードやエッジの重複を避け、編集内容を安全に送信できるようにしました。

- **バグ修正**
  - 編集中のテキスト削除がノード削除につながる問題を修正しました。
  - 無効なドロップやキャンセル時に意図せず変更される問題を防止しました。

- **テスト**
  - ノード・エッジ操作、送信内容、表示状態の回帰テストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->