### PR TITLE
feat(diagram): 右ペインに図スイッチャ（複数図の切り替え） (#247)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-issue-247.md
+++ b/docs/superpowers/plans/2026-07-23-issue-247.md
@@ -1,0 +1,389 @@
+# issue-247: 右ペイン図スイッチャ Implementation Plan
+
+> **実装担当者向け:** 各チェック項目を Red → Green → Refactor の順で進めること。各 Step は原則 2〜5 分で完了できる粒度にしている。
+
+**Goal:** worktree の `docs/diagrams/**/*.diagram.html` を右ペインで一覧し、タイトル優先の表示名から1枚を選んで切り替え、`board_open`・リロード・Socket.IO 再接続後も一覧と現在図を同期する。
+
+**Issue:** 247 (GitHub Issue 紐付けあり)
+
+**Architecture:** server に read-only の `diagram:list` Socket.IO ACK ハンドラーを追加し、管理対象 worktree の `docs/diagrams` を列挙して、既存 `readDiagramModel()` の trust boundary を通過した図だけを `{ relPath, displayName }` として返す。client は `useSocket.ts` に一覧要求を集約し、`DiagramPane` のマウント時・接続復旧時・現在図変更時に再取得する。右ペイン上部の native select をスイッチャとし、選択は `Dashboard` → `useViewerTabs` の既存 `openDiagramTab` 経路へ戻す。diagram tab は左タブバーには出さず、セッションごとに現在図を表す1件だけへ正規化するため、ユーザー選択と server の `diagram:open` (`board_open`) が同じ `relPath` 更新、`diagram:unsubscribe` → `diagram:subscribe`、iframe 再取得を通る。
+
+**Tech Stack:** React 19 / TailwindCSS 4 / Socket.IO 4 / Express 5 / Vitest 4 / Playwright / TypeScript 6
+
+---
+
+## 調査結果と変更境界
+
+- `packages/web/src/components/SplitViewPane.tsx:94-139,205-289` は `sessionTabs` の最後の diagram tab を右ペインへ出し、diagram tab の「件数増加」で live `board_open` を検出している。現在は図ごとに hidden tab が増えるため、このままではスイッチャで既存図へ戻ったときに現在図を表現できず、同じ図の `board_open` でも閉じた右ペインを再表示できない。
+- `packages/web/src/hooks/useViewerTabs.ts:147-174` / `packages/web/src/lib/diagram-tabs.ts:1-32` は同じ図を no-op、別図を追加として扱う。Issue #247 では diagram tab を「開いている図の集合」ではなく「右ペインの現在図1件」として扱い、terminal/file/html tab の順序と active index を保ったまま置換する。
+- `packages/web/src/pages/Dashboard.tsx:239-290` は live `diagram:open` と DB の `lastDiagramPath` 復元を `openDiagramTab` へ集約済みである。この入口を維持し、スイッチャの `onChange` も同じ関数へ接続する。`board_open` 側の `packages/server/src/index.ts:704-755` と既存 DB 更新は変更しない。
+- `packages/web/src/components/DiagramPane.tsx:66-144` は `worktreePath` / `relPath` の変更で fetch を中止・再実行し、表示中の1ファイルだけを `diagram:subscribe` して `diagram:updated` で再取得する。このライフサイクルを再利用し、図一覧のために全ファイルへ watcher を増やさない。
+- `packages/server/src/index.ts:486-522,2127-2196` には managed worktree の realpath / git / allowedRepos 検証と、図パスを `docs/diagrams` 内へ閉じ込める既存境界がある。`diagram:list` も必ず `resolveManagedWorktreePath()` を通し、各候補は `readDiagramModel()` で symlink 脱出・TOCTOU・モデル妥当性を再検証する。汎用 `file-manager.ts` は `/tmp` や worktree 内の一般ファイルも扱うため、図一覧には流用しない。
+- `packages/shared/src/types.ts:380-389,630-660` が Socket.IO 双方向型の正である。`DiagramListItem` / `DiagramListResponse` と `ClientToServerEvents["diagram:list"]` を `index.ts` のハンドラーと同じ実装単位で更新する。ACK 型なので新しい `ServerToClientEvents` push event は追加しない。
+- `packages/web/src/hooks/useSocket.ts:467-518` は connect / disconnect を state 化している。`listDiagrams()` はここへ集約し、`DiagramPane` は `isConnected` の false → true を依存にして再要求する。これにより初回ロード、ブラウザリロード、transport 再接続、server 再起動後の再接続を同じ供給フローで回収する。
+- 図一覧は `docs/diagrams` 直下だけでなく、既存 `resolveDiagramPath()` が許可するサブディレクトリも再帰列挙する。これにより `board_open("docs/diagrams/sub/a.diagram.html")` も「開いた図が一覧に無い」状態にならない。symlink directory は辿らず、symlink file は `readDiagramModel()` が実体を diagrams 配下と確認できた場合だけ含める。
+- 表示名はモデルの `title` が空白でなければそれを使い、欠損・空文字なら basename (`foo.diagram.html`) へフォールバックする。同名 title が複数あっても identity は `relPath` のままにし、選択肢の `title` 属性で相対パスを確認できるようにする。順序は `relPath` の決定的な昇順とする。
+- 壊れたモデル、読めないファイル、diagrams 外を指す symlink はクリックして失敗する項目として公開せず、一覧から除外する。`docs/diagrams` 自体が無い場合は正常な空配列、ディレクトリ走査そのものの権限・I/O エラーは ACK error として区別する。
+- PC の右ペインだけが対象であり、`MobileLayout` / `MobileSessionView` に図 UI を追加しない。左ペインの ttyd iframe、file/html tab、`ViewerTabBar` の diagram 除外、右ペイン幅・開閉の localStorage キーは維持する。
+- DB schema / migration は変更しない。既存 `sessions.last_diagram_path` と `lastDiagramPath` の `board_open` 復元をそのまま使う。DB schema 変更が必要と判明した場合はこの plan の実装を止め、必ず人間レビューを受ける。
+- 図スイッチャ UI は React / Tailwind と native control だけで作り、外部 stylesheet、font、icon、画像、CDN、fetch 先を追加しない。図本文の CSP / harness は別レイヤであり変更しない。
+- 図セット、manifest / front matter、prev/next、図間リンク、複数モデルの1ファイル集約、#241〜#243 の編集ハーネス変更は非ゴールとする。
+
+---
+
+## 供給・切替フロー
+
+```text
+初回表示 / reload / Socket.IO reconnect
+  DiagramPane(isConnected=true)
+    → useSocket.listDiagrams(worktreePath)
+      → diagram:list ACK
+        → resolveManagedWorktreePath
+          → listDiagramFiles + readDiagramModel
+            → [{ relPath, displayName }]
+
+スイッチャ click
+  DiagramPane.onSelectDiagram(relPath)
+    → Dashboard.openDiagramTab(sessionId, worktreePath, relPath)
+      → 現在 diagram tab 1件を置換
+        → DiagramPane relPath 変更
+          → old diagram:unsubscribe
+          → new /api/diagram fetch + diagram:subscribe
+
+MCP board_open
+  server readDiagram 成功
+    → diagram:open({ sessionId, relPath }) + lastDiagramPath 更新
+      → Dashboard.openDiagramTab(...)
+        → 同じ置換・購読・一覧再取得フロー
+```
+
+---
+
+## Task 1: 図一覧の server 契約を TDD で追加する
+
+**Files:**
+
+- Create: `packages/server/src/lib/diagram-list.ts`
+- Create: `packages/server/src/lib/diagram-list.test.ts`
+- Modify: `packages/shared/src/types.ts:1-220,380-389,630-660`
+- Modify: `packages/server/src/index.ts:53-70,2127-2207`
+- Reference: `packages/server/src/lib/diagram-reader.ts:27-143`
+- Reference: `packages/server/src/lib/diagram-path.ts:10-73`
+- Reference: `packages/server/src/index.ts:486-522`
+
+- [ ] **Step 1: 一覧 helper の正常系 test を Red にする（2〜5分）**
+
+  temp worktree の `docs/diagrams` に、title あり、title 欠損、title 空白、非 diagram HTML、通常ファイル、サブディレクトリ内の diagram を作る。`listDiagrams(worktreeReal)` が有効な `.diagram.html` だけを再帰的に返し、`displayName` は title 優先・basename fallback、`relPath` は常に `docs/diagrams/...` 形式、結果は `relPath` 昇順になることを期待する test を先に書く。
+
+- [ ] **Step 2: 空・不正ファイルの test を Red にする（2〜5分）**
+
+  `docs/diagrams` が無い worktree は `[]`、空ディレクトリも `[]` になることを固定する。壊れた `ark-diagram-model`、モデル block 無し、diagrams 外への symlink、symlink directory は一覧へ出ず、他の正常図は返り続けることを期待する。
+
+- [ ] **Step 3: ACK handler の trust boundary test を Red にする（2〜5分）**
+
+  `handleDiagramListRequest(deps, data)` の純粋な handler core を test 対象にし、null / 引数無し / 非文字列 / 長すぎる path、managed worktree 解決失敗は `{ ok: false, error }`、成功時は `{ ok: true, diagrams }` を返すことを固定する。resolver が返した正規化済み実パスだけが列挙 helper に渡ること、readdir の予期しない I/O error が ACK error に変換されることも確認する。
+
+- [ ] **Step 4: Red を確認する（2〜5分）**
+
+  Run: `pnpm --filter @ark/server exec vitest run src/lib/diagram-list.test.ts`
+
+  Expected: FAIL。`diagram-list.ts` と一覧 / handler core がまだ存在しないため import または最初の assertion で失敗する。
+
+- [ ] **Step 5: 安全な再帰列挙を実装する（2〜5分）**
+
+  `DIAGRAM_DIR` を起点に `fs.promises.readdir({ withFileTypes: true })` で再帰する。directory symlink は辿らず、`.diagram.html` 候補ごとに POSIX 形式の worktree 相対 `relPath` を作り、`readDiagramModel(worktreeReal, relPath)` が成功したものだけを採用する。候補1件の失敗で一覧全体を失敗させず、起点 directory の `ENOENT` だけを空配列として扱う。
+
+- [ ] **Step 6: title / fallback と決定的ソートを実装する（2〜5分）**
+
+  `model.title?.trim()` が空でなければ displayName、そうでなければ `path.basename(relPath)` を使う。identity や sort key に title を使わず、`relPath` で安定ソートして同名 title と filesystem 順序差を安全に扱う。
+
+- [ ] **Step 7: shared Socket.IO 型と index handler を同時に追加する（2〜5分）**
+
+  `packages/shared/src/types.ts` に `DiagramListItem` と success / error の discriminated union を export し、`ClientToServerEvents` に次の契約を追加する。
+
+  ```ts
+  "diagram:list": (
+    data: { worktreePath: string },
+    callback: (response: DiagramListResponse) => void
+  ) => void;
+  ```
+
+  `index.ts` の既存 diagram handler 群の先頭で ACK callback と unknown payload を検証し、`resolveManagedWorktreePath()` を注入した `handleDiagramListRequest()` を呼ぶ。例外や ACK callback 自体の throw を server process まで伝播させない。`ServerToClientEvents`、DB、`boardDeps.openDiagram()` は変更しない。
+
+- [ ] **Step 8: server test を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run \
+    src/lib/diagram-list.test.ts \
+    src/lib/diagram-reader.test.ts \
+    src/lib/diagram-path.test.ts
+  ```
+
+  Expected: PASS。一覧、title fallback、再帰、空状態、invalid / symlink 除外、managed worktree guard と既存 diagram reader / path 回帰がすべて Green。
+
+- [ ] **Step 9: Refactor と server 契約コミットを行う（2〜5分）**
+
+  traversal、1候補の読取、displayName 生成、handler core を短い責務へ分ける。汎用 file-manager の緩い境界、glob package、DB cache、新しい watcher を導入しない。
+
+  ```bash
+  git add packages/shared/src/types.ts \
+    packages/server/src/index.ts \
+    packages/server/src/lib/diagram-list.ts \
+    packages/server/src/lib/diagram-list.test.ts
+  git commit -m "feat(diagram): worktree の図一覧を供給"
+  ```
+
+---
+
+## Task 2: diagram tab を「現在図1件」に正規化する
+
+**Files:**
+
+- Modify: `packages/web/src/lib/diagram-tabs.test.ts`
+- Modify: `packages/web/src/lib/diagram-tabs.ts`
+- Modify: `packages/web/src/hooks/useViewerTabs.ts:147-174`
+- Modify: `packages/web/src/components/TerminalPane.tsx:67-99`
+- Modify: `packages/web/src/pages/Dashboard.tsx:224-290,742-779`
+- Modify: `packages/web/src/components/SplitViewPane.tsx:29-55,94-139,205-289`
+- Reference: `packages/web/src/lib/tab-close.ts`
+- Reference: `packages/web/src/lib/tab-close.test.ts`
+
+- [ ] **Step 1: current diagram 置換の純関数 test を Red にする（2〜5分）**
+
+  `diagram-tabs.test.ts` を「別図は別 tab を追加する」契約から変更し、図無しなら1件追加、同じ図でも live open の新しい id / `restoredOnLoad=false` へ更新、別図なら既存 diagram の位置で置換、過去の複数 diagram tabs は1件へ畳み込むことを期待する。
+
+- [ ] **Step 2: 左ペイン active tab 保持の test を Red にする（2〜5分）**
+
+  `[terminal, diagram-a, file-active, diagram-b, html]` のような旧 state を入力し、diagram を1件へ畳んでも active な file/html tab を id で追跡して補正後 index が同じ tab を指すことを固定する。active が誤って diagram を指していた場合だけ terminal へ安全に戻す。
+
+- [ ] **Step 3: Red を確認する（2〜5分）**
+
+  Run: `pnpm exec vitest run packages/web/src/lib/diagram-tabs.test.ts packages/web/src/lib/tab-close.test.ts`
+
+  Expected: FAIL。現行 `addOrFocusDiagramTab()` は別図を追加し、同じ図を no-op にするため、新しい単一 current diagram 契約に一致しない。
+
+- [ ] **Step 4: diagram tab 置換 helper を実装する（2〜5分）**
+
+  helper は `{ tabs, activeIndex }` を返し、non-diagram tab object と順序を維持しながら diagram を最大1件へする。live `board_open` / user switch では呼出側から受けた新しい id を必ず採用して SplitViewPane が再 activation を検知できるようにし、reload 復元だけ `restoredOnLoad: true` を保持する。
+
+- [ ] **Step 5: useViewerTabs で tabs と active index を原子的に更新する（2〜5分）**
+
+  `openDiagramTab()` の `setSessionTabs` updater 内で helper を呼び、必要な `setSessionActiveTab` 補正も同じ updater 内で行う。TerminalPane の active tab を diagram へ切り替えず、file/html の表示や close 補正を壊さない。関数名は既存呼出側を最小化するため `openDiagramTab` のままでよいが、コメントは「現在図を設定」に更新する。
+
+- [ ] **Step 6: SplitViewPane の live open 検知を件数から id へ変える（2〜5分）**
+
+  `prevBoardCountRef` を current diagram の id 比較へ置き換える。新しい id かつ `restoredOnLoad !== true` なら `showBoard=true` にし、同じ relPath の再 `board_open` でも閉じた右ペインが開くようにする。reload の DB 復元では既存 localStorage の閉状態を尊重する。
+
+- [ ] **Step 7: 図無しでも右ペインを開ける shell を用意する（2〜5分）**
+
+  desktop session の上部「図」トグルを current diagram の有無に依存せず表示し、`showBoard` なら `DiagramPane` を `relPath?: string` で描画する。current diagram が無い場合は fetch、`diagram:subscribe`、MessageChannel submit を開始せず、後続 Task 3 の一覧と「図を選択してください」状態だけを表示できるようにする。幅 clamp、ドラッグ中の両 iframe `pointer-events-none`、localStorage key / 書込タイミングは維持する。
+
+- [ ] **Step 8: スイッチャ選択 callback を Dashboard まで配線する（2〜5分）**
+
+  `SplitViewPane` に `onSelectDiagram(relPath)` を追加し、各 session の `openDiagramTab(session.id, session.worktreePath, relPath)` へ接続する。server `diagram:open` と reload の `lastDiagramPath` 復元も同じ関数を使い続け、mobile の別 `useViewerTabs` instance には図イベントを追加しない。
+
+- [ ] **Step 9: tab unit を Green にする（2〜5分）**
+
+  Run: `pnpm exec vitest run packages/web/src/lib/diagram-tabs.test.ts packages/web/src/lib/tab-close.test.ts`
+
+  Expected: PASS。diagram は常に最大1件、live open は再 activation 可能、左 terminal/file/html の active tab と close 補正は維持される。
+
+- [ ] **Step 10: Refactor と current diagram コミットを行う（2〜5分）**
+
+  `SplitViewPane` が tab 配列の履歴から current を推測する処理を残さず、単一 diagram tab だけを参照する。diagram を `ViewerTabBar` に再表示したり、新しい右ペイン tab strip を作ったりしない。
+
+  ```bash
+  git add packages/web/src/lib/diagram-tabs.ts \
+    packages/web/src/lib/diagram-tabs.test.ts \
+    packages/web/src/hooks/useViewerTabs.ts \
+    packages/web/src/components/TerminalPane.tsx \
+    packages/web/src/components/SplitViewPane.tsx \
+    packages/web/src/pages/Dashboard.tsx
+  git commit -m "refactor(diagram): 右ペインの現在図を単一化"
+  ```
+
+---
+
+## Task 3: useSocket の再取得と DiagramPane スイッチャを実装する
+
+**Files:**
+
+- Create: `packages/web/src/components/DiagramSwitcher.tsx`
+- Create: `packages/web/src/components/DiagramSwitcher.test.tsx`
+- Modify: `packages/web/src/hooks/useSocket.ts:28-145,467-518,1180-1210,1615-1705`
+- Modify: `packages/web/src/pages/Dashboard.tsx:80-210,742-779`
+- Modify: `packages/web/src/components/SplitViewPane.tsx:29-55,262-289`
+- Modify: `packages/web/src/components/DiagramPane.tsx:9-21,51-168,225-260`
+- Reference: `packages/shared/src/types.ts`
+
+- [ ] **Step 1: スイッチャ表示の component test を Red にする（2〜5分）**
+
+  `renderToStaticMarkup()` を使い、複数 items では title 優先の option と相対 path の `title` が並び、current `relPath` の option が selected、current 無しでは「図を選択」、0件では disabled の「図がありません」になる presentational component test を書く。current path が一覧応答に無い場合も basename の一時 option を selected にして壊れない契約を固定する。
+
+- [ ] **Step 2: Red を確認する（2〜5分）**
+
+  Run: `pnpm exec vitest run packages/web/src/components/DiagramSwitcher.test.tsx`
+
+  Expected: FAIL。`DiagramSwitcher` がまだ存在しないため import または最初の markup assertion で失敗する。
+
+- [ ] **Step 3: native select の DiagramSwitcher を実装する（2〜5分）**
+
+  右ペイン上部に固定高の header と `aria-label="表示する図"` を持つ select を置く。`value` は `relPath`、visible label は `displayName` とし、change では空 placeholder を無視して `onSelect(relPath)` だけを呼ぶ。現在図は native selected state と Tailwind の foreground / background で明示し、横幅320pxでも path が canvas を押し潰さないよう truncate する。外部 icon / CSS は使わない。
+
+- [ ] **Step 4: useSocket に typed ACK action を追加する（2〜5分）**
+
+  `UseSocketReturn` に `listDiagrams(worktreePath): Promise<DiagramListItem[]>` を追加する。未接続なら即 reject、接続中は `diagram:list` を emit し、success のみ配列を resolve、error ACK は reject する。10秒 timeout と settled guard を置き、遅延 ACK が timeout 後の Promise state を再変更しないようにする。Socket.IO event 発行を component 内へ重複実装しない。
+
+- [ ] **Step 5: DiagramPane に一覧 state と非破壊 error を追加する（2〜5分）**
+
+  `diagrams`、`listLoading`、`listError` を持ち、`isConnected === true` かつ有効な `worktreePath` で `listDiagrams()` を呼ぶ。応答が out-of-order になっても古い worktree / relPath の結果で現在 state を上書きしないよう request generation または cancelled flag を使う。一覧失敗は iframe の `error` / `submitError` と分離し、既存図を消さず header 内に短い error と再試行 button を出す。
+
+- [ ] **Step 6: reload / reconnect / board_open の再取得条件を実装する（2〜5分）**
+
+  一覧 effect を `worktreePath`、`isConnected`、current `relPath` に依存させる。初回 connect、browser reload 後の connect、network / server restart 後の false → true、`diagram:open` または user selection による relPath 変更で再取得する。さらに現在図の `diagram:updated` では既存 iframe `load()` と一覧 refresh を両方行い、モデル title の変更も追従させる。
+
+- [ ] **Step 7: current 無し / 0件を安全に描画する（2〜5分）**
+
+  current `relPath` が無い間は fetch / subscribe / submit / MessageChannel を完全に skip し、一覧が非空なら「上の一覧から図を選択」、空なら「図がありません」を canvas 領域へ表示する。0件でも右ペイン開閉、左 ttyd、リサイズ、再試行が操作できることを保つ。
+
+- [ ] **Step 8: 現在図の切替で既存購読と iframe を維持する（2〜5分）**
+
+  select change は `onSelectDiagram` へ渡すだけにし、`DiagramPane` の既存 `load` effect と subscription cleanup によって、旧図 fetch abort / port close / `diagram:unsubscribe` の後に、新図 fetch / `diagram:subscribe` / MessageChannel init が行われるようにする。subscription effect にも `isConnected` を含め、切断中は購読せず、false → true の再接続時には同じ current 図を必ず再 subscribe する。`diagram:updated` の filter は current `worktreePath` / `relPath` 完全一致のまま維持する。
+
+- [ ] **Step 9: component test と web typecheck を Green にする（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm exec vitest run \
+    packages/web/src/components/DiagramSwitcher.test.tsx \
+    packages/web/src/lib/diagram-tabs.test.ts \
+    packages/web/src/lib/tab-close.test.ts
+  ```
+
+  Expected: PASS。複数図、current highlight、placeholder、stale current、0件と current tab 状態が Green。
+
+  Run: `pnpm --filter @ark/web check`
+
+  Expected: PASS。shared ACK 型、useSocket return、Dashboard / SplitViewPane / DiagramPane props が一致する。
+
+- [ ] **Step 10: Refactor と client コミットを行う（2〜5分）**
+
+  一覧 transport は `useSocket`、一覧 presentation は `DiagramSwitcher`、表示中ファイルの fetch / watcher / submit は `DiagramPane`、current diagram ownership は `useViewerTabs` に保つ。1つの component に Socket.IO、tab mutation、rendering の全責務を集めない。
+
+  ```bash
+  git add packages/web/src/hooks/useSocket.ts \
+    packages/web/src/pages/Dashboard.tsx \
+    packages/web/src/components/SplitViewPane.tsx \
+    packages/web/src/components/DiagramPane.tsx \
+    packages/web/src/components/DiagramSwitcher.tsx \
+    packages/web/src/components/DiagramSwitcher.test.tsx
+  git commit -m "feat(diagram): 右ペインに図スイッチャを追加"
+  ```
+
+---
+
+## Task 4: クロスレイヤ回帰と実機受け入れを行う
+
+**Files:**
+
+- Verify: `packages/shared/src/types.ts`
+- Verify: `packages/server/src/index.ts`
+- Verify: `packages/server/src/lib/diagram-list.ts`
+- Verify: `packages/server/src/lib/diagram-list.test.ts`
+- Verify: `packages/web/src/hooks/useSocket.ts`
+- Verify: `packages/web/src/hooks/useViewerTabs.ts`
+- Verify: `packages/web/src/components/SplitViewPane.tsx`
+- Verify: `packages/web/src/components/DiagramPane.tsx`
+- Verify: `packages/web/src/components/DiagramSwitcher.tsx`
+- Verify only: `packages/server/src/lib/database.ts`
+- Verify only: `packages/server/src/lib/diagram-watcher.ts`
+- Verify only: `packages/web/src/components/TerminalPane.tsx`
+- Verify only: `packages/web/src/components/MobileLayout.tsx`
+- Verify only: `packages/web/src/components/MobileSessionView.tsx`
+
+- [ ] **Step 1: targeted server / client tests を実行する（2〜5分）**
+
+  Run:
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run \
+    src/lib/diagram-list.test.ts \
+    src/lib/diagram-reader.test.ts \
+    src/lib/diagram-path.test.ts \
+    src/lib/diagram-watcher.test.ts
+  ```
+
+  Expected: PASS。図一覧 handler、reader/path trust boundary、現在図 watcher が Green。
+
+  Run:
+
+  ```bash
+  pnpm exec vitest run \
+    packages/web/src/components/DiagramSwitcher.test.tsx \
+    packages/web/src/lib/diagram-tabs.test.ts \
+    packages/web/src/lib/tab-close.test.ts
+  ```
+
+  Expected: PASS。switcher state、current diagram 単一化、左タブ close 回帰が Green。
+
+- [ ] **Step 2: 静的検査と build を実行する（5〜10分）**
+
+  Run: `pnpm check`
+
+  Expected: PASS。Biome と TypeScript project references が error 0件。`shared/types.ts` と `index.ts` / `useSocket.ts` の Socket.IO 型が一致する。
+
+  Run: `pnpm build`
+
+  Expected: PASS。shared、server、web、desktop の既存 build が成功する。
+
+- [ ] **Step 3: 複数図と title fallback を desktop 実機確認する（2〜5分）**
+
+  同一 worktree に title あり、title 欠損、サブディレクトリ内の3図を置き、右ペインの「図」トグルを開く。select に title、filename fallback、nested 図が決定順で現れ、各 option の path が確認できることを確認する。選択ごとに iframe が対象図へ切り替わり、current option が selected になる。
+
+- [ ] **Step 4: 購読切替と既存編集を確認する（2〜5分）**
+
+  図 A → 図 B と切り替えた後、A の更新では表示が変わらず、B の更新では `diagram:updated` → iframe 再取得が起きることを確認する。B 上の既存編集操作と「変更を送る」が従来どおり `diagram:submit` を通り、左 ttyd iframe、file/html tab、tab close が操作できることも確認する。
+
+- [ ] **Step 5: board_open の新規図・既存図同期を確認する（2〜5分）**
+
+  右ペインを閉じた状態から別図を `board_open` し、右ペインが自動表示され、その図が一覧に載って selected になることを確認する。再度右ペインを閉じ、同じ図を `board_open` しても新しい activation id により再表示されることを確認する。別クライアントで一覧を開いている場合も `diagram:open` broadcast 後の relPath 変更から再取得される。
+
+- [ ] **Step 6: browser reload の供給フローを確認する（2〜5分）**
+
+  `board_open` 済みの current 図と右ペイン開閉状態を確認して browser reload する。`session:list.lastDiagramPath` から current diagram tab が復元され、localStorage の `ark-split-show-board` を尊重し、接続後の `diagram:list` ACK で一覧と highlight が戻ることを確認する。復元だけで閉じた右ペインを強制的に開かない。
+
+- [ ] **Step 7: Socket.IO 再接続と server 再起動を確認する（2〜5分）**
+
+  UI を開いたまま socket transport を一度切断・再接続し、`isConnected` false → true で一覧が再取得され、現在図と highlight が維持されることを確認する。続けて server を再起動し、再接続後も同じ供給が満たされ、表示中図の `diagram:subscribe` も張り直されて更新通知を受けることを確認する。
+
+- [ ] **Step 8: 0件・削除・error の非破壊性を確認する（2〜5分）**
+
+  `docs/diagrams` 無し / 空の worktree で右ペインを開き、「図がありません」が出て console error や crash が無いことを確認する。表示中図を削除した場合は server の一覧応答から消え、switcher には current を失わないための basename fallback だけが一時表示され、iframe 側には読込 error が見えることを確認する。その状態でも再試行、別図への切替、右ペイン close、左 ttyd は操作可能であること、壊れた図1件が正常図の一覧を消さないことも確認する。
+
+- [ ] **Step 9: スコープと DB 非変更を検査する（2〜5分）**
+
+  Run: `git diff --name-only origin/main...HEAD`
+
+  Expected: Issue 実装差分は plan、shared types、server の diagram list / handler、web の socket / current tab / right pane / switcher とその tests に限定される。`packages/server/src/lib/database.ts` の schema、diagram harness / model / diff、tmux / ttyd、mobile UI、図ファイル自身は変更されない。
+
+  Run: `git diff --check origin/main...HEAD`
+
+  Expected: 出力なし。
+
+---
+
+## 完了条件チェック
+
+- [ ] 右ペインから worktree の有効な `docs/diagrams/**/*.diagram.html` を一覧でき、title 優先・filename fallback で表示される。
+- [ ] 一覧の選択で current 図が切り替わり、選択項目が highlight される。
+- [ ] diagram tab はセッションごとに最大1件で、左 ttyd / file / html tab の active state を壊さない。
+- [ ] `board_open` の新規図・既存図が同じ current diagram 経路を通り、一覧再取得・highlight・右ペイン自動表示が同期する。
+- [ ] 初回ロード、browser reload、Socket.IO 再接続、server 再起動後に `diagram:list` の供給フローが再実行される。
+- [ ] 表示中図の切替で旧 `diagram:unsubscribe` と新 `diagram:subscribe` が成立し、`diagram:updated` / `diagram:submit` が現在図だけに作用する。
+- [ ] 図0件、diagrams directory 無し、壊れた図、一覧 ACK error、表示中図削除でも UI と server が crash しない。
+- [ ] 右ペイン幅・開閉 localStorage、左 ttyd iframe、右ペイントグル、既存 `lastDiagramPath` 復元、mobile 非表示が回帰していない。
+- [ ] `packages/shared/src/types.ts` と `packages/server/src/index.ts` の Socket.IO 追加が同じ実装単位で更新され、server handler は Vitest で固定される。
+- [ ] DB schema / migration、外部リソース、図セット、prev/next、相互リンク、diagram harness #241〜#243 を追加していない。

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -20,6 +20,7 @@ import { fileURLToPath } from "node:url";
 import {
   type BridgeSnapshot,
   type ClientToServerEvents,
+  type DiagramListResponse,
   MESSAGE_SHORTCUT_MAX_LENGTH,
   type ServerToClientEvents,
   type SessionGridSnapshot,
@@ -61,6 +62,7 @@ import {
 import { db } from "./lib/database.js";
 import { describeModelDiff } from "./lib/diagram-diff.js";
 import { ensureDoctype, replaceModelBlock } from "./lib/diagram-file.js";
+import { handleDiagramListRequest, listDiagrams } from "./lib/diagram-list.js";
 import { parseDiagramModel } from "./lib/diagram-model.js";
 import { resolveDiagramPath } from "./lib/diagram-path.js";
 import { readDiagram, readDiagramModel } from "./lib/diagram-reader.js";
@@ -2126,6 +2128,22 @@ export async function startServer(
 
     // ===== 図解キャンバス（board_open による表示 + 更新監視） =====
     const diagramUnsubs = new Map<string, () => void>();
+
+    socket.on("diagram:list", (data: unknown, callback: unknown) => {
+      if (typeof callback !== "function") return;
+      const reply = callback as (response: DiagramListResponse) => void;
+
+      void handleDiagramListRequest(
+        { resolveManagedWorktreePath, listDiagrams },
+        data
+      ).then(response => {
+        try {
+          reply(response);
+        } catch {
+          // ACK callback はクライアント由来。throw を server process へ伝播させない。
+        }
+      });
+    });
 
     socket.on("diagram:subscribe", (data: unknown) => {
       // payload は外部入力。分割代入前に型を検証しないと、引数なし emit や

--- a/packages/server/src/lib/diagram-list.test.ts
+++ b/packages/server/src/lib/diagram-list.test.ts
@@ -1,0 +1,219 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleDiagramListRequest, listDiagrams } from "./diagram-list.js";
+
+const tempDirs: string[] = [];
+
+function makeWorktree(withDiagramDir = true): {
+  worktree: string;
+  diagramDir: string;
+} {
+  const worktree = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ark-diagram-list-"))
+  );
+  tempDirs.push(worktree);
+  const diagramDir = path.join(worktree, "docs", "diagrams");
+  if (withDiagramDir) fs.mkdirSync(diagramDir, { recursive: true });
+  return { worktree, diagramDir };
+}
+
+function diagramHtml(title?: string): string {
+  const model = {
+    version: 1,
+    ...(title === undefined ? {} : { title }),
+    nodes: [],
+    edges: [],
+    groups: [],
+  };
+  return (
+    "<!doctype html><html><body>" +
+    `<script type="application/json" id="ark-diagram-model">${JSON.stringify(model)}</script>` +
+    "</body></html>"
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("listDiagrams", () => {
+  it("有効な図だけを再帰列挙し、title 優先・basename fallback でパス順に返す", async () => {
+    const { worktree, diagramDir } = makeWorktree();
+    fs.mkdirSync(path.join(diagramDir, "nested"), { recursive: true });
+    fs.writeFileSync(
+      path.join(diagramDir, "z.diagram.html"),
+      diagramHtml("注文フロー")
+    );
+    fs.writeFileSync(path.join(diagramDir, "a.diagram.html"), diagramHtml());
+    fs.writeFileSync(
+      path.join(diagramDir, "blank.diagram.html"),
+      diagramHtml("   ")
+    );
+    fs.writeFileSync(
+      path.join(diagramDir, "nested", "b.diagram.html"),
+      diagramHtml("サブ図")
+    );
+    fs.writeFileSync(
+      path.join(diagramDir, "not-diagram.html"),
+      diagramHtml("対象外")
+    );
+    fs.writeFileSync(path.join(diagramDir, "notes.txt"), "対象外");
+
+    await expect(listDiagrams(worktree)).resolves.toEqual([
+      {
+        relPath: "docs/diagrams/a.diagram.html",
+        displayName: "a.diagram.html",
+      },
+      {
+        relPath: "docs/diagrams/blank.diagram.html",
+        displayName: "blank.diagram.html",
+      },
+      {
+        relPath: "docs/diagrams/nested/b.diagram.html",
+        displayName: "サブ図",
+      },
+      {
+        relPath: "docs/diagrams/z.diagram.html",
+        displayName: "注文フロー",
+      },
+    ]);
+  });
+
+  it("diagrams directory が無い場合と空の場合は空配列を返す", async () => {
+    const missing = makeWorktree(false);
+    const empty = makeWorktree();
+
+    await expect(listDiagrams(missing.worktree)).resolves.toEqual([]);
+    await expect(listDiagrams(empty.worktree)).resolves.toEqual([]);
+  });
+
+  it("不正モデル・モデル無し・外向き symlink・symlink directory を除外する", async () => {
+    const { worktree, diagramDir } = makeWorktree();
+    const outside = makeWorktree();
+    fs.writeFileSync(
+      path.join(diagramDir, "valid.diagram.html"),
+      diagramHtml("正常")
+    );
+    fs.writeFileSync(
+      path.join(diagramDir, "broken.diagram.html"),
+      '<script type="application/json" id="ark-diagram-model">{</script>'
+    );
+    fs.writeFileSync(
+      path.join(diagramDir, "missing-model.diagram.html"),
+      "<html></html>"
+    );
+    const outsideFile = path.join(outside.worktree, "outside.diagram.html");
+    fs.writeFileSync(outsideFile, diagramHtml("外部"));
+    fs.symlinkSync(outsideFile, path.join(diagramDir, "outside.diagram.html"));
+    fs.mkdirSync(path.join(outside.worktree, "linked"), { recursive: true });
+    fs.writeFileSync(
+      path.join(outside.worktree, "linked", "hidden.diagram.html"),
+      diagramHtml("辿らない")
+    );
+    fs.symlinkSync(
+      path.join(outside.worktree, "linked"),
+      path.join(diagramDir, "linked"),
+      "dir"
+    );
+
+    await expect(listDiagrams(worktree)).resolves.toEqual([
+      {
+        relPath: "docs/diagrams/valid.diagram.html",
+        displayName: "正常",
+      },
+    ]);
+  });
+});
+
+describe("handleDiagramListRequest", () => {
+  it.each([
+    undefined,
+    null,
+    {},
+    { worktreePath: 1 },
+    { worktreePath: "" },
+  ])("不正 payload %j を ACK error にする", async data => {
+    const resolveManagedWorktreePath = vi.fn();
+    const list = vi.fn();
+
+    const result = await handleDiagramListRequest(
+      { resolveManagedWorktreePath, listDiagrams: list },
+      data
+    );
+
+    expect(result).toEqual({ ok: false, error: "不正なリクエストです" });
+    expect(resolveManagedWorktreePath).not.toHaveBeenCalled();
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("長すぎる path と managed worktree 解決失敗を ACK error にする", async () => {
+    const resolveManagedWorktreePath = vi.fn(() => null);
+    const list = vi.fn();
+
+    await expect(
+      handleDiagramListRequest(
+        { resolveManagedWorktreePath, listDiagrams: list },
+        { worktreePath: "x".repeat(4097) }
+      )
+    ).resolves.toEqual({ ok: false, error: "worktree のパスが長すぎます" });
+    expect(resolveManagedWorktreePath).not.toHaveBeenCalled();
+
+    await expect(
+      handleDiagramListRequest(
+        { resolveManagedWorktreePath, listDiagrams: list },
+        { worktreePath: "/unmanaged" }
+      )
+    ).resolves.toEqual({
+      ok: false,
+      error: "管理対象の worktree ではありません",
+    });
+    expect(list).not.toHaveBeenCalled();
+  });
+
+  it("resolver の正規化済み実パスだけを helper に渡して成功応答を返す", async () => {
+    const diagrams = [
+      {
+        relPath: "docs/diagrams/a.diagram.html",
+        displayName: "A",
+      },
+    ];
+    const resolveManagedWorktreePath = vi.fn(() => "/real/worktree");
+    const list = vi.fn(async () => diagrams);
+
+    await expect(
+      handleDiagramListRequest(
+        { resolveManagedWorktreePath, listDiagrams: list },
+        { worktreePath: "/input/worktree/." }
+      )
+    ).resolves.toEqual({ ok: true, diagrams });
+    expect(resolveManagedWorktreePath).toHaveBeenCalledWith(
+      "/input/worktree/."
+    );
+    expect(list).toHaveBeenCalledWith("/real/worktree");
+  });
+
+  it("列挙中の予期しない I/O error を ACK error に変換する", async () => {
+    const result = await handleDiagramListRequest(
+      {
+        resolveManagedWorktreePath: () => "/real/worktree",
+        listDiagrams: async () => {
+          throw Object.assign(new Error("permission denied"), {
+            code: "EACCES",
+          });
+        },
+      },
+      { worktreePath: "/input/worktree" }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("EACCES");
+      expect(result.error).toContain("permission denied");
+    }
+  });
+});

--- a/packages/server/src/lib/diagram-list.test.ts
+++ b/packages/server/src/lib/diagram-list.test.ts
@@ -128,6 +128,33 @@ describe("listDiagrams", () => {
       },
     ]);
   });
+
+  it("図の読み込みを同時に8件までに制限する", async () => {
+    const { worktree, diagramDir } = makeWorktree();
+    for (let index = 0; index < 17; index += 1) {
+      fs.writeFileSync(
+        path.join(diagramDir, `${index}.diagram.html`),
+        diagramHtml()
+      );
+    }
+
+    const originalOpen = fs.promises.open.bind(fs.promises);
+    let active = 0;
+    let maxActive = 0;
+    vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise(resolve => setTimeout(resolve, 5));
+      try {
+        return await originalOpen(...args);
+      } finally {
+        active -= 1;
+      }
+    });
+
+    await expect(listDiagrams(worktree)).resolves.toHaveLength(17);
+    expect(maxActive).toBe(8);
+  });
 });
 
 describe("handleDiagramListRequest", () => {

--- a/packages/server/src/lib/diagram-list.ts
+++ b/packages/server/src/lib/diagram-list.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { DiagramListItem, DiagramListResponse } from "@ark/shared";
+import { DIAGRAM_DIR } from "./diagram-path.js";
+import { readDiagramModel } from "./diagram-reader.js";
+import { errnoCode, errnoMessage } from "./errors.js";
+
+const DIAGRAM_SUFFIX = ".diagram.html";
+const MAX_WORKTREE_PATH_LENGTH = 4096;
+
+async function collectDiagramCandidates(
+  directory: string,
+  relativeParts: string[]
+): Promise<string[]> {
+  const entries = await fs.promises.readdir(directory, { withFileTypes: true });
+  const candidates: string[] = [];
+
+  for (const entry of entries) {
+    const childParts = [...relativeParts, entry.name];
+    if (entry.isDirectory()) {
+      candidates.push(
+        ...(await collectDiagramCandidates(
+          path.join(directory, entry.name),
+          childParts
+        ))
+      );
+      continue;
+    }
+    if (entry.name.endsWith(DIAGRAM_SUFFIX)) {
+      candidates.push([DIAGRAM_DIR, ...childParts].join("/"));
+    }
+  }
+
+  return candidates;
+}
+
+async function readDiagramListItem(
+  worktreeReal: string,
+  relPath: string
+): Promise<DiagramListItem | null> {
+  const result = await readDiagramModel(worktreeReal, relPath);
+  if (!result.ok) return null;
+  const title = result.model.title?.trim();
+  return {
+    relPath,
+    displayName: title || path.posix.basename(relPath),
+  };
+}
+
+/**
+ * realpath 済みの managed worktree から、有効な図だけを決定的な順序で列挙する。
+ * 個々の候補は readDiagramModel() の trust boundary を通過した場合だけ公開する。
+ */
+export async function listDiagrams(
+  worktreeReal: string
+): Promise<DiagramListItem[]> {
+  const diagramsDir = path.join(worktreeReal, DIAGRAM_DIR);
+  let candidates: string[];
+  try {
+    candidates = await collectDiagramCandidates(diagramsDir, []);
+  } catch (error) {
+    if (errnoCode(error) === "ENOENT") return [];
+    throw error;
+  }
+
+  candidates.sort((a, b) => a.localeCompare(b));
+  const items = await Promise.all(
+    candidates.map(relPath => readDiagramListItem(worktreeReal, relPath))
+  );
+  return items.filter((item): item is DiagramListItem => item !== null);
+}
+
+export interface DiagramListRequestDeps {
+  resolveManagedWorktreePath: (worktreePath: string) => string | null;
+  listDiagrams: (worktreeReal: string) => Promise<DiagramListItem[]>;
+}
+
+/** Socket.IO ACK handler から切り出した、外部入力を受ける純粋な core。 */
+export async function handleDiagramListRequest(
+  deps: DiagramListRequestDeps,
+  data: unknown
+): Promise<DiagramListResponse> {
+  const request = data as { worktreePath?: unknown } | null;
+  if (
+    !request ||
+    typeof request !== "object" ||
+    typeof request.worktreePath !== "string" ||
+    request.worktreePath.length === 0
+  ) {
+    return { ok: false, error: "不正なリクエストです" };
+  }
+  if (request.worktreePath.length > MAX_WORKTREE_PATH_LENGTH) {
+    return { ok: false, error: "worktree のパスが長すぎます" };
+  }
+
+  try {
+    const worktreeReal = deps.resolveManagedWorktreePath(request.worktreePath);
+    if (!worktreeReal) {
+      return { ok: false, error: "管理対象の worktree ではありません" };
+    }
+    const diagrams = await deps.listDiagrams(worktreeReal);
+    return { ok: true, diagrams };
+  } catch (error) {
+    return {
+      ok: false,
+      error: `図一覧の取得に失敗しました (${errnoCode(error)}): ${errnoMessage(error)}`,
+    };
+  }
+}

--- a/packages/server/src/lib/diagram-list.ts
+++ b/packages/server/src/lib/diagram-list.ts
@@ -7,6 +7,7 @@ import { errnoCode, errnoMessage } from "./errors.js";
 
 const DIAGRAM_SUFFIX = ".diagram.html";
 const MAX_WORKTREE_PATH_LENGTH = 4096;
+const DIAGRAM_READ_CONCURRENCY = 8;
 
 async function collectDiagramCandidates(
   directory: string,
@@ -64,9 +65,19 @@ export async function listDiagrams(
   }
 
   candidates.sort((a, b) => a.localeCompare(b));
-  const items = await Promise.all(
-    candidates.map(relPath => readDiagramListItem(worktreeReal, relPath))
-  );
+  const items: Array<DiagramListItem | null> = [];
+  for (
+    let offset = 0;
+    offset < candidates.length;
+    offset += DIAGRAM_READ_CONCURRENCY
+  ) {
+    const batch = candidates.slice(offset, offset + DIAGRAM_READ_CONCURRENCY);
+    items.push(
+      ...(await Promise.all(
+        batch.map(relPath => readDiagramListItem(worktreeReal, relPath))
+      ))
+    );
+  }
   return items.filter((item): item is DiagramListItem => item !== null);
 }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -343,6 +343,15 @@ export type SpecialKey =
   | "9";
 
 // WebSocket event types
+export interface DiagramListItem {
+  relPath: string;
+  displayName: string;
+}
+
+export type DiagramListResponse =
+  | { ok: true; diagrams: DiagramListItem[] }
+  | { ok: false; error: string };
+
 export interface ServerToClientEvents {
   // Repository events
   "repos:list": (repos: string[]) => void;
@@ -626,6 +635,12 @@ export interface ClientToServerEvents {
    * AskUserQuestion の自由入力モードで「1 文字ずつタイプ」する用途。
    */
   "session:send-literal": (data: { sessionId: string; text: string }) => void;
+
+  /** managed worktree にある有効な図を read-only で一覧する */
+  "diagram:list": (
+    data: { worktreePath: string },
+    callback: (response: DiagramListResponse) => void
+  ) => void;
 
   /** 図の購読開始（更新通知を受け取る）。1 セッション 1 図を想定 */
   "diagram:subscribe": (data: {

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -15,7 +15,8 @@ type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 interface DiagramPaneProps {
   sessionId: string;
   worktreePath: string;
-  relPath: string;
+  relPath?: string;
+  onSelectDiagram: (relPath: string) => void;
   /** 未接続時は null。null の間は診断購読をスキップする */
   socket: TypedSocket | null;
 }
@@ -64,6 +65,7 @@ export function DiagramPane({
   const portRef = useRef<MessagePort | null>(null);
 
   const load = useCallback(async () => {
+    if (!relPath) return;
     // 前のリクエストをキャンセル。タブ切り替え時に古い fetch が
     // 新しいタブの display を上書きするのを防ぐ（HtmlViewerPane と同じ方針）
     abortControllerRef.current?.abort();
@@ -111,17 +113,23 @@ export function DiagramPane({
   useEffect(() => {
     setHtml(null);
     setError(null);
+    if (!relPath) {
+      abortControllerRef.current?.abort();
+      portRef.current?.close();
+      portRef.current = null;
+      return;
+    }
     void load();
     return () => {
       portRef.current?.close();
       portRef.current = null;
     };
-  }, [load]);
+  }, [load, relPath]);
 
   // 図ファイルの更新監視。worktreePath / relPath が変わるたびに
   // 古い購読を解除してから新しい購読を張る。アンマウント時も同様に解除する。
   useEffect(() => {
-    if (!socket) return;
+    if (!socket || !relPath) return;
     socket.emit("diagram:subscribe", { worktreePath, relPath });
     const onUpdated = (data: { worktreePath: string; relPath: string }) => {
       if (data.worktreePath === worktreePath && data.relPath === relPath) {
@@ -148,6 +156,7 @@ export function DiagramPane({
   // エラーを表示する（非破壊）。
   const handleSubmit = useCallback(
     (model: unknown, submittedHtml: string) => {
+      if (!relPath) return;
       if (!socket) {
         setSubmitError("サーバーに未接続のため送信できません");
         return;
@@ -221,6 +230,14 @@ export function DiagramPane({
     },
     [handleSubmit, html]
   );
+
+  if (!relPath) {
+    return (
+      <div className="flex h-full items-center justify-center p-4 text-sm text-muted-foreground">
+        図を選択してください
+      </div>
+    );
+  }
 
   if (error) {
     return (

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -6,9 +6,14 @@
  * sandbox は allow-scripts のみで allow-same-origin を付けない。
  * 外部送信の遮断は本文に注入された meta CSP が担う（サーバー側で注入済み）。
  */
-import type { ClientToServerEvents, ServerToClientEvents } from "@ark/shared";
+import type {
+  ClientToServerEvents,
+  DiagramListItem,
+  ServerToClientEvents,
+} from "@ark/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
+import { DiagramSwitcher } from "./DiagramSwitcher";
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
@@ -17,6 +22,8 @@ interface DiagramPaneProps {
   worktreePath: string;
   relPath?: string;
   onSelectDiagram: (relPath: string) => void;
+  isConnected: boolean;
+  listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
   /** 未接続時は null。null の間は診断購読をスキップする */
   socket: TypedSocket | null;
 }
@@ -54,15 +61,24 @@ export function DiagramPane({
   worktreePath,
   relPath,
   socket,
+  isConnected,
+  listDiagrams,
+  onSelectDiagram,
 }: DiagramPaneProps) {
   const [html, setHtml] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [diagrams, setDiagrams] = useState<DiagramListItem[]>([]);
+  const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+  const [listRefreshKey, setListRefreshKey] = useState(0);
+  const activeListRequestRef = useRef<object | null>(null);
   // 進行中の fetch を追跡し、古いタブの結果が新しいタブを上書きしないようにする
   const abortControllerRef = useRef<AbortController | null>(null);
   // ハーネスへ渡した MessageChannel の port1（親側）。再ロードのたびに
   // 張り直すので、常に「今のロードに対応する port」だけを保持する。
   const portRef = useRef<MessagePort | null>(null);
+  const portGrantedForRef = useRef<string | null>(null);
 
   const load = useCallback(async () => {
     if (!relPath) return;
@@ -113,6 +129,7 @@ export function DiagramPane({
   useEffect(() => {
     setHtml(null);
     setError(null);
+    portGrantedForRef.current = null;
     if (!relPath) {
       abortControllerRef.current?.abort();
       portRef.current?.close();
@@ -126,14 +143,52 @@ export function DiagramPane({
     };
   }, [load, relPath]);
 
+  // mount / reconnect / current 図変更 / 明示 refresh で一覧を再取得する。
+  // request generation により、古い worktree の遅延 ACK は state へ反映しない。
+  useEffect(() => {
+    const request = { worktreePath, relPath, listRefreshKey };
+    activeListRequestRef.current = request;
+    if (!isConnected || !worktreePath) {
+      setListLoading(false);
+      return;
+    }
+
+    setListLoading(true);
+    void listDiagrams(worktreePath)
+      .then(items => {
+        if (activeListRequestRef.current !== request) return;
+        setDiagrams(items);
+        setListError(null);
+      })
+      .catch(reason => {
+        if (activeListRequestRef.current !== request) return;
+        setListError(
+          reason instanceof Error
+            ? reason.message
+            : "図一覧の取得に失敗しました"
+        );
+      })
+      .finally(() => {
+        if (activeListRequestRef.current === request) {
+          setListLoading(false);
+        }
+      });
+    return () => {
+      if (activeListRequestRef.current === request) {
+        activeListRequestRef.current = null;
+      }
+    };
+  }, [worktreePath, isConnected, relPath, listDiagrams, listRefreshKey]);
+
   // 図ファイルの更新監視。worktreePath / relPath が変わるたびに
   // 古い購読を解除してから新しい購読を張る。アンマウント時も同様に解除する。
   useEffect(() => {
-    if (!socket || !relPath) return;
+    if (!socket || !isConnected || !relPath) return;
     socket.emit("diagram:subscribe", { worktreePath, relPath });
     const onUpdated = (data: { worktreePath: string; relPath: string }) => {
       if (data.worktreePath === worktreePath && data.relPath === relPath) {
         void load();
+        setListRefreshKey(key => key + 1);
       }
     };
     socket.on("diagram:updated", onUpdated);
@@ -141,7 +196,7 @@ export function DiagramPane({
       socket.off("diagram:updated", onUpdated);
       socket.emit("diagram:unsubscribe", { worktreePath, relPath });
     };
-  }, [socket, worktreePath, relPath, load]);
+  }, [socket, isConnected, worktreePath, relPath, load]);
 
   // アンマウント時に進行中の fetch を中止。タブ切り替え直後の
   // アンマウント時に古い fetch が返された結果でステート更新されるのを防ぐ
@@ -157,7 +212,7 @@ export function DiagramPane({
   const handleSubmit = useCallback(
     (model: unknown, submittedHtml: string) => {
       if (!relPath) return;
-      if (!socket) {
+      if (!socket || !isConnected) {
         setSubmitError("サーバーに未接続のため送信できません");
         return;
       }
@@ -173,7 +228,7 @@ export function DiagramPane({
         }
       );
     },
-    [socket, sessionId, worktreePath, relPath]
+    [socket, isConnected, sessionId, worktreePath, relPath]
   );
 
   // iframe のロード（初回表示 / worktreePath・relPath 変更 / diagram:updated
@@ -188,7 +243,6 @@ export function DiagramPane({
   // 止められない（spec §4.2.2）ので、ここで port を渡すと遷移先の外部
   // ドキュメントに diagram:submit の書き込み経路まで開いてしまう（codex
   // review P1 指摘）。初回限定にすることでこの経路を塞ぐ。
-  const portGrantedForRef = useRef<string | null>(null);
   const handleIframeLoad = useCallback(
     (e: React.SyntheticEvent<HTMLIFrameElement>) => {
       const iframeWindow = e.currentTarget.contentWindow;
@@ -231,49 +285,53 @@ export function DiagramPane({
     [handleSubmit, html]
   );
 
-  if (!relPath) {
-    return (
-      <div className="flex h-full items-center justify-center p-4 text-sm text-muted-foreground">
-        図を選択してください
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex h-full items-center justify-center p-4 text-sm text-destructive">
-        {error}
-      </div>
-    );
-  }
-  if (html === null) {
-    return (
-      <div className="flex h-full items-center justify-center p-4 text-sm text-muted-foreground">
-        読み込み中…
-      </div>
-    );
-  }
   return (
-    <div className="relative flex h-full flex-col">
-      {submitError && (
-        <div className="flex shrink-0 items-start justify-between gap-2 border-b border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          <span className="flex-1">{submitError}</span>
-          <button
-            type="button"
-            className="shrink-0 text-xs underline"
-            onClick={() => setSubmitError(null)}
-          >
-            閉じる
-          </button>
-        </div>
-      )}
-      <iframe
-        title={relPath}
-        srcDoc={html}
-        sandbox="allow-scripts"
-        className="h-full w-full flex-1 border-0 bg-white"
-        onLoad={handleIframeLoad}
+    <div className="flex h-full flex-col">
+      <DiagramSwitcher
+        diagrams={diagrams}
+        currentRelPath={relPath}
+        onSelect={onSelectDiagram}
+        listLoading={listLoading}
+        listError={listError}
+        onRetry={() => setListRefreshKey(key => key + 1)}
       />
+      <div className="relative min-h-0 flex-1">
+        {!relPath ? (
+          <div className="flex h-full items-center justify-center p-4 text-sm text-muted-foreground">
+            {diagrams.length > 0 ? "上の一覧から図を選択" : "図がありません"}
+          </div>
+        ) : error ? (
+          <div className="flex h-full items-center justify-center p-4 text-sm text-destructive">
+            {error}
+          </div>
+        ) : html === null ? (
+          <div className="flex h-full items-center justify-center p-4 text-sm text-muted-foreground">
+            読み込み中…
+          </div>
+        ) : (
+          <div className="flex h-full flex-col">
+            {submitError && (
+              <div className="flex shrink-0 items-start justify-between gap-2 border-b border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                <span className="flex-1">{submitError}</span>
+                <button
+                  type="button"
+                  className="shrink-0 text-xs underline"
+                  onClick={() => setSubmitError(null)}
+                >
+                  閉じる
+                </button>
+              </div>
+            )}
+            <iframe
+              title={relPath}
+              srcDoc={html}
+              sandbox="allow-scripts"
+              className="min-h-0 w-full flex-1 border-0 bg-white"
+              onLoad={handleIframeLoad}
+            />
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -21,7 +21,7 @@ interface DiagramPaneProps {
   sessionId: string;
   worktreePath: string;
   relPath?: string;
-  onSelectDiagram: (relPath: string) => void;
+  onSelectDiagram: (relPath: string, worktreePath: string) => void;
   isConnected: boolean;
   listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
   /** 未接続時は null。null の間は診断購読をスキップする */
@@ -290,7 +290,9 @@ export function DiagramPane({
       <DiagramSwitcher
         diagrams={diagrams}
         currentRelPath={relPath}
-        onSelect={onSelectDiagram}
+        onSelect={selectedRelPath =>
+          onSelectDiagram(selectedRelPath, worktreePath)
+        }
         listLoading={listLoading}
         listError={listError}
         onRetry={() => setListRefreshKey(key => key + 1)}

--- a/packages/web/src/components/DiagramSwitcher.test.tsx
+++ b/packages/web/src/components/DiagramSwitcher.test.tsx
@@ -1,0 +1,77 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { DiagramSwitcher } from "./DiagramSwitcher";
+
+const diagrams = [
+  {
+    relPath: "docs/diagrams/a.diagram.html",
+    displayName: "注文フロー",
+  },
+  {
+    relPath: "docs/diagrams/nested/b.diagram.html",
+    displayName: "b.diagram.html",
+  },
+];
+
+describe("DiagramSwitcher", () => {
+  it("表示名と相対 path を並べ、現在図を selected にする", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DiagramSwitcher, {
+        diagrams,
+        currentRelPath: "docs/diagrams/nested/b.diagram.html",
+        onSelect: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('aria-label="表示する図"');
+    expect(markup).toContain(
+      '<option value="docs/diagrams/a.diagram.html" title="docs/diagrams/a.diagram.html">注文フロー</option>'
+    );
+    expect(markup).toContain(
+      '<option value="docs/diagrams/nested/b.diagram.html" title="docs/diagrams/nested/b.diagram.html" selected="">b.diagram.html</option>'
+    );
+  });
+
+  it("current 無しでは「図を選択」を selected placeholder にする", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DiagramSwitcher, {
+        diagrams,
+        currentRelPath: undefined,
+        onSelect: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain('<option value="" selected="">図を選択</option>');
+  });
+
+  it("0件では disabled の「図がありません」を表示する", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DiagramSwitcher, {
+        diagrams: [],
+        currentRelPath: undefined,
+        onSelect: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain("<select");
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain(
+      '<option value="" selected="">図がありません</option>'
+    );
+  });
+
+  it("current が一覧に無い場合も basename の一時 option を selected にする", () => {
+    const markup = renderToStaticMarkup(
+      createElement(DiagramSwitcher, {
+        diagrams,
+        currentRelPath: "docs/diagrams/deleted.diagram.html",
+        onSelect: vi.fn(),
+      })
+    );
+
+    expect(markup).toContain(
+      '<option value="docs/diagrams/deleted.diagram.html" title="docs/diagrams/deleted.diagram.html" selected="">deleted.diagram.html</option>'
+    );
+  });
+});

--- a/packages/web/src/components/DiagramSwitcher.test.tsx
+++ b/packages/web/src/components/DiagramSwitcher.test.tsx
@@ -26,10 +26,10 @@ describe("DiagramSwitcher", () => {
 
     expect(markup).toContain('aria-label="表示する図"');
     expect(markup).toContain(
-      '<option value="docs/diagrams/a.diagram.html" title="docs/diagrams/a.diagram.html">注文フロー</option>'
+      '<option value="docs/diagrams/a.diagram.html" title="docs/diagrams/a.diagram.html">注文フロー — a.diagram.html</option>'
     );
     expect(markup).toContain(
-      '<option value="docs/diagrams/nested/b.diagram.html" title="docs/diagrams/nested/b.diagram.html" selected="">b.diagram.html</option>'
+      '<option value="docs/diagrams/nested/b.diagram.html" title="docs/diagrams/nested/b.diagram.html" selected="">nested/b.diagram.html</option>'
     );
   });
 
@@ -61,17 +61,17 @@ describe("DiagramSwitcher", () => {
     );
   });
 
-  it("current が一覧に無い場合も basename の一時 option を selected にする", () => {
+  it("current が一覧に無い場合も整形した一時 option を selected にする", () => {
     const markup = renderToStaticMarkup(
       createElement(DiagramSwitcher, {
         diagrams,
-        currentRelPath: "docs/diagrams/deleted.diagram.html",
+        currentRelPath: "docs/diagrams/deleted/deleted.diagram.html",
         onSelect: vi.fn(),
       })
     );
 
     expect(markup).toContain(
-      '<option value="docs/diagrams/deleted.diagram.html" title="docs/diagrams/deleted.diagram.html" selected="">deleted.diagram.html</option>'
+      '<option value="docs/diagrams/deleted/deleted.diagram.html" title="docs/diagrams/deleted/deleted.diagram.html" selected="">deleted/deleted.diagram.html</option>'
     );
   });
 });

--- a/packages/web/src/components/DiagramSwitcher.tsx
+++ b/packages/web/src/components/DiagramSwitcher.tsx
@@ -1,5 +1,6 @@
 import type { DiagramListItem } from "@ark/shared";
 import type { ChangeEvent } from "react";
+import { formatDiagramOptionLabel } from "../lib/diagram-option-label";
 
 interface DiagramSwitcherProps {
   diagrams: DiagramListItem[];
@@ -8,10 +9,6 @@ interface DiagramSwitcherProps {
   listLoading?: boolean;
   listError?: string | null;
   onRetry?: () => void;
-}
-
-function basename(relPath: string): string {
-  return relPath.split("/").at(-1) ?? relPath;
 }
 
 export function DiagramSwitcher({
@@ -43,7 +40,10 @@ export function DiagramSwitcher({
         {!currentRelPath && <option value="">{placeholder}</option>}
         {currentIsStale && currentRelPath && (
           <option value={currentRelPath} title={currentRelPath}>
-            {basename(currentRelPath)}
+            {formatDiagramOptionLabel(
+              currentRelPath.split("/").at(-1) ?? currentRelPath,
+              currentRelPath
+            )}
           </option>
         )}
         {diagrams.map(diagram => (
@@ -52,7 +52,7 @@ export function DiagramSwitcher({
             value={diagram.relPath}
             title={diagram.relPath}
           >
-            {diagram.displayName}
+            {formatDiagramOptionLabel(diagram.displayName, diagram.relPath)}
           </option>
         ))}
       </select>

--- a/packages/web/src/components/DiagramSwitcher.tsx
+++ b/packages/web/src/components/DiagramSwitcher.tsx
@@ -1,0 +1,109 @@
+import type { DiagramListItem } from "@ark/shared";
+import { type ChangeEvent, createElement } from "react";
+
+interface DiagramSwitcherProps {
+  diagrams: DiagramListItem[];
+  currentRelPath?: string;
+  onSelect: (relPath: string) => void;
+  listLoading?: boolean;
+  listError?: string | null;
+  onRetry?: () => void;
+}
+
+function basename(relPath: string): string {
+  return relPath.split("/").at(-1) ?? relPath;
+}
+
+export function DiagramSwitcher({
+  diagrams,
+  currentRelPath,
+  onSelect,
+  listLoading = false,
+  listError = null,
+  onRetry,
+}: DiagramSwitcherProps) {
+  const currentIsStale =
+    currentRelPath !== undefined &&
+    !diagrams.some(diagram => diagram.relPath === currentRelPath);
+  const disabled = diagrams.length === 0 && !currentRelPath;
+  const placeholder = diagrams.length === 0 ? "図がありません" : "図を選択";
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    if (event.target.value) onSelect(event.target.value);
+  };
+
+  const options = [
+    !currentRelPath
+      ? createElement("option", { key: "", value: "" }, placeholder)
+      : null,
+    currentIsStale && currentRelPath
+      ? createElement(
+          "option",
+          {
+            key: currentRelPath,
+            value: currentRelPath,
+            title: currentRelPath,
+          },
+          basename(currentRelPath)
+        )
+      : null,
+    ...diagrams.map(diagram =>
+      createElement(
+        "option",
+        {
+          key: diagram.relPath,
+          value: diagram.relPath,
+          title: diagram.relPath,
+        },
+        diagram.displayName
+      )
+    ),
+  ];
+
+  return createElement(
+    "div",
+    {
+      className:
+        "flex h-10 shrink-0 items-center gap-2 border-b border-border bg-sidebar px-2",
+    },
+    createElement(
+      "select",
+      {
+        "aria-label": "表示する図",
+        className:
+          "h-7 min-w-0 flex-1 truncate rounded border border-border bg-background px-2 text-xs text-foreground",
+        disabled,
+        value: currentRelPath ?? "",
+        onChange: handleChange,
+      },
+      ...options
+    ),
+    listLoading
+      ? createElement(
+          "span",
+          { className: "shrink-0 text-[10px] text-muted-foreground" },
+          "更新中…"
+        )
+      : null,
+    listError
+      ? createElement(
+          "span",
+          {
+            className: "min-w-0 max-w-28 truncate text-[10px] text-destructive",
+            title: listError,
+          },
+          listError
+        )
+      : null,
+    listError && onRetry
+      ? createElement(
+          "button",
+          {
+            type: "button",
+            className: "shrink-0 text-[10px] underline",
+            onClick: onRetry,
+          },
+          "再試行"
+        )
+      : null
+  );
+}

--- a/packages/web/src/components/DiagramSwitcher.tsx
+++ b/packages/web/src/components/DiagramSwitcher.tsx
@@ -1,5 +1,5 @@
 import type { DiagramListItem } from "@ark/shared";
-import { type ChangeEvent, createElement } from "react";
+import type { ChangeEvent } from "react";
 
 interface DiagramSwitcherProps {
   diagrams: DiagramListItem[];
@@ -31,79 +31,53 @@ export function DiagramSwitcher({
     if (event.target.value) onSelect(event.target.value);
   };
 
-  const options = [
-    !currentRelPath
-      ? createElement("option", { key: "", value: "" }, placeholder)
-      : null,
-    currentIsStale && currentRelPath
-      ? createElement(
-          "option",
-          {
-            key: currentRelPath,
-            value: currentRelPath,
-            title: currentRelPath,
-          },
-          basename(currentRelPath)
-        )
-      : null,
-    ...diagrams.map(diagram =>
-      createElement(
-        "option",
-        {
-          key: diagram.relPath,
-          value: diagram.relPath,
-          title: diagram.relPath,
-        },
-        diagram.displayName
-      )
-    ),
-  ];
-
-  return createElement(
-    "div",
-    {
-      className:
-        "flex h-10 shrink-0 items-center gap-2 border-b border-border bg-sidebar px-2",
-    },
-    createElement(
-      "select",
-      {
-        "aria-label": "表示する図",
-        className:
-          "h-7 min-w-0 flex-1 truncate rounded border border-border bg-background px-2 text-xs text-foreground",
-        disabled,
-        value: currentRelPath ?? "",
-        onChange: handleChange,
-      },
-      ...options
-    ),
-    listLoading
-      ? createElement(
-          "span",
-          { className: "shrink-0 text-[10px] text-muted-foreground" },
-          "更新中…"
-        )
-      : null,
-    listError
-      ? createElement(
-          "span",
-          {
-            className: "min-w-0 max-w-28 truncate text-[10px] text-destructive",
-            title: listError,
-          },
-          listError
-        )
-      : null,
-    listError && onRetry
-      ? createElement(
-          "button",
-          {
-            type: "button",
-            className: "shrink-0 text-[10px] underline",
-            onClick: onRetry,
-          },
-          "再試行"
-        )
-      : null
+  return (
+    <div className="flex h-10 shrink-0 items-center gap-2 border-b border-border bg-sidebar px-2">
+      <select
+        aria-label="表示する図"
+        className="h-7 min-w-0 flex-1 truncate rounded border border-border bg-background px-2 text-xs text-foreground"
+        disabled={disabled}
+        value={currentRelPath ?? ""}
+        onChange={handleChange}
+      >
+        {!currentRelPath && <option value="">{placeholder}</option>}
+        {currentIsStale && currentRelPath && (
+          <option value={currentRelPath} title={currentRelPath}>
+            {basename(currentRelPath)}
+          </option>
+        )}
+        {diagrams.map(diagram => (
+          <option
+            key={diagram.relPath}
+            value={diagram.relPath}
+            title={diagram.relPath}
+          >
+            {diagram.displayName}
+          </option>
+        ))}
+      </select>
+      {listLoading && (
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          更新中…
+        </span>
+      )}
+      {listError && (
+        <span
+          className="min-w-0 max-w-28 truncate text-[10px] text-destructive"
+          title={listError}
+        >
+          {listError}
+        </span>
+      )}
+      {listError && onRetry && (
+        <button
+          type="button"
+          className="shrink-0 text-[10px] underline"
+          onClick={onRetry}
+        >
+          再試行
+        </button>
+      )}
+    </div>
   );
 }

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -2,15 +2,14 @@
  * SplitViewPane - PC 用セッションビュー（ターミナル + 右ペインの左右2ペイン）
  *
  * 左ペイン = TerminalPane（ttyd + file/html タブ）を常時表示、
- * 右ペインは diagram タブがあるときだけ意味を持ち、上部バーのトグルで開閉する。
+ * 右ペインは図が未選択でも上部バーのトグルで開閉できる。
  * 中身は DiagramPane（B-0a の図ペイン）。
  * 会話ビュー（SplitChatPane）は使わない — チャット内容を確認したい場合は
  * ttyd の生ターミナル（左ペイン）を直接見る。
  *
  * - diagram は TerminalPane のタブ機構から外れ、右ペイン専属になった
  *   （タブ自体は sessionTabs 上には残るが、非表示のまま「開いている印」として使う）
- * - 図（openDiagramTab）が開かれると下の useEffect が検知して showBoard を自動 true にする
- * - diagram タブが無くなったら右ペインは自動的に閉じる（表示するものが無いため）
+ * - 図（openDiagramTab）の activation id が変わると showBoard を自動 true にする
  * - 右ペイン幅 / 開閉状態は localStorage に永続化
  */
 
@@ -43,6 +42,7 @@ interface SplitViewPaneProps {
   activeTabIndex: number;
   onTabSelect: (index: number) => void;
   onTabClose: (index: number) => void;
+  onSelectDiagram: (relPath: string) => void;
   onSendMessage: (message: string) => void;
   onSendKey: (key: SpecialKey) => void;
   onDeleteSession: () => void;
@@ -91,13 +91,13 @@ export function SplitViewPane(props: SplitViewPaneProps) {
     readSavedShowBoard()
   );
 
-  // 右ペインに出す図（最後に開かれたもの）。diagram タブはタブバーから
-  // 除外されており、ここでのみ描画される。
-  const diagramTab = props.tabs.findLast(t => t.type === "diagram");
+  // 現在図は session ごとに最大1件。diagram タブは左タブバーから除外され、
+  // ここでのみ参照する。
+  const diagramTab = props.tabs.find(t => t.type === "diagram");
 
-  // diagram タブが sessionTabs に新規追加されたら右ペインを自動表示する。
+  // current diagram の activation id が変わったら右ペインを自動表示する。
   // tabs は session 単位でスコープされているため、他セッションの変化には反応しない。
-  // 数の増加時のみ true 化し、ユーザーが後で閉じた操作は尊重する。
+  // 同じ relPath の board_open でも id は新しくなるため再表示できる。
   //
   // 「lastDiagramPath からの復元」除外について:
   // このコンポーネントは Dashboard.tsx で全セッション分が session.id をキーに
@@ -108,35 +108,21 @@ export function SplitViewPane(props: SplitViewPaneProps) {
   // そのため「マウント時点で図タブが既にあれば増加とみなさない」という直感的な
   // 前提は成り立たない ― prevBoardCountRef は常にマウント直後は 0 から始まり、
   // 直後に復元 openDiagramTab が発火すると 0→1 の「増加」として観測されてしまう。
-  // ここでは live な board_open による新規オープンだけを「増加」としてカウント
-  // したいので、restoredOnLoad タグの付いた復元タブを母数から除外する
+  // ここでは live な board_open / user switch だけを自動表示したいので、
+  // restoredOnLoad タグの付いた復元タブは除外する
   // （タグは openDiagramTab の呼び出し元 = Dashboard.tsx の復元 effect が付与する）。
-  const prevBoardCountRef = useRef(0);
+  const prevDiagramIdRef = useRef<string | undefined>(undefined);
   useEffect(() => {
-    const boardCount = props.tabs.filter(
-      t => t.type === "diagram" && !t.restoredOnLoad
-    ).length;
-    if (boardCount > prevBoardCountRef.current) {
+    const currentId = diagramTab?.id;
+    if (
+      currentId !== undefined &&
+      currentId !== prevDiagramIdRef.current &&
+      diagramTab?.restoredOnLoad !== true
+    ) {
       setShowBoard(true);
     }
-    prevBoardCountRef.current = boardCount;
-  }, [props.tabs]);
-
-  // diagram タブが無くなったら右ペインに表示するものが無いので自動的に閉じる
-  //
-  // 注意: diagram タブには閉じるボタンが無く（ViewerTabBar はタブバー自体から
-  // diagram を除外しており、タブバー経由の close 導線が存在しない）、他に
-  // props.tabs から diagram タブを削除する経路も現状無いため、diagramTab が
-  // 存在した状態から falsy になる（= !diagramTab && showBoard が true になる）
-  // ケースは実質到達しない。到達しなくても描画側は下で
-  // `showBoard && diagramTab` により二重に守られているため実害は無いが、
-  // 「なぜ動いているのを見たことがないのか」で悩まないよう明記しておく。
-  // 将来 diagram タブの削除経路が追加されたときのための保険として残す。
-  useEffect(() => {
-    if (!diagramTab && showBoard) {
-      setShowBoard(false);
-    }
-  }, [diagramTab, showBoard]);
+    prevDiagramIdRef.current = currentId;
+  }, [diagramTab]);
 
   // コンテナ幅変化時に board 幅を最大比率内に丸める（表示中のみ意味あり）
   useEffect(() => {
@@ -204,27 +190,25 @@ export function SplitViewPane(props: SplitViewPaneProps) {
 
   return (
     <div className="h-full flex flex-col">
-      {/* 上部バー: 右ペイン開閉トグル（diagram タブがあるときのみ表示） */}
+      {/* 上部バー: 右ペイン開閉トグル */}
       {/* pr-12: SidebarMainLayout の Beacon 展開ボタン（absolute top-2 right-2 の浮遊）が
           右端トグルに重なってクリックを奪うため、その分の余白を常に確保する。
           Beacon 表示中は無駄な余白になるが、右端にはトグルしか無いので実害はない */}
-      {diagramTab && (
-        <div className="h-8 shrink-0 border-b border-border bg-sidebar flex items-center justify-end pl-2 pr-12">
-          <button
-            type="button"
-            onClick={handleToggleBoard}
-            className={`text-[11px] px-2 py-1 rounded-md font-medium flex items-center gap-1 transition-colors ${
-              showBoard
-                ? "bg-primary text-primary-foreground"
-                : "bg-muted hover:bg-muted/70 text-foreground"
-            }`}
-            title={showBoard ? "右ペインを閉じる" : "図を開く"}
-          >
-            <span>📐</span>
-            <span>{showBoard ? "閉じる" : "図"}</span>
-          </button>
-        </div>
-      )}
+      <div className="h-8 shrink-0 border-b border-border bg-sidebar flex items-center justify-end pl-2 pr-12">
+        <button
+          type="button"
+          onClick={handleToggleBoard}
+          className={`text-[11px] px-2 py-1 rounded-md font-medium flex items-center gap-1 transition-colors ${
+            showBoard
+              ? "bg-primary text-primary-foreground"
+              : "bg-muted hover:bg-muted/70 text-foreground"
+          }`}
+          title={showBoard ? "右ペインを閉じる" : "図を開く"}
+        >
+          <span>📐</span>
+          <span>{showBoard ? "閉じる" : "図"}</span>
+        </button>
+      </div>
 
       <div ref={containerRef} className="flex-1 min-h-0 flex relative">
         {/* 左ペイン: ターミナル（常時表示）
@@ -259,8 +243,8 @@ export function SplitViewPane(props: SplitViewPaneProps) {
           />
         </div>
 
-        {/* リサイザ・右ペインは diagram タブ表示時のみ */}
-        {showBoard && diagramTab && (
+        {/* リサイザ・右ペイン */}
+        {showBoard && (
           <>
             <button
               type="button"
@@ -281,8 +265,11 @@ export function SplitViewPane(props: SplitViewPaneProps) {
               <DiagramPane
                 socket={props.socket}
                 sessionId={props.session.id}
-                worktreePath={diagramTab.worktreePath}
-                relPath={diagramTab.relPath}
+                worktreePath={
+                  diagramTab?.worktreePath ?? props.session.worktreePath
+                }
+                relPath={diagramTab?.relPath}
+                onSelectDiagram={props.onSelectDiagram}
               />
             </div>
           </>

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -45,7 +45,7 @@ interface SplitViewPaneProps {
   activeTabIndex: number;
   onTabSelect: (index: number) => void;
   onTabClose: (index: number) => void;
-  onSelectDiagram: (relPath: string) => void;
+  onSelectDiagram: (relPath: string, worktreePath: string) => void;
   onSendMessage: (message: string) => void;
   onSendKey: (key: SpecialKey) => void;
   onDeleteSession: () => void;

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -15,6 +15,7 @@
 
 import type {
   ClientToServerEvents,
+  DiagramListItem,
   ManagedSession,
   MessageShortcut,
   ServerToClientEvents,
@@ -35,6 +36,8 @@ const STORAGE_KEY_SHOW_BOARD = "ark-split-show-board";
 
 interface SplitViewPaneProps {
   socket: TypedSocket | null;
+  isConnected: boolean;
+  listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
   session: ManagedSession;
   worktree: Worktree | undefined;
   repoName?: string;
@@ -264,6 +267,8 @@ export function SplitViewPane(props: SplitViewPaneProps) {
             >
               <DiagramPane
                 socket={props.socket}
+                isConnected={props.isConnected}
+                listDiagrams={props.listDiagrams}
                 sessionId={props.session.id}
                 worktreePath={
                   diagramTab?.worktreePath ?? props.session.worktreePath

--- a/packages/web/src/components/TerminalPane.tsx
+++ b/packages/web/src/components/TerminalPane.tsx
@@ -88,7 +88,7 @@ export type ViewerTab =
       relPath: string;
       /**
        * リロード直後の DB 復元（lastDiagramPath）で開かれたタブなら true。
-       * SplitViewPane の「図タブが増えたら右ペインを自動表示する」トリガーから
+       * SplitViewPane の「現在図 id が変わったら右ペインを自動表示する」トリガーから
        * 除外するために使う（復元のたびに右ペインが強制で開くのを防ぐ）。
        * board_open による通常のライブオープンでは付与しない。
        */

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -13,6 +13,7 @@ import type {
   BrowserSession,
   ChatMessage,
   ClientToServerEvents,
+  DiagramListItem,
   FsListResult,
   ManagedSession,
   McpConnectionInfo,
@@ -75,6 +76,9 @@ interface UseSocketReturn {
 
   // Folder browser
   listDirectory: (path?: string) => Promise<FsListResult>;
+
+  // Diagram list
+  listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
 
   // Repository
   repoList: string[];
@@ -1201,6 +1205,37 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     });
   }, []);
 
+  const listDiagrams = useCallback(
+    (worktreePath: string): Promise<DiagramListItem[]> => {
+      return new Promise((resolve, reject) => {
+        const socket = socketRef.current;
+        if (!socket?.connected) {
+          reject(new Error("ソケットが切断されています"));
+          return;
+        }
+
+        let settled = false;
+        const timeoutId = window.setTimeout(() => {
+          if (settled) return;
+          settled = true;
+          reject(new Error("図一覧の取得がタイムアウトしました"));
+        }, 10000);
+
+        socket.emit("diagram:list", { worktreePath }, response => {
+          if (settled) return;
+          settled = true;
+          window.clearTimeout(timeoutId);
+          if (response.ok) {
+            resolve(response.diagrams);
+          } else {
+            reject(new Error(response.error));
+          }
+        });
+      });
+    },
+    []
+  );
+
   // Worktree actions
   const createWorktree = useCallback(
     (branchName: string, baseBranch?: string) => {
@@ -1621,6 +1656,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     isScanning,
     scanRepos,
     listDirectory,
+    listDiagrams,
     repoList,
     repoPath,
     selectRepo,

--- a/packages/web/src/hooks/useViewerTabs.ts
+++ b/packages/web/src/hooks/useViewerTabs.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { ViewerTab } from "../components/TerminalPane";
-import { addOrFocusDiagramTab } from "../lib/diagram-tabs";
+import { setCurrentDiagramTab } from "../lib/diagram-tabs";
 import { correctActiveIndexAfterClose } from "../lib/tab-close";
 
 /**
@@ -144,11 +144,10 @@ export function useViewerTabs(
     []
   );
 
-  // diagram は右ペイン（SplitViewPane の DiagramPane）専属になった
-  // ため、ここでは sessionTabs への追加のみ行い、アクティブタブは変更しない（変更すると
-  // TerminalPane の表示対象が diagram タブになり、diagram を描画しない TerminalPane では
-  // 画面が空白になってしまう）。sessionTabs への追加自体は、SplitViewPane 側の
-  // 「diagram タブ数が増えたら右ペインを自動表示する」effect のトリガーとして必要。
+  // diagram は右ペインの「現在図」1件として設定する。左ペインの active tab は
+  // id で追跡して維持し、旧 state に複数 diagram があっても同時に畳み込む。
+  // live open ごとに新しい id を採用し、SplitViewPane の再表示トリガーにする。
+  const diagramTabSequenceRef = useRef(0);
   const openDiagramTab = useCallback(
     (
       sessionId: string,
@@ -156,17 +155,36 @@ export function useViewerTabs(
       relPath: string,
       restoredOnLoad?: boolean
     ) => {
+      diagramTabSequenceRef.current += 1;
+      const id = `diagram-${Date.now()}-${diagramTabSequenceRef.current}`;
       setSessionTabs(prev => {
         const current = prev[sessionId] ?? [
           { type: "terminal" as const, id: "terminal" },
         ];
-        const tabs = addOrFocusDiagramTab(
+        const { tabs } = setCurrentDiagramTab(
           current,
+          0,
           worktreePath,
           relPath,
-          `diagram-${Date.now()}`,
+          id,
           restoredOnLoad
         );
+
+        setSessionActiveTab(prevActive => {
+          const activeIndex = prevActive[sessionId] ?? 0;
+          const next = setCurrentDiagramTab(
+            current,
+            activeIndex,
+            worktreePath,
+            relPath,
+            id,
+            restoredOnLoad
+          ).activeIndex;
+          return next === activeIndex
+            ? prevActive
+            : { ...prevActive, [sessionId]: next };
+        });
+
         return { ...prev, [sessionId]: tabs };
       });
     },

--- a/packages/web/src/hooks/useViewerTabs.ts
+++ b/packages/web/src/hooks/useViewerTabs.ts
@@ -31,6 +31,10 @@ export function useViewerTabs(
   const [sessionActiveTab, setSessionActiveTab] = useState<
     Record<string, number>
   >({});
+  const sessionTabsRef = useRef(sessionTabs);
+  const sessionActiveTabRef = useRef(sessionActiveTab);
+  sessionTabsRef.current = sessionTabs;
+  sessionActiveTabRef.current = sessionActiveTab;
 
   const getTabsForSession = useCallback(
     (sessionId: string): ViewerTab[] => {
@@ -157,35 +161,33 @@ export function useViewerTabs(
     ) => {
       diagramTabSequenceRef.current += 1;
       const id = `diagram-${Date.now()}-${diagramTabSequenceRef.current}`;
-      setSessionTabs(prev => {
-        const current = prev[sessionId] ?? [
-          { type: "terminal" as const, id: "terminal" },
-        ];
-        const { tabs } = setCurrentDiagramTab(
-          current,
-          0,
-          worktreePath,
-          relPath,
-          id,
-          restoredOnLoad
-        );
+      const currentTabs = sessionTabsRef.current[sessionId] ?? [
+        { type: "terminal" as const, id: "terminal" },
+      ];
+      const currentActiveIndex = sessionActiveTabRef.current[sessionId] ?? 0;
+      const { tabs, activeIndex } = setCurrentDiagramTab(
+        currentTabs,
+        currentActiveIndex,
+        worktreePath,
+        relPath,
+        id,
+        restoredOnLoad
+      );
 
-        setSessionActiveTab(prevActive => {
-          const activeIndex = prevActive[sessionId] ?? 0;
-          const next = setCurrentDiagramTab(
-            current,
-            activeIndex,
-            worktreePath,
-            relPath,
-            id,
-            restoredOnLoad
-          ).activeIndex;
-          return next === activeIndex
-            ? prevActive
-            : { ...prevActive, [sessionId]: next };
-        });
-
-        return { ...prev, [sessionId]: tabs };
+      sessionTabsRef.current = {
+        ...sessionTabsRef.current,
+        [sessionId]: tabs,
+      };
+      sessionActiveTabRef.current = {
+        ...sessionActiveTabRef.current,
+        [sessionId]: activeIndex,
+      };
+      setSessionTabs(prev => ({ ...prev, [sessionId]: tabs }));
+      setSessionActiveTab(prev => {
+        const previousActiveIndex = prev[sessionId] ?? 0;
+        return activeIndex === previousActiveIndex
+          ? prev
+          : { ...prev, [sessionId]: activeIndex };
       });
     },
     []

--- a/packages/web/src/lib/diagram-option-label.test.ts
+++ b/packages/web/src/lib/diagram-option-label.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatDiagramOptionLabel } from "./diagram-option-label";
+
+describe("formatDiagramOptionLabel", () => {
+  it("タイトルと docs/diagrams/ より後ろの path を表示する", () => {
+    expect(
+      formatDiagramOptionLabel(
+        "注文フロー",
+        "docs/diagrams/promarche-order-status.diagram.html"
+      )
+    ).toBe("注文フロー — promarche-order-status.diagram.html");
+  });
+
+  it("displayName が basename と同じ場合は path だけを表示する", () => {
+    expect(
+      formatDiagramOptionLabel("b.diagram.html", "docs/diagrams/b.diagram.html")
+    ).toBe("b.diagram.html");
+  });
+
+  it("ネストした path を保つ", () => {
+    expect(
+      formatDiagramOptionLabel(
+        "b.diagram.html",
+        "docs/diagrams/nested/b.diagram.html"
+      )
+    ).toBe("nested/b.diagram.html");
+  });
+
+  it("docs/diagrams/ 以外の relPath は全体を path として使う", () => {
+    expect(
+      formatDiagramOptionLabel(
+        "注文フロー",
+        "other/diagrams/order.diagram.html"
+      )
+    ).toBe("注文フロー — other/diagrams/order.diagram.html");
+  });
+});

--- a/packages/web/src/lib/diagram-option-label.ts
+++ b/packages/web/src/lib/diagram-option-label.ts
@@ -1,0 +1,18 @@
+const DIAGRAMS_PREFIX = "docs/diagrams/";
+
+function basename(relPath: string): string {
+  return relPath.split("/").at(-1) ?? relPath;
+}
+
+export function formatDiagramOptionLabel(
+  displayName: string,
+  relPath: string
+): string {
+  const displayPath = relPath.startsWith(DIAGRAMS_PREFIX)
+    ? relPath.slice(DIAGRAMS_PREFIX.length)
+    : relPath;
+
+  if (displayName === basename(relPath)) return displayPath;
+
+  return `${displayName} — ${displayPath}`;
+}

--- a/packages/web/src/lib/diagram-tabs.test.ts
+++ b/packages/web/src/lib/diagram-tabs.test.ts
@@ -1,56 +1,172 @@
 import { describe, expect, it } from "vitest";
 import type { ViewerTab } from "../components/TerminalPane";
-import { addOrFocusDiagramTab } from "./diagram-tabs";
+import { setCurrentDiagramTab } from "./diagram-tabs";
 
-const base: ViewerTab[] = [{ type: "terminal", id: "terminal" }];
+const terminal: ViewerTab = { type: "terminal", id: "terminal" };
+const diagram = (
+  id: string,
+  relPath: string,
+  restoredOnLoad?: boolean
+): ViewerTab => ({
+  type: "diagram",
+  id,
+  worktreePath: "/wt",
+  relPath,
+  restoredOnLoad,
+});
+const file = (id: string): ViewerTab => ({
+  type: "file",
+  id,
+  filePath: `/${id}.txt`,
+  content: "",
+  mimeType: "text/plain",
+  size: 0,
+});
+const html = (id: string): ViewerTab => ({
+  type: "html",
+  id,
+  filePath: `/${id}.html`,
+});
 
-describe("addOrFocusDiagramTab", () => {
-  it("図タブが無ければ追加する", () => {
-    const tabs = addOrFocusDiagramTab(base, "/wt", "a.diagram.html", "d1");
+describe("setCurrentDiagramTab", () => {
+  it("図タブが無ければ現在図を1件追加する", () => {
+    const result = setCurrentDiagramTab(
+      [terminal],
+      0,
+      "/wt",
+      "a.diagram.html",
+      "d1"
+    );
 
-    expect(tabs).toHaveLength(2);
-    expect(tabs[1]).toEqual({
-      type: "diagram",
-      id: "d1",
-      worktreePath: "/wt",
-      relPath: "a.diagram.html",
+    expect(result).toEqual({
+      tabs: [
+        terminal,
+        {
+          type: "diagram",
+          id: "d1",
+          worktreePath: "/wt",
+          relPath: "a.diagram.html",
+          restoredOnLoad: undefined,
+        },
+      ],
+      activeIndex: 0,
     });
   });
 
-  it("同じ図が既に開いていれば追加しない（配列をそのまま返す）", () => {
-    const first = addOrFocusDiagramTab(base, "/wt", "a.diagram.html", "d1");
-
-    const second = addOrFocusDiagramTab(first, "/wt", "a.diagram.html", "d2");
-
-    expect(second).toHaveLength(2);
-    expect(second).toBe(first); // 変更が無いので同じ参照を返す
-  });
-
-  it("別の図は別タブとして追加する", () => {
-    const first = addOrFocusDiagramTab(base, "/wt", "a.diagram.html", "d1");
-
-    const second = addOrFocusDiagramTab(first, "/wt", "b.diagram.html", "d2");
-
-    expect(second).toHaveLength(3);
-  });
-
-  it("restoredOnLoad=true で追加したタブはそのフラグを持つ", () => {
-    const tabs = addOrFocusDiagramTab(
-      base,
+  it("同じ図の live open でも新しい id と restoredOnLoad=false へ更新する", () => {
+    const result = setCurrentDiagramTab(
+      [terminal, diagram("old", "a.diagram.html", true)],
+      0,
       "/wt",
       "a.diagram.html",
-      "d1",
+      "live"
+    );
+
+    expect(result.tabs).toHaveLength(2);
+    expect(result.tabs[1]).toEqual({
+      type: "diagram",
+      id: "live",
+      worktreePath: "/wt",
+      relPath: "a.diagram.html",
+      restoredOnLoad: undefined,
+    });
+  });
+
+  it("別図なら既存 diagram の位置で置換する", () => {
+    const f1 = file("f1");
+    const result = setCurrentDiagramTab(
+      [terminal, diagram("old", "a.diagram.html"), f1],
+      2,
+      "/wt",
+      "b.diagram.html",
+      "new"
+    );
+
+    expect(result.tabs.map(tab => tab.id)).toEqual(["terminal", "new", "f1"]);
+    expect(result.tabs[1]).toMatchObject({
+      type: "diagram",
+      relPath: "b.diagram.html",
+    });
+    expect(result.activeIndex).toBe(2);
+  });
+
+  it("過去の複数 diagram tabs を現在図1件へ畳み込む", () => {
+    const result = setCurrentDiagramTab(
+      [
+        terminal,
+        diagram("a", "a.diagram.html"),
+        file("f1"),
+        diagram("b", "b.diagram.html"),
+        html("h1"),
+      ],
+      4,
+      "/wt",
+      "c.diagram.html",
+      "current"
+    );
+
+    expect(result.tabs.map(tab => tab.id)).toEqual([
+      "terminal",
+      "current",
+      "f1",
+      "h1",
+    ]);
+    expect(result.tabs.filter(tab => tab.type === "diagram")).toHaveLength(1);
+  });
+
+  it("reload 復元だけ restoredOnLoad=true を保持する", () => {
+    const result = setCurrentDiagramTab(
+      [terminal],
+      0,
+      "/wt",
+      "a.diagram.html",
+      "restored",
       true
     );
 
-    expect(tabs[1]).toMatchObject({ type: "diagram", restoredOnLoad: true });
+    expect(result.tabs[1]).toMatchObject({
+      type: "diagram",
+      restoredOnLoad: true,
+    });
   });
 
-  it("restoredOnLoad は省略時 undefined になる（通常の live open）", () => {
-    const tabs = addOrFocusDiagramTab(base, "/wt", "a.diagram.html", "d1");
+  it.each([
+    { active: 2, expected: 2, label: "file" },
+    { active: 4, expected: 3, label: "html" },
+  ])("複数 diagram を畳んでも active $label を id で追跡する", ({
+    active,
+    expected,
+  }) => {
+    const tabs = [
+      terminal,
+      diagram("a", "a.diagram.html"),
+      file("active-file"),
+      diagram("b", "b.diagram.html"),
+      html("active-html"),
+    ];
 
-    expect((tabs[1] as { restoredOnLoad?: boolean }).restoredOnLoad).toBe(
-      undefined
+    const result = setCurrentDiagramTab(
+      tabs,
+      active,
+      "/wt",
+      "c.diagram.html",
+      "current"
     );
+
+    expect(result.activeIndex).toBe(expected);
+    expect(result.tabs[result.activeIndex]?.id).toBe(tabs[active]?.id);
+  });
+
+  it("active が diagram を指していた場合だけ terminal へ戻す", () => {
+    const result = setCurrentDiagramTab(
+      [terminal, diagram("a", "a.diagram.html"), file("f1")],
+      1,
+      "/wt",
+      "b.diagram.html",
+      "current"
+    );
+
+    expect(result.activeIndex).toBe(0);
+    expect(result.tabs[0]).toBe(terminal);
   });
 });

--- a/packages/web/src/lib/diagram-tabs.ts
+++ b/packages/web/src/lib/diagram-tabs.ts
@@ -1,35 +1,55 @@
 /**
- * 図タブの追加・フォーカス（純関数）。
- * id を引数で受け取り、テスト可能な純関数として保つ。
+ * 右ペインの現在図を設定する純関数。
+ * diagram 以外のタブとその順序を保ち、diagram は最大1件へ正規化する。
  */
 import type { ViewerTab } from "../components/TerminalPane";
 
-/**
- * 図タブを追加した（または既存を再利用した）後の tabs 配列を返す。
- *
- * diagram タブは右ペイン専属でタブバー上の active 概念を持たないため、
- * 呼び出し側は追加後の active index を必要としない（openDiagramTab は
- * setSessionActiveTab を呼ばない）。そのため配列だけを返す。
- */
-export function addOrFocusDiagramTab(
+export interface CurrentDiagramTabResult {
+  tabs: ViewerTab[];
+  activeIndex: number;
+}
+
+export function setCurrentDiagramTab(
   tabs: ViewerTab[],
+  activeIndex: number,
   worktreePath: string,
   relPath: string,
   id: string,
   restoredOnLoad?: boolean
-): ViewerTab[] {
-  const existing = tabs.some(
-    t =>
-      t.type === "diagram" &&
-      t.worktreePath === worktreePath &&
-      t.relPath === relPath
-  );
-  // 既存タブがあればそのまま返す。restoredOnLoad タグは最初に追加された時点の
-  // ものを維持する（後から同じ図を live open しても付け替えない）。
-  if (existing) return tabs;
+): CurrentDiagramTabResult {
+  const currentActiveTab = tabs[activeIndex];
+  const firstDiagramIndex = tabs.findIndex(tab => tab.type === "diagram");
+  const nextDiagram: ViewerTab = {
+    type: "diagram",
+    id,
+    worktreePath,
+    relPath,
+    restoredOnLoad,
+  };
 
-  return [
-    ...tabs,
-    { type: "diagram", id, worktreePath, relPath, restoredOnLoad },
-  ];
+  const nextTabs: ViewerTab[] = tabs.filter(tab => tab.type !== "diagram");
+  if (firstDiagramIndex < 0) {
+    nextTabs.push(nextDiagram);
+  } else {
+    const insertionIndex = tabs
+      .slice(0, firstDiagramIndex)
+      .filter(tab => tab.type !== "diagram").length;
+    nextTabs.splice(insertionIndex, 0, nextDiagram);
+  }
+
+  if (!currentActiveTab || currentActiveTab.type === "diagram") {
+    const terminalIndex = nextTabs.findIndex(tab => tab.type === "terminal");
+    return {
+      tabs: nextTabs,
+      activeIndex: terminalIndex >= 0 ? terminalIndex : 0,
+    };
+  }
+
+  const nextActiveIndex = nextTabs.findIndex(
+    tab => tab.id === currentActiveTab.id
+  );
+  return {
+    tabs: nextTabs,
+    activeIndex: nextActiveIndex >= 0 ? nextActiveIndex : 0,
+  };
 }

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -77,6 +77,7 @@ export default function Dashboard() {
     isScanning,
     scanRepos,
     listDirectory,
+    listDiagrams,
     worktrees,
     createWorktree,
     deleteWorktree,
@@ -777,7 +778,12 @@ export default function Dashboard() {
                       key={session.id}
                       className={isActive ? "h-full flex flex-col" : "hidden"}
                     >
-                      <SplitViewPane socket={socket} {...paneProps} />
+                      <SplitViewPane
+                        socket={socket}
+                        isConnected={isConnected}
+                        listDiagrams={listDiagrams}
+                        {...paneProps}
+                      />
                     </div>
                   );
                 })}

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -753,6 +753,8 @@ export default function Dashboard() {
                       handleTabSelect(session.id, idx),
                     onTabClose: (idx: number) =>
                       handleTabClose(session.id, idx),
+                    onSelectDiagram: (relPath: string) =>
+                      openDiagramTab(session.id, session.worktreePath, relPath),
                     onSendMessage: (msg: string) =>
                       sendMessage(session.id, msg),
                     onSendKey: (key: SpecialKey) => sendKey(session.id, key),

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -754,8 +754,8 @@ export default function Dashboard() {
                       handleTabSelect(session.id, idx),
                     onTabClose: (idx: number) =>
                       handleTabClose(session.id, idx),
-                    onSelectDiagram: (relPath: string) =>
-                      openDiagramTab(session.id, session.worktreePath, relPath),
+                    onSelectDiagram: (relPath: string, worktreePath: string) =>
+                      openDiagramTab(session.id, worktreePath, relPath),
                     onSendMessage: (msg: string) =>
                       sendMessage(session.id, msg),
                     onSendKey: (key: SpecialKey) => sendKey(session.id, key),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,11 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  oxc: {
+    jsx: {
+      runtime: "automatic",
+    },
+  },
   test: {
     include: [
       "packages/server/src/**/*.test.ts",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     include: [
       "packages/server/src/**/*.test.ts",
       "packages/shared/src/**/*.test.ts",
-      "packages/web/src/**/*.test.ts",
+      "packages/web/src/**/*.test.{ts,tsx}",
     ],
     environment: "node",
   },


### PR DESCRIPTION
## 概要

右ペインに**図スイッチャ**を追加する。worktree の `docs/diagrams/**/*.diagram.html` を一覧し、`<select>` で切り替えられる。#241-243 の server 注入ハーネスと違い**クロスレイヤ**（server 一覧 + Socket.IO + client UI）。

## 実装

- **server**: read-only の `diagram:list` Socket.IO ACK ハンドラー（新規 `diagram-list.ts`）。パス解決は既存 `resolveManagedWorktreePath()`、図の妥当性は既存 `readDiagramModel()` に委ね、**trust boundary を再利用**（symlink 脱出・TOCTOU・不正ファイル）。読み込みは**同時8件**に制限
- **表示**: `タイトル — パス`（`docs/diagrams/` を除いた相対パス）。タイトルが無い図はパスのみ（重複回避）、hover tooltip は relPath 全体。整形は純関数 `formatDiagramOptionLabel` に切り出し
- **client**: `DiagramPane` が **mount / 再接続(isConnected false→true) / 現在図の変更 / 図の更新**で一覧を再取得 → リロード・再接続・server 再起動を同じ供給フローで回収（CLAUDE.md のクロスレイヤ規約）。request generation で古い ACK は捨てる
- **diagram タブを「現在図1件」に正規化**。累積タブをやめ、`board_open` で既存図へ戻れない不具合も解消。`board_open` とスイッチャは同じ `openDiagramTab` に収束
- 📐 トグルを常時表示に変更（図が未選択でも右ペインを開ける）。図0件・未選択・削除済み current・一覧エラーは非破壊に表示
- **DB スキーマ変更なし**・PC 右ペイン限定・外部リソースなし

## 検証

- `pnpm check` / `pnpm build`: PASS
- unit: **39 files / 574 tests PASS**
- Chromium E2E（diagram）: **49 PASS**
- **実機プレビューで動作確認済み**（17件の図を title 表示で一覧・切替）
- 稼働中サーバーへの直接検証: 非管理 worktree（`/etc`）→ `管理対象の worktree ではありません`、不正 payload（`null`）→ `不正なリクエストです`

## レビュー指摘の反映（Claude P4 レビュー）

- `DiagramSwitcher` の `createElement` 直書き → JSX へ（コードベース慣習）
- `useViewerTabs` の updater 内 setState → 独立した pure updater へ（React の updater 純粋性）
- 一覧取得と図選択で worktreePath が別経路だった → 統一
- `listDiagrams` の無制限 `Promise.all` → 同時8件に制限（回帰テスト付き）

## フォローアップ

実機で「検証用に作った図が溜まって一覧が実用的でなくなる」ことが分かったため、図の削除（図管理）は #255 に切り出した。この PR は read-only のまま。

Closes #247
