### PR TITLE
図ペインからの図削除 (#255)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-issue-255.md
+++ b/docs/superpowers/plans/2026-07-24-issue-255.md
@@ -1,0 +1,609 @@
+# Issue #255: 図ペインからの図ファイル削除 実装プラン
+
+> **実装担当者向け:** この文書は設計承認用の実装プランである。実装は各 Task を Red → Green → Refactor の順に進める。各 Task は原則 2〜5 分で完了できる粒度に分けている。
+
+**Goal:** PC の右図ペインから、管理対象 worktree の `.claude/diagrams/**/*.diagram.html` を安全に1件ずつ削除し、一覧・現在図1件・`lastDiagramPath`・他クライアントを削除結果へ同期する。
+
+**Issue:** GitHub Issue #255
+
+**Architecture:** `diagram:delete` は `sessionId` から server 管理下の worktree を引き、`resolveManagedWorktreePath()` → `resolveDiagramPath()` の順で trust boundary を通す。削除 helper は `O_NOFOLLOW` で開いた file descriptor の inode/device、realpath、削除直前の `lstat` を照合し、検証した同じ絶対 path だけを `unlink` する。client は #247 の native `<select>` を維持して隣に現在図1件の削除ボタンを置き、tracked/untracked 別の必須確認後に ACK を待つ。成功時は server が `diagram:deleted({ sessionId, relPath })` を全クライアントへ通知し、現在図を空にして一覧を再取得する。
+
+**Tech Stack:** Node.js 22 / TypeScript 6 / Socket.IO 4 / React 19 / Radix AlertDialog / TailwindCSS 4 / SQLite / Vitest 4 / Playwright
+
+---
+
+## 1. 調査で確認した現状
+
+- Issue 本文の `docs/diagrams` は #256 より前の記述である。現行コードでは `packages/shared/src/types.ts` の `DIAGRAM_DIR = ".claude/diagrams"` が単一の正準値であり、旧ルートを削除対象へ戻さない。
+- `packages/server/src/lib/diagram-path.ts`
+  - `resolveDiagramPath(worktreeReal, relPath)` は空、1024文字超、絶対 path、`.diagram.html` 以外、`..` を拒否する。
+  - filename だけの入力には `DIAGRAM_DIR` を補い、`path.resolve()` 後にも `.claude/diagrams` 配下かを二重確認する。
+  - ここは文字列上の封じ込めであり、filesystem の symlink は検証しない。
+- `packages/server/src/lib/diagram-reader.ts`
+  - `open → fstat → realpath + stat` の inode/device 一致を確認し、実体の realpath が `worktreeReal/DIAGRAM_DIR` 配下に収まる場合だけ、開いた fd から読む。
+  - 外向き symlink、差し替え、ENOENT、権限エラーを区別する。この水準が削除 helper の最低基準である。
+- `packages/server/src/lib/diagram-list.ts`
+  - `.claude/diagrams` を再帰列挙し、directory symlink は辿らず、各候補を `readDiagramModel()` に通してから `{ relPath, displayName }` を返す。
+  - `diagram:list` の外部入力 core は、必ず `resolveManagedWorktreePath()` の正規化済み実 path を `listDiagrams()` へ渡す。
+- `packages/server/src/lib/managed-worktree.ts` / `packages/server/src/index.ts`
+  - `resolveManagedWorktreePath()` は worktree path を realpath 化し、directory、`.git`、`allowedRepos` を検証する。
+  - `diagram:submit` は read 検証後、`O_NOFOLLOW` で最終要素の symlink 差し替えを拒否して、開いた fd へ書く。
+  - `diagram:updated` は表示中の socket の watcher からだけ送られ、削除を他クライアントへ同期する broadcast ではない。
+- `packages/web/src/components/DiagramSwitcher.tsx`
+  - #247 の native `<select>` は title + 相対 path、tooltip、0件、未選択、一覧から消えた stale current を非破壊で表示する。
+  - option 自体に安全な個別 action を置けない。
+- `packages/web/src/components/DiagramPane.tsx`
+  - mount、再接続、current 変更、`diagram:updated` で一覧を再取得する。`listRefreshKey` と request generation があるため、削除通知もこの再取得機構へ合流できる。
+  - current が無い場合は fetch、subscribe、submit、MessageChannel を作らず、右ペインの空状態を表示できる。
+- `packages/web/src/hooks/useViewerTabs.ts` / `packages/web/src/lib/diagram-tabs.ts`
+  - diagram tab は左タブバーに表示されず、セッションごとの「現在図1件」として正規化される。
+  - 現在図を設定する helper はあるが、削除通知に対して relPath 一致時だけ現在図を外す helper はない。
+- `packages/server/src/lib/database.ts`
+  - `sessions.last_diagram_path` は schema 上 nullable で、`updateSessionLastDiagram(sessionId, null)` も既に使える。
+  - 現在の更新 API は無条件更新なので、「削除確認後に別の `board_open` が新しい path を保存した」競合時に新値まで消さない conditional clear が必要である。
+- `packages/shared/src/types.ts`
+  - `DiagramListItem` は現在 `{ relPath, displayName }`、`diagram:list` は ACK 型である。
+  - 新しい delete request/response と削除通知もここを唯一の Socket.IO 契約にする。
+- PC の `SplitViewPane` だけが `DiagramPane` を描画する。MobileLayout に図ペインはなく、今回も追加しない。
+
+---
+
+## 2. 7つの設計判断
+
+### 2.1 セキュリティ: 最終 symlink は辿らず 403、検証した inode/path だけを unlink する
+
+**採用:**
+
+1. client は絶対 `worktreePath` を delete payload に送らない。`{ sessionId, relPath, expectedTracked }` だけを送り、server が `sessionId` から保持中の worktree path を得る。
+2. server はセッションの worktree path であっても無条件には信頼せず、毎回 `resolveManagedWorktreePath()` を通して realpath 済み managed worktree を得る。
+3. 外部入力の `relPath` は必ず `resolveDiagramPath()` に通し、`.claude/diagrams` 配下の `*.diagram.html` に文字列上封じ込める。
+4. 削除 helper は以下の順序を固定する。
+   - `fs.promises.open(absPath, O_RDONLY | O_NOFOLLOW)`。最終要素が symlink なら、リンク先が root 内でも root 外でも 403 にし、リンク自体もリンク先も削除しない。
+   - `fd.stat()` で通常 file であることを確認する。
+   - `realpath(absPath)` と `stat(realPath)` を取り、fd と inode/device が一致すること、realPath が `worktreeReal/DIAGRAM_DIR` 配下であることを確認する。ancestor symlink が root 外へ出る場合も 403。
+   - fd を開いたまま、削除直前に `lstatSync(absPath)` を行い、通常 file かつ fd と inode/device が一致することを再確認する。
+   - `lstatSync(absPath)` と `unlinkSync(absPath)` の間には `await`、callback、ログ、DB、git 操作を挟まない。同じ `resolved.absPath` 変数を両方へ渡す。これにより Node process 内の task interleaving で path を差し替える窓を作らない。
+   - unlink 完了後に fd を閉じる。
+5. `ENOENT` は `NOT_FOUND`、path/symlink/inode 不一致は `FORBIDDEN`、tracked 状態の変化は `CONFLICT`、その他の I/O は `IO_ERROR` として ACK で区別する。
+
+**TOCTOU の境界:** Node の `unlink` は inode ではなく pathname を受けるため、別 process が最後の同期 `lstat` と `unlink` の数命令間で同一 path を差し替える可能性を OS API 上ゼロにはできない。ただし同じ OS user で任意に directory を変更できる process は元から対象 file を直接 unlink できる。Ark が防ぐべき socket 起点・repository symlink 起点・Ark process 内競合については、`O_NOFOLLOW`、fd/realpath/lstat の二段 inode 照合、同期した直前 check と同一 path の unlink で、既存 reader より緩めない。inode 指定削除のための native addon は導入しない。
+
+### 2.2 確認フロー: 必須 AlertDialog、即 unlink、Ark 独自の undo/ゴミ箱は作らない
+
+**採用:** 削除ボタンを押しただけでは request を送らず、Radix `AlertDialog` で title、相対 path、tracked 状態、「取り消せない」ことを表示する。明示的な「削除する」で1件だけ送信する。
+
+- 未追跡 file: 「Git から復元できない」ことを強調する。
+- tracked file: 「worktree に削除差分が残る。必要なら Git で復元できる」ことを示す。
+- tracked 用に二重 dialog は出さない。全削除に1回の明示確認を必須とし、状態別の警告を具体化する方が dialog fatigue を増やさない。
+- OS ごとに挙動が違う Trash API や、`.claude/diagrams` 内へ独自 `.trash` を作る機能は導入しない。退避 directory の寿命、容量、復元 UI、tracked 状態の扱いが新しい機能になるためである。
+- request 中は delete/select/confirm の連打を止める。失敗時は dialog または header に理由を残し、成功時だけ閉じる。
+
+### 2.3 tracked / untracked: 一覧で明示し、git rm は使わず unlink だけを行う
+
+**採用:**
+
+- `DiagramListItem` に `tracked: boolean` を追加する。
+- 一覧取得時に `git -C <worktreeReal> ls-files --cached -z -- .claude/diagrams` を `execFile`（shell なし）で1回だけ実行し、NUL 区切りの tracked path set を作る。各 file ごとの git process は起動しない。git 判定失敗を全件 `false` に丸めず、一覧 ACK error にする。
+- native option の表示は既存の「title — 相対 path」を残し、その末尾へ `Git管理` / `未追跡` を追加する。current の状態も select 横に短く表示し、tooltip には完全な相対 path と状態を残す。
+- 削除 request は一覧時の `expectedTracked` を送り、server が削除直前に shell を介さない git コマンドで再判定する。不一致なら `CONFLICT` で削除せず、client は一覧を更新して再確認を求める。
+- Ark は `git rm`、`git add -u`、commit を実行しない。通常の `unlink` だけを行う。tracked file は `git status` 上の削除、untracked file は filesystem から消滅となる。index を暗黙に変更しない。
+
+### 2.4 現在図を削除した後: 次へ移らず空状態、DB は比較付きで null
+
+**採用:**
+
+- #247 の current diagram は1件だけなので、削除成功通知が current の `sessionId + relPath` と一致した場合、その diagram tab を取り除く。右ペイン自体は開いたままにし、残件があれば「上の一覧から図を選択」、0件なら「図がありません」を表示する。
+- 並び順上の次/前の file へ自動遷移しない。破壊操作直後に別 file を暗黙に current にすると、ユーザーが続けて削除ボタンを押した際の対象が変わるためである。
+- `clearSessionLastDiagramIfMatches(sessionId, deletedRelPath)` を DB に追加し、単一 SQL の `WHERE id = ? AND last_diagram_path = ?` で一致時だけ `NULL` にする。確認中または unlink 中に別の `board_open` が新しい path を保存しても、その新値は消さない。
+- conditional clear が実際に更新した場合だけ、更新後の `session:updated` を broadcast して全 client の `ManagedSession.lastDiagramPath` を null にする。
+- filesystem unlink が commit point である。unlink 後の DB 更新に失敗しても ACK を「削除失敗」には戻さず、`ok: true` と `warning` を返し、削除通知は送る。server は DB エラーを記録し、client は「file は削除済みだが復元情報の消去に失敗」を表示する。
+
+### 2.5 UI: #247 の select を維持し、現在図の隣に単一削除ボタンを置く
+
+**採用:** ポップオーバー/独自 list への全面置換はせず、`DiagramSwitcher` を「native select + tracked 状態 + trash icon button + AlertDialog」に拡張する。
+
+- #247 の title + path、tooltip、0件、未選択、stale current の一時 option を維持する。
+- delete button は current が一覧内の有効な `DiagramListItem` として見つかる場合だけ有効にする。stale current は従来どおり非破壊表示し、一覧で tracked 状態を再確認できないため削除不可にする。
+- 一覧 loading、socket 切断、delete request 中も削除不可にする。
+- `DiagramPane`、`SplitViewPane`、`Dashboard`、`useViewerTabs` を通して delete API と current clear を配線する。
+- UI は PC の `SplitViewPane` 内だけ。MobileLayout / MobileSessionView は変更しない。
+
+### 2.6 一括削除: 初回リリースには入れない
+
+**採用:** 1件ずつの削除だけを実装する。
+
+**理由:** 一括削除には複数選択 UI、tracked/untracked 混在警告、対象ごとの再検証、途中失敗時の部分成功表示、複数 current/DB/broadcast の整合が必要になる。初めての破壊的操作で blast radius を広げない。デモ図掃除の需要は認めるが、単体削除の利用実績と error taxonomy が固まった後に、別 Issue で「選択した path の明示一覧 + 件数入力確認 + target ごとの独立結果」を設計する。
+
+### 2.7 Socket.IO: ACK で結果、専用 broadcast で全 client、既存 list を再取得
+
+**採用契約:**
+
+```ts
+export interface DiagramDeleteRequest {
+  sessionId: string;
+  relPath: string;
+  expectedTracked: boolean;
+}
+
+export type DiagramDeleteResponse =
+  | {
+      ok: true;
+      relPath: string;
+      tracked: boolean;
+      warning?: string;
+    }
+  | {
+      ok: false;
+      code:
+        | "BAD_REQUEST"
+        | "SESSION_NOT_FOUND"
+        | "NOT_FOUND"
+        | "FORBIDDEN"
+        | "CONFLICT"
+        | "IO_ERROR";
+      error: string;
+    };
+
+// ClientToServerEvents
+"diagram:delete": (
+  data: DiagramDeleteRequest,
+  callback: (response: DiagramDeleteResponse) => void
+) => void;
+
+// ServerToClientEvents
+"diagram:deleted": (data: { sessionId: string; relPath: string }) => void;
+```
+
+- ACK callback 自体も `typeof callback === "function"` を検証し、callback throw を server process へ伝播させない。
+- success ACK に新しい一覧全体は載せない。`DiagramPane` は `diagram:deleted` を受けて既存 `listRefreshKey` を増やし、#247 の `diagram:list` を再取得する。これにより一覧の title/path/tracked 判定の正を1経路に保つ。
+- `diagram:deleted` は unlink 成功後だけ `io.emit` する。絶対 worktree path を全 client へ配らず、既存 session identity と相対 path だけを通知する。
+- 発行元を含む全 client が通知を処理する。別 client が同じ current を開いていれば tab を空にし、別図を開いていても一覧だけは更新する。
+- `diagram:updated` は「購読中 file の内容更新」であり socket-local なので、削除通知へ流用しない。
+
+---
+
+## 3. 削除シーケンス
+
+```text
+PC DiagramSwitcher
+  → current item の tracked 状態を含む AlertDialog
+  → diagram:delete({ sessionId, relPath, expectedTracked }, ACK)
+    → sessionId から server-side worktreePath を取得
+    → resolveManagedWorktreePath(session.worktreePath)
+    → resolveDiagramPath(worktreeReal, relPath)
+    → server が tracked 状態を再確認（一致しなければ CONFLICT）
+    → O_NOFOLLOW open
+    → fd.stat ↔ realpath+stat の inode/device・root containment 確認
+    → lstatSync ↔ fd.stat の最終一致確認
+    → unlinkSync(同じ resolved.absPath)
+    → clearSessionLastDiagramIfMatches(sessionId, relPath)
+    → 必要時 session:updated
+    → diagram:deleted({ sessionId, relPath }) を全 client へ broadcast
+    → ACK
+
+各 client
+  diagram:deleted
+    ├─ current が同じ sessionId + relPath → diagram tab を除去
+    └─ 対象 session の DiagramPane → listRefreshKey++ → diagram:list ACK
+```
+
+---
+
+## 4. 影響範囲
+
+| レイヤ | 変更 | 明示的に維持するもの |
+|---|---|---|
+| shared | `DiagramListItem.tracked`、delete request/response、`diagram:delete`、`diagram:deleted` 型 | `DIAGRAM_DIR` の単一定数、既存 list/submit 契約 |
+| server | tracked 判定、削除 helper、payload handler、ACK、broadcast | managed worktree、path suffix/長さ/containment、reader/submit の既存境界 |
+| client | delete transport、状態別確認、削除中/error、通知による list refresh | #247 native select、title/path/tooltip、stale current、iframe/submit |
+| tab state | current diagram の比較付き除去 | diagram 最大1件、terminal/file/html の順序と active index |
+| DB | `last_diagram_path` の atomic conditional clear | schema/migration、他の session data |
+| Git | tracked 情報を read-only 取得、file は unlink | index、branch、commit を Ark が変更しない |
+| watcher / multi-client | `diagram:deleted` を追加 | `diagram:updated` の意味と current file subscription |
+| e2e | PC の確認・削除・空状態・Git差分を acceptance 対象に追加 | diagram harness の編集 E2E、mobile 非対象 |
+| mobile | 変更なし | MobileLayout に図削除導線を出さない |
+
+---
+
+## 5. 実装タスク（順序固定、各2〜5分）
+
+### Task 1: shared の tracked 表示契約を Red にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/shared/src/types.ts`
+- Modify: `packages/server/src/lib/diagram-list.test.ts`
+
+**テスト（REDで何を書くか）:** tracked と untracked の temp git worktree fixture を作り、`listDiagrams()` の各 item が `{ relPath, displayName, tracked }` を返す期待へ変える。既存実装で `tracked` が無いため FAIL することを確認する。
+
+**完了条件:** RED の理由が `tracked` 欠落だけであり、`.claude/diagrams`、title fallback、path sort の既存期待は残っている。
+
+### Task 2: git index の一括 tracked 判定を Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/diagram-list.ts`
+- Modify: `packages/server/src/lib/diagram-list.test.ts`
+- Modify: `packages/shared/src/types.ts`
+
+**テスト（REDで何を書くか）:** tracked、untracked、ignored-untracked、nested tracked を混在させ、状態が正しく分かれる test と、git command failure が全件 untracked ではなく一覧 error になる test を追加する。
+
+**実装:** `execFile("git", ["-C", worktreeReal, "ls-files", "--cached", "-z", "--", DIAGRAM_DIR])` の NUL 区切り結果を Set にし、各 item に boolean を付ける。
+
+**完了条件:** git process は一覧1回につき1回、shell 不使用、既存の symlink/invalid model 除外 test も Green。
+
+### Task 3: delete の shared Socket.IO 契約を追加する（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/shared/src/types.ts`
+
+**テスト（REDで何を書くか）:** 次 Task の server test から `DiagramDeleteRequest` / `DiagramDeleteResponse` を import し、成功・error code の型を使う compile failure を先に作る。
+
+**完了条件:** `ClientToServerEvents["diagram:delete"]` が ACK 型、`ServerToClientEvents["diagram:deleted"]` が `{ sessionId, relPath }` だけを持ち、絶対 path を契約に含めない。
+
+### Task 4: delete payload validation を Red にする（2〜5分）
+
+**変更するファイル:**
+
+- Create: `packages/server/src/lib/diagram-delete.ts`
+- Create: `packages/server/src/lib/diagram-delete.test.ts`
+
+**テスト（REDで何を書くか）:** `undefined`、`null`、array、空 object、空/非文字列/長すぎる `sessionId`、空/非文字列 `relPath`、boolean でない `expectedTracked` を table test にし、resolver・filesystem・DB dependency が一度も呼ばれず `BAD_REQUEST` になる期待を書く。
+
+**完了条件:** 不正 payload が throw せず ACK error へ畳まれる RED が揃う。
+
+### Task 5: session 由来 worktree の trust boundary を Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/diagram-delete.ts`
+- Modify: `packages/server/src/lib/diagram-delete.test.ts`
+
+**テスト（REDで何を書くか）:** 不明 session は `SESSION_NOT_FOUND`、session が持つ path を `resolveManagedWorktreePath()` が拒否した場合は `FORBIDDEN`、成功時は resolver の realpath だけが file helper へ渡る期待を書く。
+
+**完了条件:** request に `worktreePath` が無く、server-side session path も必ず managed worktree 検証を通る。
+
+### Task 6: 文字列 path 拒否 matrix を Red にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/diagram-delete.test.ts`
+- Reference: `packages/server/src/lib/diagram-path.test.ts`
+
+**テスト（REDで何を書くか）:** `..`、absolute path、空、1024文字超、suffix 不正、旧 `docs/diagrams` の物理 file、`.claude/diagrams` 外を指す指定を用意し、対象も外部 file も残って `FORBIDDEN` になる期待を書く。
+
+**完了条件:** delete helper が独自 path join をせず、`resolveDiagramPath()` の拒否結果を使う RED が揃う。
+
+### Task 7: symlink と file 種別の拒否を Red にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/diagram-delete.test.ts`
+
+**テスト（REDで何を書くか）:** root 外への file symlink、root 内への file symlink、外向き ancestor symlink、`.diagram.html` 名の directory/FIFO（対応 OS で可能なもの）を対象にし、403 相当の `FORBIDDEN`、symlink 自体・リンク先・外部 file がすべて残る期待を書く。
+
+**完了条件:** 「リンク自体を消す」挙動を明確に禁止する test 名と期待になっている。
+
+### Task 8: fd/realpath 検証付き delete helper を Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/diagram-delete.ts`
+- Modify: `packages/server/src/lib/diagram-delete.test.ts`
+
+**テスト（REDで何を書くか）:** `.claude/diagrams` 直下と nested の通常 file が1件だけ消え、隣接 file は残る正常系を書く。存在しない path は `NOT_FOUND`、EACCES/EPERM は `FORBIDDEN`、その他は errno を含む `IO_ERROR` を期待する。
+
+**実装:** `O_NOFOLLOW` open、fd/realpath stat 一致、root containment、regular file、final lstat、same-path unlink、finally close を順に実装する。
+
+**完了条件:** 正常系だけが unlink し、error taxonomy が ACK 用 result へ保持される。
+
+### Task 9: TOCTOU 差し替え test を Red → Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/diagram-delete.ts`
+- Modify: `packages/server/src/lib/diagram-delete.test.ts`
+
+**テスト（REDで何を書くか）:** filesystem dependency の test seam で最終 identity check 直前に、(a) 外向き symlink、(b) 別 inode の root 内 regular file へ path を差し替える。いずれも `FORBIDDEN` で、差し替え先・外部 target は削除されないことを期待する。
+
+**実装:** fd の inode/device と直前 `lstatSync` を比較し、`lstatSync` と `unlinkSync` を同じ同期 block・同じ `absPath` で連続実行する。
+
+**完了条件:** 差し替え test が Green、`lstat` と `unlink` の間に await/副作用が無いことを review で確認できる。
+
+### Task 10: tracked 状態の再確認を Red → Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/diagram-delete.ts`
+- Modify: `packages/server/src/lib/diagram-delete.test.ts`
+
+**テスト（REDで何を書くか）:** expected/current が tracked/tracked、untracked/untracked なら進み、tracked/untracked と untracked/tracked の両不一致は `CONFLICT` で file が残る期待を書く。git error も unlink 前の `IO_ERROR` とする。
+
+**完了条件:** UI の古い状態表示を信じて削除せず、server 再判定後だけ helper が呼ばれる。
+
+### Task 11: DB conditional clear を Red → Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/database.ts`
+- Modify: `packages/server/src/lib/database.test.ts`
+
+**テスト（REDで何を書くか）:** `last_diagram_path` が削除 path と一致すると null・戻り値 true、別 path/null/不明 session なら値を維持・戻り値 falseになる test を書く。
+
+**実装:** `UPDATE ... SET last_diagram_path = NULL, updated_at = ? WHERE id = ? AND last_diagram_path = ?` の `changes` を boolean で返す。
+
+**完了条件:** schema migration は増えず、比較と clear が単一 SQL で atomic。
+
+### Task 12: delete core の side-effect 順序を固定する（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/lib/diagram-delete.ts`
+- Modify: `packages/server/src/lib/diagram-delete.test.ts`
+
+**テスト（REDで何を書くか）:** unlink 成功後だけ conditional clear が呼ばれる、unlink 失敗時は DB/broadcast 無し、DB clear failure 時は `ok: true` + warning で file は削除済み、という dependency call order を期待する。
+
+**完了条件:** filesystem の commit point 後に false failure を返さず、partial success が型と message で見える。
+
+### Task 13: `index.ts` に ACK handler と broadcast を接続する（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/server/src/index.ts`
+- Modify: `packages/server/src/lib/diagram-delete.test.ts`
+
+**テスト（REDで何を書くか）:** core dependency spy で成功時だけ `diagram:deleted`、conditional clear が true のときだけ更新後 `session:updated` が発行される期待を書く。callback 無し/非関数/throw でも server handler が throw しないケースを追加する。
+
+**完了条件:** `diagram:delete` は ACK を必ず1回だけ返し、unlink 前には broadcast せず、通知 payload に絶対 path を含めない。
+
+### Task 14: current diagram 除去 helper を Red → Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/web/src/lib/diagram-tabs.ts`
+- Modify: `packages/web/src/lib/diagram-tabs.test.ts`
+
+**テスト（REDで何を書くか）:** session の current relPath 一致時だけ diagram tab を除去し、不一致通知は no-op、terminal/file/html の順序と active item id を維持、過去の複数 diagram も除去、legacy に diagram が active なら terminal へ戻す期待を書く。
+
+**完了条件:** delete event が遅れて届いても、すでに開いた別 current を消さない。
+
+### Task 15: `useViewerTabs` と Dashboard に削除通知を配線する（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/web/src/hooks/useViewerTabs.ts`
+- Modify: `packages/web/src/pages/Dashboard.tsx`
+
+**テスト（REDで何を書くか）:** pure helper test を先に Red にし、Dashboard の `diagram:deleted` handler が `clearDiagramTab(sessionId, relPath)` を呼ぶ型接続を web typecheck で検証する。
+
+**完了条件:** 全 client で一致 current だけが空になり、`diagram:open` と lastDiagramPath 復元の既存入口は変わらない。
+
+### Task 16: client delete transport を Red → Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/web/src/hooks/useSocket.ts`
+
+**テスト（REDで何を書くか）:** ACK success、typed error、未接続、10秒 timeout、late ACK 無視を listDiagrams と同じ pattern で期待する transport test、または transport core を切り出した unit test を書く。
+
+**完了条件:** `deleteDiagram(sessionId, relPath, expectedTracked)` が Promise を返し、timeout listener/timer を多重 resolve せず、server error code/message を UI へ渡す。
+
+### Task 17: select の tracked/untracked 表示を Red → Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/web/src/components/DiagramSwitcher.tsx`
+- Modify: `packages/web/src/components/DiagramSwitcher.test.tsx`
+- 必要時 Modify: `packages/web/src/lib/diagram-option-label.ts`
+- 必要時 Modify: `packages/web/src/lib/diagram-option-label.test.ts`
+
+**テスト（REDで何を書くか）:** title + path を保持したまま各 option に `Git管理` / `未追跡` が出る、完全 path の tooltip が残る、0件/未選択/stale current の既存 markup が維持される期待を書く。
+
+**完了条件:** #247 の4つの既存 component test が Green のまま、状態表示だけが追加される。
+
+### Task 18: 削除ボタンと状態別 AlertDialog を Red → Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/web/src/components/DiagramSwitcher.tsx`
+- Modify: `packages/web/src/components/DiagramSwitcher.test.tsx`
+
+**テスト（REDで何を書くか）:** current item ありだけ button が有効、stale/no current/loading/disconnected/deleting は無効、未追跡は Git 復元不可、tracked は worktree に削除差分が残る文面、cancel では callback 無し、confirm で current 1件の引数だけを渡す期待を書く。
+
+**実装:** 既存 `AlertDialog` primitives を使い、destructive color、明示 label、二重 submit 防止を付ける。
+
+**完了条件:** option 内に action を埋めず、select + 隣接 button の keyboard/aria label がある。
+
+### Task 19: DiagramPane に delete と list refresh を接続する（2〜5分）
+
+**変更するファイル:**
+
+- Modify: `packages/web/src/components/DiagramPane.tsx`
+- Modify: `packages/web/src/components/SplitViewPane.tsx`
+- Modify: `packages/web/src/pages/Dashboard.tsx`
+
+**テスト（REDで何を書くか）:** `diagram:deleted` が同じ sessionId なら current が別図でも `listRefreshKey` を増やし、他 session は無視する。成功、CONFLICT、NOT_FOUND、warning の UI state 遷移を component/pure-state test にする。
+
+**完了条件:** success は通知経由で current clear と一覧再取得、CONFLICT/NOT_FOUND は file が消えたと決めつけず一覧再取得、warning は消去結果と DB 問題を区別して表示する。
+
+### Task 20: PC 限定と既存表示の回帰を確認する（2〜5分）
+
+**変更するファイル:**
+
+- Verify: `packages/web/src/components/SplitViewPane.tsx`
+- Verify: `packages/web/src/components/DiagramPane.tsx`
+- Verify unchanged: mobile component 群
+
+**テスト（REDで何を書くか）:** current 削除後、残件ありなら「上の一覧から図を選択」、0件なら「図がありません」、次図を自動選択しない期待を書く。mobile 用 props/types に delete API を追加していないことを typecheck で確認する。
+
+**完了条件:** 右ペインの開閉/幅、left terminal、stale current、submit error 表示に回帰がない。
+
+### Task 21: server の集中 test を Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Verify: `packages/server/src/lib/diagram-delete.test.ts`
+- Verify: `packages/server/src/lib/diagram-list.test.ts`
+- Verify: `packages/server/src/lib/diagram-path.test.ts`
+- Verify: `packages/server/src/lib/diagram-reader.test.ts`
+- Verify: `packages/server/src/lib/database.test.ts`
+
+**テスト（REDで何を書くか）:** ここまでの security matrix がすべて存在することを checklist で確認する。不足ケースを追加してから実行する。
+
+**Run:**
+
+```bash
+pnpm exec vitest run \
+  packages/server/src/lib/diagram-delete.test.ts \
+  packages/server/src/lib/diagram-list.test.ts \
+  packages/server/src/lib/diagram-path.test.ts \
+  packages/server/src/lib/diagram-reader.test.ts \
+  packages/server/src/lib/database.test.ts
+```
+
+**完了条件:** symlink 脱出、`..`、非管理 worktree、存在しない path、TOCTOU、invalid payload、tracked conflict が全件 PASS。
+
+### Task 22: web の集中 test を Green にする（2〜5分）
+
+**変更するファイル:**
+
+- Verify: `packages/web/src/components/DiagramSwitcher.test.tsx`
+- Verify: `packages/web/src/lib/diagram-tabs.test.ts`
+- Verify: `packages/web/src/lib/diagram-option-label.test.ts`
+
+**テスト（REDで何を書くか）:** tracked 表示、確認文、button guard、current clear、#247 表示回帰の各期待が前 Task までに Red → Green になっていることを checklist で確認し、不足ケースがあれば集中実行前に追加する。
+
+**Run:**
+
+```bash
+pnpm exec vitest run \
+  packages/web/src/components/DiagramSwitcher.test.tsx \
+  packages/web/src/lib/diagram-tabs.test.ts \
+  packages/web/src/lib/diagram-option-label.test.ts
+```
+
+**完了条件:** tracked 表示、確認文、button guard、current clear、#247 表示回帰が PASS。
+
+### Task 23: typecheck と全 unit test を実行する（2〜5分）
+
+**変更するファイル:** なし（検証のみ）
+
+**テスト（REDで何を書くか）:** 追加 test だけでなく shared 契約変更の利用漏れを検出するため全 check/test を実行する。
+
+**Run:**
+
+```bash
+pnpm check
+pnpm --filter @ark/server test
+pnpm build
+```
+
+**完了条件:** lint/format/typecheck、server 全 Vitest、production build が PASS。`DiagramListItem` fixture の `tracked` 追加漏れがない。
+
+### Task 24: PC 実機 acceptance と既存 E2E を確認する（2〜5分/ケース）
+
+**変更するファイル:**
+
+- E2E source は初回実装では変更しない
+- Verify: `e2e/diagram-harness.spec.ts`
+
+**理由:** 現在の Playwright 設定は外部で起動済みの `localhost:4001` と既存 tmux/session を前提とし、test 自身が一時 managed session を安全に bootstrap/破棄する fixture を持たない。repository file を破壊する不安定な自動 test は追加せず、security/contract/state は deterministic な Vitest で固定する。managed-session E2E fixture は別 Issue とする。
+
+**テスト（REDで何を書くか）:** 自動化可能な diagram editing 回帰は既存 E2E をそのまま実行する。managed session を必要とする削除フローは、以下の acceptance checklist のいずれかが満たせなければ未完了（RED）として扱い、実装または unit/component test へ戻る。
+
+**手動 acceptance:**
+
+1. 一時 git worktree に tracked 1件、untracked 2件を用意し、3件の状態・title・path を確認する。
+2. cancel で何も消えないこと、untracked confirm でその1件だけ消えることを確認する。
+3. tracked confirm 後に `git status --short` が ` D .claude/diagrams/...` となり、index は変わらないことを確認する。
+4. current 削除後に右ペインが空になり、次図を自動選択しないこと、reload 後に削除図が復元されないことを確認する。
+5. browser を2つ接続し、一方の削除で双方の current/list が同期することを確認する。
+6. mobile viewport に削除 UI が出ないことを確認する。
+7. stale current、socket 切断、tracked conflict では削除 button/error が安全側になることを確認する。
+
+**Run:**
+
+```bash
+pnpm test:e2e -- --grep "diagram"
+```
+
+**完了条件:** 既存 diagram editing E2E が PASS し、上記 acceptance の証跡を PR に添付する。fixture worktree は test 後に通常の worktree 削除手順で片付ける。
+
+---
+
+## 6. セキュリティ test matrix
+
+| ケース | 期待 | 削除されないことを確認する対象 |
+|---|---|---|
+| 正常な tracked regular file | success、Git index 不変、worktree は deleted | 隣接 file |
+| 正常な untracked regular file | success | 隣接 file |
+| `../x.diagram.html` / 中間 `..` | `FORBIDDEN` | root 内外すべて |
+| absolute path | `FORBIDDEN` | 指定した外部 file |
+| `.diagram.html` 以外 / 長さ超過 | `FORBIDDEN` | 同名 file |
+| 非管理 worktree / allowedRepos 外 | `FORBIDDEN` | その worktree の file |
+| 不明 session | `SESSION_NOT_FOUND` | 全 file |
+| 存在しない path | `NOT_FOUND` | directory 内容 |
+| root 外を指す最終 symlink | `FORBIDDEN` | link 自体と外部 target |
+| root 内を指す最終 symlink | `FORBIDDEN` | link 自体と内部 target |
+| ancestor symlink で root 外へ脱出 | `FORBIDDEN` | 外部 target |
+| directory/FIFO/device | `FORBIDDEN` | 対象 entry |
+| open 後に外向き symlink へ交換 | `FORBIDDEN` | 交換後 link/target |
+| open 後に別 inode へ交換 | `FORBIDDEN` | 交換後 file |
+| expectedTracked と現 index が不一致 | `CONFLICT` | 対象 file |
+| null/array/型違い/callback 不正 | `BAD_REQUEST` または安全な無視 | 全 file、server process |
+| EACCES/EPERM | `FORBIDDEN` | 対象 file |
+| その他 I/O / git error | `IO_ERROR` | unlink 前なら対象 file |
+
+---
+
+## 7. テスト戦略
+
+1. **pure path/security unit:** `diagram-delete.test.ts` の実 filesystem fixture と injected seam で、path、inode、symlink、TOCTOU、errno を固定する。
+2. **request/core unit:** dependency spy で invalid payload、managed worktree、tracked conflict、side-effect order、ACK を固定する。
+3. **DB unit:** conditional clear の一致/不一致/競合を SQLite test DB で固定する。
+4. **client pure unit:** diagram tab 除去を current relPath の比較付き純関数として固定する。
+5. **component unit:** #247 の SSR markup test を維持し、tracked 表示、button guard、AlertDialog 文言を追加する。interaction が SSR で表現できない部分は小さな state/handler を純関数へ切り出して test する。
+6. **type/build regression:** shared の双方向契約、server emit、client emit/handler の不一致を `pnpm check` と build で検出する。
+7. **E2E/manual:** 既存 harness の編集回帰を自動実行し、実 managed session が必要な破壊操作は一時 worktree の手動 acceptance で確認する。自動 managed-session fixture ができた時点で同じ checklist を Playwright 化する。
+
+---
+
+## 8. ロールバック手順
+
+1. 実装 commit を通常の `git revert <commit>` で戻す。hook は bypass しない。
+2. DB schema migration は無いため DB file の rollback は不要。conditional clear で null になった `last_diagram_path` は cache 情報なので、次の `board_open` で再構築される。
+3. shared の追加 event/field は server/client を同じ release で戻す。旧 client は `DiagramListItem.tracked` の追加 field を無視できるが、新 client + 旧 server は delete ACK timeout になるため、片側だけ rollback しない。
+4. `diagram:deleted` の listener を外した後も既存 `diagram:list` / reader / submit はそのまま動く。
+5. 既に削除された tracked file は対象 worktree で `git restore -- .claude/diagrams/<name>.diagram.html` により復元できる。Ark は自動復元しない。
+6. 既に削除された untracked file は code rollback では復元できない。実装検証は使い捨ての一時 worktree/fixture だけで行い、実データで試す前に backup の有無を確認する。
+
+---
+
+## 9. 非ゴール
+
+- 図の rename、move、duplicate
+- 図の新規作成
+- `DIAGRAM_DIR` の設定可能化、旧 `docs/diagrams` の互換削除
+- 一括選択、一括削除、glob delete
+- OS Trash、Ark 独自ゴミ箱、undo/restore UI
+- `git rm`、`git add`、commit、branch 操作
+- 壊れたモデルや一覧に出ない stale path を UI から強制削除する機能
+- MobileLayout への図管理 UI
+- directory の自動掃除、空 directory の削除
+- managed-session を自動 bootstrap する Playwright fixture（別 Issue）
+
+---
+
+## 10. 実装完了の Definition of Done
+
+- delete path が `resolveManagedWorktreePath()` → `resolveDiagramPath()` → fd/realpath/lstat 検証を必ず通る。
+- final symlink は link 自体も target も削除せず拒否する。
+- `lstatSync` と同じ absolute path を、await を挟まず `unlinkSync` する。
+- tracked/untracked が一覧と確認 dialog で判別でき、状態変化時は再確認を求める。
+- Ark は git index を変更せず、1件だけ unlink する。
+- current 削除後は右ペインが空になり、次図を自動選択しない。
+- `last_diagram_path` は削除 path と一致する場合だけ atomic に null になる。
+- 発行元を含む全 client が `diagram:deleted` で current/list を同期する。
+- 0件/未選択/stale current/title/path/tooltip と PC 限定の #247 挙動が維持される。
+- security matrix、server/web unit、typecheck、build、既存 diagram E2E、手動 acceptance が完了する。

--- a/docs/superpowers/plans/2026-07-24-issue-255.md
+++ b/docs/superpowers/plans/2026-07-24-issue-255.md
@@ -58,13 +58,15 @@
 2. server はセッションの worktree path であっても無条件には信頼せず、毎回 `resolveManagedWorktreePath()` を通して realpath 済み managed worktree を得る。
 3. 外部入力の `relPath` は必ず `resolveDiagramPath()` に通し、`.claude/diagrams` 配下の `*.diagram.html` に文字列上封じ込める。
 4. 削除 helper は以下の順序を固定する。
-   - `fs.promises.open(absPath, O_RDONLY | O_NOFOLLOW)`。最終要素が symlink なら、リンク先が root 内でも root 外でも 403 にし、リンク自体もリンク先も削除しない。
+   - Unix 系では `fs.promises.open(absPath, O_RDONLY | O_NOFOLLOW)` を使う。最終要素が symlink なら、リンク先が root 内でも root 外でも 403 にし、リンク自体もリンク先も削除しない。
    - `fd.stat()` で通常 file であることを確認する。
    - `realpath(absPath)` と `stat(realPath)` を取り、fd と inode/device が一致すること、realPath が `worktreeReal/DIAGRAM_DIR` 配下であることを確認する。ancestor symlink が root 外へ出る場合も 403。
    - fd を開いたまま、削除直前に `lstatSync(absPath)` を行い、通常 file かつ fd と inode/device が一致することを再確認する。
    - `lstatSync(absPath)` と `unlinkSync(absPath)` の間には `await`、callback、ログ、DB、git 操作を挟まない。同じ `resolved.absPath` 変数を両方へ渡す。これにより Node process 内の task interleaving で path を差し替える窓を作らない。
    - unlink 完了後に fd を閉じる。
 5. `ENOENT` は `NOT_FOUND`、path/symlink/inode 不一致は `FORBIDDEN`、tracked 状態の変化は `CONFLICT`、その他の I/O は `IO_ERROR` として ACK で区別する。
+
+**対応 OS の境界:** Node.js の `O_NOFOLLOW` を有効な symlink 防御として扱えない Windows では、安全な代替 guard を保証できないため削除 helper は filesystem に触れず `FORBIDDEN` を返す。Windows を許可するのは、reparse point を追わずに開ける代替実装と Windows CI の security test を追加した後とする。
 
 **TOCTOU の境界:** Node の `unlink` は inode ではなく pathname を受けるため、別 process が最後の同期 `lstat` と `unlink` の数命令間で同一 path を差し替える可能性を OS API 上ゼロにはできない。ただし同じ OS user で任意に directory を変更できる process は元から対象 file を直接 unlink できる。Ark が防ぐべき socket 起点・repository symlink 起点・Ark process 内競合については、`O_NOFOLLOW`、fd/realpath/lstat の二段 inode 照合、同期した直前 check と同一 path の unlink で、既存 reader より緩めない。inode 指定削除のための native addon は導入しない。
 
@@ -83,7 +85,7 @@
 **採用:**
 
 - `DiagramListItem` に `tracked: boolean` を追加する。
-- 一覧取得時に `git -C <worktreeReal> ls-files --cached -z -- .claude/diagrams` を `execFile`（shell なし）で1回だけ実行し、NUL 区切りの tracked path set を作る。各 file ごとの git process は起動しない。git 判定失敗を全件 `false` に丸めず、一覧 ACK error にする。
+- 一覧取得時に `git -C <worktreeReal> ls-files --cached -z -- .claude/diagrams` を `execFile`（shell なし）で1回だけ実行し、NUL 区切りの tracked path set を作る。各 file ごとの git process は起動しない。一覧取得と削除前再判定の両方に10秒の timeout と10 MiBの `maxBuffer` を設定し、timeout・buffer 超過・キャンセルを含む git 判定失敗を `false` に丸めず ACK error にする。
 - native option の表示は既存の「title — 相対 path」を残し、その末尾へ `Git管理` / `未追跡` を追加する。current の状態も select 横に短く表示し、tooltip には完全な相対 path と状態を残す。
 - 削除 request は一覧時の `expectedTracked` を送り、server が削除直前に shell を介さない git コマンドで再判定する。不一致なら `CONFLICT` で削除せず、client は一覧を更新して再確認を求める。
 - Ark は `git rm`、`git add -u`、commit を実行しない。通常の `unlink` だけを行う。tracked file は `git status` 上の削除、untracked file は filesystem から消滅となる。index を暗黙に変更しない。
@@ -249,7 +251,7 @@ PC DiagramSwitcher
 - Create: `packages/server/src/lib/diagram-delete.ts`
 - Create: `packages/server/src/lib/diagram-delete.test.ts`
 
-**テスト（REDで何を書くか）:** `undefined`、`null`、array、空 object、空/非文字列/長すぎる `sessionId`、空/非文字列 `relPath`、boolean でない `expectedTracked` を table test にし、resolver・filesystem・DB dependency が一度も呼ばれず `BAD_REQUEST` になる期待を書く。
+**テスト（REDで何を書くか）:** `undefined`、`null`、array、空 object、空/非文字列/長すぎる `sessionId`、空/非文字列または NUL 文字（`\0`）を含む `relPath`、boolean でない `expectedTracked` を table test にし、resolver・filesystem・DB dependency が一度も呼ばれず `BAD_REQUEST` になる期待を書く。
 
 **完了条件:** 不正 payload が throw せず ACK error へ畳まれる RED が揃う。
 
@@ -495,11 +497,12 @@ pnpm exec vitest run \
 
 ```bash
 pnpm check
+pnpm exec vitest run
 pnpm --filter @ark/server test
 pnpm build
 ```
 
-**完了条件:** lint/format/typecheck、server 全 Vitest、production build が PASS。`DiagramListItem` fixture の `tracked` 追加漏れがない。
+**完了条件:** lint/format/typecheck、root 設定に含まれる server/web/shared の全 Vitest、server package 設定の全 Vitest、production build が PASS。`DiagramPane`、`useSocket`、`Dashboard`、共有契約を含め、`DiagramListItem` fixture の `tracked` 追加漏れがない。
 
 ### Task 24: PC 実機 acceptance と既存 E2E を確認する（2〜5分/ケース）
 
@@ -516,7 +519,11 @@ pnpm build
 
 1. 一時 git worktree に tracked 1件、untracked 2件を用意し、3件の状態・title・path を確認する。
 2. cancel で何も消えないこと、untracked confirm でその1件だけ消えることを確認する。
-3. tracked confirm 後に `git status --short` が ` D .claude/diagrams/...` となり、index は変わらないことを確認する。
+3. tracked confirm 後に `git status --short` が次の出力となり、index は変わらないことを確認する。
+
+   ```text
+    D .claude/diagrams/...
+   ```
 4. current 削除後に右ペインが空になり、次図を自動選択しないこと、reload 後に削除図が復元されないことを確認する。
 5. browser を2つ接続し、一方の削除で双方の current/list が同期することを確認する。
 6. mobile viewport に削除 UI が出ないことを確認する。

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -60,6 +60,11 @@ import {
   WS_PORT_START,
 } from "./lib/constants.js";
 import { db } from "./lib/database.js";
+import {
+  createDiagramDeleteSocketHandler,
+  deleteDiagramFile,
+  isDiagramTracked,
+} from "./lib/diagram-delete.js";
 import { describeModelDiff } from "./lib/diagram-diff.js";
 import { ensureDoctype, replaceModelBlock } from "./lib/diagram-file.js";
 import { handleDiagramListRequest, listDiagrams } from "./lib/diagram-list.js";
@@ -2144,6 +2149,34 @@ export async function startServer(
         }
       });
     });
