### PR TITLE
auto-layout を group 対応にする (#248)

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -79,8 +79,19 @@ auto として扱われる。標準は node 座標を省略し、図全体の `m
   配置される。manual node は動かさず、auto node がそれを避ける
 - auto 座標は表示専用で model へ書き戻されない。node をドラッグしたときだけ、その
   node の有限な x/y が保存され、以後 manual になる
-- group は配置後の member node を囲み、edge は配置後の node 外周を結ぶ。
-  `group.ext` / `edge.ext` の既存語彙は layout 設定とは独立してそのまま使う
+- 座標を省略した、互いに member が重ならない flat group は cluster として自動配置
+  される。group 内で閉じる edge は member の読み順、group をまたぐ edge は cluster
+  間の読み順に使われ、edge 自体は配置後の node 外周を結ぶ
+- node の幅・高さと authored group 境界の余白は表示 DOM から実測される。field 数や
+  label 長から高さを見積もる必要はなく、折返しや field 編集後も再配置される
+- manual 座標は group 内でも絶対優先される。manual member を含む group は固定
+  cluster となり、残りの auto member と他の auto cluster がその境界を避ける
+- group-aware auto layout では **1 node 1 group** にする。同じ node を複数 group に
+  入れた図は重なる境界・疑似階層を保つため従来の node 単位 layout へ fallback する。
+  region / VPC / subnet の疑似階層、timeline、swimlane の厳密な位置は全 node に有限な
+  `ext.x/y` を指定して manual のまま作る
+- group は配置後の member node を囲む。`group.ext` / `edge.ext` の既存語彙は layout
+  設定とは独立してそのまま使う
 
 ## 語彙: kind
 

--- a/docs/superpowers/plans/2026-07-24-issue-248.md
+++ b/docs/superpowers/plans/2026-07-24-issue-248.md
@@ -1,0 +1,500 @@
+# issue-248: group 対応 auto-layout Implementation Plan
+
+**Goal:** flat group の member を 1 クラスタとして coordinate-less に配置し、DOM 実測サイズに基づいてクラスタ内 node 間、クラスタ間、クラスタと自由 node 間の overlap をゼロにする。既存の手動座標、group 境界、edge、非還流契約は維持する。
+
+**Issue:** #248「auto-layout を group 対応にする」
+
+**Architecture:** group ごとに member node を現行と同じ layered layout でサブレイアウトし、member の外接矩形と authored group 境界の実測 outsets を合わせた矩形を 1 つの合成ノードにする。group に属さない node は 1 node の layout unit とし、group 合成ノードと自由 node を上位の layered layout へ渡す。group 内 edge はサブレイアウト、group をまたぐ edge は上位レイアウトの rank にだけ使う。node と group 境界の寸法は注入済みブラウザ DOM で測り、純粋な geometry kernel が座標を決定し、結果は CSS custom property と `graph.positionsById` にだけ保持する。
+
+**Tech Stack:** TypeScript / injected vanilla DOM・CSS・inline SVG / Vitest / Playwright
+
+---
+
+## 調査結果
+
+### 現行 auto-layout（#228）
+
+- `packages/server/src/lib/diagram-harness.ts:462-480` の `graphPosition()` は `node.ext.x` と `node.ext.y` が両方とも有限数のときだけ manual 座標とみなす。`readLayoutConfig()` の入力は `model.ext.layout` で、`direction`、`rankSpacing`、`nodeSpacing`、`padding` を既定値・上限付きで読む。
+- `graphModelNodes(graph)` は model 順 index、node、同じ graph 内の投影 element を入力 entry にする。`assignLayerRanks(graph)` は同じ graph 内で解決できる node / edge を使い、self-edge を除外し、Tarjan SCC で循環を畳み、component DAG の longest depth を rank として返す。model 順で adjacency、SCC member、queue を安定化している。
+- `assignLayerRanks()` は `group` と `kind` を入力に使わない。`kind` は `[data-kind]` の authored CSS を通じて DOM の幅・高さへ間接的に効くだけである。
+- `layoutGraph(graph)` は全 node の `getBoundingClientRect()` から width / height を実測し、LR / TB の rank 主軸と rank 内副軸を計算する。出力は `--ark-harness-graph-x/y` と `graph.positionsById` の表示座標、および graph の一時 min-width / min-height であり、model へは書き戻さない。
+- 現行の `rectanglesCollide()` と `occupied` により、auto-auto と auto-manual の node 矩形は `nodeSpacing` 込みで衝突回避する。manual-manual の重なりは authored 指定を優先してそのまま残す。group 境界は obstacle ではなく、member が同じ場所にまとまる制約もない。
+- `ResizeObserver` は container と各 node を監視し、text / field / kind による寸法変更後も `scheduleGraphRender()` から再計算する。
+
+### 現行 group 境界（#227）
+
+- `renderGraphGroups()` は `groups[].nodes` を `graph.nodesById` へ解決し、全 member の `getBoundingClientRect()` から min-left / min-top / max-right / max-bottom を求める。
+- member の生の外接矩形を `--ark-harness-group-x/y/width/height` に設定し、`.ark-harness-graph-group` を付ける。境界の label 帯、余白、border は authored CSS の `calc()` が追加するため、画面上の group element の bounding box はこの生の外接矩形より大きくなり得る。
+- 空 group、member 投影欠損、別 graph の member を含む group は geometry を消して表示対象外にする。新レイアウトでもこの有効性判定と 4 custom properties の意味を変えない。
+- `renderGraph()` は layout → group → edge / label / handle / control の順で描画する。
+
+### model、保存、非還流
+
+- `packages/server/src/lib/diagram-model.ts` の node は `{ id, label, kind?, fields?, ext? }`、edge は `{ id, from, to, label?, ext? }`、group は `{ id, label, nodes: string[], ext? }` である。field は node の `fields[]` にあり、各 entry は `{ id, label, ext? }`。座標は専用型ではなく `node.ext.x/y`、layout 設定は `model.ext.layout` にある。
+- parser は group member が実在 node id であることを検証するが、同じ node の複数 group 所属は拒否しない。group id を `groups[].nodes` に入れることは node 参照検証で拒否されるため、model 上の group nesting はない。
+- サーバ側の model / HTML parser は computed style、font metrics、折返し、field 行高を持たず、任意 authored CSS の node 高さを安全に見積もれない。注入ハーネスは最終 DOM の `getBoundingClientRect()` を読める。
+- `buildSubmissionHtml()` は harness の node 座標、graph extent、group geometry、UI class を clone から除去する。`handleSubmit()` は `state.model` 自体を送るため、auto 座標を state.model に書かなければ model は coordinate-less のまま保存される。
+- production `diagram-diff.ts` の `describeModelDiff()` は node label / fields と edge の endpoint / label だけを比較する。既存 test は node ext 座標、top-level `ext.layout`、group、kind の変更を非還流と固定している。#241〜243 の「見た目・座標・layout は会話へ非還流」の境界を変更しない。
+
+### 既存 test
+
+- `packages/server/src/lib/diagram-harness.test.ts` は layout helper の注入、外部依存なし、危険な DOM API なし、group custom properties、`<128KiB` を文字列契約として検証する。
+- `e2e/diagram-harness.spec.ts` は `graphNodeBoxes()` / `boxesOverlap()` / `expectNoOverlaps()` で node 矩形を機械的に比較し、LR / TB、SCC、self-edge、孤立 node、manual / auto 混在、resize、非永続化を検証する。
+- 現行 group test は boundary が各 member を含むことを検証するが、group boundary 同士、boundary と自由 node、非 member の侵入、group member のクラスタ保持は検証しない。既存 `autoLayoutModel()` の `cycle_group` も境界が member を囲むことしか固定していない。
+
+### 実図 2 件
+
+依頼に記載された 2 ファイルはこの Ark worktree には存在せず、同じ親ディレクトリの別 repository `../claude-code-manager/.claude/diagrams/` にあったため、参照専用で確認した。
+
+- `promarche-context-map.diagram.html` は 9 node、10 edge、2 group。`new-build` は 6 node、`developed` は 2 node、`payment` は自由 node。group 内 edge、group 間 edge、group と自由 node 間 edgeが共存し、全 node に手動 `ext.x/y` がある。node 自体に fields はなく、note text の折返しで高さが変わり得る。
+- `promarche-aggregates.diagram.html` は 11 node、10 edge、3 group。Cart は 3 node、Order は 4 node、在庫は 2 node、`unit` と `principle` は自由 node。group 内 edge、group 間 edge、group と自由 node 間 edgeがすべてある。各 node は 2〜6 fields を持ち、特に `inv_cart` 5 行、`inv_order` 6 行で高さが大きく異なる。全 node に手動 `ext.x/y` があり、この高さ差と固定 y 間隔が overlap の原因になり得る。
+- 実装 test は外部 repository のファイルを直接参照せず、上記の構造（3 group、自由 node、内部 / 外部 edge、2〜6 fields）を Ark の E2E fixture へ最小再現する。2 実図の座標除去や更新は別 repository の作業なので本 Issue の変更対象にしない。
+
+### 注入サイズ
+
+- 現在の `diagram-harness.ts` は 110,104 bytes。
+- graph 付き最小 HTML へ `injectHarness()` した UTF-8 サイズは 106,887 bytes。guard は 131,072 bytes で、現在の headroom は 24,185 bytes。
+- group topology / packing kernel、DOM adapter、test seam の追加は注入後 8〜12KiB を目安とし、最終 119KiB 以下、少なくとも約 12KiB の余裕を目標にする。実測 guard が正であり、超えた場合は上限を緩めず helper の重複と文字列を整理する。
+
+---
+
+## 6 論点の設計結論
+
+### 1. アルゴリズム
+
+**採用:** 案 (a)「group ごとのサブレイアウト → group を 1 合成ノードとして上位 layered layout」にする。
+
+理由は、現行 SCC layered layout を内部・上位の 2 回再利用でき、group 内 node と group 外 node の責務が分離し、合成ノードの矩形非重複からクラスタ間 overlap ゼロを直接保証できるためである。案 (b) の group 制約付き単一 rank assignment は、同じ group の member が複数 rank にまたがると他 group が間へ入り込むため、追加の連続区間制約・後処理が必要になり、最低ラインに対して複雑である。
+
+処理順は次で固定する。
+
+1. 同じ graph 内で全 member 投影を解決できる、空でない、互いに member が重複しない flat group を layout group とする。
+2. 各 group の member と、group に属さない各自由 node を layout unit にする。自由 node は size が node 実寸の 1-node unit である。
+3. group 内で両端が閉じる edge だけを使い、member を現行 SCC layered layout で配置する。self-edge は rank に影響させず、循環は SCC 内同 rank、孤立 member は rank 0、同 rank は model 順とする。
+4. endpoint の layout unit が異なる edge を unit 間 edge に縮約し、重複 edge を除去する。group 間、group→自由、自由→group、自由 node 間を同じ上位 SCC layered layout に渡す。内部 edge は上位 rank へ重複して効かせない。
+5. group member の node 外接矩形と、実測した authored boundary outsets を合わせた実画面上の group boundary 矩形を合成ノード size にする。
+6. 上位 layout で group 合成ノードと自由 node を配置し、group の member 全体を同じ delta で移動する。unit の安定順は最小 member model index、次に group model 順、最後に id とする。
+
+group 内部の edge は内部の読み順、group をまたぐ edge はクラスタ間の読み順にだけ効く。cross edge が接続する特定 member を group 内の端へ寄せる、edge crossing を最小化する、直交 routing をすることは美的改善であり非ゴールとする。edge 描画は最終 node 外周を結ぶ既存処理をそのまま使う。
+
+同一 node の複数 group 所属は、infrastructure 例が重なる境界で階層感を近似するために使っており、flat な「独立クラスタ」にはできない。重複 membership を含む group set は group-aware auto-layout の対象外として現行 node layout に deterministic fallback し、境界描画自体は維持する。座標なしの独立クラスタを使う場合は 1 node 1 group とする。この fallback と制約を test / authoring skill に明記し、parser schema は変更しない。
+
+### 2. 可変高
+
+高さは field 数からの上限見積りではなく、最終 DOM の `getBoundingClientRect()` を使う。任意 authored CSS、折返し、kind、font fallback、field inline edit をサーバ側で安全に上限見積りできないためである。
+
+browser adapter は layout frame ごとに全 node の width / height を実測し、純粋 kernel へ渡す。group 内 packing と上位 packing はこの同じ実測値を使う。ResizeObserver による text / field / kind 変更後の再計算も維持する。これにより 2 行 node と 6 行 node を同じ固定高として扱わず、実際の bottom + `nodeSpacing` から次 slot を始めるため、可視 node の overlap ゼロを構造的に保つ。
+
+### 3. 衝突回避と決定性
+
+- group 内は rank ごとの最大 primary size と、各 node の実測 secondary size + `nodeSpacing` で slot を作る。manual obstacle または先に置いた auto node と交差した場合は、衝突矩形の secondary end + spacing へ単調に送る。
+- 上位は group の実画面 boundary 矩形と自由 node 矩形を unit obstacle にし、同じ rank packing を使う。したがって group-group、group-free、free-free が非重複になる。
+- authored boundary outsets は、provisional member 座標へ既存 4 custom propertiesを設定し `.ark-harness-graph-group` を付けた後、boundary 自身の `getBoundingClientRect()` と member hull の差を測る。最終描画でも `renderGraphGroups()` は従来どおり member hull を 4 変数へ設定し、layout が使った合成矩形と実画面 boundary を一致させる。
+- adjacency、SCC、rank queue、member、unit、collision candidate はすべて model / group 順で sort する。候補探索は副軸の正方向だけへ単調に進め、node / unit 数から導く上限と末尾 fallback を持つ。同一 model、DOM 寸法、layout config なら同じ座標を返す。
+- 小数の DOM 寸法は捨てず、比較に epsilon を使う。最終 CSS 座標だけ安定した単位へ丸める場合も、丸め後矩形で再度 collision を確認する。
+
+### 4. 既存図と後方互換
+
+- 有限な `ext.x/y` を持つ node は引き続き絶対優先で、group のために移動しない。全 node が manual の既存 ProMarche 2 図は現行座標と境界をそのまま維持する。
+- manual member を 1 つ以上持つ group は fixed cluster とし、manual node を obstacle / anchor にして auto member だけを内部配置する。他の auto cluster / 自由 node はその実測 boundary を避ける。
+- 明示座標同士が既に重なる場合は、作者指定を壊さない現行契約を優先する。したがって overlap ゼロの構造保証は coordinate-less node、および auto node 対 manual obstacle に対するものであり、manual-manual の矛盾を勝手に修正しない。
+- group が 0 件の graph は現行 `assignLayerRanks()` / `layoutGraph()` fast path を残し、#228 の座標なし通常図の座標・順序・fallback を変えない。
+- empty / cross-graph / member projection 欠損 group は現行どおり境界を出さず、layout unit にもしない。
+- `kind`、field、edge ext、group ext は layout の意味入力に増やさず、DOM size または既存 edge endpoint としてだけ扱う。
+
+### 5. 座標の還流
+
+auto-layout の結果は model に書き戻さない。出力は `graph.positionsById`、`--ark-harness-graph-x/y`、graph extent、group geometryだけに置き、`buildSubmissionHtml()` が一時 style / class を除去する既存契約を維持する。
+
+何も操作せず送信した coordinate-less group 図は、送信 model が初期 model と deep-equal で、`describeModelDiff()` は `[]` になる。node を個別 drag したときだけ、その node が既存処理で `ext.x/y` を得て manual に昇格する。座標変更だけなら production `diagram-diff.ts` は引き続き `[]` を返す。group layout の座標保存、group ext への bbox 保存、server 側座標計算、production `diagram-diff.ts` の変更は行わない。
+
+### 6. 検証
+
+目視、スクリーンショット比較、MCP Playwright の常設 profile に依存しない。
+
+- pure geometry kernel を Node / Vitest から直接呼び、可変 width / height、LR / TB、内部 / cross edge、cycle、self-edge、孤立 node、自由 node、manual obstacle を table-driven に検証する。全 node pair、全 top-level unit pairを矩形計算で非重複 assert し、各 member rect が group member hull に含まれ、同じ入力の複数実行が同じ座標になることを assert する。
+- browser E2E は実 DOM の `getBoundingClientRect()` を取得し、全 node pair、全 group boundary pair、group boundary と自由 node pair を計算で比較する。各 group が全 member を含み、非 member node を含まないことも assert する。
+- field 2 / 3 / 5 / 6 行の node、長い label の折返し、kind による width 変更後に ResizeObserver 経由で再配置され、poll 後の矩形が非重複であることを assert する。
+- Playwright は repository の test runner が作る分離 profile、`--workers=1` の targeted test と明示 timeout を使う。環境で browser 起動自体が hang した場合も unit kernel test を代替の「目視 PASS」にはせず、E2E infrastructure failure として記録し CI の機械判定を待つ。
+
+---
+
+## 変更範囲
+
+**Production:**
+
+- Add: `packages/server/src/lib/diagram-layout.ts`
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+
+**Tests:**
+
+- Add: `packages/server/src/lib/diagram-layout.test.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Modify: `e2e/diagram-harness.spec.ts`
+
+**Documentation:**
+
+- Modify: `.claude/skills/diagram-authoring/SKILL.md`
+
+**Verify only:**
+
+- `packages/server/src/lib/diagram-model.ts`
+- `packages/server/src/lib/diagram-model.test.ts`
+- `packages/server/src/lib/diagram-file.test.ts`
+- `packages/server/src/lib/diagram-diff.ts`
+- `packages/server/src/lib/diagram-diff.test.ts`
+- `.claude/diagrams/sample.diagram.html`
+
+model shape、production diff、file persistence、Socket.IO / MessageChannel payload、React、shared types、DB、既存 diagram artifact は変更しない。
+
+---
+
+## Task 1: pure geometry kernel の契約を Red で固定する
+
+**変更ファイル:**
+
+- Add: `packages/server/src/lib/diagram-layout.test.ts`
+- Add: `packages/server/src/lib/diagram-layout.ts`（型と stub のみ）
+
+**テスト（RED）:** `pnpm --filter @ark/server exec vitest run src/lib/diagram-layout.test.ts`
+
+- [ ] **Step 1: geometry input / output fixture を作る（2〜5分）**
+
+  3 group、2 自由 node、group 内 edge、group 間 edge、group↔自由 edgeを持つ plain object fixture を作る。node size は field 可変高を模して 64 / 96 / 152 / 224px を混在させ、group boundary outsets も group ごとに変える。
+
+- [ ] **Step 2: containment と node overlap の Red を書く（2〜5分）**
+
+  全 node pair が gap 0 で非重複、各 group の member rect が member hull に含まれることを計算 assert する。自由 node が group member hull に入らないことも固定する。
+
+- [ ] **Step 3: cluster overlap の Red を書く（2〜5分）**
+
+  group の authored outsets 込み outer rect 同士、および outer rect と自由 node rect が `nodeSpacing` 込みで非重複になることを全 pair で assert する。
+
+- [ ] **Step 4: edge scope と LR / TB の Red を書く（2〜5分）**
+
+  内部 edge が member rank、cross edge が unit rank に効き、LR は後続 unit の x、TB は y が増えることを固定する。self-edge と SCC cycle が無限 loop にならないことも加える。
+
+- [ ] **Step 5: 決定性の Red を書く（2〜5分）**
+
+  同じ入力を複数回渡した結果を deep-equal にし、edge 配列の重複や Map 生成順に依存しないことを固定する。
+
+- [ ] **Step 6: manual / auto 境界の Red を書く（2〜5分）**
+
+  manual member / manual free node の座標は不変、auto unit は manual obstacle を避け、manual-manual overlap だけは保持する fixture を加える。
+
+**完了条件:** stub に対して containment または overlap assertion が意図どおり FAIL し、失敗理由がスクリーンショットではなく矩形 id を含む。
+
+---
+
+## Task 2: 二段階 group layout kernel を実装する
+
+**変更ファイル:**
+
+- Modify: `packages/server/src/lib/diagram-layout.ts`
+- Modify: `packages/server/src/lib/diagram-layout.test.ts`
+
+**テスト（RED→GREEN）:** Task 1 の全 test
+
+- [ ] **Step 1: layout unit と membership を正規化する（2〜5分）**
+
+  group member set、自由 node unit、node→unit map を model 順で作る。空 group、欠損 member、重複 membership は結果に理由付きで fallback 対象として返し、例外や暗黙の二重所有にしない。
+
+- [ ] **Step 2: SCC rank helper を一般化する（2〜5分）**
+
+  plain node id / edge / stable order を受ける自己完結 helper を kernel 内に置き、self-edge 除外、重複 edge 除去、Tarjan SCC、component DAG rank を現行と同じ規則で実装する。
+
+- [ ] **Step 3: group 内 rank slot を配置する（2〜5分）**
+
+  実測 size から primary rank start と secondary cursor を作り、LR / TB の axis だけを切り替える。field 高の合計見積りは使わない。
+
+- [ ] **Step 4: group 内 collision packing を実装する（2〜5分）**
+
+  manual member と配置済み auto member を occupied に入れ、衝突末尾へ単調に送る。試行上限と deterministic fallback を加え、配置後に member hull を返す。
+
+- [ ] **Step 5: group outer rect を合成 node にする（2〜5分）**
+
+  browser adapter から渡された left / top / right / bottom outsets を member hull に加え、top-level unit の offset と width / height を返す。
+
+- [ ] **Step 6: cross edge を unit edge へ縮約する（2〜5分）**
+
+  endpoint unit が同じ edge を除き、異なる unit 間だけを重複除去して上位 SCC rank に渡す。
+
+- [ ] **Step 7: top-level packing と member translation を実装する（2〜5分）**
+
+  group outer rect と自由 node rect を occupied として非重複配置し、movable group の全 member に同じ delta を適用する。fixed cluster は動かさず他の auto unit の obstacle にする。
+
+- [ ] **Step 8: kernel を self-contained にする（2〜5分）**
+
+  browser harness へ同じ実装を inline 化できるよう closure 外参照をなくす。`diagram-harness.ts` は transpile 後の trusted function source を function literal として埋め込み、browser で `eval` / `new Function` / dynamic import は使わない。
+
+- [ ] **Step 9: unit test を Green にする（2〜5分）**
+
+  `pnpm --filter @ark/server exec vitest run src/lib/diagram-layout.test.ts`
+
+**完了条件:** LR / TB、可変高、内部 / cross edge、SCC、自由 node、manual obstacle の全矩形 assertion と決定性 assertion が PASS し、kernel が model や DOM を mutate しない。
+
+---
+
+## Task 3: 実 DOM の group-aware acceptance を Red にする
+
+**変更ファイル:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+
+**テスト（RED）:**
+
+```bash
+pnpm exec playwright test e2e/diagram-harness.spec.ts \
+  --project=chromium --workers=1 \
+  --grep "group-aware auto layout"
+```
+
+- [ ] **Step 1: ProMarche 型 coordinate-less fixture を作る（2〜5分）**
+
+  3 disjoint flat group、2 自由 node、内部 / group 間 / group↔自由 edge、2〜6 fields、異なる node width、group ごとに異なる境界 padding を持たせ、全 node から `ext.x/y` を省く。
+
+- [ ] **Step 2: 全 node 非重複の Red を書く（2〜5分）**
+
+  `graphNodeBoxes()` の全 pair を `expectNoOverlaps()` に通し、2 行 node と 6 行 node の実測 height が異なることも前提 assertion にする。
+
+- [ ] **Step 3: group / free の非重複 Red を書く（2〜5分）**
+
+  actual boundary box 全 pair、boundary と全自由 node box の pair が非重複であることを計算 assert する。
+
+- [ ] **Step 4: cluster 保持の Red を書く（2〜5分）**
+
+  各 boundary が全 member を含み、他 group member / 自由 node の中心点を含まないことを assert する。4 custom properties が member の生 hull と一致し、actual boundary が authored outsets 分だけ広いことも固定する。
+
+- [ ] **Step 5: LR / TB と cross edge の Red を書く（2〜5分）**
+
+  direction ごとに代表 cluster の主軸順を確認し、全 original edge が最終 member node 外周間に描かれることを件数と endpoint geometry で固定する。
+
+- [ ] **Step 6: rerender 決定性の Red を書く（2〜5分）**
+
+  同じ model を直接編集から再適用した前後の座標を比較し、許容誤差 0.5px 以内で一致することを assert する。
+
+- [ ] **Step 7: variable-height resize の Red を書く（2〜5分）**
+
+  field label を折り返す長さへ編集し、ResizeObserver 後に当該 node の高さが増え、全 node / cluster pair が再び非重複になるまで poll する。
+
+**完了条件:** 現行 layout で、group boundary 同士の overlap、自由 node の boundary 侵入、または member 分散のいずれかにより明確に FAIL する。
+
+---
+
+## Task 4: harness を二段階 layout へ接続する
+
+**変更ファイル:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+**テスト（RED→GREEN）:** Task 3 の targeted E2E と `diagram-harness.test.ts`
+
+- [ ] **Step 1: kernel 注入 contract の unit Red を書く（2〜5分）**
+
+  injected HTML に group layout kernel、unit edge、group outset measurement、legacy fast path の marker が 1 回だけ含まれることを assert する。
+
+- [ ] **Step 2: eligible flat group を収集する（2〜5分）**
+
+  `groupsById`、`group.nodes`、`nodesById` から同じ graph で完結する disjoint group だけを作る。空 / cross-graph / duplicate membership は既存表示規則または legacy fallback へ送る。
+
+- [ ] **Step 3: node size を実測して kernel input を作る（2〜5分）**
+
+  graph container 座標へ正規化した width / height、manual position、model index、edge、layout config を plain input にする。`kind` と field 数は input enum にせず、実測 size に反映させる。
+
+- [ ] **Step 4: provisional node position を適用する（2〜5分）**
+
+  zero-outset の kernel 結果を CSS へ一時適用し、既存 `renderGraphGroups()` の 4 custom propertiesと class を使って group boundary を表示可能な状態にする。同一 frame 内の中間配置であり model は変更しない。
+
+- [ ] **Step 5: authored boundary outsets を実測する（2〜5分）**
+
+  member hull と boundary の `getBoundingClientRect()` の差を graph 座標で取得する。非表示・非有限・解決不能 boundary は member hull を outer rect とする安全 fallback にし、既存 geometry cleanup を壊さない。
+
+- [ ] **Step 6: final kernel と CSS 座標を適用する（2〜5分）**
+
+  measured outsets で kernel を再実行し、最終 `positionsById`、node custom properties、container extent を更新する。group の member 全体は同じ delta、自由 node は unit 座標を使う。
+
+- [ ] **Step 7: render 順を安定させる（2〜5分）**
+
+  final layout → final group geometry → edge / labels / handles / controls の順を維持し、中間 group geometry が clean submission や paint 後に残らないようにする。
+
+- [ ] **Step 8: group-free fast path を保持する（2〜5分）**
+
+  group 0 件では現行 layout 関数をそのまま通す。group があっても全 node manual なら座標を再計算せず、現行境界描画だけを行う。
+
+- [ ] **Step 9: targeted unit / E2E を Green にする（2〜5分）**
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run src/lib/diagram-layout.test.ts src/lib/diagram-harness.test.ts
+  pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --workers=1 --grep "group-aware auto layout"
+  ```
+
+**完了条件:** 実 DOM の node、actual group boundary、自由 node の全対象 pair が非重複で、member containment、LR / TB、cross edge、resize、決定性が機械的に PASS する。
+
+---
+
+## Task 5: manual / auto、非還流、既存 group 契約を固定する
+
+**変更ファイル:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.test.ts`
+- Verify only: `packages/server/src/lib/diagram-file.test.ts`
+
+**テスト（RED）:** group-aware fixture の mixed / submission case
+
+- [ ] **Step 1: fixed group と auto unit の Red を書く（2〜5分）**
+
+  1 group に manual member と auto member、別の auto group、manual free node を置く。manual 座標不変、auto member の内部非重複、auto cluster と fixed boundary / manual free node の非重複を assert する。
+
+- [ ] **Step 2: authored manual conflict の互換 test を書く（2〜5分）**
+
+  manual-manual が同じ座標の既存 fixtureを維持し、group-aware code が勝手に移動しないことを明示する。これは overlap ゼロ保証の例外を意図的に固定する test とする。
+
+- [ ] **Step 3: auto 座標非永続化の Red を書く（2〜5分）**
+
+  何も操作せず submit し、submission model が initial model と deep-equal、全 auto node に `ext.x/y` なし、`describeModelDiff()` が `[]` であることを assert する。
+
+- [ ] **Step 4: clean HTML の Red を書く（2〜5分）**
+
+  submission HTML に `--ark-harness-graph-x/y`、graph extent、`--ark-harness-group-*`、`.ark-harness-graph-group`、layout kernel UI が残らず、authored group root / model script は残ることを固定する。
+
+- [ ] **Step 5: drag 昇格と再 packing の Red を書く（2〜5分）**
+
+  group 内 auto node を drag してその node だけ有限 `ext.x/y` を得ること、他 member は coordinate-less のまま、再 render 後も manual node を除く全 auto rect が衝突しないことを assert する。座標だけの diff は `[]` とする。
+
+- [ ] **Step 6: invalid group fallback を固定する（2〜5分）**
+
+  empty、cross-graph、projection 欠損、duplicate membership で page error がなく、現行 boundary cleanup と deterministic legacy node layout が維持されることを assert する。
+
+- [ ] **Step 7: compatibility suite を Green にする（2〜5分）**
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --workers=1 \
+    --grep "自動配置|group-aware|手動座標|表示時は座標を非永続化|group は"
+  pnpm --filter @ark/server exec vitest run \
+    src/lib/diagram-diff.test.ts src/lib/diagram-file.test.ts
+  ```
+
+**完了条件:** manual 優先、auto overlap ゼロ、coordinate-less submission、drag 昇格、clean HTML、invalid group fallback が同時に PASS し、production `diagram-diff.ts` と model / file code に変更がない。
+
+---
+
+## Task 6: authoring 契約と regression guard を仕上げる
+
+**変更ファイル:**
+
+- Modify: `.claude/skills/diagram-authoring/SKILL.md`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Verify only: `.claude/diagrams/sample.diagram.html`
+- Verify only: 過去の `docs/superpowers/plans/*.md`
+
+**テスト（RED）:** size / external resource / sample group acceptance
+
+- [ ] **Step 1: authoring skill の group auto-layout 説明を更新する（2〜5分）**
+
+  coordinate-less の disjoint flat group は cluster layout されること、内部 / cross edge の扱い、DOM 実測可変高、manual 優先、1 node 1 group、重なる疑似階層 / timeline は manual のままであることを記載する。「group の自動レイアウト未対応」という旧記述だけを現在の契約へ直す。
+
+- [ ] **Step 2: sample の機械検証を強める（2〜5分）**
+
+  既に座標なし group を持つ `.claude/diagrams/sample.diagram.html` 自体は変更せず、既存 E2E に boundary / member / node 非重複と model script 不変の assertion を追加する。
+
+- [ ] **Step 3: injection size の最終値を固定する（2〜5分）**
+
+  graph 付き最小 HTML の UTF-8 byte 数を出し、`<128KiB` assertion を維持する。目標 119KiB を超えた場合は重複 helper / message / CSS を縮め、128KiB の定数は変更しない。
+
+- [ ] **Step 4: no-external-resource guard を再確認する（2〜5分）**
+
+  `fetch(`、`import(`、`new Worker`、`blob:`、`https://`、`@font-face`、外部 stylesheet / image / font が注入 output にない既存 assertion を維持する。package / lockfile に layout dependency を追加しない。
+
+- [ ] **Step 5: server unit と build を実行する（2〜5分）**
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run \
+    src/lib/diagram-layout.test.ts \
+    src/lib/diagram-harness.test.ts \
+    src/lib/diagram-model.test.ts \
+    src/lib/diagram-file.test.ts \
+    src/lib/diagram-diff.test.ts
+  pnpm --filter @ark/server build
+  ```
+
+- [ ] **Step 6: diagram harness E2E 全体を実行する（2〜5分）**
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --workers=1
+  ```
+
+  browser 起動 hang は test failure として記録し、スクリーンショット目視で代替しない。targeted E2E と pure unit の結果を分けて報告する。
+
+- [ ] **Step 7: static check と差分境界を確認する（2〜5分）**
+
+  ```bash
+  pnpm check
+  git diff --check
+  git diff --stat
+  ```
+
+  production 変更が `diagram-layout.ts` / `diagram-harness.ts` に閉じ、model / diff / DB / UI 層と過去 plan が無変更であることを確認する。
+
+**完了条件:** unit、build、targeted E2E、可能な環境では diagram harness 全 E2E、static check が Green。注入後 HTML は 128KiB 未満、外部依存・外部リソース・DB 変更なしで、authoring skill と実装契約が一致する。
+
+---
+
+## テスト戦略まとめ
+
+| 層 | 検証内容 | 目視依存 |
+| --- | --- | --- |
+| Vitest geometry kernel | SCC / rank、内部 / cross edge、可変矩形、node / cluster pair 非重複、containment、manual obstacle、決定性 | なし |
+| Vitest injection contract | kernel 注入、legacy fast path、group measurement、サイズ、CSP / 外部依存禁止 | なし |
+| Playwright targeted | 実 DOM 高、authored boundary outsets、LR / TB、resize、全 pair 非重複、cluster 保持、edge、非永続化 | なし |
+| Existing regressions | group-free #228、manual drag、kind / field / edge control、clean submission、sample | なし |
+| Human review | layout の美観は参考確認のみ。acceptance 判定には使わない | 任意 |
+
+overlap assertion は edge が交差するかではなく、node content box と actual group boundary box を対象にする。group 自身は member を囲むため member との交差が正常であり、比較対象は group-group、group-free、node-node に分ける。
+
+---
+
+## 影響範囲
+
+- 全 graph の初回 / resize render で group がある場合だけ、node 実測、provisional placement、boundary 実測、final placement の 2 pass が増える。典型の数〜数十 node を対象とし、外部 layout engine は使わない。
+- edge geometry、endpoint handle、control は final position 後に既存処理で再描画される。edge routing の形状自体は変えない。
+- model schema、diagram file format、server submit、conversation diff、DB、web / desktop / mobile UI への影響はない。
+- group-free graph は legacy fast path のため、#228 の配置を維持する。
+- authored manual group は座標不変。coordinate-less disjoint flat group だけが新しい cluster behavior を得る。
+
+---
+
+## ロールバック
+
+- DB migration、model migration、保存済み座標の一括変換がないため、`diagram-layout.ts`、harness adapter、対応 test / skill 更新の feature commit を revert すれば現行 #228 behavior に戻せる。
+- rollback 後も coordinate-less model、手動 `ext.x/y`、既存 4 group custom properties は有効で、データ修復は不要。
+- 問題が group path だけに限定される場合も size guard や test を無効化せず、group-aware dispatch を revert して legacy path へ戻す。
+
+---
+
+## 制約・非ゴール
+
+- 注入後 HTML の **128KiB guard は緩和しない**。現在 106,887 bytes / headroom 24,185 bytes。
+- external CDN、font、image、stylesheet、layout package、Worker、WASM、Blob URL、network fetch を追加しない。
+- DB schema / migration / Socket.IO event / MessageChannel payloadを変更しない。
+- 過去の `docs/superpowers/plans` / specs は改変しない。
+- group nesting、同一 node の複数 group 所属を auto cluster 化すること、group 一括 drag、snap / grid は非ゴール。
+- edge crossing 最小化、orthogonal routing、port 選択、cross edge に応じた member 並べ替え、最適な縦横比は非ゴール。
+- authored manual-manual overlap の自動修正は非ゴール。
+- ProMarche 2 図の座標除去・別 repository への反映は非ゴール。
+- 完璧な美観ではなく、coordinate-less disjoint flat group の **node overlap ゼロ、cluster outer rect overlap ゼロ、group member 保持**を acceptance とする。
+
+---
+
+## 未確定事項・実装時 stop condition
+
+- ProMarche 2 図は Ark worktree にない。Ark 内 E2E fixture で再現する方針は確定しているが、別 repository の実ファイルを coordinate-less へ移行する時期と担当は本 Issue 外で未確定。
+- infrastructure 例の region / VPC / subnet は同じ node を複数 group に列挙して疑似 nesting を表す。これは manual fallback を維持する。将来これを auto 化するなら、nested / overlapping group semantics を別 Issue で定義する。
+- authored group CSS が transform、percentage、viewport 依存 min/max を使い、translation 後に outsets 自体が変わる場合は複数 frame で収束しない可能性がある。現行 contract の 4 custom properties + absolute `calc()` は実測 2 pass で扱うが、非収束 CSS まで一般解に広げない。再現した場合は fixture と contract を提示して設計レビューで止める。
+- self-contained kernel の function source inline が production esbuild 後に同一動作しない場合は、duplicate implementation を作らず build artifact test を Red にして注入方法を再設計する。
+- `<128KiB` を超えた場合、guard 引上げや外部 script 化へ進まず、実装を止めて kernel / adapter の重複削減を行う。

--- a/docs/superpowers/plans/2026-07-24-issue-248.md
+++ b/docs/superpowers/plans/2026-07-24-issue-248.md
@@ -96,7 +96,7 @@ browser adapter は layout frame ごとに全 node の width / height を実測�
 ### 4. 既存図と後方互換
 
 - 有限な `ext.x/y` を持つ node は引き続き絶対優先で、group のために移動しない。全 node が manual の既存 ProMarche 2 図は現行座標と境界をそのまま維持する。
-- manual member を 1 つ以上持つ group は fixed cluster とし、manual node を obstacle / anchor にして auto member だけを内部配置する。他の auto cluster / 自由 node はその実測 boundary を避ける。
+- manual member を 1 つ以上持つ group は fixed cluster とし、manual node を obstacle / anchor にして auto member だけを内部配置する。他の auto cluster / 自由 node はその実測 boundary を避ける。**fixed cluster は上位 layered layout に「その実測位置に固定された manual unit」として参加し、rank も自身の位置から解決される。上位 packing は fixed cluster を移動対象にせず obstacle としてのみ使うため、fixed cluster の member（manual 座標）と group boundary は delta 移動されない**（実装: 合成 unit を `manual: { x, y }` として packer へ渡し、`if (!unit.fixed)` で delta 適用を除外する）。
 - 明示座標同士が既に重なる場合は、作者指定を壊さない現行契約を優先する。したがって overlap ゼロの構造保証は coordinate-less node、および auto node 対 manual obstacle に対するものであり、manual-manual の矛盾を勝手に修正しない。
 - group が 0 件の graph は現行 `assignLayerRanks()` / `layoutGraph()` fast path を残し、#228 の座標なし通常図の座標・順序・fallback を変えない。
 - empty / cross-graph / member projection 欠損 group は現行どおり境界を出さず、layout unit にもしない。
@@ -164,7 +164,7 @@ model shape、production diff、file persistence、Socket.IO / MessageChannel pa
 
 - [ ] **Step 2: containment と node overlap の Red を書く（2〜5分）**
 
-  全 node pair が gap 0 で非重複、各 group の member rect が member hull に含まれることを計算 assert する。自由 node が group member hull に入らないことも固定する。
+  **auto / auto-vs-manual の** node pair が gap 0 で非重複、各 group の member rect が member hull に含まれることを計算 assert する。自由 node が group member hull に入らないことも固定する。**非重複 assertion は意図的に重ねた manual-manual pair を対象にしない**（Step 6 の manual-manual overlap fixture と矛盾しないよう、非重複対象は coordinate-less node・auto node 対 manual obstacle・group outer rect に限定する。実装テストは重なる manual node を disjoint 検査から除外する）。
 
 - [ ] **Step 3: cluster overlap の Red を書く（2〜5分）**
 
@@ -496,5 +496,6 @@ overlap assertion は edge が交差するかではなく、node content box と
 - ProMarche 2 図は Ark worktree にない。Ark 内 E2E fixture で再現する方針は確定しているが、別 repository の実ファイルを coordinate-less へ移行する時期と担当は本 Issue 外で未確定。
 - infrastructure 例の region / VPC / subnet は同じ node を複数 group に列挙して疑似 nesting を表す。これは manual fallback を維持する。将来これを auto 化するなら、nested / overlapping group semantics を別 Issue で定義する。
 - authored group CSS が transform、percentage、viewport 依存 min/max を使い、translation 後に outsets 自体が変わる場合は複数 frame で収束しない可能性がある。現行 contract の 4 custom properties + absolute `calc()` は実測 2 pass で扱うが、非収束 CSS まで一般解に広げない。再現した場合は fixture と contract を提示して設計レビューで止める。
+- **ただし実行時は非収束でも無限ループ・provisional 残留を起こさない**。(1) kernel の collision packing は `items.length * 4 + 8` の試行上限で bounded で、上限到達時は全 occupied の外側へ送る deterministic fallback を返すため、kernel は常に有限・非重複の最終座標を返す。(2) browser adapter の再レイアウトは `scheduleGraphRender` の `graph.scheduled` ガード + `requestAnimationFrame` で 1 frame 1 回に coalesce し、レイアウトは node の intrinsic size（内容由来）を変えないため ResizeObserver フィードバックループにならない。(3) 描画は provisional geometry を最終 `positionsById` / 4 custom properties で必ず上書きし、可変高 resize 後の最終矩形が非重複であることを E2E で poll 検証する。measurement を無制限に繰り返す経路は設けない。
 - self-contained kernel の function source inline が production esbuild 後に同一動作しない場合は、duplicate implementation を作らず build artifact test を Red にして注入方法を再設計する。
 - `<128KiB` を超えた場合、guard 引上げや外部 script 化へ進まず、実装を止めて kernel / adapter の重複削減を行う。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -275,6 +275,192 @@ function autoLayoutHtml(
   </body></html>`);
 }
 
+function groupAwareModel(direction: "LR" | "TB" = "LR"): DiagramModel {
+  const node = (id: string, label: string, fieldCount: number) => ({
+    id,
+    label,
+    fields: Array.from({ length: fieldCount }, (_, index) => ({
+      id: `${id}_field_${index}`,
+      label: `${id} field ${index + 1}`,
+    })),
+  });
+  return {
+    version: 1,
+    ext: {
+      layout: {
+        direction,
+        rankSpacing: 72,
+        nodeSpacing: 32,
+        padding: 20,
+      },
+    },
+    nodes: [
+      node("cart", "Cart", 2),
+      node("cart_item", "Cart item with wider content", 5),
+      node("order", "Order", 3),
+      node("order_line", "Order line", 6),
+      node("stock", "Stock", 2),
+      node("stock_event", "Stock reserved", 3),
+      node("customer", "Customer", 2),
+      node("policy", "Fulfillment policy", 5),
+    ],
+    edges: [
+      { id: "e_cart_item", from: "cart", to: "cart_item" },
+      { id: "e_order_line", from: "order", to: "order_line" },
+      { id: "e_stock_event", from: "stock", to: "stock_event" },
+      { id: "e_cart_order", from: "cart_item", to: "order" },
+      { id: "e_order_stock", from: "order_line", to: "stock" },
+      { id: "e_customer_cart", from: "customer", to: "cart" },
+      { id: "e_stock_policy", from: "stock_event", to: "policy" },
+      { id: "e_policy_self", from: "policy", to: "policy" },
+    ],
+    groups: [
+      { id: "cart_group", label: "Cart", nodes: ["cart", "cart_item"] },
+      {
+        id: "order_group",
+        label: "Order",
+        nodes: ["order", "order_line"],
+      },
+      {
+        id: "stock_group",
+        label: "Stock",
+        nodes: ["stock", "stock_event"],
+      },
+    ],
+  };
+}
+
+function groupAwareHtml(direction: "LR" | "TB" = "LR"): string {
+  const diagramModel = groupAwareModel(direction);
+  const outsets = [
+    ["cart_group", 12, 28, 16, 14],
+    ["order_group", 20, 34, 20, 18],
+    ["stock_group", 10, 24, 12, 12],
+  ] as const;
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .graph { width: 420px; height: 320px; background: #f8fafc; }
+    .node {
+      box-sizing: border-box; width: var(--node-width, 156px); min-height: 64px;
+      padding: 10px; border: 1px solid #64748b; background: white;
+      overflow-wrap: anywhere;
+    }
+    .node h2 { margin: 0 0 8px; font: 600 16px/20px sans-serif; }
+    .node ul { margin: 0; padding-left: 18px; }
+    .node li { min-height: 22px; font: 14px/20px sans-serif; }
+    [data-model-id="cart_item"] { --node-width: 196px; }
+    [data-model-id="order_line"] { --node-width: 184px; }
+    [data-model-id="stock_event"] { --node-width: 140px; }
+    .group-boundary {
+      display: none; box-sizing: border-box; position: absolute;
+      left: calc(var(--ark-harness-group-x) - var(--out-left));
+      top: calc(var(--ark-harness-group-y) - var(--out-top));
+      width: calc(var(--ark-harness-group-width) + var(--out-left) + var(--out-right));
+      height: calc(var(--ark-harness-group-height) + var(--out-top) + var(--out-bottom));
+      border: 2px solid #0f766e; background: rgba(15, 118, 110, .04);
+    }
+    .group-boundary.ark-harness-graph-group { display: block; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
+    <div class="graph" data-ark-container="graph">
+      ${outsets
+        .map(
+          ([id, left, top, right, bottom]) =>
+            `<section class="group-boundary" data-ark-group data-model-id="${id}" style="--out-left:${left}px;--out-top:${top}px;--out-right:${right}px;--out-bottom:${bottom}px"><span data-model-id="${id}">${id}</span></section>`
+        )
+        .join("\n")}
+      ${diagramModel.nodes
+        .map(
+          node =>
+            `<section class="node" data-model-id="${node.id}"><h2 data-model-id="${node.id}">${node.label}</h2><ul>${(
+              node.fields ?? []
+            )
+              .map(
+                field => `<li data-model-id="${field.id}">${field.label}</li>`
+              )
+              .join("")}</ul></section>`
+        )
+        .join("\n")}
+    </div>
+  </body></html>`);
+}
+
+function mixedGroupAwareHtml(): string {
+  const diagramModel = groupAwareModel();
+  diagramModel.nodes = diagramModel.nodes.map(node => {
+    if (node.id === "cart") return { ...node, ext: { x: 260, y: 180 } };
+    if (node.id === "customer" || node.id === "policy")
+      return { ...node, ext: { x: 20, y: 20 } };
+    return node;
+  });
+  return groupAwareHtml().replace(
+    JSON.stringify(groupAwareModel()),
+    JSON.stringify(diagramModel)
+  );
+}
+
+function invalidGroupLayoutHtml(): string {
+  const diagramModel: DiagramModel = {
+    version: 1,
+    ext: {
+      layout: {
+        direction: "LR",
+        rankSpacing: 64,
+        nodeSpacing: 28,
+        padding: 16,
+      },
+    },
+    nodes: [
+      { id: "a", label: "A" },
+      { id: "b", label: "B" },
+      { id: "c", label: "C" },
+      { id: "outside", label: "Outside" },
+    ],
+    edges: [
+      { id: "e_ab", from: "a", to: "b" },
+      { id: "e_bc", from: "b", to: "c" },
+    ],
+    groups: [
+      { id: "first", label: "First", nodes: ["a", "b"] },
+      { id: "duplicate", label: "Duplicate", nodes: ["b", "c"] },
+      { id: "empty", label: "Empty", nodes: [] },
+      { id: "cross", label: "Cross", nodes: ["a", "outside"] },
+    ],
+  };
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .graph { width: 320px; height: 220px; }
+    .node { box-sizing: border-box; width: 120px; height: 64px; border: 1px solid; }
+    .boundary {
+      display: none; position: absolute;
+      left: calc(var(--ark-harness-group-x) - 10px);
+      top: calc(var(--ark-harness-group-y) - 20px);
+      width: calc(var(--ark-harness-group-width) + 20px);
+      height: calc(var(--ark-harness-group-height) + 30px);
+      border: 1px solid;
+    }
+    .boundary.ark-harness-graph-group { display: block; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(diagramModel)}</script>
+    <div class="graph" data-ark-container="graph">
+      ${diagramModel.groups
+        .map(
+          group =>
+            `<section class="boundary" data-ark-group data-model-id="${group.id}">${group.label}</section>`
+        )
+        .join("")}
+      ${diagramModel.nodes
+        .filter(node => node.id !== "outside")
+        .map(
+          node =>
+            `<section class="node" data-model-id="${node.id}">${node.label}</section>`
+        )
+        .join("")}
+    </div>
+    <section data-model-id="outside">Outside</section>
+  </body></html>`);
+}
+
 function mixedLayoutHtml(): string {
   const mixedModel = {
     version: 1,
@@ -639,6 +825,25 @@ async function graphNodeBoxes(page: Page) {
       };
     })
   );
+}
+
+async function graphGroupBoxes(page: Page) {
+  return page
+    .locator(
+      '[data-ark-container="graph"] > [data-ark-group].ark-harness-graph-group'
+    )
+    .evaluateAll(elements =>
+      elements.map(element => {
+        const box = element.getBoundingClientRect();
+        return {
+          id: element.getAttribute("data-model-id") || "",
+          x: box.x,
+          y: box.y,
+          width: box.width,
+          height: box.height,
+        };
+      })
+    );
 }
 
 function expectNoOverlaps(
@@ -1697,6 +1902,357 @@ test("自動配置は text resize とモデル JSON 再適用で再計算する"
       return byId.branch_a.y > byId.source.y + byId.source.height;
     })
     .toBe(true);
+});
+
+for (const direction of ["LR", "TB"] as const) {
+  test(`group-aware auto layout ${direction} は全矩形を分離して cluster を保持する`, async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on("pageerror", error => errors.push(error.message));
+    const initialModel = groupAwareModel(direction);
+    await page.setContent(groupAwareHtml(direction));
+
+    const graph = page.locator('[data-ark-container="graph"]');
+    const nodeBoxes = await graphNodeBoxes(page);
+    const nodeById = Object.fromEntries(nodeBoxes.map(box => [box.id, box]));
+    expect(nodeById.order_line.height).toBeGreaterThan(nodeById.cart.height);
+    expectNoOverlaps(nodeBoxes);
+
+    const groupBoxes = await graphGroupBoxes(page);
+    expect(groupBoxes).toHaveLength(initialModel.groups.length);
+    expectNoOverlaps(groupBoxes, 31);
+    const groupById = Object.fromEntries(groupBoxes.map(box => [box.id, box]));
+    const freeBoxes = ["customer", "policy"].map(id => nodeById[id]);
+    for (const groupBox of groupBoxes) {
+      for (const freeBox of freeBoxes) {
+        expect(
+          boxesOverlap(groupBox, freeBox, 31),
+          `${groupBox.id} と ${freeBox.id} が重なっています`
+        ).toBe(false);
+      }
+    }
+
+    for (const group of initialModel.groups) {
+      const boundary = groupById[group.id];
+      for (const id of group.nodes) {
+        expectBoxToContain(boundary, nodeById[id]);
+      }
+      for (const node of initialModel.nodes.filter(
+        node => !group.nodes.includes(node.id)
+      )) {
+        const box = nodeById[node.id];
+        const center = { x: box.x + box.width / 2, y: box.y + box.height / 2 };
+        expect(
+          center.x > boundary.x &&
+            center.x < boundary.x + boundary.width &&
+            center.y > boundary.y &&
+            center.y < boundary.y + boundary.height,
+          `${node.id} が ${group.id} に侵入しています`
+        ).toBe(false);
+      }
+    }
+
+    const geometry = await graph
+      .locator(":scope > [data-ark-group]")
+      .evaluateAll(elements =>
+        elements.map(element => {
+          const style = (element as HTMLElement).style;
+          return {
+            id: element.getAttribute("data-model-id") || "",
+            x: Number.parseFloat(
+              style.getPropertyValue("--ark-harness-group-x")
+            ),
+            y: Number.parseFloat(
+              style.getPropertyValue("--ark-harness-group-y")
+            ),
+            width: Number.parseFloat(
+              style.getPropertyValue("--ark-harness-group-width")
+            ),
+            height: Number.parseFloat(
+              style.getPropertyValue("--ark-harness-group-height")
+            ),
+          };
+        })
+      );
+    const graphBox = await requiredBoundingBox(graph);
+    for (const group of initialModel.groups) {
+      const raw = geometry.find(entry => entry.id === group.id);
+      if (!raw) throw new Error(`${group.id} の geometry がありません`);
+      const members = group.nodes.map(id => nodeById[id]);
+      const left = Math.min(...members.map(box => box.x));
+      const top = Math.min(...members.map(box => box.y));
+      const right = Math.max(...members.map(box => box.x + box.width));
+      const bottom = Math.max(...members.map(box => box.y + box.height));
+      expect(raw.x).toBeCloseTo(left - graphBox.x, 1);
+      expect(raw.y).toBeCloseTo(top - graphBox.y, 1);
+      expect(raw.width).toBeCloseTo(right - left, 1);
+      expect(raw.height).toBeCloseTo(bottom - top, 1);
+    }
+
+    const primary = direction === "LR" ? "x" : "y";
+    expect(groupById.order_group[primary]).toBeGreaterThan(
+      groupById.cart_group[primary]
+    );
+    expect(groupById.stock_group[primary]).toBeGreaterThan(
+      groupById.order_group[primary]
+    );
+    const edges = graph.locator(".ark-harness-edge-main[data-ark-edge-id]");
+    await expect(edges).toHaveCount(initialModel.edges.length);
+    expect(
+      await edges.evaluateAll(elements =>
+        elements.every(element =>
+          ["line", "path"].includes(element.tagName.toLowerCase())
+        )
+      )
+    ).toBe(true);
+
+    const before = Object.fromEntries(
+      nodeBoxes.map(box => [box.id, { x: box.x, y: box.y }])
+    );
+    await page
+      .getByRole("button", { name: "モデル JSON を直接編集する" })
+      .click();
+    await page
+      .locator(".ark-harness-textarea")
+      .fill(JSON.stringify(initialModel));
+    await page.getByRole("button", { name: "反映", exact: true }).click();
+    await expect
+      .poll(async () => {
+        const after = await graphNodeBoxes(page);
+        return after.every(
+          box =>
+            Math.abs(box.x - before[box.id].x) <= 0.5 &&
+            Math.abs(box.y - before[box.id].y) <= 0.5
+        );
+      })
+      .toBe(true);
+    expect(errors).toEqual([]);
+  });
+}
+
+test("group-aware auto layout は実測した可変高 resize 後も全矩形を再配置する", async ({
+  page,
+}) => {
+  await page.setContent(groupAwareHtml());
+  const beforeNodes = await graphNodeBoxes(page);
+  const before = Object.fromEntries(beforeNodes.map(box => [box.id, box]));
+  await page
+    .locator(
+      '[data-model-id="order_line"] li[data-model-id="order_line_field_0"] .ark-harness-text'
+    )
+    .fill("実測高さを増やすために十分長い field label ".repeat(12));
+
+  await expect
+    .poll(async () => {
+      const nodes = await graphNodeBoxes(page);
+      const current = Object.fromEntries(nodes.map(box => [box.id, box]));
+      if (current.order_line.height <= before.order_line.height + 20)
+        return false;
+      expectNoOverlaps(nodes);
+      const groups = await graphGroupBoxes(page);
+      expectNoOverlaps(groups, 31);
+      for (const group of groups) {
+        for (const id of ["customer", "policy"]) {
+          expect(boxesOverlap(group, current[id], 31)).toBe(false);
+        }
+      }
+      return true;
+    })
+    .toBe(true);
+});
+
+test("group-aware auto layout は manual cluster を固定し auto unit だけを退避する", async ({
+  page,
+}) => {
+  await page.setContent(mixedGroupAwareHtml());
+  const graph = page.locator('[data-ark-container="graph"]');
+  const graphBox = await requiredBoundingBox(graph);
+  const nodes = await graphNodeBoxes(page);
+  const byId = Object.fromEntries(nodes.map(box => [box.id, box]));
+  expect(byId.cart.x - graphBox.x).toBeCloseTo(260, 0);
+  expect(byId.cart.y - graphBox.y).toBeCloseTo(180, 0);
+  for (const id of ["customer", "policy"]) {
+    expect(byId[id].x - graphBox.x).toBeCloseTo(20, 0);
+    expect(byId[id].y - graphBox.y).toBeCloseTo(20, 0);
+  }
+  expect(boxesOverlap(byId.customer, byId.policy)).toBe(true);
+  expectNoOverlaps(nodes.filter(node => node.id !== "policy"));
+
+  const groups = await graphGroupBoxes(page);
+  const groupById = Object.fromEntries(groups.map(box => [box.id, box]));
+  expectBoxToContain(groupById.cart_group, byId.cart);
+  expectBoxToContain(groupById.cart_group, byId.cart_item);
+  for (const id of ["order_group", "stock_group"]) {
+    expect(boxesOverlap(groupById[id], groupById.cart_group, 31)).toBe(false);
+    expect(boxesOverlap(groupById[id], byId.customer, 31)).toBe(false);
+    expect(boxesOverlap(groupById[id], byId.policy, 31)).toBe(false);
+  }
+});
+
+test("group-aware auto layout は座標を還流せず drag した member だけ manual にする", async ({
+  page,
+}) => {
+  const initialModel = groupAwareModel();
+  await page.setContent(groupAwareHtml());
+  await connectSubmissionPort(page);
+  const submit = page.getByRole("button", {
+    name: "変更を親フレームへ送信する",
+  });
+  await submit.click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  let submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel; html: string };
+        }
+      ).arkHarnessSubmission
+  );
+  expect(submission?.model).toEqual(initialModel);
+  expect(
+    describeModelDiff(initialModel, submission?.model as DiagramModel)
+  ).toEqual([]);
+  for (const node of submission?.model.nodes ?? []) {
+    expect(node.ext?.x).toBeUndefined();
+    expect(node.ext?.y).toBeUndefined();
+  }
+  expect(submission?.html).toContain('id="ark-diagram-model"');
+  expect(submission?.html).toContain("data-ark-group");
+  for (const transient of [
+    "--ark-harness-graph-x",
+    "--ark-harness-graph-y",
+    "--ark-harness-graph-min-width",
+    "groupAwareLayout",
+  ]) {
+    expect(submission?.html).not.toContain(transient);
+  }
+  const cleanGroupGeometry = await page.evaluate(html => {
+    const parsed = new DOMParser().parseFromString(html || "", "text/html");
+    return Array.from(parsed.querySelectorAll("[data-ark-group]")).map(
+      element => {
+        const htmlElement = element as HTMLElement;
+        return {
+          harnessClass: htmlElement.classList.contains(
+            "ark-harness-graph-group"
+          ),
+          properties: [
+            "--ark-harness-group-x",
+            "--ark-harness-group-y",
+            "--ark-harness-group-width",
+            "--ark-harness-group-height",
+          ].map(property => htmlElement.style.getPropertyValue(property)),
+        };
+      }
+    );
+  }, submission?.html);
+  expect(
+    cleanGroupGeometry.every(
+      group =>
+        !group.harnessClass && group.properties.every(value => value === "")
+    )
+  ).toBe(true);
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const member = graph.locator('[data-model-id="cart_item"]').first();
+  const memberBefore = await requiredBoundingBox(member);
+  const handle = await requiredBoundingBox(
+    member.locator(".ark-harness-graph-handle")
+  );
+  await page.evaluate(() => {
+    delete (window as typeof window & { arkHarnessSubmission?: unknown })
+      .arkHarnessSubmission;
+  });
+  await page.mouse.move(
+    handle.x + handle.width / 2,
+    handle.y + handle.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    handle.x + handle.width / 2 + 48,
+    handle.y + handle.height / 2 + 36
+  );
+  await page.mouse.up();
+  await expect
+    .poll(async () => (await requiredBoundingBox(member)).x)
+    .toBeCloseTo(memberBefore.x + 48, 0);
+  await submit.click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel; html: string };
+        }
+      ).arkHarnessSubmission
+  );
+  const dragged = submission?.model.nodes.find(node => node.id === "cart_item");
+  expect(Number.isFinite(dragged?.ext?.x)).toBe(true);
+  expect(Number.isFinite(dragged?.ext?.y)).toBe(true);
+  for (const node of submission?.model.nodes.filter(
+    node => node.id !== "cart_item"
+  ) ?? []) {
+    expect(node.ext?.x).toBeUndefined();
+    expect(node.ext?.y).toBeUndefined();
+  }
+  expect(
+    describeModelDiff(initialModel, submission?.model as DiagramModel)
+  ).toEqual([]);
+  expectNoOverlaps(await graphNodeBoxes(page));
+});
+
+test("group-aware auto layout は重複 membership などを deterministic legacy layout へ fallback する", async ({
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", error => errors.push(error.message));
+  await page.setContent(invalidGroupLayoutHtml());
+  const before = await graphNodeBoxes(page);
+  expectNoOverlaps(before);
+  const graph = page.locator('[data-ark-container="graph"]');
+  await expect(
+    graph.locator('[data-ark-group][data-model-id="first"]')
+  ).toHaveClass(/ark-harness-graph-group/);
+  await expect(
+    graph.locator('[data-ark-group][data-model-id="duplicate"]')
+  ).toHaveClass(/ark-harness-graph-group/);
+  for (const id of ["empty", "cross"]) {
+    await expect(
+      graph.locator(`[data-ark-group][data-model-id="${id}"]`)
+    ).not.toHaveClass(/ark-harness-graph-group/);
+  }
+
+  const current = await readCurrentModel(page);
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  await page.locator(".ark-harness-textarea").fill(JSON.stringify(current));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+  await expect
+    .poll(async () => {
+      const after = await graphNodeBoxes(page);
+      return after.every(
+        box =>
+          Math.abs(
+            box.x - (before.find(entry => entry.id === box.id)?.x ?? 0)
+          ) <= 0.5 &&
+          Math.abs(
+            box.y - (before.find(entry => entry.id === box.id)?.y ?? 0)
+          ) <= 0.5
+      );
+    })
+    .toBe(true);
+  expect(errors).toEqual([]);
 });
 
 test("ext 座標の2次元配置と edge で node 外周を結ぶ", async ({ page }) => {
@@ -3384,7 +3940,9 @@ test("sample group は2 node を囲むラベル付き境界として表示する
 }) => {
   await openSampleDiagram(page);
 
-  const groups = await page.locator("#ark-diagram-model").evaluate(element => {
+  const modelScript = page.locator("#ark-diagram-model");
+  const initialModelText = await modelScript.textContent();
+  const groups = await modelScript.evaluate(element => {
     const parsed = JSON.parse(element.textContent || "") as {
       groups: Array<{ id: string; label: string; nodes: string[] }>;
     };
@@ -3411,8 +3969,41 @@ test("sample group は2 node を囲むラベル付き境界として表示する
   ]);
   expectBoxToContain(boundaryBox, firstNodeBox);
   expectBoxToContain(boundaryBox, secondNodeBox);
+  expectNoOverlaps([
+    { id: sampleGroup.nodes[0], ...firstNodeBox },
+    { id: sampleGroup.nodes[1], ...secondNodeBox },
+  ]);
+  const graphBox = await requiredBoundingBox(graph);
+  const rawGeometry = await boundary.evaluate(element => {
+    const style = (element as HTMLElement).style;
+    return {
+      x: Number.parseFloat(style.getPropertyValue("--ark-harness-group-x")),
+      y: Number.parseFloat(style.getPropertyValue("--ark-harness-group-y")),
+      width: Number.parseFloat(
+        style.getPropertyValue("--ark-harness-group-width")
+      ),
+      height: Number.parseFloat(
+        style.getPropertyValue("--ark-harness-group-height")
+      ),
+    };
+  });
+  const rawLeft = Math.min(firstNodeBox.x, secondNodeBox.x);
+  const rawTop = Math.min(firstNodeBox.y, secondNodeBox.y);
+  const rawRight = Math.max(
+    firstNodeBox.x + firstNodeBox.width,
+    secondNodeBox.x + secondNodeBox.width
+  );
+  const rawBottom = Math.max(
+    firstNodeBox.y + firstNodeBox.height,
+    secondNodeBox.y + secondNodeBox.height
+  );
+  expect(rawGeometry.x).toBeCloseTo(rawLeft - graphBox.x, 1);
+  expect(rawGeometry.y).toBeCloseTo(rawTop - graphBox.y, 1);
+  expect(rawGeometry.width).toBeCloseTo(rawRight - rawLeft, 1);
+  expect(rawGeometry.height).toBeCloseTo(rawBottom - rawTop, 1);
   await expect(boundary).toContainText(sampleGroup.label);
   await expect(boundary.locator(".group-label")).toBeVisible();
+  expect(await modelScript.textContent()).toBe(initialModelText);
 });
 
 test("ER edge semantics artifact は記号を投影して端点を張り替えられる", async ({

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -1,3 +1,8 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { build } from "esbuild";
 import { describe, expect, it } from "vitest";
 import { DIAGRAM_HARNESS_MARKER, injectHarness } from "./diagram-harness.js";
 
@@ -88,6 +93,59 @@ describe("injectHarness", () => {
     expect(out).not.toContain("@font-face");
     expect(out).not.toContain('rel="stylesheet"');
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  });
+
+  it("group layout kernel を function literal で一度だけ注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><section data-ark-group data-model-id="group"></section><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(
+      out.match(/var groupAwareLayout = function layoutDiagram/g)
+    ).toHaveLength(1);
+    expect(out.match(/function layoutGroupAwareGraph\(/g)).toHaveLength(1);
+    expect(out.match(/function measureGroupOutsets\(/g)).toHaveLength(1);
+    expect(out.match(/\bunitEdges=/g)).toHaveLength(1);
+    expect(out).toContain(
+      "if (!layoutGroupAwareGraph(graph)) layoutGraph(graph);"
+    );
+    expect(out).not.toContain("eval(");
+    expect(out).not.toContain("new Function");
+  });
+
+  it("esbuild artifact からも group kernel を function literal として注入する", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "ark-diagram-harness-"));
+    const outfile = join(directory, "diagram-harness.mjs");
+    try {
+      await build({
+        entryPoints: [join(import.meta.dirname, "diagram-harness.ts")],
+        outfile,
+        bundle: true,
+        format: "esm",
+        platform: "node",
+      });
+      const artifact = (await import(
+        `${pathToFileURL(outfile).href}?test=${Date.now()}`
+      )) as typeof import("./diagram-harness.js");
+      const out = artifact.injectHarness(
+        page(
+          '<div data-ark-container="graph"><section data-ark-group data-model-id="group"></section><div data-model-id="node"></div></div>'
+        )
+      );
+
+      expect(
+        out.match(/var groupAwareLayout = function layoutDiagram/g)
+      ).toHaveLength(1);
+      expect(out.match(/function layoutGroupAwareGraph\(/g)).toHaveLength(1);
+      expect(Buffer.byteLength(out, "utf8")).toBeLessThan(128 * 1024);
+      expect(out).not.toContain("eval(");
+      expect(out).not.toContain("new Function");
+      expect(out).not.toContain("import(");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
   });
 
   it("edge ext の cardinality・direction・type 投影契約を注入する", () => {

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -27,12 +27,53 @@
  */
 
 import { MODEL_SCRIPT_ID } from "./diagram-file.js";
+import { layoutDiagram } from "./diagram-layout.js";
 
 /**
  * 二重注入検出に使うマーカー。注入する `<script>` タグの id 属性の値として
  * 一度だけ現れる（HARNESS_JS / HARNESS_STYLE の中では絶対に使わない）。
  */
 export const DIAGRAM_HARNESS_MARKER = "ark-diagram-harness";
+
+/**
+ * 注入サイズを抑えるため、既知の trusted source から文字列外の空白だけを除く。
+ * 対象にする kernel / adapter 区間には comment と正規表現 literal を置かない。
+ */
+function compactTrustedJavaScript(source: string): string {
+  let result = "";
+  let quote = "";
+  let escaped = false;
+  const isWord = (character: string | undefined) =>
+    character !== undefined && /[A-Za-z0-9_$]/.test(character);
+  for (let index = 0; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote) {
+      result += character;
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === quote) quote = "";
+      continue;
+    }
+    if (character === '"' || character === "'" || character === "`") {
+      quote = character;
+      result += character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      let next = index + 1;
+      while (next < source.length && /\s/.test(source[next])) next += 1;
+      if (isWord(result.at(-1)) && isWord(source[next])) result += " ";
+      index = next - 1;
+      continue;
+    }
+    result += character;
+  }
+  return result;
+}
+
+const GROUP_LAYOUT_KERNEL_SOURCE = compactTrustedJavaScript(
+  layoutDiagram.toString()
+);
 
 const HARNESS_STYLE = `<style data-ark-harness-ui="1">
 .ark-harness-toolbar {
@@ -236,12 +277,13 @@ body { padding-bottom: var(--ark-harness-toolbar-height, 3.4rem) !important; }
 /**
  * ブラウザで実行するハーネス本体。バッククォート（テンプレートリテラル）を
  * 使うと TS 側のテンプレートリテラルとネストして壊れるため、文字列連結のみで
- * 書く。`${MODEL_SCRIPT_ID}` の 1 箇所だけ TS 側の定数を埋め込む。
+ * 書く。model script id と trusted kernel の function literal を TS 側で埋め込む。
  */
-const HARNESS_JS = `(function () {
+const RAW_HARNESS_JS = `(function () {
   "use strict";
 
   var MODEL_SCRIPT_ID = "${MODEL_SCRIPT_ID}";
+  var groupAwareLayout = ${GROUP_LAYOUT_KERNEL_SOURCE};
   var GROUP_GEOMETRY_PROPERTIES = [
     "--ark-harness-group-x",
     "--ark-harness-group-y",
@@ -633,6 +675,35 @@ const HARNESS_JS = `(function () {
       left.y + left.height + gap > right.y;
   }
 
+  function applyLayoutPositions(graph, entries, measured, nextPositions, config) {
+    var maxRight = 0;
+    var maxBottom = 0;
+    entries.forEach(function (entry) {
+      var position = nextPositions.get(entry.id);
+      var size = measured.get(entry.id);
+      if (!position || !size) return;
+      var previous = graph.positionsById.get(entry.id);
+      if (!previous || previous.x !== position.x || previous.y !== position.y) {
+        entry.el.style.setProperty("--ark-harness-graph-x", position.x + "px");
+        entry.el.style.setProperty("--ark-harness-graph-y", position.y + "px");
+      }
+      maxRight = Math.max(maxRight, position.x + size.width);
+      maxBottom = Math.max(maxBottom, position.y + size.height);
+    });
+    graph.positionsById = nextPositions;
+    var minWidth = Math.ceil(maxRight + config.padding) + "px";
+    var minHeight = Math.ceil(maxBottom + config.padding) + "px";
+    if (graph.layoutExtent.width !== minWidth) {
+      graph.container.style.setProperty("--ark-harness-graph-min-width", minWidth);
+      graph.layoutExtent.width = minWidth;
+    }
+    if (graph.layoutExtent.height !== minHeight) {
+      graph.container.style.setProperty("--ark-harness-graph-min-height", minHeight);
+      graph.layoutExtent.height = minHeight;
+    }
+    graph.container.classList.add("ark-harness-graph-layout");
+  }
+
   function layoutGraph(graph) {
     var config = readLayoutConfig(state.model);
     var direction = config.direction;
@@ -732,33 +803,118 @@ const HARNESS_JS = `(function () {
       });
     });
 
-    var maxRight = 0;
-    var maxBottom = 0;
-    entries.forEach(function (entry) {
-      var position = nextPositions.get(entry.id);
-      var size = measured.get(entry.id);
-      if (!position || !size) return;
-      var previous = graph.positionsById.get(entry.id);
-      if (!previous || previous.x !== position.x || previous.y !== position.y) {
-        entry.el.style.setProperty("--ark-harness-graph-x", position.x + "px");
-        entry.el.style.setProperty("--ark-harness-graph-y", position.y + "px");
-      }
-      maxRight = Math.max(maxRight, position.x + size.width);
-      maxBottom = Math.max(maxBottom, position.y + size.height);
-    });
-    graph.positionsById = nextPositions;
+    applyLayoutPositions(graph, entries, measured, nextPositions, config);
+  }
 
-    var minWidth = Math.ceil(maxRight + config.padding) + "px";
-    var minHeight = Math.ceil(maxBottom + config.padding) + "px";
-    if (graph.layoutExtent.width !== minWidth) {
-      graph.container.style.setProperty("--ark-harness-graph-min-width", minWidth);
-      graph.layoutExtent.width = minWidth;
-    }
-    if (graph.layoutExtent.height !== minHeight) {
-      graph.container.style.setProperty("--ark-harness-graph-min-height", minHeight);
-      graph.layoutExtent.height = minHeight;
-    }
-    graph.container.classList.add("ark-harness-graph-layout");
+  function applyGroupLayout(graph, entries, measured, result, config) {
+    var nextPositions = new Map();
+    entries.forEach(function (entry) {
+      var position = result.positions[entry.id];
+      if (position) nextPositions.set(entry.id, position);
+    });
+    applyLayoutPositions(graph, entries, measured, nextPositions, config);
+  }
+
+  function measureGroupOutsets(graph, groups) {
+    var outsets = new Map();
+    groups.forEach(function (group) {
+      var boundary = graph.groupsById.get(group.id);
+      var memberEls = group.nodes.map(function (id) {
+        return graph.nodesById.get(id);
+      });
+      if (!boundary || memberEls.some(function (el) { return !el; })) {
+        outsets.set(group.id, { left: 0, top: 0, right: 0, bottom: 0 });
+        return;
+      }
+      var first = memberEls[0].getBoundingClientRect();
+      var left = first.left;
+      var top = first.top;
+      var right = first.right;
+      var bottom = first.bottom;
+      memberEls.slice(1).forEach(function (el) {
+        var rect = el.getBoundingClientRect();
+        left = Math.min(left, rect.left);
+        top = Math.min(top, rect.top);
+        right = Math.max(right, rect.right);
+        bottom = Math.max(bottom, rect.bottom);
+      });
+      var boundaryRect = boundary.getBoundingClientRect();
+      var values = {
+        left: Math.max(0, left - boundaryRect.left),
+        top: Math.max(0, top - boundaryRect.top),
+        right: Math.max(0, boundaryRect.right - right),
+        bottom: Math.max(0, boundaryRect.bottom - bottom)
+      };
+      if (!Object.keys(values).every(function (key) {
+        return finiteNumber(values[key]);
+      })) values = { left: 0, top: 0, right: 0, bottom: 0 };
+      outsets.set(group.id, values);
+    });
+    return outsets;
+  }
+
+  function layoutGroupAwareGraph(graph) {
+    if (graph.groupsById.size === 0) return false;
+    var entries = graphModelNodes(graph);
+    if (entries.length === 0 || entries.every(function (entry) {
+      return !!graphPosition(entry.node);
+    })) return false;
+    var modelGroups = state.model && Array.isArray(state.model.groups)
+      ? state.model.groups
+      : [];
+    var groups = [];
+    modelGroups.forEach(function (group, index) {
+      if (!group || !graph.groupsById.has(group.id)) return;
+      groups.push({
+        id: group.id,
+        index: index,
+        nodes: Array.isArray(group.nodes) ? group.nodes.slice() : [],
+        outsets: { left: 0, top: 0, right: 0, bottom: 0 }
+      });
+    });
+    if (groups.length === 0 || groups.length !== graph.groupsById.size) return false;
+
+    var config = readLayoutConfig(state.model);
+    var measured = new Map();
+    var nodes = entries.map(function (entry) {
+      var rect = entry.el.getBoundingClientRect();
+      var size = { width: rect.width, height: rect.height };
+      measured.set(entry.id, size);
+      var manual = graphPosition(entry.node);
+      return {
+        id: entry.id,
+        index: entry.index,
+        width: size.width,
+        height: size.height,
+        manual: manual || undefined
+      };
+    });
+    var edges = state.model && Array.isArray(state.model.edges)
+      ? state.model.edges.map(function (edge) {
+          return { from: edge.from, to: edge.to };
+        })
+      : [];
+    var input = {
+      nodes: nodes,
+      edges: edges,
+      groups: groups,
+      direction: config.direction,
+      rankSpacing: config.rankSpacing,
+      nodeSpacing: config.nodeSpacing,
+      padding: config.padding
+    };
+    var provisional = groupAwareLayout(input);
+    if (provisional.fallback) return false;
+    applyGroupLayout(graph, entries, measured, provisional, config);
+    renderGraphGroups(graph);
+    var measuredOutsets = measureGroupOutsets(graph, groups);
+    groups.forEach(function (group) {
+      group.outsets = measuredOutsets.get(group.id);
+    });
+    var finalLayout = groupAwareLayout(input);
+    if (finalLayout.fallback) return false;
+    applyGroupLayout(graph, entries, measured, finalLayout, config);
+    return true;
   }
 
   function svgElement(name) {
@@ -1058,7 +1214,7 @@ const HARNESS_JS = `(function () {
 
   function renderGraph(graph) {
     graph.scheduled = false;
-    layoutGraph(graph);
+    if (!layoutGroupAwareGraph(graph)) layoutGraph(graph);
     renderGraphGroups(graph);
     while (graph.svg.firstChild) graph.svg.removeChild(graph.svg.firstChild);
     appendGraphMarker(graph.svg, graph.markerId);
@@ -2935,6 +3091,20 @@ const HARNESS_JS = `(function () {
     }
   });
 })();`;
+
+const GROUP_ADAPTER_START = "  function applyGroupLayout(";
+const GROUP_ADAPTER_END = "  function svgElement(";
+const groupAdapterStart = RAW_HARNESS_JS.indexOf(GROUP_ADAPTER_START);
+const groupAdapterEnd = RAW_HARNESS_JS.indexOf(
+  GROUP_ADAPTER_END,
+  groupAdapterStart
+);
+const HARNESS_JS =
+  RAW_HARNESS_JS.slice(0, groupAdapterStart) +
+  compactTrustedJavaScript(
+    RAW_HARNESS_JS.slice(groupAdapterStart, groupAdapterEnd)
+  ) +
+  RAW_HARNESS_JS.slice(groupAdapterEnd);
 
 export const DIAGRAM_HARNESS_SCRIPT = `${HARNESS_STYLE}
 <script id="${DIAGRAM_HARNESS_MARKER}" data-ark-harness-ui="1">

--- a/packages/server/src/lib/diagram-layout.test.ts
+++ b/packages/server/src/lib/diagram-layout.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest";
+import {
+  type DiagramLayoutInput,
+  type DiagramLayoutRect,
+  layoutDiagram,
+} from "./diagram-layout.js";
+
+const fixture = (direction: "LR" | "TB" = "LR"): DiagramLayoutInput => ({
+  direction,
+  rankSpacing: 72,
+  nodeSpacing: 32,
+  padding: 20,
+  nodes: [
+    { id: "cart", index: 0, width: 148, height: 64 },
+    { id: "cart_item", index: 1, width: 176, height: 152 },
+    { id: "order", index: 2, width: 160, height: 96 },
+    { id: "order_line", index: 3, width: 184, height: 224 },
+    { id: "stock", index: 4, width: 152, height: 96 },
+    { id: "stock_event", index: 5, width: 132, height: 64 },
+    { id: "customer", index: 6, width: 144, height: 96 },
+    { id: "policy", index: 7, width: 168, height: 152 },
+  ],
+  edges: [
+    { from: "cart", to: "cart_item" },
+    { from: "order", to: "order_line" },
+    { from: "stock", to: "stock_event" },
+    { from: "cart_item", to: "order" },
+    { from: "order_line", to: "stock" },
+    { from: "customer", to: "cart" },
+    { from: "stock_event", to: "policy" },
+    { from: "policy", to: "policy" },
+  ],
+  groups: [
+    {
+      id: "cart_group",
+      index: 0,
+      nodes: ["cart", "cart_item"],
+      outsets: { left: 12, top: 28, right: 16, bottom: 14 },
+    },
+    {
+      id: "order_group",
+      index: 1,
+      nodes: ["order", "order_line"],
+      outsets: { left: 20, top: 34, right: 20, bottom: 18 },
+    },
+    {
+      id: "stock_group",
+      index: 2,
+      nodes: ["stock", "stock_event"],
+      outsets: { left: 10, top: 24, right: 12, bottom: 12 },
+    },
+  ],
+});
+
+function rects(input: DiagramLayoutInput) {
+  const result = layoutDiagram(input);
+  const size = Object.fromEntries(
+    input.nodes.map(node => [
+      node.id,
+      { width: node.width, height: node.height },
+    ])
+  );
+  return {
+    result,
+    nodes: Object.fromEntries(
+      Object.entries(result.positions).map(([id, point]) => [
+        id,
+        { ...point, ...size[id] },
+      ])
+    ) as Record<string, DiagramLayoutRect>,
+  };
+}
+
+function expectDisjoint(entries: Array<[string, DiagramLayoutRect]>, gap = 0) {
+  for (let left = 0; left < entries.length; left += 1) {
+    for (let right = left + 1; right < entries.length; right += 1) {
+      const [leftId, a] = entries[left];
+      const [rightId, b] = entries[right];
+      const collide =
+        a.x < b.x + b.width + gap &&
+        a.x + a.width + gap > b.x &&
+        a.y < b.y + b.height + gap &&
+        a.y + a.height + gap > b.y;
+      expect(collide, `${leftId} と ${rightId} が重なっています`).toBe(false);
+    }
+  }
+}
+
+function expectContains(
+  container: DiagramLayoutRect,
+  member: DiagramLayoutRect
+) {
+  expect(container.x).toBeLessThanOrEqual(member.x);
+  expect(container.y).toBeLessThanOrEqual(member.y);
+  expect(container.x + container.width).toBeGreaterThanOrEqual(
+    member.x + member.width
+  );
+  expect(container.y + container.height).toBeGreaterThanOrEqual(
+    member.y + member.height
+  );
+}
+
+describe("layoutDiagram", () => {
+  it.each([
+    "LR",
+    "TB",
+  ] as const)("%s で可変高 node と cluster の全矩形を重ねず member を保持する", direction => {
+    const input = fixture(direction);
+    const { result, nodes } = rects(input);
+
+    expect(result.fallback).toBeNull();
+    expectDisjoint(Object.entries(nodes));
+    for (const group of input.groups) {
+      const geometry = result.groups[group.id];
+      for (const id of group.nodes) {
+        expectContains(geometry.member, nodes[id]);
+      }
+      for (const node of input.nodes.filter(
+        node => !group.nodes.includes(node.id)
+      )) {
+        const center = {
+          x: nodes[node.id].x + nodes[node.id].width / 2,
+          y: nodes[node.id].y + nodes[node.id].height / 2,
+        };
+        expect(
+          center.x > geometry.member.x &&
+            center.x < geometry.member.x + geometry.member.width &&
+            center.y > geometry.member.y &&
+            center.y < geometry.member.y + geometry.member.height,
+          `${node.id} が ${group.id} の member hull に侵入しています`
+        ).toBe(false);
+      }
+    }
+    expectDisjoint(
+      result.units.map(unit => [unit.id, unit.rect]),
+      input.nodeSpacing
+    );
+  });
+
+  it.each([
+    "LR",
+    "TB",
+  ] as const)("%s で内部 edge と cross edge を別の rank に反映する", direction => {
+    const { result, nodes } = rects(fixture(direction));
+    const primary = direction === "LR" ? "x" : "y";
+    expect(nodes.cart_item[primary]).toBeGreaterThan(nodes.cart[primary]);
+    expect(result.groups.order_group.outer[primary]).toBeGreaterThan(
+      result.groups.cart_group.outer[primary]
+    );
+    expect(result.groups.stock_group.outer[primary]).toBeGreaterThan(
+      result.groups.order_group.outer[primary]
+    );
+  });
+
+  it("cycle・self-edge・重複 edge があっても決定的で入力を mutate しない", () => {
+    const input = fixture();
+    input.edges.push(
+      { from: "stock_event", to: "stock" },
+      { from: "cart", to: "cart_item" },
+      { from: "cart", to: "cart_item" }
+    );
+    const original = structuredClone(input);
+    const reversedEdges = {
+      ...input,
+      edges: [...input.edges].reverse(),
+    };
+
+    expect(layoutDiagram(input)).toEqual(layoutDiagram(input));
+    expect(layoutDiagram(reversedEdges)).toEqual(layoutDiagram(input));
+    expect(input).toEqual(original);
+  });
+
+  it("manual 座標を固定し auto node / cluster を obstacle の外へ送る", () => {
+    const input = fixture();
+    input.nodes[0].manual = { x: 260, y: 180 };
+    input.nodes[6].manual = { x: 20, y: 20 };
+    input.nodes[7].manual = { x: 20, y: 20 };
+    const { result } = rects(input);
+
+    expect(result.positions.cart).toEqual({ x: 260, y: 180 });
+    expect(result.positions.customer).toEqual({ x: 20, y: 20 });
+    expect(result.positions.policy).toEqual({ x: 20, y: 20 });
+    expectDisjoint(
+      result.units
+        .filter(unit => unit.id !== "node:policy")
+        .map(unit => [unit.id, unit.rect]),
+      input.nodeSpacing
+    );
+  });
+
+  it.each([
+    {
+      mutate: (input: DiagramLayoutInput) => {
+        input.groups[0].nodes = [];
+      },
+      reason: "empty-group",
+    },
+    {
+      mutate: (input: DiagramLayoutInput) => {
+        input.groups[0].nodes.push("missing");
+      },
+      reason: "missing-member",
+    },
+    {
+      mutate: (input: DiagramLayoutInput) => {
+        input.groups[1].nodes.push("cart");
+      },
+      reason: "duplicate-membership",
+    },
+  ] as const)("不正 group を $reason fallback にする", ({ mutate, reason }) => {
+    const input = fixture();
+    mutate(input);
+    expect(layoutDiagram(input).fallback).toBe(reason);
+  });
+});

--- a/packages/server/src/lib/diagram-layout.ts
+++ b/packages/server/src/lib/diagram-layout.ts
@@ -1,0 +1,484 @@
+export interface DiagramLayoutNode {
+  id: string;
+  index: number;
+  width: number;
+  height: number;
+  manual?: { x: number; y: number };
+}
+
+export interface DiagramLayoutEdge {
+  from: string;
+  to: string;
+}
+
+export interface DiagramLayoutGroup {
+  id: string;
+  index: number;
+  nodes: string[];
+  outsets: { left: number; top: number; right: number; bottom: number };
+}
+
+export interface DiagramLayoutInput {
+  nodes: DiagramLayoutNode[];
+  edges: DiagramLayoutEdge[];
+  groups: DiagramLayoutGroup[];
+  direction: "LR" | "TB";
+  rankSpacing: number;
+  nodeSpacing: number;
+  padding: number;
+}
+
+export interface DiagramLayoutRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DiagramLayoutResult {
+  fallback: null | "empty-group" | "missing-member" | "duplicate-membership";
+  positions: Record<string, { x: number; y: number }>;
+  groups: Record<
+    string,
+    { member: DiagramLayoutRect; outer: DiagramLayoutRect }
+  >;
+  units: Array<{ id: string; rect: DiagramLayoutRect; group: boolean }>;
+}
+
+/**
+ * DOM に依存しない group-aware layout kernel。
+ *
+ * browser harness へ function literal として埋め込めるよう、実装はこの関数の
+ * closure 内だけで完結させる。
+ */
+export function layoutDiagram(_input: DiagramLayoutInput): DiagramLayoutResult {
+  type Item = {
+    id: string;
+    order: number;
+    width: number;
+    height: number;
+    rank: number;
+    manual?: { x: number; y: number };
+  };
+  type Unit = {
+    id: string;
+    order: number;
+    group: boolean;
+    groupId?: string;
+    nodeIds: string[];
+    rect: DiagramLayoutRect;
+    fixed: boolean;
+  };
+
+  const input = _input;
+  const positions: Record<string, { x: number; y: number }> = {};
+  const groupGeometry: DiagramLayoutResult["groups"] = {};
+  const nodeById = new Map(input.nodes.map(node => [node.id, node]));
+  const membership = new Map<string, string>();
+  let fallback: DiagramLayoutResult["fallback"] = null;
+
+  for (const group of input.groups) {
+    if (group.nodes.length === 0) {
+      fallback = "empty-group";
+      break;
+    }
+    for (const id of group.nodes) {
+      if (!nodeById.has(id)) {
+        fallback = "missing-member";
+        break;
+      }
+      if (membership.has(id)) {
+        fallback = "duplicate-membership";
+        break;
+      }
+      membership.set(id, group.id);
+    }
+    if (fallback) break;
+  }
+  if (fallback) {
+    for (const node of input.nodes) {
+      if (node.manual) positions[node.id] = { ...node.manual };
+    }
+    return { fallback, positions, groups: {}, units: [] };
+  }
+
+  const collide = (
+    left: DiagramLayoutRect,
+    right: DiagramLayoutRect,
+    gap: number
+  ) =>
+    left.x < right.x + right.width + gap &&
+    left.x + left.width + gap > right.x &&
+    left.y < right.y + right.height + gap &&
+    left.y + left.height + gap > right.y;
+
+  const ranksFor = (
+    ids: string[],
+    edges: DiagramLayoutEdge[],
+    orderById: Map<string, number>
+  ) => {
+    const idSet = new Set(ids);
+    const adjacency = new Map(ids.map(id => [id, [] as string[]]));
+    const seen = new Set<string>();
+    for (const edge of edges) {
+      if (edge.from === edge.to || !idSet.has(edge.from) || !idSet.has(edge.to))
+        continue;
+      const key = `${edge.from}\0${edge.to}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      adjacency.get(edge.from)?.push(edge.to);
+    }
+    for (const targets of adjacency.values()) {
+      targets.sort(
+        (left, right) =>
+          (orderById.get(left) ?? 0) - (orderById.get(right) ?? 0)
+      );
+    }
+
+    let nextIndex = 0;
+    const stack: string[] = [];
+    const onStack = new Set<string>();
+    const indexes = new Map<string, number>();
+    const lowLinks = new Map<string, number>();
+    const components: string[][] = [];
+    const visit = (id: string) => {
+      indexes.set(id, nextIndex);
+      lowLinks.set(id, nextIndex);
+      nextIndex += 1;
+      stack.push(id);
+      onStack.add(id);
+      for (const target of adjacency.get(id) ?? []) {
+        if (!indexes.has(target)) {
+          visit(target);
+          lowLinks.set(
+            id,
+            Math.min(lowLinks.get(id) ?? 0, lowLinks.get(target) ?? 0)
+          );
+        } else if (onStack.has(target)) {
+          lowLinks.set(
+            id,
+            Math.min(lowLinks.get(id) ?? 0, indexes.get(target) ?? 0)
+          );
+        }
+      }
+      if (lowLinks.get(id) !== indexes.get(id)) return;
+      const component: string[] = [];
+      let member: string;
+      do {
+        member = stack.pop() as string;
+        onStack.delete(member);
+        component.push(member);
+      } while (member !== id);
+      component.sort(
+        (left, right) =>
+          (orderById.get(left) ?? 0) - (orderById.get(right) ?? 0)
+      );
+      components.push(component);
+    };
+    for (const id of ids) {
+      if (!indexes.has(id)) visit(id);
+    }
+    components.sort(
+      (left, right) =>
+        (orderById.get(left[0]) ?? 0) - (orderById.get(right[0]) ?? 0)
+    );
+
+    const componentById = new Map<string, number>();
+    const componentOrder: number[] = [];
+    components.forEach((component, componentIndex) => {
+      componentOrder[componentIndex] = orderById.get(component[0]) ?? 0;
+      for (const id of component) componentById.set(id, componentIndex);
+    });
+    const outgoing = components.map(() => new Set<number>());
+    const indegrees = components.map(() => 0);
+    for (const [from, targets] of adjacency) {
+      const fromComponent = componentById.get(from) as number;
+      for (const to of targets) {
+        const toComponent = componentById.get(to) as number;
+        if (
+          fromComponent === toComponent ||
+          outgoing[fromComponent].has(toComponent)
+        )
+          continue;
+        outgoing[fromComponent].add(toComponent);
+        indegrees[toComponent] += 1;
+      }
+    }
+    const byOrder = (left: number, right: number) =>
+      componentOrder[left] - componentOrder[right];
+    const queue = indegrees
+      .map((degree, index) => ({ degree, index }))
+      .filter(entry => entry.degree === 0)
+      .map(entry => entry.index)
+      .sort(byOrder);
+    const componentRanks = components.map(() => 0);
+    while (queue.length > 0) {
+      const current = queue.shift() as number;
+      for (const target of [...outgoing[current]].sort(byOrder)) {
+        componentRanks[target] = Math.max(
+          componentRanks[target],
+          componentRanks[current] + 1
+        );
+        indegrees[target] -= 1;
+        if (indegrees[target] === 0) {
+          queue.push(target);
+          queue.sort(byOrder);
+        }
+      }
+    }
+    return Object.fromEntries(
+      ids.map(id => [id, componentRanks[componentById.get(id) as number] ?? 0])
+    ) as Record<string, number>;
+  };
+
+  const pack = (items: Item[], gap: number, padding: number) => {
+    const direction = input.direction;
+    const result: Record<string, { x: number; y: number }> = {};
+    const occupied: Array<DiagramLayoutRect & { id: string }> = [];
+    const manualItems = items.filter(item => item.manual);
+    const primaryOrigin =
+      manualItems.length === 0
+        ? padding
+        : Math.min(
+            ...manualItems.map(item =>
+              direction === "TB"
+                ? (item.manual as { y: number }).y
+                : (item.manual as { x: number }).x
+            )
+          );
+    const secondaryOrigin =
+      manualItems.length === 0
+        ? padding
+        : Math.min(
+            ...manualItems.map(item =>
+              direction === "TB"
+                ? (item.manual as { x: number }).x
+                : (item.manual as { y: number }).y
+            )
+          );
+    for (const item of manualItems) {
+      const manual = item.manual as { x: number; y: number };
+      result[item.id] = { ...manual };
+      occupied.push({
+        id: item.id,
+        ...manual,
+        width: item.width,
+        height: item.height,
+      });
+    }
+
+    const maxRank = Math.max(0, ...items.map(item => item.rank));
+    const primaryStarts: number[] = [];
+    let primary = primaryOrigin;
+    for (let rank = 0; rank <= maxRank; rank += 1) {
+      primaryStarts[rank] = primary;
+      const rankItems = items.filter(item => item.rank === rank);
+      const largest = Math.max(
+        0,
+        ...rankItems.map(item =>
+          direction === "TB" ? item.height : item.width
+        )
+      );
+      primary += largest + input.rankSpacing;
+    }
+
+    for (let rank = 0; rank <= maxRank; rank += 1) {
+      let secondary = secondaryOrigin;
+      for (const item of items
+        .filter(entry => entry.rank === rank && !entry.manual)
+        .sort(
+          (left, right) =>
+            left.order - right.order || left.id.localeCompare(right.id)
+        )) {
+        const rect: DiagramLayoutRect & { id: string } = {
+          id: item.id,
+          x: direction === "TB" ? secondary : primaryStarts[rank],
+          y: direction === "TB" ? primaryStarts[rank] : secondary,
+          width: item.width,
+          height: item.height,
+        };
+        const maximumAttempts = items.length * 4 + 8;
+        let attempts = 0;
+        while (attempts < maximumAttempts) {
+          const collision = occupied.find(other => collide(rect, other, gap));
+          if (!collision) break;
+          secondary =
+            (direction === "TB"
+              ? collision.x + collision.width
+              : collision.y + collision.height) + gap;
+          if (direction === "TB") rect.x = secondary;
+          else rect.y = secondary;
+          attempts += 1;
+        }
+        if (attempts === maximumAttempts) {
+          secondary = Math.max(
+            secondaryOrigin,
+            ...occupied.map(other =>
+              direction === "TB"
+                ? other.x + other.width + gap
+                : other.y + other.height + gap
+            )
+          );
+          if (direction === "TB") rect.x = secondary;
+          else rect.y = secondary;
+        }
+        result[item.id] = { x: rect.x, y: rect.y };
+        occupied.push(rect);
+        secondary =
+          (direction === "TB" ? rect.x + rect.width : rect.y + rect.height) +
+          gap;
+      }
+    }
+    return result;
+  };
+
+  const hullFor = (ids: string[]): DiagramLayoutRect => {
+    const firstNode = nodeById.get(ids[0]) as DiagramLayoutNode;
+    const firstPosition = positions[ids[0]];
+    let left = firstPosition.x;
+    let top = firstPosition.y;
+    let right = left + firstNode.width;
+    let bottom = top + firstNode.height;
+    for (const id of ids.slice(1)) {
+      const node = nodeById.get(id) as DiagramLayoutNode;
+      const position = positions[id];
+      left = Math.min(left, position.x);
+      top = Math.min(top, position.y);
+      right = Math.max(right, position.x + node.width);
+      bottom = Math.max(bottom, position.y + node.height);
+    }
+    return { x: left, y: top, width: right - left, height: bottom - top };
+  };
+
+  const units: Unit[] = [];
+  for (const group of input.groups) {
+    const members = group.nodes
+      .map(id => nodeById.get(id) as DiagramLayoutNode)
+      .sort(
+        (left, right) =>
+          left.index - right.index || left.id.localeCompare(right.id)
+      );
+    const memberIds = members.map(member => member.id);
+    const orderById = new Map(members.map(member => [member.id, member.index]));
+    const ranks = ranksFor(memberIds, input.edges, orderById);
+    const internal = pack(
+      members.map(member => ({
+        id: member.id,
+        order: member.index,
+        width: member.width,
+        height: member.height,
+        rank: ranks[member.id],
+        manual: member.manual && { ...member.manual },
+      })),
+      input.nodeSpacing,
+      0
+    );
+    Object.assign(positions, internal);
+    const member = hullFor(memberIds);
+    const outer = {
+      x: member.x - group.outsets.left,
+      y: member.y - group.outsets.top,
+      width: member.width + group.outsets.left + group.outsets.right,
+      height: member.height + group.outsets.top + group.outsets.bottom,
+    };
+    groupGeometry[group.id] = { member, outer };
+    units.push({
+      id: `group:${group.id}`,
+      order: Math.min(...members.map(member => member.index)),
+      group: true,
+      groupId: group.id,
+      nodeIds: memberIds,
+      rect: outer,
+      fixed: members.some(member => Boolean(member.manual)),
+    });
+  }
+  for (const node of input.nodes) {
+    if (membership.has(node.id)) continue;
+    if (node.manual) positions[node.id] = { ...node.manual };
+    units.push({
+      id: `node:${node.id}`,
+      order: node.index,
+      group: false,
+      nodeIds: [node.id],
+      rect: {
+        x: node.manual?.x ?? 0,
+        y: node.manual?.y ?? 0,
+        width: node.width,
+        height: node.height,
+      },
+      fixed: Boolean(node.manual),
+    });
+  }
+  units.sort(
+    (left, right) => left.order - right.order || left.id.localeCompare(right.id)
+  );
+
+  const unitByNode = new Map<string, string>();
+  for (const unit of units) {
+    for (const id of unit.nodeIds) unitByNode.set(id, unit.id);
+  }
+  const unitEdges: DiagramLayoutEdge[] = [];
+  const seenUnitEdges = new Set<string>();
+  for (const edge of input.edges) {
+    const from = unitByNode.get(edge.from);
+    const to = unitByNode.get(edge.to);
+    if (!from || !to || from === to) continue;
+    const key = `${from}\0${to}`;
+    if (seenUnitEdges.has(key)) continue;
+    seenUnitEdges.add(key);
+    unitEdges.push({ from, to });
+  }
+  const unitIds = units.map(unit => unit.id);
+  const unitOrder = new Map(units.map((unit, index) => [unit.id, index]));
+  const unitRanks = ranksFor(unitIds, unitEdges, unitOrder);
+  const topPositions = pack(
+    units.map((unit, index) => ({
+      id: unit.id,
+      order: index,
+      width: unit.rect.width,
+      height: unit.rect.height,
+      rank: unitRanks[unit.id],
+      manual: unit.fixed ? { x: unit.rect.x, y: unit.rect.y } : undefined,
+    })),
+    input.nodeSpacing,
+    input.padding
+  );
+
+  for (const unit of units) {
+    const target = topPositions[unit.id];
+    const delta = {
+      x: target.x - unit.rect.x,
+      y: target.y - unit.rect.y,
+    };
+    if (!unit.fixed) {
+      for (const id of unit.nodeIds) {
+        const current = positions[id] ?? { x: 0, y: 0 };
+        positions[id] = { x: current.x + delta.x, y: current.y + delta.y };
+      }
+      unit.rect = { ...unit.rect, x: target.x, y: target.y };
+    }
+    if (unit.group && unit.groupId) {
+      const member = hullFor(unit.nodeIds);
+      const old = groupGeometry[unit.groupId];
+      groupGeometry[unit.groupId] = {
+        member,
+        outer: {
+          ...old.outer,
+          x: unit.rect.x,
+          y: unit.rect.y,
+        },
+      };
+    }
+  }
+
+  return {
+    fallback: null,
+    positions,
+    groups: groupGeometry,
+    units: units.map(unit => ({
+      id: unit.id,
+      rect: { ...unit.rect },
+      group: unit.group,
+    })),
+  };
+}


### PR DESCRIPTION
## 概要

#228 の座標なし layered auto-layout を **group 対応**にする。group 図（集約境界・コンテキスト境界）を**手座標なしで overlap なく**組めるようにし、レンダリング目視確認を不要にする（Issue のゴール）。

## 実装

- **二段構成**: group ごとに member を現行 SCC layered layout でサブレイアウト → group を**1つの合成ノード**にして、自由 node と共に上位 SCC layered layout へ配置。クラスタ間・クラスタ内・クラスタと自由 node の overlap をゼロに
- **可変高**: `getBoundingClientRect()` で node/group 境界を**実測**（ResizeObserver で再計算）。実測 bottom + spacing で次 slot → 2行 node と 6行 node を同じ高さ扱いしない
- **pure kernel を分離**: DOM 非依存の `diagram-layout.ts`（`layoutDiagram`）を Vitest で検証し、`layoutDiagram.toString()` を **compact して function literal でハーネスへ 1回だけ埋め込む**（単一ソース・複製なし・browser の `eval`/`new Function`/dynamic import は不使用）。**esbuild 後の inline 成立を build-artifact test（実 esbuild 実行）で担保**
- **後方互換**: `ext.x/y` は絶対優先（既存 promarche 2図は不動）。group 0件の通常図は #228 fast path を維持。#227 の group 境界（4 custom props）と合成矩形を一致。**重複 membership group は現行 layout に fallback**（境界描画は維持、group ネストは非ゴール）
- **非還流**: auto 座標は `graph.positionsById`/CSS のみ、model へ書き戻さない。`describeModelDiff`・production `diagram-diff.ts` 不変

## 検証（目視・スクショに依存しない）

- kernel unit: **9** PASS（DOM 参照 0 の pure 関数）
- 全 unit: **678** PASS
- E2E（Chromium/workers=1）: **55** PASS（うち **group-aware 6**：全 node pair・全 group boundary pair・boundary↔自由 node の**非重複を getBoundingClientRect で計算 assert**、cluster 保持、可変高 resize 後の再配置）
- `pnpm check` / `pnpm build` / `git diff --check`: PASS
- **注入サイズ実測 119,182 bytes** / guard 131,072（余裕 11.9KiB・**閾値変更なし**）・function literal 1回
- **実機プレビューで座標なし group 図（3集約・可変高フィールド・自由 node）を確認** → クラスタ保持・overlap なし

Closes #248