+
+    socket.on(
+      "diagram:delete",
+      createDiagramDeleteSocketHandler({
+        getSession: sessionId => sessionOrchestrator.getSession(sessionId),
+        resolveManagedWorktreePath,
+        isDiagramTracked,
+        deleteDiagramFile,
+        clearSessionLastDiagramIfMatches: (sessionId, relPath) => {
+          try {
+            return db.clearSessionLastDiagramIfMatches(sessionId, relPath);
+          } catch (error) {
+            console.error(
+              "[Diagram] last_diagram_path の消去に失敗しました:",
+              getErrorMessage(error)
+            );
+            throw error;
+          }
+        },
+        onSessionCleared: sessionId => {
+          const session = sessionOrchestrator.getSession(sessionId);
+          if (session) io.emit("session:updated", session);
+        },
+        onDeleted: data => {
+          io.emit("diagram:deleted", data);
+        },
+      })
+    );
 
     socket.on("diagram:subscribe", (data: unknown) => {
       // payload は外部入力。分割代入前に型を検証しないと、引数なし emit や

--- a/packages/server/src/lib/database.test.ts
+++ b/packages/server/src/lib/database.test.ts
@@ -392,6 +392,54 @@ describe("SessionDatabase - profiles / repo_profile_links", () => {
   // ============================================================
 
   describe("updateSessionLastDiagram / lastDiagramPath 永続化", () => {
+    it("一致する lastDiagramPath だけを単一条件付き更新で null にする", () => {
+      for (const [id, relPath] of [
+        ["matched", ".claude/diagrams/a.diagram.html"],
+        ["different", ".claude/diagrams/b.diagram.html"],
+        ["already-null", null],
+      ] as const) {
+        testDb.upsertSession({
+          id,
+          worktreeId: `wt-${id}`,
+          worktreePath: `/repo/${id}`,
+          status: "active",
+        });
+        if (relPath !== null) testDb.updateSessionLastDiagram(id, relPath);
+      }
+
+      expect(
+        testDb.clearSessionLastDiagramIfMatches(
+          "matched",
+          ".claude/diagrams/a.diagram.html"
+        )
+      ).toBe(true);
+      expect(testDb.getSession("matched")?.lastDiagramPath).toBeNull();
+
+      expect(
+        testDb.clearSessionLastDiagramIfMatches(
+          "different",
+          ".claude/diagrams/a.diagram.html"
+        )
+      ).toBe(false);
+      expect(testDb.getSession("different")?.lastDiagramPath).toBe(
+        ".claude/diagrams/b.diagram.html"
+      );
+
+      expect(
+        testDb.clearSessionLastDiagramIfMatches(
+          "already-null",
+          ".claude/diagrams/a.diagram.html"
+        )
+      ).toBe(false);
+      expect(testDb.getSession("already-null")?.lastDiagramPath).toBeNull();
+      expect(
+        testDb.clearSessionLastDiagramIfMatches(
+          "missing",
+          ".claude/diagrams/a.diagram.html"
+        )
+      ).toBe(false);
+    });
+
     it("upsert直後は lastDiagramPath が null", () => {
       testDb.upsertSession({
         id: "sess-diag-1",

--- a/packages/server/src/lib/database.ts
+++ b/packages/server/src/lib/database.ts
@@ -678,6 +678,21 @@ export class SessionDatabase {
   }
 
   /**
+   * 指定 path が現在値と一致する場合だけ last_diagram_path を消去する。
+   * board_open との競合で保存された別 path を消さないよう比較と更新を単一 SQL にする。
+   */
+  clearSessionLastDiagramIfMatches(
+    sessionId: string,
+    relPath: string
+  ): boolean {
+    const now = new Date().toISOString();
+    const stmt = this.db.prepare(
+      "UPDATE sessions SET last_diagram_path = NULL, updated_at = ? WHERE id = ? AND last_diagram_path = ?"
+    );
+    return stmt.run(now, sessionId, relPath).changes > 0;
+  }
+
+  /**
    * セッションを削除（関連するメッセージも自動削除）
    *
    * @param id - セッションID

--- a/packages/server/src/lib/diagram-delete-git.test.ts
+++ b/packages/server/src/lib/diagram-delete-git.test.ts
@@ -34,6 +34,10 @@ it("git ls-files の pathspec magic を明示的に無効化する", async () =>
       "--",
       ".claude/diagrams/:(glob)*.diagram.html",
     ],
-    { encoding: "utf8" }
+    {
+      encoding: "utf8",
+      timeout: 10_000,
+      maxBuffer: 10 * 1024 * 1024,
+    }
   );
 });

--- a/packages/server/src/lib/diagram-delete-git.test.ts
+++ b/packages/server/src/lib/diagram-delete-git.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+const gitMocks = vi.hoisted(() => {
+  const execFileAsync = vi.fn(async () => ({ stdout: "", stderr: "" }));
+  const execFile = vi.fn();
+  Object.defineProperty(execFile, Symbol.for("nodejs.util.promisify.custom"), {
+    value: execFileAsync,
+  });
+  return { execFile, execFileAsync };
+});
+
+vi.mock("node:child_process", () => ({ execFile: gitMocks.execFile }));
+
+import { isDiagramTracked } from "./diagram-delete.js";
+
+beforeEach(() => {
+  gitMocks.execFileAsync.mockClear();
+});
+
+it("git ls-files の pathspec magic を明示的に無効化する", async () => {
+  await expect(
+    isDiagramTracked("/managed/worktree", ":(glob)*.diagram.html")
+  ).resolves.toBe(false);
+
+  expect(gitMocks.execFileAsync).toHaveBeenCalledWith(
+    "git",
+    [
+      "-C",
+      "/managed/worktree",
+      "--literal-pathspecs",
+      "ls-files",
+      "--cached",
+      "-z",
+      "--",
+      ".claude/diagrams/:(glob)*.diagram.html",
+    ],
+    { encoding: "utf8" }
+  );
+});

--- a/packages/server/src/lib/diagram-delete.test.ts
+++ b/packages/server/src/lib/diagram-delete.test.ts
@@ -1,0 +1,734 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { DiagramDeleteRequest, DiagramDeleteResponse } from "@ark/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createDiagramDeleteSocketHandler,
+  type DiagramDeleteRequestDeps,
+  deleteDiagramFile,
+  handleDiagramDeleteRequest,
+  isDiagramTracked,
+} from "./diagram-delete.js";
+
+const tempDirs: string[] = [];
+
+function makeDeleteFixture(): {
+  worktree: string;
+  diagramsDir: string;
+  outside: string;
+} {
+  const root = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ark-diagram-delete-"))
+  );
+  tempDirs.push(root);
+  const worktree = path.join(root, "worktree");
+  const diagramsDir = path.join(worktree, ".claude", "diagrams");
+  const outside = path.join(root, "outside.diagram.html");
+  fs.mkdirSync(diagramsDir, { recursive: true });
+  fs.writeFileSync(outside, "outside");
+  return { worktree, diagramsDir, outside };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("diagram delete shared contract", () => {
+  it("request と success/error response を共有型で表現する", () => {
+    const request: DiagramDeleteRequest = {
+      sessionId: "session-1",
+      relPath: ".claude/diagrams/a.diagram.html",
+      expectedTracked: true,
+    };
+    const success: DiagramDeleteResponse = {
+      ok: true,
+      relPath: request.relPath,
+      tracked: true,
+    };
+    const failure: DiagramDeleteResponse = {
+      ok: false,
+      code: "FORBIDDEN",
+      error: "拒否",
+    };
+
+    expect(success.ok).toBe(true);
+    expect(failure.ok).toBe(false);
+  });
+});
+
+function makeRequestDeps(): DiagramDeleteRequestDeps {
+  return {
+    getSession: vi.fn(() => ({
+      id: "session-1",
+      worktreePath: "/input/worktree",
+    })),
+    resolveManagedWorktreePath: vi.fn(() => "/real/worktree"),
+    isDiagramTracked: vi.fn(async () => true),
+    deleteDiagramFile: vi.fn(async () => ({
+      ok: true as const,
+      absPath: "/real/worktree/.claude/diagrams/a.diagram.html",
+    })),
+    clearSessionLastDiagramIfMatches: vi.fn(() => false),
+    onSessionCleared: vi.fn(),
+    onDeleted: vi.fn(),
+  };
+}
+
+describe("handleDiagramDeleteRequest payload validation", () => {
+  it.each([
+    undefined,
+    null,
+    [],
+    {},
+    { sessionId: "", relPath: "a.diagram.html", expectedTracked: true },
+    { sessionId: 1, relPath: "a.diagram.html", expectedTracked: true },
+    {
+      sessionId: "x".repeat(1025),
+      relPath: "a.diagram.html",
+      expectedTracked: true,
+    },
+    { sessionId: "session-1", relPath: "", expectedTracked: true },
+    { sessionId: "session-1", relPath: 1, expectedTracked: true },
+    {
+      sessionId: "session-1",
+      relPath: "a.diagram.html",
+      expectedTracked: "true",
+    },
+  ])("不正 payload %j は依存処理を呼ばず BAD_REQUEST にする", async data => {
+    const deps = makeRequestDeps();
+
+    await expect(handleDiagramDeleteRequest(deps, data)).resolves.toEqual({
+      ok: false,
+      code: "BAD_REQUEST",
+      error: "不正なリクエストです",
+    });
+    for (const dependency of Object.values(deps)) {
+      expect(dependency).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe("handleDiagramDeleteRequest managed worktree boundary", () => {
+  const request: DiagramDeleteRequest = {
+    sessionId: "session-1",
+    relPath: ".claude/diagrams/a.diagram.html",
+    expectedTracked: true,
+  };
+
+  it("不明 session を SESSION_NOT_FOUND にする", async () => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.getSession).mockReturnValue(null);
+
+    await expect(handleDiagramDeleteRequest(deps, request)).resolves.toEqual({
+      ok: false,
+      code: "SESSION_NOT_FOUND",
+      error: "セッションが見つかりません",
+    });
+    expect(deps.resolveManagedWorktreePath).not.toHaveBeenCalled();
+    expect(deps.deleteDiagramFile).not.toHaveBeenCalled();
+  });
+
+  it("session の worktree が管理対象外なら FORBIDDEN にする", async () => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.resolveManagedWorktreePath).mockReturnValue(null);
+
+    await expect(handleDiagramDeleteRequest(deps, request)).resolves.toEqual({
+      ok: false,
+      code: "FORBIDDEN",
+      error: "管理対象の worktree ではありません",
+    });
+    expect(deps.resolveManagedWorktreePath).toHaveBeenCalledWith(
+      "/input/worktree"
+    );
+    expect(deps.deleteDiagramFile).not.toHaveBeenCalled();
+  });
+
+  it("resolver の realpath だけを file helper に渡す", async () => {
+    const deps = makeRequestDeps();
+
+    await expect(
+      handleDiagramDeleteRequest(deps, request)
+    ).resolves.toMatchObject({ ok: true });
+    expect(deps.deleteDiagramFile).toHaveBeenCalledWith(
+      "/real/worktree",
+      request.relPath
+    );
+    expect(deps.deleteDiagramFile).not.toHaveBeenCalledWith(
+      "/input/worktree",
+      request.relPath
+    );
+  });
+});
+
+describe("handleDiagramDeleteRequest tracked 再確認", () => {
+  it.each([
+    { expectedTracked: true, currentTracked: true },
+    { expectedTracked: false, currentTracked: false },
+  ])("expected=$expectedTracked/current=$currentTracked なら削除へ進む", async ({
+    expectedTracked,
+    currentTracked,
+  }) => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.isDiagramTracked).mockResolvedValue(currentTracked);
+
+    await expect(
+      handleDiagramDeleteRequest(deps, {
+        sessionId: "session-1",
+        relPath: ".claude/diagrams/a.diagram.html",
+        expectedTracked,
+      })
+    ).resolves.toEqual({
+      ok: true,
+      relPath: ".claude/diagrams/a.diagram.html",
+      tracked: currentTracked,
+    });
+    expect(deps.deleteDiagramFile).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { expectedTracked: true, currentTracked: false },
+    { expectedTracked: false, currentTracked: true },
+  ])("expected=$expectedTracked/current=$currentTracked の不一致は CONFLICT で削除しない", async ({
+    expectedTracked,
+    currentTracked,
+  }) => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.isDiagramTracked).mockResolvedValue(currentTracked);
+
+    await expect(
+      handleDiagramDeleteRequest(deps, {
+        sessionId: "session-1",
+        relPath: ".claude/diagrams/a.diagram.html",
+        expectedTracked,
+      })
+    ).resolves.toMatchObject({ ok: false, code: "CONFLICT" });
+    expect(deps.deleteDiagramFile).not.toHaveBeenCalled();
+  });
+
+  it("git error は unlink 前の IO_ERROR にする", async () => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.isDiagramTracked).mockRejectedValue(
+      Object.assign(new Error("git failed"), { code: "EIO" })
+    );
+
+    const result = await handleDiagramDeleteRequest(deps, {
+      sessionId: "session-1",
+      relPath: ".claude/diagrams/a.diagram.html",
+      expectedTracked: true,
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "IO_ERROR" });
+    if (!result.ok) expect(result.error).toContain("git failed");
+    expect(deps.deleteDiagramFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("handleDiagramDeleteRequest side-effect order", () => {
+  const request: DiagramDeleteRequest = {
+    sessionId: "session-1",
+    relPath: ".claude/diagrams/a.diagram.html",
+    expectedTracked: true,
+  };
+
+  it("unlink 成功後だけ conditional clear と通知を順に行う", async () => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.clearSessionLastDiagramIfMatches).mockReturnValue(true);
+
+    await expect(handleDiagramDeleteRequest(deps, request)).resolves.toEqual({
+      ok: true,
+      relPath: request.relPath,
+      tracked: true,
+    });
+    expect(deps.deleteDiagramFile).toHaveBeenCalledBefore(
+      vi.mocked(deps.clearSessionLastDiagramIfMatches)
+    );
+    expect(deps.clearSessionLastDiagramIfMatches).toHaveBeenCalledWith(
+      request.sessionId,
+      request.relPath
+    );
+    expect(deps.clearSessionLastDiagramIfMatches).toHaveBeenCalledBefore(
+      vi.mocked(deps.onSessionCleared)
+    );
+    expect(deps.onSessionCleared).toHaveBeenCalledBefore(
+      vi.mocked(deps.onDeleted)
+    );
+    expect(deps.onDeleted).toHaveBeenCalledWith({
+      sessionId: request.sessionId,
+      relPath: request.relPath,
+    });
+  });
+
+  it("unlink 失敗時は DB と broadcast を呼ばない", async () => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.deleteDiagramFile).mockResolvedValue({
+      ok: false,
+      code: "NOT_FOUND",
+      error: "missing",
+    });
+
+    await expect(
+      handleDiagramDeleteRequest(deps, request)
+    ).resolves.toMatchObject({ ok: false, code: "NOT_FOUND" });
+    expect(deps.clearSessionLastDiagramIfMatches).not.toHaveBeenCalled();
+    expect(deps.onSessionCleared).not.toHaveBeenCalled();
+    expect(deps.onDeleted).not.toHaveBeenCalled();
+  });
+
+  it("DB clear failure は success + warning で削除通知を送る", async () => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.clearSessionLastDiagramIfMatches).mockImplementation(() => {
+      throw new Error("database unavailable");
+    });
+
+    const result = await handleDiagramDeleteRequest(deps, request);
+
+    expect(result).toMatchObject({
+      ok: true,
+      relPath: request.relPath,
+      tracked: true,
+    });
+    if (result.ok) {
+      expect(result.warning).toContain("database unavailable");
+    }
+    expect(deps.onSessionCleared).not.toHaveBeenCalled();
+    expect(deps.onDeleted).toHaveBeenCalledWith({
+      sessionId: request.sessionId,
+      relPath: request.relPath,
+    });
+  });
+});
+
+describe("diagram:delete ACK handler", () => {
+  it("ACK を成功結果で1回だけ呼ぶ", async () => {
+    const response: DiagramDeleteResponse = {
+      ok: true,
+      relPath: ".claude/diagrams/a.diagram.html",
+      tracked: true,
+    };
+    const requestHandler = vi.fn(async () => response);
+    const callback = vi.fn();
+    const handler = createDiagramDeleteSocketHandler(
+      makeRequestDeps(),
+      requestHandler
+    );
+
+    handler({ sessionId: "session-1" }, callback);
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledOnce());
+    expect(callback).toHaveBeenCalledWith(response);
+    expect(requestHandler).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    undefined,
+    null,
+    "callback",
+  ])("callback が関数でない場合 (%j) は core を呼ばず安全に無視する", async callback => {
+    const requestHandler = vi.fn();
+    const handler = createDiagramDeleteSocketHandler(
+      makeRequestDeps(),
+      requestHandler
+    );
+
+    expect(() => handler({}, callback)).not.toThrow();
+    await Promise.resolve();
+    expect(requestHandler).not.toHaveBeenCalled();
+  });
+
+  it("ACK callback が throw しても handler から伝播しない", async () => {
+    const handler = createDiagramDeleteSocketHandler(
+      makeRequestDeps(),
+      async () => ({
+        ok: false,
+        code: "BAD_REQUEST",
+        error: "bad request",
+      })
+    );
+    const callback = vi.fn(() => {
+      throw new Error("client callback failed");
+    });
+
+    expect(() => handler({}, callback)).not.toThrow();
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledOnce());
+  });
+
+  it("core が reject しても IO_ERROR の ACK を1回だけ返す", async () => {
+    const requestHandler = vi.fn(async (): Promise<DiagramDeleteResponse> => {
+      throw new Error("unexpected core failure");
+    });
+    const callback = vi.fn();
+    const handler = createDiagramDeleteSocketHandler(
+      makeRequestDeps(),
+      requestHandler
+    );
+
+    handler({}, callback);
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledOnce());
+    expect(callback).toHaveBeenCalledWith({
+      ok: false,
+      code: "IO_ERROR",
+      error: "図ファイルの削除に失敗しました: unexpected core failure",
+    });
+  });
+});
+
+describe("deleteDiagramFile path boundary", () => {
+  it.each([
+    "../outside.diagram.html",
+    ".claude/diagrams/nested/../../../outside.diagram.html",
+    "",
+    `${"a".repeat(1025)}.diagram.html`,
+    ".claude/diagrams/not-diagram.html",
+    "docs/diagrams/legacy.diagram.html",
+    ".claude/other/outside.diagram.html",
+  ])("不正な相対 path %j を FORBIDDEN にして何も削除しない", async relPath => {
+    const { worktree, diagramsDir, outside } = makeDeleteFixture();
+    const neighbor = path.join(diagramsDir, "neighbor.diagram.html");
+    const legacy = path.join(
+      worktree,
+      "docs",
+      "diagrams",
+      "legacy.diagram.html"
+    );
+    fs.mkdirSync(path.dirname(legacy), { recursive: true });
+    fs.writeFileSync(neighbor, "neighbor");
+    fs.writeFileSync(legacy, "legacy");
+
+    await expect(deleteDiagramFile(worktree, relPath)).resolves.toMatchObject({
+      ok: false,
+      code: "FORBIDDEN",
+    });
+    expect(fs.readFileSync(outside, "utf8")).toBe("outside");
+    expect(fs.readFileSync(neighbor, "utf8")).toBe("neighbor");
+    expect(fs.readFileSync(legacy, "utf8")).toBe("legacy");
+  });
+
+  it("絶対 path を FORBIDDEN にして外部 file を残す", async () => {
+    const { worktree, outside } = makeDeleteFixture();
+
+    await expect(deleteDiagramFile(worktree, outside)).resolves.toMatchObject({
+      ok: false,
+      code: "FORBIDDEN",
+    });
+    expect(fs.readFileSync(outside, "utf8")).toBe("outside");
+  });
+
+  it.each([
+    "../outside.diagram.html",
+    "/tmp/outside.diagram.html",
+    "docs/diagrams/legacy.diagram.html",
+    ".claude/other/outside.diagram.html",
+  ])("request core は不正 path %j を Git 判定より前に FORBIDDEN にする", async relPath => {
+    const deps = makeRequestDeps();
+
+    await expect(
+      handleDiagramDeleteRequest(deps, {
+        sessionId: "session-1",
+        relPath,
+        expectedTracked: true,
+      })
+    ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+    expect(deps.isDiagramTracked).not.toHaveBeenCalled();
+    expect(deps.deleteDiagramFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("deleteDiagramFile symlink と file 種別", () => {
+  it.each([
+    "outside",
+    "inside",
+  ] as const)("最終要素が %s 向き symlink なら link と target を残して FORBIDDEN にする", async direction => {
+    const { worktree, diagramsDir, outside } = makeDeleteFixture();
+    const inside = path.join(diagramsDir, "target.diagram.html");
+    const link = path.join(diagramsDir, "link.diagram.html");
+    fs.writeFileSync(inside, "inside");
+    const target = direction === "outside" ? outside : inside;
+    fs.symlinkSync(target, link);
+
+    await expect(
+      deleteDiagramFile(worktree, ".claude/diagrams/link.diagram.html")
+    ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(target, "utf8")).toBe(direction);
+  });
+
+  it("外向き ancestor symlink を辿らず外部 target を残す", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    const outsideDir = path.join(path.dirname(worktree), "outside-dir");
+    const outsideTarget = path.join(outsideDir, "target.diagram.html");
+    fs.mkdirSync(outsideDir);
+    fs.writeFileSync(outsideTarget, "outside-target");
+    fs.symlinkSync(outsideDir, path.join(diagramsDir, "linked"), "dir");
+
+    await expect(
+      deleteDiagramFile(worktree, ".claude/diagrams/linked/target.diagram.html")
+    ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+    expect(fs.readFileSync(outsideTarget, "utf8")).toBe("outside-target");
+    expect(
+      fs.lstatSync(path.join(diagramsDir, "linked")).isSymbolicLink()
+    ).toBe(true);
+  });
+
+  it("directory を FORBIDDEN にして entry を残す", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    const directory = path.join(diagramsDir, "directory.diagram.html");
+    fs.mkdirSync(directory);
+
+    await expect(
+      deleteDiagramFile(worktree, ".claude/diagrams/directory.diagram.html")
+    ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+    expect(fs.statSync(directory).isDirectory()).toBe(true);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "FIFO を FORBIDDEN にして entry を残す",
+    async () => {
+      const { worktree, diagramsDir } = makeDeleteFixture();
+      const fifo = path.join(diagramsDir, "pipe.diagram.html");
+      execFileSync("mkfifo", [fifo]);
+
+      await expect(
+        deleteDiagramFile(worktree, ".claude/diagrams/pipe.diagram.html", {
+          fs: {
+            open: (filePath, flags) =>
+              fs.promises.open(filePath, flags | fs.constants.O_NONBLOCK),
+            realpath: fs.promises.realpath,
+            stat: fs.promises.stat,
+            lstatSync: fs.lstatSync,
+            unlinkSync: fs.unlinkSync,
+          },
+        })
+      ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+      expect(fs.lstatSync(fifo).isFIFO()).toBe(true);
+    }
+  );
+});
+
+describe("deleteDiagramFile verified unlink", () => {
+  it.each([
+    ".claude/diagrams/direct.diagram.html",
+    ".claude/diagrams/nested/deep.diagram.html",
+  ])("通常 file %s だけを削除する", async relPath => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    const target = path.join(worktree, relPath);
+    const neighbor = path.join(diagramsDir, "neighbor.diagram.html");
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, "target");
+    fs.writeFileSync(neighbor, "neighbor");
+    let openFlags = 0;
+
+    await expect(
+      deleteDiagramFile(worktree, relPath, {
+        fs: {
+          open: (filePath, flags) => {
+            openFlags = flags;
+            return fs.promises.open(filePath, flags);
+          },
+          realpath: fs.promises.realpath,
+          stat: fs.promises.stat,
+          lstatSync: fs.lstatSync,
+          unlinkSync: fs.unlinkSync,
+        },
+      })
+    ).resolves.toEqual({ ok: true, absPath: target });
+    expect(openFlags & fs.constants.O_NOFOLLOW).toBe(fs.constants.O_NOFOLLOW);
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.readFileSync(neighbor, "utf8")).toBe("neighbor");
+  });
+
+  it("存在しない path を NOT_FOUND にして directory 内容を維持する", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    const neighbor = path.join(diagramsDir, "neighbor.diagram.html");
+    fs.writeFileSync(neighbor, "neighbor");
+
+    await expect(
+      deleteDiagramFile(worktree, ".claude/diagrams/missing.diagram.html")
+    ).resolves.toMatchObject({ ok: false, code: "NOT_FOUND" });
+    expect(fs.readFileSync(neighbor, "utf8")).toBe("neighbor");
+  });
+
+  it.each([
+    "EACCES",
+    "EPERM",
+  ])("%s を FORBIDDEN にして unlink しない", async code => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    const target = path.join(diagramsDir, "denied.diagram.html");
+    fs.writeFileSync(target, "target");
+    const unlinkSync = vi.fn();
+
+    await expect(
+      deleteDiagramFile(worktree, ".claude/diagrams/denied.diagram.html", {
+        fs: {
+          open: async () => {
+            throw Object.assign(new Error("denied"), { code });
+          },
+          realpath: fs.promises.realpath,
+          stat: fs.promises.stat,
+          lstatSync: fs.lstatSync,
+          unlinkSync,
+        },
+      })
+    ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+    expect(unlinkSync).not.toHaveBeenCalled();
+    expect(fs.readFileSync(target, "utf8")).toBe("target");
+  });
+
+  it("その他 I/O error は errno を含む IO_ERROR にする", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    const target = path.join(diagramsDir, "io.diagram.html");
+    fs.writeFileSync(target, "target");
+
+    const result = await deleteDiagramFile(
+      worktree,
+      ".claude/diagrams/io.diagram.html",
+      {
+        fs: {
+          open: async () => {
+            throw Object.assign(new Error("device failure"), { code: "EIO" });
+          },
+          realpath: fs.promises.realpath,
+          stat: fs.promises.stat,
+          lstatSync: fs.lstatSync,
+          unlinkSync: fs.unlinkSync,
+        },
+      }
+    );
+
+    expect(result).toMatchObject({ ok: false, code: "IO_ERROR" });
+    if (!result.ok) {
+      expect(result.error).toContain("EIO");
+      expect(result.error).toContain("device failure");
+    }
+    expect(fs.readFileSync(target, "utf8")).toBe("target");
+  });
+});
+
+describe("deleteDiagramFile TOCTOU final identity", () => {
+  it("open 後に外向き symlink へ交換された path を削除しない", async () => {
+    const { worktree, diagramsDir, outside } = makeDeleteFixture();
+    const target = path.join(diagramsDir, "race.diagram.html");
+    const openedOriginal = path.join(diagramsDir, "opened-original");
+    fs.writeFileSync(target, "original");
+
+    const beforeFinalIdentityCheck = vi.fn(() => {
+      fs.renameSync(target, openedOriginal);
+      fs.symlinkSync(outside, target);
+    });
+    await expect(
+      deleteDiagramFile(worktree, ".claude/diagrams/race.diagram.html", {
+        beforeFinalIdentityCheck,
+      })
+    ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+
+    expect(beforeFinalIdentityCheck).toHaveBeenCalledWith(target);
+    expect(fs.lstatSync(target).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(outside, "utf8")).toBe("outside");
+    expect(fs.readFileSync(openedOriginal, "utf8")).toBe("original");
+  });
+
+  it("open 後に root 内の別 inode へ交換された path を削除しない", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    const target = path.join(diagramsDir, "race.diagram.html");
+    const openedOriginal = path.join(diagramsDir, "opened-original");
+    fs.writeFileSync(target, "original");
+
+    await expect(
+      deleteDiagramFile(worktree, ".claude/diagrams/race.diagram.html", {
+        beforeFinalIdentityCheck: () => {
+          fs.renameSync(target, openedOriginal);
+          fs.writeFileSync(target, "replacement");
+        },
+      })
+    ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+
+    expect(fs.readFileSync(target, "utf8")).toBe("replacement");
+    expect(fs.readFileSync(openedOriginal, "utf8")).toBe("original");
+  });
+});
+
+describe("tracked/untracked unlink integration", () => {
+  function initializeGitWorktree(worktree: string): void {
+    execFileSync("git", ["init", "-q", worktree]);
+    execFileSync("git", ["-C", worktree, "config", "user.name", "Ark Test"]);
+    execFileSync("git", [
+      "-C",
+      worktree,
+      "config",
+      "user.email",
+      "ark-test@example.com",
+    ]);
+  }
+
+  function realDeps(worktree: string): DiagramDeleteRequestDeps {
+    return {
+      getSession: () => ({ id: "session-1", worktreePath: worktree }),
+      resolveManagedWorktreePath: () => worktree,
+      isDiagramTracked,
+      deleteDiagramFile,
+      clearSessionLastDiagramIfMatches: () => false,
+      onSessionCleared: vi.fn(),
+      onDeleted: vi.fn(),
+    };
+  }
+
+  it("tracked regular file は index を変えず worktree に削除差分だけを残す", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    initializeGitWorktree(worktree);
+    const target = path.join(diagramsDir, "tracked.diagram.html");
+    const neighbor = path.join(diagramsDir, "neighbor.diagram.html");
+    fs.writeFileSync(target, "tracked");
+    fs.writeFileSync(neighbor, "neighbor");
+    execFileSync("git", ["-C", worktree, "add", "--", ".claude/diagrams"]);
+    execFileSync("git", ["-C", worktree, "commit", "-qm", "fixture"]);
+    const indexBefore = execFileSync("git", [
+      "-C",
+      worktree,
+      "ls-files",
+      "--stage",
+    ]).toString();
+
+    await expect(
+      handleDiagramDeleteRequest(realDeps(worktree), {
+        sessionId: "session-1",
+        relPath: ".claude/diagrams/tracked.diagram.html",
+        expectedTracked: true,
+      })
+    ).resolves.toMatchObject({ ok: true, tracked: true });
+
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.readFileSync(neighbor, "utf8")).toBe("neighbor");
+    expect(
+      execFileSync("git", ["-C", worktree, "ls-files", "--stage"]).toString()
+    ).toBe(indexBefore);
+    expect(
+      execFileSync("git", ["-C", worktree, "status", "--short"]).toString()
+    ).toContain(" D .claude/diagrams/tracked.diagram.html");
+  });
+
+  it("untracked regular file は対象1件だけを unlink する", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    initializeGitWorktree(worktree);
+    const target = path.join(diagramsDir, "untracked.diagram.html");
+    const neighbor = path.join(diagramsDir, "neighbor.diagram.html");
+    fs.writeFileSync(target, "untracked");
+    fs.writeFileSync(neighbor, "neighbor");
+
+    await expect(
+      handleDiagramDeleteRequest(realDeps(worktree), {
+        sessionId: "session-1",
+        relPath: ".claude/diagrams/untracked.diagram.html",
+        expectedTracked: false,
+      })
+    ).resolves.toMatchObject({ ok: true, tracked: false });
+
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.readFileSync(neighbor, "utf8")).toBe("neighbor");
+    expect(execFileSync("git", ["-C", worktree, "ls-files"]).toString()).toBe(
+      ""
+    );
+  });
+});

--- a/packages/server/src/lib/diagram-delete.test.ts
+++ b/packages/server/src/lib/diagram-delete.test.ts
@@ -226,6 +226,41 @@ describe("handleDiagramDeleteRequest tracked 再確認", () => {
     if (!result.ok) expect(result.error).toContain("git failed");
     expect(deps.deleteDiagramFile).not.toHaveBeenCalled();
   });
+
+  it("filename-only 入力を正準化して全処理と ACK に使う", async () => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.clearSessionLastDiagramIfMatches).mockReturnValue(true);
+
+    await expect(
+      handleDiagramDeleteRequest(deps, {
+        sessionId: "session-1",
+        relPath: "a.diagram.html",
+        expectedTracked: true,
+      })
+    ).resolves.toEqual({
+      ok: true,
+      relPath: ".claude/diagrams/a.diagram.html",
+      tracked: true,
+    });
+
+    const canonicalRelPath = ".claude/diagrams/a.diagram.html";
+    expect(deps.isDiagramTracked).toHaveBeenCalledWith(
+      "/real/worktree",
+      canonicalRelPath
+    );
+    expect(deps.deleteDiagramFile).toHaveBeenCalledWith(
+      "/real/worktree",
+      canonicalRelPath
+    );
+    expect(deps.clearSessionLastDiagramIfMatches).toHaveBeenCalledWith(
+      "session-1",
+      canonicalRelPath
+    );
+    expect(deps.onDeleted).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      relPath: canonicalRelPath,
+    });
+  });
 });
 
 describe("handleDiagramDeleteRequest side-effect order", () => {
@@ -730,5 +765,65 @@ describe("tracked/untracked unlink integration", () => {
     expect(execFileSync("git", ["-C", worktree, "ls-files"]).toString()).toBe(
       ""
     );
+  });
+
+  it("filename-only 入力でも正準位置の tracked file を判定して削除する", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    initializeGitWorktree(worktree);
+    const target = path.join(diagramsDir, "filename-only.diagram.html");
+    fs.writeFileSync(target, "tracked");
+    execFileSync("git", [
+      "-C",
+      worktree,
+      "add",
+      "--",
+      ".claude/diagrams/filename-only.diagram.html",
+    ]);
+    execFileSync("git", ["-C", worktree, "commit", "-qm", "fixture"]);
+    const deps = realDeps(worktree);
+    deps.clearSessionLastDiagramIfMatches = vi.fn(() => true);
+
+    await expect(
+      handleDiagramDeleteRequest(deps, {
+        sessionId: "session-1",
+        relPath: "filename-only.diagram.html",
+        expectedTracked: true,
+      })
+    ).resolves.toEqual({
+      ok: true,
+      relPath: ".claude/diagrams/filename-only.diagram.html",
+      tracked: true,
+    });
+
+    expect(fs.existsSync(target)).toBe(false);
+    expect(deps.clearSessionLastDiagramIfMatches).toHaveBeenCalledWith(
+      "session-1",
+      ".claude/diagrams/filename-only.diagram.html"
+    );
+    expect(deps.onDeleted).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      relPath: ".claude/diagrams/filename-only.diagram.html",
+    });
+  });
+
+  it.each([
+    ":(glob)*.diagram.html",
+    ":(top)victim.diagram.html",
+  ])("pathspec magic %s を通常ファイル名として扱う", async relPath => {
+    const { worktree } = makeDeleteFixture();
+    initializeGitWorktree(worktree);
+    const rootTracked = path.join(worktree, "victim.diagram.html");
+    fs.writeFileSync(rootTracked, "tracked");
+    execFileSync("git", ["-C", worktree, "add", "--", "victim.diagram.html"]);
+
+    await expect(
+      handleDiagramDeleteRequest(realDeps(worktree), {
+        sessionId: "session-1",
+        relPath,
+        expectedTracked: false,
+      })
+    ).resolves.toMatchObject({ ok: false, code: "NOT_FOUND" });
+
+    expect(fs.readFileSync(rootTracked, "utf8")).toBe("tracked");
   });
 });

--- a/packages/server/src/lib/diagram-delete.test.ts
+++ b/packages/server/src/lib/diagram-delete.test.ts
@@ -93,6 +93,11 @@ describe("handleDiagramDeleteRequest payload validation", () => {
       expectedTracked: true,
     },
     { sessionId: "session-1", relPath: "", expectedTracked: true },
+    {
+      sessionId: "session-1",
+      relPath: ".claude/diagrams/a\0.diagram.html",
+      expectedTracked: true,
+    },
     { sessionId: "session-1", relPath: 1, expectedTracked: true },
     {
       sessionId: "session-1",
@@ -224,6 +229,26 @@ describe("handleDiagramDeleteRequest tracked 再確認", () => {
 
     expect(result).toMatchObject({ ok: false, code: "IO_ERROR" });
     if (!result.ok) expect(result.error).toContain("git failed");
+    expect(deps.deleteDiagramFile).not.toHaveBeenCalled();
+  });
+
+  it("git timeout kill は未追跡扱いにせず unlink 前の IO_ERROR にする", async () => {
+    const deps = makeRequestDeps();
+    vi.mocked(deps.isDiagramTracked).mockRejectedValue(
+      Object.assign(new Error("git timed out"), {
+        killed: true,
+        signal: "SIGTERM",
+      })
+    );
+
+    const result = await handleDiagramDeleteRequest(deps, {
+      sessionId: "session-1",
+      relPath: ".claude/diagrams/a.diagram.html",
+      expectedTracked: false,
+    });
+
+    expect(result).toMatchObject({ ok: false, code: "IO_ERROR" });
+    if (!result.ok) expect(result.error).toContain("git timed out");
     expect(deps.deleteDiagramFile).not.toHaveBeenCalled();
   });
 
@@ -473,6 +498,31 @@ describe("deleteDiagramFile path boundary", () => {
 });
 
 describe("deleteDiagramFile symlink と file 種別", () => {
+  it("Windows では filesystem に触れず FORBIDDEN にする", async () => {
+    const { worktree, diagramsDir } = makeDeleteFixture();
+    const target = path.join(diagramsDir, "target.diagram.html");
+    fs.writeFileSync(target, "target");
+    const open = vi.fn();
+    const unlinkSync = vi.fn();
+
+    await expect(
+      deleteDiagramFile(worktree, ".claude/diagrams/target.diagram.html", {
+        platform: "win32",
+        fs: {
+          open,
+          realpath: fs.promises.realpath,
+          stat: fs.promises.stat,
+          lstatSync: fs.lstatSync,
+          unlinkSync,
+        },
+      })
+    ).resolves.toMatchObject({ ok: false, code: "FORBIDDEN" });
+
+    expect(open).not.toHaveBeenCalled();
+    expect(unlinkSync).not.toHaveBeenCalled();
+    expect(fs.readFileSync(target, "utf8")).toBe("target");
+  });
+
   it.each([
     "outside",
     "inside",

--- a/packages/server/src/lib/diagram-delete.ts
+++ b/packages/server/src/lib/diagram-delete.ts
@@ -84,12 +84,24 @@ export async function isDiagramTracked(
   worktreeReal: string,
   relPath: string
 ): Promise<boolean> {
+  const resolved = resolveDeleteDiagramPath(worktreeReal, relPath);
+  if (!resolved.ok) return false;
+
   const { stdout } = await execFileAsync(
     "git",
-    ["-C", worktreeReal, "ls-files", "--cached", "-z", "--", relPath],
+    [
+      "-C",
+      worktreeReal,
+      "--literal-pathspecs",
+      "ls-files",
+      "--cached",
+      "-z",
+      "--",
+      resolved.relPath,
+    ],
     { encoding: "utf8" }
   );
-  return stdout.split("\0").some(candidate => candidate === relPath);
+  return stdout.split("\0").some(candidate => candidate === resolved.relPath);
 }
 
 export async function deleteDiagramFile(
@@ -223,10 +235,11 @@ export async function handleDiagramDeleteRequest(
       error: resolved.error,
     };
   }
+  const relPath = resolved.relPath;
 
   let tracked: boolean;
   try {
-    tracked = await deps.isDiagramTracked(worktreeReal, data.relPath);
+    tracked = await deps.isDiagramTracked(worktreeReal, relPath);
   } catch (error) {
     return {
       ok: false,
@@ -242,23 +255,23 @@ export async function handleDiagramDeleteRequest(
     };
   }
 
-  const deleted = await deps.deleteDiagramFile(worktreeReal, data.relPath);
+  const deleted = await deps.deleteDiagramFile(worktreeReal, relPath);
   if (!deleted.ok) return deleted;
 
   let warning: string | undefined;
   try {
     const cleared = deps.clearSessionLastDiagramIfMatches(
       data.sessionId,
-      data.relPath
+      relPath
     );
     if (cleared) deps.onSessionCleared(data.sessionId);
   } catch (error) {
     warning = `ファイルは削除済みですが復元情報の消去に失敗しました: ${errnoMessage(error)}`;
   }
-  deps.onDeleted({ sessionId: data.sessionId, relPath: data.relPath });
+  deps.onDeleted({ sessionId: data.sessionId, relPath });
   return {
     ok: true,
-    relPath: data.relPath,
+    relPath,
     tracked,
     ...(warning ? { warning } : {}),
   };

--- a/packages/server/src/lib/diagram-delete.ts
+++ b/packages/server/src/lib/diagram-delete.ts
@@ -7,6 +7,8 @@ import { DIAGRAM_DIR, resolveDiagramPath } from "./diagram-path.js";
 import { errnoCode, errnoMessage } from "./errors.js";
 
 const MAX_SESSION_ID_LENGTH = 1024;
+const GIT_TIMEOUT_MS = 10_000;
+const GIT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const execFileAsync = promisify(execFile);
 
 export type DeleteDiagramFileResult =
@@ -48,6 +50,7 @@ interface DiagramDeleteFs {
 
 interface DeleteDiagramFileOptions {
   fs?: DiagramDeleteFs;
+  platform?: NodeJS.Platform;
   beforeFinalIdentityCheck?: (absPath: string) => void;
 }
 
@@ -99,7 +102,11 @@ export async function isDiagramTracked(
       "--",
       resolved.relPath,
     ],
-    { encoding: "utf8" }
+    {
+      encoding: "utf8",
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: GIT_MAX_BUFFER_BYTES,
+    }
   );
   return stdout.split("\0").some(candidate => candidate === resolved.relPath);
 }
@@ -112,6 +119,11 @@ export async function deleteDiagramFile(
   const resolved = resolveDeleteDiagramPath(worktreeReal, relPath);
   if (!resolved.ok) {
     return forbidden(resolved.error);
+  }
+  if ((options.platform ?? process.platform) === "win32") {
+    return forbidden(
+      "この環境では symlink を安全に検証できないため図ファイルを削除できません"
+    );
   }
 
   const deleteFs = options.fs ?? defaultDeleteFs;
@@ -194,6 +206,7 @@ function isValidRequest(
     request.sessionId.length <= MAX_SESSION_ID_LENGTH &&
     typeof request.relPath === "string" &&
     request.relPath.length > 0 &&
+    !request.relPath.includes("\0") &&
     typeof request.expectedTracked === "boolean"
   );
 }

--- a/packages/server/src/lib/diagram-delete.ts
+++ b/packages/server/src/lib/diagram-delete.ts
@@ -1,0 +1,294 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { promisify } from "node:util";
+import type { DiagramDeleteResponse } from "@ark/shared";
+import { DIAGRAM_DIR, resolveDiagramPath } from "./diagram-path.js";
+import { errnoCode, errnoMessage } from "./errors.js";
+
+const MAX_SESSION_ID_LENGTH = 1024;
+const execFileAsync = promisify(execFile);
+
+export type DeleteDiagramFileResult =
+  | { ok: true; absPath: string }
+  | {
+      ok: false;
+      code: "NOT_FOUND" | "FORBIDDEN" | "IO_ERROR";
+      error: string;
+    };
+
+export interface DiagramDeleteRequestDeps {
+  getSession: (
+    sessionId: string
+  ) => { id: string; worktreePath: string } | null | undefined;
+  resolveManagedWorktreePath: (worktreePath: string) => string | null;
+  isDiagramTracked: (worktreeReal: string, relPath: string) => Promise<boolean>;
+  deleteDiagramFile: (
+    worktreeReal: string,
+    relPath: string
+  ) => Promise<DeleteDiagramFileResult>;
+  clearSessionLastDiagramIfMatches: (
+    sessionId: string,
+    relPath: string
+  ) => boolean;
+  onSessionCleared: (sessionId: string) => void;
+  onDeleted: (data: { sessionId: string; relPath: string }) => void;
+}
+
+interface DiagramDeleteFs {
+  open: (
+    filePath: string,
+    flags: number
+  ) => Promise<import("node:fs/promises").FileHandle>;
+  realpath: (filePath: string) => Promise<string>;
+  stat: (filePath: string) => Promise<fs.Stats>;
+  lstatSync: (filePath: string) => fs.Stats;
+  unlinkSync: (filePath: string) => void;
+}
+
+interface DeleteDiagramFileOptions {
+  fs?: DiagramDeleteFs;
+  beforeFinalIdentityCheck?: (absPath: string) => void;
+}
+
+const defaultDeleteFs: DiagramDeleteFs = {
+  open: fs.promises.open,
+  realpath: fs.promises.realpath,
+  stat: fs.promises.stat,
+  lstatSync: fs.lstatSync,
+  unlinkSync: fs.unlinkSync,
+};
+
+function forbidden(error: string): DeleteDiagramFileResult {
+  return { ok: false, code: "FORBIDDEN", error };
+}
+
+function resolveDeleteDiagramPath(
+  worktreeReal: string,
+  relPath: string
+): ReturnType<typeof resolveDiagramPath> {
+  const normalized = path.normalize(relPath);
+  if (
+    path.dirname(normalized) !== "." &&
+    !normalized.startsWith(`${DIAGRAM_DIR}${path.sep}`)
+  ) {
+    return {
+      ok: false,
+      error: `図ファイルは ${DIAGRAM_DIR} 配下で指定してください`,
+    };
+  }
+  return resolveDiagramPath(worktreeReal, relPath);
+}
+
+export async function isDiagramTracked(
+  worktreeReal: string,
+  relPath: string
+): Promise<boolean> {
+  const { stdout } = await execFileAsync(
+    "git",
+    ["-C", worktreeReal, "ls-files", "--cached", "-z", "--", relPath],
+    { encoding: "utf8" }
+  );
+  return stdout.split("\0").some(candidate => candidate === relPath);
+}
+
+export async function deleteDiagramFile(
+  worktreeReal: string,
+  relPath: string,
+  options: DeleteDiagramFileOptions = {}
+): Promise<DeleteDiagramFileResult> {
+  const resolved = resolveDeleteDiagramPath(worktreeReal, relPath);
+  if (!resolved.ok) {
+    return forbidden(resolved.error);
+  }
+
+  const deleteFs = options.fs ?? defaultDeleteFs;
+  const diagramsDir = path.join(worktreeReal, DIAGRAM_DIR);
+  let fd: import("node:fs/promises").FileHandle | null = null;
+  try {
+    fd = await deleteFs.open(
+      resolved.absPath,
+      fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW
+    );
+    const fdStat = await fd.stat();
+    if (!fdStat.isFile()) {
+      return forbidden("削除対象は通常ファイルではありません");
+    }
+
+    const realPath = await deleteFs.realpath(resolved.absPath);
+    const realStat = await deleteFs.stat(realPath);
+    if (fdStat.ino !== realStat.ino || fdStat.dev !== realStat.dev) {
+      return forbidden("図ファイルの実体を検証できません");
+    }
+    if (
+      realPath !== diagramsDir &&
+      !realPath.startsWith(diagramsDir + path.sep)
+    ) {
+      return forbidden(
+        `図ファイルの実体が worktree の ${DIAGRAM_DIR} から出ています`
+      );
+    }
+
+    options.beforeFinalIdentityCheck?.(resolved.absPath);
+    const finalStat = deleteFs.lstatSync(resolved.absPath);
+    if (
+      !finalStat.isFile() ||
+      finalStat.ino !== fdStat.ino ||
+      finalStat.dev !== fdStat.dev
+    ) {
+      return forbidden("削除直前に図ファイルの実体が変化しました");
+    }
+    deleteFs.unlinkSync(resolved.absPath);
+    return { ok: true, absPath: resolved.absPath };
+  } catch (error) {
+    const code = errnoCode(error);
+    if (code === "ENOENT") {
+      return {
+        ok: false,
+        code: "NOT_FOUND",
+        error: "図ファイルが見つかりません",
+      };
+    }
+    if (
+      code === "EACCES" ||
+      code === "EPERM" ||
+      code === "ELOOP" ||
+      code === "EMLINK"
+    ) {
+      return forbidden(`図ファイルへのアクセスが拒否されました (${code})`);
+    }
+    return {
+      ok: false,
+      code: "IO_ERROR",
+      error: `図ファイルの削除に失敗しました (${code}): ${errnoMessage(error)}`,
+    };
+  } finally {
+    try {
+      await fd?.close();
+    } catch {
+      // unlink の成否を close error で反転させない。
+    }
+  }
+}
+
+function isValidRequest(
+  data: unknown
+): data is { sessionId: string; relPath: string; expectedTracked: boolean } {
+  if (!data || typeof data !== "object" || Array.isArray(data)) return false;
+  const request = data as Record<string, unknown>;
+  return (
+    typeof request.sessionId === "string" &&
+    request.sessionId.length > 0 &&
+    request.sessionId.length <= MAX_SESSION_ID_LENGTH &&
+    typeof request.relPath === "string" &&
+    request.relPath.length > 0 &&
+    typeof request.expectedTracked === "boolean"
+  );
+}
+
+export async function handleDiagramDeleteRequest(
+  deps: DiagramDeleteRequestDeps,
+  data: unknown
+): Promise<DiagramDeleteResponse> {
+  if (!isValidRequest(data)) {
+    return {
+      ok: false,
+      code: "BAD_REQUEST",
+      error: "不正なリクエストです",
+    };
+  }
+
+  const session = deps.getSession(data.sessionId);
+  if (!session) {
+    return {
+      ok: false,
+      code: "SESSION_NOT_FOUND",
+      error: "セッションが見つかりません",
+    };
+  }
+  const worktreeReal = deps.resolveManagedWorktreePath(session.worktreePath);
+  if (!worktreeReal) {
+    return {
+      ok: false,
+      code: "FORBIDDEN",
+      error: "管理対象の worktree ではありません",
+    };
+  }
+
+  const resolved = resolveDeleteDiagramPath(worktreeReal, data.relPath);
+  if (!resolved.ok) {
+    return {
+      ok: false,
+      code: "FORBIDDEN",
+      error: resolved.error,
+    };
+  }
+
+  let tracked: boolean;
+  try {
+    tracked = await deps.isDiagramTracked(worktreeReal, data.relPath);
+  } catch (error) {
+    return {
+      ok: false,
+      code: "IO_ERROR",
+      error: `Git 管理状態の確認に失敗しました (${errnoCode(error)}): ${errnoMessage(error)}`,
+    };
+  }
+  if (tracked !== data.expectedTracked) {
+    return {
+      ok: false,
+      code: "CONFLICT",
+      error: "Git 管理状態が変化しました。一覧を更新して再確認してください",
+    };
+  }
+
+  const deleted = await deps.deleteDiagramFile(worktreeReal, data.relPath);
+  if (!deleted.ok) return deleted;
+
+  let warning: string | undefined;
+  try {
+    const cleared = deps.clearSessionLastDiagramIfMatches(
+      data.sessionId,
+      data.relPath
+    );
+    if (cleared) deps.onSessionCleared(data.sessionId);
+  } catch (error) {
+    warning = `ファイルは削除済みですが復元情報の消去に失敗しました: ${errnoMessage(error)}`;
+  }
+  deps.onDeleted({ sessionId: data.sessionId, relPath: data.relPath });
+  return {
+    ok: true,
+    relPath: data.relPath,
+    tracked,
+    ...(warning ? { warning } : {}),
+  };
+}
+
+type DiagramDeleteRequestHandler = (
+  deps: DiagramDeleteRequestDeps,
+  data: unknown
+) => Promise<DiagramDeleteResponse>;
+
+export function createDiagramDeleteSocketHandler(
+  deps: DiagramDeleteRequestDeps,
+  requestHandler: DiagramDeleteRequestHandler = handleDiagramDeleteRequest
+): (data: unknown, callback: unknown) => void {
+  return (data: unknown, callback: unknown): void => {
+    if (typeof callback !== "function") return;
+    const reply = callback as (response: DiagramDeleteResponse) => void;
+    const safeReply = (response: DiagramDeleteResponse): void => {
+      try {
+        reply(response);
+      } catch {
+        // ACK callback は client 由来。throw を server process へ伝播させない。
+      }
+    };
+    void requestHandler(deps, data).then(safeReply, error => {
+      safeReply({
+        ok: false,
+        code: "IO_ERROR",
+        error: `図ファイルの削除に失敗しました: ${errnoMessage(error)}`,
+      });
+    });
+  };
+}

--- a/packages/server/src/lib/diagram-list-git.test.ts
+++ b/packages/server/src/lib/diagram-list-git.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+const gitMocks = vi.hoisted(() => {
+  const execFileAsync = vi.fn(async () => ({ stdout: "", stderr: "" }));
+  const execFile = vi.fn();
+  Object.defineProperty(execFile, Symbol.for("nodejs.util.promisify.custom"), {
+    value: execFileAsync,
+  });
+  return { execFile, execFileAsync };
+});
+
+vi.mock("node:child_process", () => ({ execFile: gitMocks.execFile }));
+
+import { handleDiagramListRequest, listDiagrams } from "./diagram-list.js";
+
+beforeEach(() => {
+  gitMocks.execFileAsync.mockReset();
+  gitMocks.execFileAsync.mockResolvedValue({ stdout: "", stderr: "" });
+});
+
+it("git ls-files に timeout と maxBuffer を設定する", async () => {
+  await expect(listDiagrams("/managed/worktree")).resolves.toEqual([]);
+
+  expect(gitMocks.execFileAsync).toHaveBeenCalledWith(
+    "git",
+    [
+      "-C",
+      "/managed/worktree",
+      "ls-files",
+      "--cached",
+      "-z",
+      "--",
+      ".claude/diagrams",
+    ],
+    {
+      encoding: "utf8",
+      timeout: 10_000,
+      maxBuffer: 10 * 1024 * 1024,
+    }
+  );
+});
+
+it("git timeout kill を未追跡扱いにせず一覧 ACK error にする", async () => {
+  gitMocks.execFileAsync.mockRejectedValue(
+    Object.assign(new Error("git timed out"), {
+      killed: true,
+      signal: "SIGTERM",
+    })
+  );
+
+  const result = await handleDiagramListRequest(
+    {
+      resolveManagedWorktreePath: () => "/managed/worktree",
+      listDiagrams,
+    },
+    { worktreePath: "/input/worktree" }
+  );
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) expect(result.error).toContain("git timed out");
+});

--- a/packages/server/src/lib/diagram-list.test.ts
+++ b/packages/server/src/lib/diagram-list.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -15,6 +16,7 @@ function makeWorktree(withDiagramDir = true): {
     fs.mkdtempSync(path.join(os.tmpdir(), "ark-diagram-list-"))
   );
   tempDirs.push(worktree);
+  execFileSync("git", ["init", "-q", worktree]);
   const diagramDir = path.join(worktree, DIAGRAM_DIR);
   if (withDiagramDir) fs.mkdirSync(diagramDir, { recursive: true });
   return { worktree, diagramDir };
@@ -64,23 +66,35 @@ describe("listDiagrams", () => {
       diagramHtml("対象外")
     );
     fs.writeFileSync(path.join(diagramDir, "notes.txt"), "対象外");
+    execFileSync("git", [
+      "-C",
+      worktree,
+      "add",
+      "--",
+      ".claude/diagrams/a.diagram.html",
+      ".claude/diagrams/nested/b.diagram.html",
+    ]);
 
     await expect(listDiagrams(worktree)).resolves.toEqual([
       {
         relPath: ".claude/diagrams/a.diagram.html",
         displayName: "a.diagram.html",
+        tracked: true,
       },
       {
         relPath: ".claude/diagrams/blank.diagram.html",
         displayName: "blank.diagram.html",
+        tracked: false,
       },
       {
         relPath: ".claude/diagrams/nested/b.diagram.html",
         displayName: "サブ図",
+        tracked: true,
       },
       {
         relPath: ".claude/diagrams/z.diagram.html",
         displayName: "注文フロー",
+        tracked: false,
       },
     ]);
   });
@@ -91,6 +105,77 @@ describe("listDiagrams", () => {
 
     await expect(listDiagrams(missing.worktree)).resolves.toEqual([]);
     await expect(listDiagrams(empty.worktree)).resolves.toEqual([]);
+  });
+
+  it("tracked、untracked、ignored-untracked、nested tracked を一括判定する", async () => {
+    const { worktree, diagramDir } = makeWorktree();
+    fs.mkdirSync(path.join(diagramDir, "nested"), { recursive: true });
+    fs.writeFileSync(
+      path.join(diagramDir, "tracked.diagram.html"),
+      diagramHtml("tracked")
+    );
+    fs.writeFileSync(
+      path.join(diagramDir, "untracked.diagram.html"),
+      diagramHtml("untracked")
+    );
+    fs.writeFileSync(
+      path.join(diagramDir, "ignored.diagram.html"),
+      diagramHtml("ignored")
+    );
+    fs.writeFileSync(
+      path.join(diagramDir, "nested", "tracked.diagram.html"),
+      diagramHtml("nested")
+    );
+    fs.writeFileSync(
+      path.join(worktree, ".gitignore"),
+      ".claude/diagrams/ignored.diagram.html\n"
+    );
+    execFileSync("git", [
+      "-C",
+      worktree,
+      "add",
+      "--",
+      ".gitignore",
+      ".claude/diagrams/tracked.diagram.html",
+      ".claude/diagrams/nested/tracked.diagram.html",
+    ]);
+
+    await expect(listDiagrams(worktree)).resolves.toEqual([
+      {
+        relPath: ".claude/diagrams/ignored.diagram.html",
+        displayName: "ignored",
+        tracked: false,
+      },
+      {
+        relPath: ".claude/diagrams/nested/tracked.diagram.html",
+        displayName: "nested",
+        tracked: true,
+      },
+      {
+        relPath: ".claude/diagrams/tracked.diagram.html",
+        displayName: "tracked",
+        tracked: true,
+      },
+      {
+        relPath: ".claude/diagrams/untracked.diagram.html",
+        displayName: "untracked",
+        tracked: false,
+      },
+    ]);
+  });
+
+  it("git index の取得失敗を全件 untracked に丸めず一覧 error にする", async () => {
+    const { worktree, diagramDir } = makeWorktree();
+    fs.writeFileSync(
+      path.join(diagramDir, "valid.diagram.html"),
+      diagramHtml("正常")
+    );
+    fs.renameSync(
+      path.join(worktree, ".git"),
+      path.join(worktree, ".git-broken")
+    );
+
+    await expect(listDiagrams(worktree)).rejects.toThrow();
   });
 
   it("旧 docs/diagrams にだけ有効な図があっても空配列を返す", async () => {
@@ -138,6 +223,7 @@ describe("listDiagrams", () => {
       {
         relPath: ".claude/diagrams/valid.diagram.html",
         displayName: "正常",
+        tracked: false,
       },
     ]);
   });
@@ -220,6 +306,7 @@ describe("handleDiagramListRequest", () => {
       {
         relPath: ".claude/diagrams/a.diagram.html",
         displayName: "A",
+        tracked: true,
       },
     ];
     const resolveManagedWorktreePath = vi.fn(() => "/real/worktree");

--- a/packages/server/src/lib/diagram-list.ts
+++ b/packages/server/src/lib/diagram-list.ts
@@ -1,5 +1,7 @@
+import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { promisify } from "node:util";
 import type { DiagramListItem, DiagramListResponse } from "@ark/shared";
 import { DIAGRAM_DIR } from "./diagram-path.js";
 import { readDiagramModel } from "./diagram-reader.js";
@@ -8,6 +10,18 @@ import { errnoCode, errnoMessage } from "./errors.js";
 const DIAGRAM_SUFFIX = ".diagram.html";
 const MAX_WORKTREE_PATH_LENGTH = 4096;
 const DIAGRAM_READ_CONCURRENCY = 8;
+const execFileAsync = promisify(execFile);
+
+async function listTrackedDiagramPaths(
+  worktreeReal: string
+): Promise<Set<string>> {
+  const { stdout } = await execFileAsync(
+    "git",
+    ["-C", worktreeReal, "ls-files", "--cached", "-z", "--", DIAGRAM_DIR],
+    { encoding: "utf8" }
+  );
+  return new Set(stdout.split("\0").filter(Boolean));
+}
 
 async function collectDiagramCandidates(
   directory: string,
@@ -37,7 +51,8 @@ async function collectDiagramCandidates(
 
 async function readDiagramListItem(
   worktreeReal: string,
-  relPath: string
+  relPath: string,
+  trackedPaths: ReadonlySet<string>
 ): Promise<DiagramListItem | null> {
   const result = await readDiagramModel(worktreeReal, relPath);
   if (!result.ok) return null;
@@ -45,6 +60,7 @@ async function readDiagramListItem(
   return {
     relPath,
     displayName: title || path.posix.basename(relPath),
+    tracked: trackedPaths.has(relPath),
   };
 }
 
@@ -55,6 +71,7 @@ async function readDiagramListItem(
 export async function listDiagrams(
   worktreeReal: string
 ): Promise<DiagramListItem[]> {
+  const trackedPaths = await listTrackedDiagramPaths(worktreeReal);
   const diagramsDir = path.join(worktreeReal, DIAGRAM_DIR);
   let candidates: string[];
   try {
@@ -74,7 +91,9 @@ export async function listDiagrams(
     const batch = candidates.slice(offset, offset + DIAGRAM_READ_CONCURRENCY);
     items.push(
       ...(await Promise.all(
-        batch.map(relPath => readDiagramListItem(worktreeReal, relPath))
+        batch.map(relPath =>
+          readDiagramListItem(worktreeReal, relPath, trackedPaths)
+        )
       ))
     );
   }

--- a/packages/server/src/lib/diagram-list.ts
+++ b/packages/server/src/lib/diagram-list.ts
@@ -10,6 +10,8 @@ import { errnoCode, errnoMessage } from "./errors.js";
 const DIAGRAM_SUFFIX = ".diagram.html";
 const MAX_WORKTREE_PATH_LENGTH = 4096;
 const DIAGRAM_READ_CONCURRENCY = 8;
+const GIT_TIMEOUT_MS = 10_000;
+const GIT_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
 const execFileAsync = promisify(execFile);
 
 async function listTrackedDiagramPaths(
@@ -18,7 +20,11 @@ async function listTrackedDiagramPaths(
   const { stdout } = await execFileAsync(
     "git",
     ["-C", worktreeReal, "ls-files", "--cached", "-z", "--", DIAGRAM_DIR],
-    { encoding: "utf8" }
+    {
+      encoding: "utf8",
+      timeout: GIT_TIMEOUT_MS,
+      maxBuffer: GIT_MAX_BUFFER_BYTES,
+    }
   );
   return new Set(stdout.split("\0").filter(Boolean));
 }

--- a/packages/server/src/lib/diagram-path.test.ts
+++ b/packages/server/src/lib/diagram-path.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { DIAGRAM_DIR, resolveDiagramPath } from "./diagram-path.js";
+import {
+  DIAGRAM_DIR,
+  normalizeDiagramRelPath,
+  resolveDiagramPath,
+} from "./diagram-path.js";
 
 let wt: string;
 
@@ -38,10 +42,18 @@ describe("resolveDiagramPath", () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
+      expect(result.relPath).toBe(".claude/diagrams/a.diagram.html");
       expect(result.absPath).toBe(
         path.join(wt, ".claude", "diagrams", "a.diagram.html")
       );
     }
+  });
+
+  it("relPath の正規化だけでも同じ正準形を返す", () => {
+    expect(normalizeDiagramRelPath("a.diagram.html")).toEqual({
+      ok: true,
+      relPath: ".claude/diagrams/a.diagram.html",
+    });
   });
 
   it("worktree の外へ出る指定を拒否する", () => {

--- a/packages/server/src/lib/diagram-path.ts
+++ b/packages/server/src/lib/diagram-path.ts
@@ -13,17 +13,17 @@ export { DIAGRAM_DIR };
 const DIAGRAM_SUFFIX = ".diagram.html";
 
 export type DiagramPathResult =
-  | { ok: true; absPath: string }
+  | { ok: true; absPath: string; relPath: string }
+  | { ok: false; error: string };
+
+export type DiagramRelPathResult =
+  | { ok: true; relPath: string }
   | { ok: false; error: string };
 
 /**
- * @param worktreeReal realpath 済みの worktree 絶対パス
  * @param relPath `${DIAGRAM_DIR}/x.diagram.html` または `x.diagram.html`
  */
-export function resolveDiagramPath(
-  worktreeReal: string,
-  relPath: string
-): DiagramPathResult {
+export function normalizeDiagramRelPath(relPath: string): DiagramRelPathResult {
   if (typeof relPath !== "string" || relPath.length === 0) {
     return { ok: false, error: "図のパスが空です" };
   }
@@ -58,8 +58,22 @@ export function resolveDiagramPath(
     ? normalized
     : path.join(DIAGRAM_DIR, normalized);
 
+  return { ok: true, relPath: withDir };
+}
+
+/**
+ * @param worktreeReal realpath 済みの worktree 絶対パス
+ * @param relPath `${DIAGRAM_DIR}/x.diagram.html` または `x.diagram.html`
+ */
+export function resolveDiagramPath(
+  worktreeReal: string,
+  relPath: string
+): DiagramPathResult {
+  const normalized = normalizeDiagramRelPath(relPath);
+  if (!normalized.ok) return normalized;
+
   const base = path.join(worktreeReal, DIAGRAM_DIR);
-  const absPath = path.resolve(worktreeReal, withDir);
+  const absPath = path.resolve(worktreeReal, normalized.relPath);
 
   // 二重チェック：パス解決後も DIAGRAM_DIR 配下であることを確認
   if (absPath !== base && !absPath.startsWith(base + path.sep)) {
@@ -68,5 +82,5 @@ export function resolveDiagramPath(
       error: `図のパスが worktree の ${DIAGRAM_DIR} から出ています`,
     };
   }
-  return { ok: true, absPath };
+  return { ok: true, absPath, relPath: normalized.relPath };
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -350,11 +350,37 @@ export type SpecialKey =
 export interface DiagramListItem {
   relPath: string;
   displayName: string;
+  tracked: boolean;
 }
 
 export type DiagramListResponse =
   | { ok: true; diagrams: DiagramListItem[] }
   | { ok: false; error: string };
+
+export interface DiagramDeleteRequest {
+  sessionId: string;
+  relPath: string;
+  expectedTracked: boolean;
+}
+
+export type DiagramDeleteResponse =
+  | {
+      ok: true;
+      relPath: string;
+      tracked: boolean;
+      warning?: string;
+    }
+  | {
+      ok: false;
+      code:
+        | "BAD_REQUEST"
+        | "SESSION_NOT_FOUND"
+        | "NOT_FOUND"
+        | "FORBIDDEN"
+        | "CONFLICT"
+        | "IO_ERROR";
+      error: string;
+    };
 
 export interface ServerToClientEvents {
   // Repository events
@@ -400,6 +426,9 @@ export interface ServerToClientEvents {
 
   /** 監視中の図ファイルが更新された。クライアントは再読込する */
   "diagram:updated": (data: { worktreePath: string; relPath: string }) => void;
+
+  /** 管理対象の図ファイルが削除された。絶対 path は通知しない */
+  "diagram:deleted": (data: { sessionId: string; relPath: string }) => void;
 
   // Session events（ManagedSessionを使用）
   "session:list": (sessions: ManagedSession[]) => void;
@@ -644,6 +673,12 @@ export interface ClientToServerEvents {
   "diagram:list": (
     data: { worktreePath: string },
     callback: (response: DiagramListResponse) => void
+  ) => void;
+
+  /** session に紐づく現在図を1件削除する */
+  "diagram:delete": (
+    data: DiagramDeleteRequest,
+    callback: (response: DiagramDeleteResponse) => void
   ) => void;
 
   /** 図の購読開始（更新通知を受け取る）。1 セッション 1 図を想定 */

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -8,11 +8,17 @@
  */
 import type {
   ClientToServerEvents,
+  DiagramDeleteResponse,
   DiagramListItem,
   ServerToClientEvents,
 } from "@ark/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
+import {
+  applyDiagramDeleteResponse,
+  getDiagramEmptyState,
+  shouldRefreshDiagramList,
+} from "../lib/diagram-delete-state";
 import { DiagramSwitcher } from "./DiagramSwitcher";
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
@@ -24,6 +30,11 @@ interface DiagramPaneProps {
   onSelectDiagram: (relPath: string, worktreePath: string) => void;
   isConnected: boolean;
   listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
+  deleteDiagram: (
+    sessionId: string,
+    relPath: string,
+    expectedTracked: boolean
+  ) => Promise<DiagramDeleteResponse>;
   /** 未接続時は null。null の間は診断購読をスキップする */
   socket: TypedSocket | null;
 }
@@ -63,6 +74,7 @@ export function DiagramPane({
   socket,
   isConnected,
   listDiagrams,
+  deleteDiagram,
   onSelectDiagram,
 }: DiagramPaneProps) {
   const [html, setHtml] = useState<string | null>(null);
@@ -72,7 +84,10 @@ export function DiagramPane({
   const [listLoading, setListLoading] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
   const [listRefreshKey, setListRefreshKey] = useState(0);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteMessage, setDeleteMessage] = useState<string | null>(null);
   const activeListRequestRef = useRef<object | null>(null);
+  const deleteInFlightRef = useRef(false);
   // 進行中の fetch を追跡し、古いタブの結果が新しいタブを上書きしないようにする
   const abortControllerRef = useRef<AbortController | null>(null);
   // ハーネスへ渡した MessageChannel の port1（親側）。再ロードのたびに
@@ -198,6 +213,51 @@ export function DiagramPane({
     };
   }, [socket, isConnected, worktreePath, relPath, load]);
 
+  useEffect(() => {
+    if (!socket) return;
+    const onDeleted = (data: { sessionId: string; relPath: string }) => {
+      if (shouldRefreshDiagramList(sessionId, data)) {
+        setListRefreshKey(key => key + 1);
+      }
+    };
+    socket.on("diagram:deleted", onDeleted);
+    return () => {
+      socket.off("diagram:deleted", onDeleted);
+    };
+  }, [socket, sessionId]);
+
+  const handleDelete = useCallback(
+    async (
+      targetRelPath: string,
+      expectedTracked: boolean
+    ): Promise<boolean> => {
+      if (deleteInFlightRef.current) return false;
+      deleteInFlightRef.current = true;
+      setIsDeleting(true);
+      setDeleteMessage(null);
+      try {
+        const response = await deleteDiagram(
+          sessionId,
+          targetRelPath,
+          expectedTracked
+        );
+        const next = applyDiagramDeleteResponse(response);
+        setDeleteMessage(next.message);
+        if (next.refreshList) setListRefreshKey(key => key + 1);
+        return response.ok;
+      } catch (reason) {
+        setDeleteMessage(
+          reason instanceof Error ? reason.message : "図の削除に失敗しました"
+        );
+        return false;
+      } finally {
+        deleteInFlightRef.current = false;
+        setIsDeleting(false);
+      }
+    },
+    [deleteDiagram, sessionId]
+  );
+
   // アンマウント時に進行中の fetch を中止。タブ切り替え直後の
   // アンマウント時に古い fetch が返された結果でステート更新されるのを防ぐ
   useEffect(() => {
@@ -296,11 +356,22 @@ export function DiagramPane({
         listLoading={listLoading}
         listError={listError}
         onRetry={() => setListRefreshKey(key => key + 1)}
+        onDelete={handleDelete}
+        isConnected={isConnected}
+        isDeleting={isDeleting}
       />
+      {deleteMessage && (
+        <div
+          className="shrink-0 border-b border-destructive/20 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+          role="status"
+        >
+          {deleteMessage}
+        </div>
+      )}
       <div className="relative min-h-0 flex-1">
         {!relPath ? (
           <div className="flex h-full items-center justify-center p-4 text-sm text-muted-foreground">
-            {diagrams.length > 0 ? "上の一覧から図を選択" : "図がありません"}
+            {getDiagramEmptyState(diagrams.length)}
           </div>
         ) : error ? (
           <div className="flex h-full items-center justify-center p-4 text-sm text-destructive">

--- a/packages/web/src/components/DiagramSwitcher.test.tsx
+++ b/packages/web/src/components/DiagramSwitcher.test.tsx
@@ -1,16 +1,22 @@
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { DiagramSwitcher } from "./DiagramSwitcher";
+import {
+  DiagramSwitcher,
+  getDiagramDeleteWarning,
+  handleDiagramDeleteConfirmation,
+} from "./DiagramSwitcher";
 
 const diagrams = [
   {
     relPath: ".claude/diagrams/a.diagram.html",
     displayName: "注文フロー",
+    tracked: true,
   },
   {
     relPath: ".claude/diagrams/nested/b.diagram.html",
     displayName: "b.diagram.html",
+    tracked: false,
   },
 ];
 
@@ -26,11 +32,15 @@ describe("DiagramSwitcher", () => {
 
     expect(markup).toContain('aria-label="表示する図"');
     expect(markup).toContain(
-      '<option value=".claude/diagrams/a.diagram.html" title=".claude/diagrams/a.diagram.html">注文フロー — a.diagram.html</option>'
+      '<option value=".claude/diagrams/a.diagram.html" title=".claude/diagrams/a.diagram.html（Git管理）">注文フロー — a.diagram.html — Git管理</option>'
     );
     expect(markup).toContain(
-      '<option value=".claude/diagrams/nested/b.diagram.html" title=".claude/diagrams/nested/b.diagram.html" selected="">nested/b.diagram.html</option>'
+      '<option value=".claude/diagrams/nested/b.diagram.html" title=".claude/diagrams/nested/b.diagram.html（未追跡）" selected="">nested/b.diagram.html — 未追跡</option>'
     );
+    expect(markup).toContain(
+      'title=".claude/diagrams/nested/b.diagram.html（未追跡）"'
+    );
+    expect(markup).toContain(">未追跡</span>");
   });
 
   it("current 無しでは「図を選択」を selected placeholder にする", () => {
@@ -73,5 +83,63 @@ describe("DiagramSwitcher", () => {
     expect(markup).toContain(
       '<option value=".claude/diagrams/deleted/deleted.diagram.html" title=".claude/diagrams/deleted/deleted.diagram.html" selected="">deleted/deleted.diagram.html</option>'
     );
+  });
+
+  it("current item が有効なときだけ削除ボタンを有効にする", () => {
+    const enabled = renderToStaticMarkup(
+      createElement(DiagramSwitcher, {
+        diagrams,
+        currentRelPath: diagrams[0].relPath,
+        onSelect: vi.fn(),
+        onDelete: vi.fn(),
+        isConnected: true,
+      })
+    );
+    expect(enabled).toContain('aria-label="現在の図を削除"');
+    expect(enabled).not.toContain('aria-label="現在の図を削除" disabled=""');
+
+    for (const props of [
+      { currentRelPath: undefined },
+      { currentRelPath: ".claude/diagrams/stale.diagram.html" },
+      { currentRelPath: diagrams[0].relPath, listLoading: true },
+      { currentRelPath: diagrams[0].relPath, isConnected: false },
+      { currentRelPath: diagrams[0].relPath, isDeleting: true },
+    ]) {
+      const markup = renderToStaticMarkup(
+        createElement(DiagramSwitcher, {
+          diagrams,
+          onSelect: vi.fn(),
+          onDelete: vi.fn(),
+          isConnected: true,
+          ...props,
+        })
+      );
+      expect(markup).toContain('aria-label="現在の図を削除" disabled=""');
+    }
+  });
+
+  it("tracked/untracked ごとの取り消せない警告を返す", () => {
+    expect(getDiagramDeleteWarning(diagrams[0])).toContain(
+      "worktree に削除差分が残ります"
+    );
+    expect(getDiagramDeleteWarning(diagrams[0])).toContain("Git で復元");
+    expect(getDiagramDeleteWarning(diagrams[1])).toContain(
+      "Git から復元できません"
+    );
+    expect(getDiagramDeleteWarning(diagrams[1])).toContain("取り消せません");
+  });
+
+  it("cancel は callback 無し、confirm は current 1件だけを渡して成否を返す", async () => {
+    const onDelete = vi.fn(async () => false);
+
+    await expect(
+      handleDiagramDeleteConfirmation(false, diagrams[0], onDelete)
+    ).resolves.toBe(false);
+    expect(onDelete).not.toHaveBeenCalled();
+    await expect(
+      handleDiagramDeleteConfirmation(true, diagrams[1], onDelete)
+    ).resolves.toBe(false);
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledWith(diagrams[1].relPath, false);
   });
 });

--- a/packages/web/src/components/DiagramSwitcher.tsx
+++ b/packages/web/src/components/DiagramSwitcher.tsx
@@ -1,6 +1,19 @@
 import type { DiagramListItem } from "@ark/shared";
+import { Trash2 } from "lucide-react";
 import type { ChangeEvent } from "react";
+import { useState } from "react";
 import { formatDiagramOptionLabel } from "../lib/diagram-option-label";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "./ui/alert-dialog";
 
 interface DiagramSwitcherProps {
   diagrams: DiagramListItem[];
@@ -9,6 +22,30 @@ interface DiagramSwitcherProps {
   listLoading?: boolean;
   listError?: string | null;
   onRetry?: () => void;
+  onDelete?: (
+    relPath: string,
+    expectedTracked: boolean
+  ) => boolean | Promise<boolean>;
+  isConnected?: boolean;
+  isDeleting?: boolean;
+}
+
+export function getDiagramDeleteWarning(item: DiagramListItem): string {
+  return item.tracked
+    ? "worktree に削除差分が残ります。必要なら Git で復元できます。この操作は取り消せません。"
+    : "未追跡ファイルは Git から復元できません。この操作は取り消せません。";
+}
+
+export function handleDiagramDeleteConfirmation(
+  confirmed: boolean,
+  item: DiagramListItem,
+  onDelete: (
+    relPath: string,
+    expectedTracked: boolean
+  ) => boolean | Promise<boolean>
+): Promise<boolean> {
+  if (!confirmed) return Promise.resolve(false);
+  return Promise.resolve(onDelete(item.relPath, item.tracked));
 }
 
 export function DiagramSwitcher({
@@ -18,11 +55,22 @@ export function DiagramSwitcher({
   listLoading = false,
   listError = null,
   onRetry,
+  onDelete,
+  isConnected = true,
+  isDeleting = false,
 }: DiagramSwitcherProps) {
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const currentItem = diagrams.find(
+    diagram => diagram.relPath === currentRelPath
+  );
   const currentIsStale =
     currentRelPath !== undefined &&
     !diagrams.some(diagram => diagram.relPath === currentRelPath);
-  const disabled = diagrams.length === 0 && !currentRelPath;
+  const deletePending = isDeleting || confirmingDelete;
+  const disabled = (diagrams.length === 0 && !currentRelPath) || deletePending;
+  const deleteDisabled =
+    !currentItem || listLoading || !isConnected || deletePending || !onDelete;
   const placeholder = diagrams.length === 0 ? "図がありません" : "図を選択";
   const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     if (event.target.value) onSelect(event.target.value);
@@ -50,12 +98,81 @@ export function DiagramSwitcher({
           <option
             key={diagram.relPath}
             value={diagram.relPath}
-            title={diagram.relPath}
+            title={`${diagram.relPath}（${diagram.tracked ? "Git管理" : "未追跡"}）`}
           >
-            {formatDiagramOptionLabel(diagram.displayName, diagram.relPath)}
+            {`${formatDiagramOptionLabel(diagram.displayName, diagram.relPath)} — ${
+              diagram.tracked ? "Git管理" : "未追跡"
+            }`}
           </option>
         ))}
       </select>
+      {currentItem && (
+        <span
+          className="shrink-0 text-[10px] text-muted-foreground"
+          title={`${currentItem.relPath}（${currentItem.tracked ? "Git管理" : "未追跡"}）`}
+        >
+          {currentItem.tracked ? "Git管理" : "未追跡"}
+        </span>
+      )}
+      <AlertDialog
+        open={deleteDialogOpen}
+        onOpenChange={open => {
+          if (!deletePending) setDeleteDialogOpen(open);
+        }}
+      >
+        <AlertDialogTrigger asChild>
+          <button
+            type="button"
+            aria-label="現在の図を削除"
+            disabled={deleteDisabled}
+            className="inline-flex size-7 shrink-0 items-center justify-center rounded text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Trash2 className="size-4" aria-hidden="true" />
+          </button>
+        </AlertDialogTrigger>
+        {currentItem && (
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                「{currentItem.displayName}」を削除しますか？
+              </AlertDialogTitle>
+              <AlertDialogDescription asChild>
+                <div className="space-y-2">
+                  <p className="break-all">{currentItem.relPath}</p>
+                  <p>{currentItem.tracked ? "Git管理" : "未追跡"}</p>
+                  <p>{getDiagramDeleteWarning(currentItem)}</p>
+                </div>
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={deletePending}>
+                キャンセル
+              </AlertDialogCancel>
+              <AlertDialogAction
+                disabled={deletePending}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                onClick={async event => {
+                  event.preventDefault();
+                  if (!onDelete || deletePending) return;
+                  setConfirmingDelete(true);
+                  try {
+                    const succeeded = await handleDiagramDeleteConfirmation(
+                      true,
+                      currentItem,
+                      onDelete
+                    );
+                    if (succeeded) setDeleteDialogOpen(false);
+                  } finally {
+                    setConfirmingDelete(false);
+                  }
+                }}
+              >
+                {deletePending ? "削除中…" : "削除する"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        )}
+      </AlertDialog>
       {listLoading && (
         <span className="shrink-0 text-[10px] text-muted-foreground">
           更新中…

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -15,6 +15,7 @@
 
 import type {
   ClientToServerEvents,
+  DiagramDeleteResponse,
   DiagramListItem,
   ManagedSession,
   MessageShortcut,
@@ -38,6 +39,11 @@ interface SplitViewPaneProps {
   socket: TypedSocket | null;
   isConnected: boolean;
   listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
+  deleteDiagram: (
+    sessionId: string,
+    relPath: string,
+    expectedTracked: boolean
+  ) => Promise<DiagramDeleteResponse>;
   session: ManagedSession;
   worktree: Worktree | undefined;
   repoName?: string;
@@ -269,6 +275,7 @@ export function SplitViewPane(props: SplitViewPaneProps) {
                 socket={props.socket}
                 isConnected={props.isConnected}
                 listDiagrams={props.listDiagrams}
+                deleteDiagram={props.deleteDiagram}
                 sessionId={props.session.id}
                 worktreePath={
                   diagramTab?.worktreePath ?? props.session.worktreePath

--- a/packages/web/src/components/ui/alert-dialog.tsx
+++ b/packages/web/src/components/ui/alert-dialog.tsx
@@ -1,7 +1,7 @@
 import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 import type * as React from "react";
-import { buttonVariants } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
+import { buttonVariants } from "./button";
 
 function AlertDialog({
   ...props

--- a/packages/web/src/components/ui/button.tsx
+++ b/packages/web/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -13,6 +13,7 @@ import type {
   BrowserSession,
   ChatMessage,
   ClientToServerEvents,
+  DiagramDeleteResponse,
   DiagramListItem,
   FsListResult,
   ManagedSession,
@@ -33,6 +34,7 @@ import type {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { io, type Socket } from "socket.io-client";
 import { toast } from "sonner";
+import { requestDiagramDelete } from "../lib/diagram-delete-transport";
 import {
   addWorktree,
   clearRepo,
@@ -79,6 +81,11 @@ interface UseSocketReturn {
 
   // Diagram list
   listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
+  deleteDiagram: (
+    sessionId: string,
+    relPath: string,
+    expectedTracked: boolean
+  ) => Promise<DiagramDeleteResponse>;
 
   // Repository
   repoList: string[];
@@ -1236,6 +1243,17 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     []
   );
 
+  const deleteDiagram = useCallback(
+    (sessionId: string, relPath: string, expectedTracked: boolean) =>
+      requestDiagramDelete(
+        socketRef.current,
+        sessionId,
+        relPath,
+        expectedTracked
+      ),
+    []
+  );
+
   // Worktree actions
   const createWorktree = useCallback(
     (branchName: string, baseBranch?: string) => {
@@ -1657,6 +1675,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     scanRepos,
     listDirectory,
     listDiagrams,
+    deleteDiagram,
     repoList,
     repoPath,
     selectRepo,

--- a/packages/web/src/hooks/useViewerTabs.ts
+++ b/packages/web/src/hooks/useViewerTabs.ts
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ViewerTab } from "../components/TerminalPane";
-import { setCurrentDiagramTab } from "../lib/diagram-tabs";
+import {
+  clearCurrentDiagramTab,
+  setCurrentDiagramTab,
+} from "../lib/diagram-tabs";
 import { correctActiveIndexAfterClose } from "../lib/tab-close";
 
 /**
@@ -193,6 +196,35 @@ export function useViewerTabs(
     []
   );
 
+  const clearDiagramTab = useCallback((sessionId: string, relPath: string) => {
+    const currentTabs = sessionTabsRef.current[sessionId] ?? [
+      { type: "terminal" as const, id: "terminal" },
+    ];
+    const currentActiveIndex = sessionActiveTabRef.current[sessionId] ?? 0;
+    const { tabs, activeIndex } = clearCurrentDiagramTab(
+      currentTabs,
+      currentActiveIndex,
+      relPath
+    );
+    if (tabs === currentTabs) return;
+
+    sessionTabsRef.current = {
+      ...sessionTabsRef.current,
+      [sessionId]: tabs,
+    };
+    sessionActiveTabRef.current = {
+      ...sessionActiveTabRef.current,
+      [sessionId]: activeIndex,
+    };
+    setSessionTabs(prev => ({ ...prev, [sessionId]: tabs }));
+    setSessionActiveTab(prev => {
+      const previousActiveIndex = prev[sessionId] ?? 0;
+      return activeIndex === previousActiveIndex
+        ? prev
+        : { ...prev, [sessionId]: activeIndex };
+    });
+  }, []);
+
   // postMessageリスナー（ttyd iframe内のリンククリックを受信）
   useEffect(() => {
     if (!enabled) return;
@@ -290,5 +322,6 @@ export function useViewerTabs(
     handleTabClose,
     openFileTab,
     openDiagramTab,
+    clearDiagramTab,
   };
 }

--- a/packages/web/src/lib/diagram-delete-state.test.ts
+++ b/packages/web/src/lib/diagram-delete-state.test.ts
@@ -1,0 +1,63 @@
+import type { DiagramDeleteResponse } from "@ark/shared";
+import { describe, expect, it } from "vitest";
+import {
+  applyDiagramDeleteResponse,
+  getDiagramEmptyState,
+  shouldRefreshDiagramList,
+} from "./diagram-delete-state";
+
+describe("diagram delete client state", () => {
+  it("同じ sessionId の diagram:deleted だけで一覧を更新する", () => {
+    expect(
+      shouldRefreshDiagramList("session-1", {
+        sessionId: "session-1",
+        relPath: ".claude/diagrams/other.diagram.html",
+      })
+    ).toBe(true);
+    expect(
+      shouldRefreshDiagramList("session-1", {
+        sessionId: "session-2",
+        relPath: ".claude/diagrams/a.diagram.html",
+      })
+    ).toBe(false);
+  });
+
+  it.each([
+    "CONFLICT",
+    "NOT_FOUND",
+  ] as const)("%s は削除済みと決めつけず error と一覧更新を返す", code => {
+    const response: DiagramDeleteResponse = {
+      ok: false,
+      code,
+      error: `${code} error`,
+    };
+
+    expect(applyDiagramDeleteResponse(response)).toEqual({
+      message: `${code} error`,
+      refreshList: true,
+    });
+  });
+
+  it("success は通知経由の更新を待ち、warning を区別して表示する", () => {
+    expect(
+      applyDiagramDeleteResponse({
+        ok: true,
+        relPath: ".claude/diagrams/a.diagram.html",
+        tracked: true,
+      })
+    ).toEqual({ message: null, refreshList: false });
+    expect(
+      applyDiagramDeleteResponse({
+        ok: true,
+        relPath: ".claude/diagrams/a.diagram.html",
+        tracked: true,
+        warning: "DB clear failed",
+      })
+    ).toEqual({ message: "DB clear failed", refreshList: false });
+  });
+
+  it("current 削除後は次図を選ばず残件数に応じた空状態を返す", () => {
+    expect(getDiagramEmptyState(2)).toBe("上の一覧から図を選択");
+    expect(getDiagramEmptyState(0)).toBe("図がありません");
+  });
+});

--- a/packages/web/src/lib/diagram-delete-state.ts
+++ b/packages/web/src/lib/diagram-delete-state.ts
@@ -1,0 +1,28 @@
+import type { DiagramDeleteResponse } from "@ark/shared";
+
+export function shouldRefreshDiagramList(
+  sessionId: string,
+  event: { sessionId: string; relPath: string }
+): boolean {
+  return event.sessionId === sessionId;
+}
+
+export function applyDiagramDeleteResponse(response: DiagramDeleteResponse): {
+  message: string | null;
+  refreshList: boolean;
+} {
+  if (response.ok) {
+    return {
+      message: response.warning ?? null,
+      refreshList: false,
+    };
+  }
+  return {
+    message: response.error,
+    refreshList: response.code === "CONFLICT" || response.code === "NOT_FOUND",
+  };
+}
+
+export function getDiagramEmptyState(diagramCount: number): string {
+  return diagramCount > 0 ? "上の一覧から図を選択" : "図がありません";
+}

--- a/packages/web/src/lib/diagram-delete-transport.test.ts
+++ b/packages/web/src/lib/diagram-delete-transport.test.ts
@@ -1,0 +1,102 @@
+import type { DiagramDeleteResponse } from "@ark/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { requestDiagramDelete } from "./diagram-delete-transport";
+
+function makeSocket(connected = true) {
+  let ack: ((response: DiagramDeleteResponse) => void) | undefined;
+  return {
+    socket: {
+      connected,
+      emit: vi.fn(
+        (
+          _event: "diagram:delete",
+          _data: unknown,
+          callback: (response: DiagramDeleteResponse) => void
+        ) => {
+          ack = callback;
+        }
+      ),
+    },
+    reply: (response: DiagramDeleteResponse) => ack?.(response),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("requestDiagramDelete", () => {
+  it("ACK success を返す", async () => {
+    const fake = makeSocket();
+    const pending = requestDiagramDelete(
+      fake.socket,
+      "session-1",
+      ".claude/diagrams/a.diagram.html",
+      true
+    );
+    const response: DiagramDeleteResponse = {
+      ok: true,
+      relPath: ".claude/diagrams/a.diagram.html",
+      tracked: true,
+    };
+    fake.reply(response);
+
+    await expect(pending).resolves.toEqual(response);
+  });
+
+  it("typed ACK error を code/message ごと返す", async () => {
+    const fake = makeSocket();
+    const pending = requestDiagramDelete(
+      fake.socket,
+      "session-1",
+      ".claude/diagrams/a.diagram.html",
+      false
+    );
+    const response: DiagramDeleteResponse = {
+      ok: false,
+      code: "CONFLICT",
+      error: "状態が変化しました",
+    };
+    fake.reply(response);
+
+    await expect(pending).resolves.toEqual(response);
+  });
+
+  it("未接続なら emit せず reject する", async () => {
+    const fake = makeSocket(false);
+
+    await expect(
+      requestDiagramDelete(
+        fake.socket,
+        "session-1",
+        ".claude/diagrams/a.diagram.html",
+        true
+      )
+    ).rejects.toThrow("ソケットが切断されています");
+    expect(fake.socket.emit).not.toHaveBeenCalled();
+  });
+
+  it("10秒で timeout し、late ACK を無視する", async () => {
+    vi.useFakeTimers();
+    const fake = makeSocket();
+    const pending = requestDiagramDelete(
+      fake.socket,
+      "session-1",
+      ".claude/diagrams/a.diagram.html",
+      true
+    );
+    const rejection = expect(pending).rejects.toThrow(
+      "図の削除がタイムアウトしました"
+    );
+
+    await vi.advanceTimersByTimeAsync(10000);
+    await rejection;
+    expect(() =>
+      fake.reply({
+        ok: true,
+        relPath: ".claude/diagrams/a.diagram.html",
+        tracked: true,
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/web/src/lib/diagram-delete-transport.ts
+++ b/packages/web/src/lib/diagram-delete-transport.ts
@@ -1,0 +1,42 @@
+import type { DiagramDeleteRequest, DiagramDeleteResponse } from "@ark/shared";
+
+interface DiagramDeleteSocket {
+  connected: boolean;
+  emit: (
+    event: "diagram:delete",
+    data: DiagramDeleteRequest,
+    callback: (response: DiagramDeleteResponse) => void
+  ) => void;
+}
+
+export function requestDiagramDelete(
+  socket: DiagramDeleteSocket | null,
+  sessionId: string,
+  relPath: string,
+  expectedTracked: boolean
+): Promise<DiagramDeleteResponse> {
+  return new Promise((resolve, reject) => {
+    if (!socket?.connected) {
+      reject(new Error("ソケットが切断されています"));
+      return;
+    }
+
+    let settled = false;
+    const timeoutId = globalThis.setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error("図の削除がタイムアウトしました"));
+    }, 10000);
+
+    socket.emit(
+      "diagram:delete",
+      { sessionId, relPath, expectedTracked },
+      response => {
+        if (settled) return;
+        settled = true;
+        globalThis.clearTimeout(timeoutId);
+        resolve(response);
+      }
+    );
+  });
+}

--- a/packages/web/src/lib/diagram-tabs.test.ts
+++ b/packages/web/src/lib/diagram-tabs.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { ViewerTab } from "../components/TerminalPane";
-import { setCurrentDiagramTab } from "./diagram-tabs";
+import { clearCurrentDiagramTab, setCurrentDiagramTab } from "./diagram-tabs";
 
 const terminal: ViewerTab = { type: "terminal", id: "terminal" };
 const diagram = (
@@ -168,5 +168,60 @@ describe("setCurrentDiagramTab", () => {
 
     expect(result.activeIndex).toBe(0);
     expect(result.tabs[0]).toBe(terminal);
+  });
+});
+
+describe("clearCurrentDiagramTab", () => {
+  it("current relPath 一致時だけ diagram を除去して non-diagram 順序と active id を維持する", () => {
+    const tabs = [
+      terminal,
+      diagram("current", "a.diagram.html"),
+      file("active-file"),
+      html("h1"),
+    ];
+
+    const result = clearCurrentDiagramTab(tabs, 2, "a.diagram.html");
+
+    expect(result.tabs.map(tab => tab.id)).toEqual([
+      "terminal",
+      "active-file",
+      "h1",
+    ]);
+    expect(result.tabs[result.activeIndex]?.id).toBe("active-file");
+  });
+
+  it("不一致の遅延通知は別 current を消さない no-op", () => {
+    const tabs = [terminal, diagram("current", "new.diagram.html")];
+
+    expect(clearCurrentDiagramTab(tabs, 0, "old.diagram.html")).toEqual({
+      tabs,
+      activeIndex: 0,
+    });
+  });
+
+  it("legacy の複数 diagram は current 一致時にすべて除去する", () => {
+    const tabs = [
+      terminal,
+      diagram("current", "a.diagram.html"),
+      file("f1"),
+      diagram("legacy", "old.diagram.html"),
+      html("h1"),
+    ];
+
+    const result = clearCurrentDiagramTab(tabs, 4, "a.diagram.html");
+
+    expect(result.tabs.map(tab => tab.id)).toEqual(["terminal", "f1", "h1"]);
+    expect(result.tabs[result.activeIndex]?.id).toBe("h1");
+  });
+
+  it("legacy state で diagram が active なら terminal へ戻す", () => {
+    const result = clearCurrentDiagramTab(
+      [terminal, diagram("current", "a.diagram.html"), file("f1")],
+      1,
+      "a.diagram.html"
+    );
+
+    expect(result.tabs.map(tab => tab.id)).toEqual(["terminal", "f1"]);
+    expect(result.activeIndex).toBe(0);
   });
 });

--- a/packages/web/src/lib/diagram-tabs.ts
+++ b/packages/web/src/lib/diagram-tabs.ts
@@ -53,3 +53,39 @@ export function setCurrentDiagramTab(
     activeIndex: nextActiveIndex >= 0 ? nextActiveIndex : 0,
   };
 }
+
+/**
+ * 削除通知が現在図と一致する場合だけ diagram state を空にする。
+ * legacy state の複数 diagram はまとめて除去するが、別図を開いた後に届いた
+ * 古い通知では現在図を変更しない。
+ */
+export function clearCurrentDiagramTab(
+  tabs: ViewerTab[],
+  activeIndex: number,
+  relPath: string
+): CurrentDiagramTabResult {
+  const currentDiagram = tabs.find(tab => tab.type === "diagram");
+  if (
+    !currentDiagram ||
+    currentDiagram.type !== "diagram" ||
+    currentDiagram.relPath !== relPath
+  ) {
+    return { tabs, activeIndex };
+  }
+
+  const activeTab = tabs[activeIndex];
+  const nextTabs = tabs.filter(tab => tab.type !== "diagram");
+  if (!activeTab || activeTab.type === "diagram") {
+    const terminalIndex = nextTabs.findIndex(tab => tab.type === "terminal");
+    return {
+      tabs: nextTabs,
+      activeIndex: terminalIndex >= 0 ? terminalIndex : 0,
+    };
+  }
+
+  const nextActiveIndex = nextTabs.findIndex(tab => tab.id === activeTab.id);
+  return {
+    tabs: nextTabs,
+    activeIndex: nextActiveIndex >= 0 ? nextActiveIndex : 0,
+  };
+}

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -78,6 +78,7 @@ export default function Dashboard() {
     scanRepos,
     listDirectory,
     listDiagrams,
+    deleteDiagram,
     worktrees,
     createWorktree,
     deleteWorktree,
@@ -228,6 +229,7 @@ export default function Dashboard() {
     handleTabSelect,
     handleTabClose,
     openDiagramTab,
+    clearDiagramTab,
   } = useViewerTabs(
     selectedSessionId,
     sessions,
@@ -252,6 +254,17 @@ export default function Dashboard() {
       socket.off("diagram:open", onDiagramOpen);
     };
   }, [socket, sessions, openDiagramTab]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onDiagramDeleted = (data: { sessionId: string; relPath: string }) => {
+      clearDiagramTab(data.sessionId, data.relPath);
+    };
+    socket.on("diagram:deleted", onDiagramDeleted);
+    return () => {
+      socket.off("diagram:deleted", onDiagramDeleted);
+    };
+  }, [socket, clearDiagramTab]);
 
   // セッションで最後に開いていた図（lastDiagramPath）をリロード後に復元する。
   // 「セッションが見つからなければ何もしない」という diagram:open ハンドラと
@@ -782,6 +795,7 @@ export default function Dashboard() {
                         socket={socket}
                         isConnected={isConnected}
                         listDiagrams={listDiagrams}
+                        deleteDiagram={deleteDiagram}
                         {...paneProps}
                       />
                     </div>


### PR DESCRIPTION
## 概要

PC の右ペインから**図を1件ずつ削除**できるようにする。#247 の read-only 一覧に**初めての破壊的操作**を足す。

## 実装

- **UI**: #247 の native `<select>` を維持し、隣に🗑ボタン + Radix AlertDialog（明示確認）。一覧と確認に tracked/untracked を表示。stale current・切断中・loading・削除中は削除不可。PC の SplitViewPane 限定（モバイル不変）
- **Socket.IO**: `diagram:delete`（ACK 型・`{sessionId, relPath, expectedTracked}`）、成功時に `diagram:deleted({sessionId, relPath})` を全 client へ broadcast → 各 client は #247 の `diagram:list` を再取得。**絶対パスは契約に載せない**
- **現在図を消したら**: 次へ自動遷移せず右ペインを空に。`lastDiagramPath` は削除パスと一致する時だけ atomic に NULL（`WHERE id=? AND last_diagram_path=?`）。unlink 後の DB 失敗は削除失敗にせず `ok:true`＋warning
- **確認のみ・即 unlink**（undo/ゴミ箱なし）。tracked は `unlink` のみで `git rm` しない（worktree に削除差分が残る）。**一括削除は入れない**（承認方針通り）

## セキュリティ（このPRの核）

削除は実体を壊すので read（#247）より検証を緩めない:

- client は絶対 `worktreePath` を送らない。server が `sessionId` から worktree を引き、**毎回 `resolveManagedWorktreePath()` で再検証** → `resolveDiagramPath()` で `.claude/diagrams/**/*.diagram.html` に封じ込め
- 削除 helper 固定順序: `O_NOFOLLOW` open → `fd.stat` isFile → `realpath+stat` の inode/dev 一致 & root containment → 直前 `lstatSync` 再照合 → **`await`/log/DB/git を挟まず同一 absPath を `unlinkSync`**
- **最終要素が symlink なら内外問わず 403**
- **tracked 判定と削除で同一の正準 relPath**を使用（filename-only 入力も `.claude/diagrams/` へ正規化）。`git ls-files` は **`--literal-pathspecs`** で pathspec magic を無効化

## 検証

- `pnpm check` / `pnpm build`: PASS
- unit: **44 files / 662 tests PASS**（security matrix **18/18**）
- `e2e/diagram-harness.spec.ts`: **49 PASS**（既存編集フローの回帰なし）

**実機プレビューで稼働中サーバーに破壊パスを直接 acceptance**（throwaway 図で実施、実在図は無傷）:

| ケース | 結果 |
|---|---|
| `../` 脱出 / suffix 不正 | FORBIDDEN |
| 存在しない / 不正 payload / 不明 session | NOT_FOUND / BAD_REQUEST / SESSION_NOT_FOUND |
| tracked conflict | CONFLICT |
| pathspec magic `:(glob)…` | glob 展開されず（literal-pathspecs 実証）|
| untracked 削除 | ok, tracked:false → 消滅 |
| tracked 削除 | ok, tracked:true → worktree に削除差分・index 不変 |

E2E 自動化（一時 managed session の bootstrap fixture）は本 PR では追加せず、承認方針通り手動 acceptance とした（別 Issue 化予定）。

Closes #255


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 右側の図ペインから図ファイルを個別に削除できるようになりました。
  * 削除前に確認ダイアログを表示し、Git管理対象かどうかに応じた注意事項を確認できます。
  * 図一覧にGit管理・未追跡の状態を表示します。
  * 削除結果を全画面・全クライアントへ反映し、関連する図タブも自動的に閉じます。

* **改善**
  * 削除失敗や競合時に、内容に応じたエラーを表示します。
  * 図一覧更新や削除処理の安定性・安全性を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->