### PR TITLE
flow state をユーザー専用 runtime directory へ移す (#219)

### DIFF
--- a/.claude/lib/cleanup.sh
+++ b/.claude/lib/cleanup.sh
@@ -14,6 +14,13 @@
 
 set -euo pipefail
 
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  echo "ERROR: CLAUDE_PROJECT_DIR が未設定です (cleanup.sh は project context から source してください)" >&2
+  return 1
+fi
+# shellcheck source=/dev/null
+source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"
+
 # === 公開関数 ===
 
 # PR を squash merge し、ローカル main を最新化する。
@@ -152,17 +159,23 @@ cleanup_flow_state_files() {
       return 1
       ;;
   esac
-  local base="${CLEANUP_FLOW_STATE_DIR:-/tmp}"
+  local base
+  if [ -n "${CLEANUP_FLOW_STATE_DIR:-}" ]; then
+    base="$CLEANUP_FLOW_STATE_DIR"
+  else
+    flow_state_dir_init || return 1
+    base="$FLOW_STATE_DIR"
+  fi
   # 削除対象 (state-io.sh / codex-gate.sh の出力に対応):
   #   final mode のみ削除 (flock 取得して atomic):
-  #     /tmp/flow-progress-<scope>.json
-  #     /tmp/flow-kpi-<scope>.json (削除前に flow-kpi-history.jsonl に append)
-  #     /tmp/flow-context-<scope>.json
+  #     flow-progress-<scope>.json
+  #     flow-kpi-<scope>.json (削除前に flow-kpi-history.jsonl に append)
+  #     flow-context-<scope>.json
   #   両 mode で削除:
-  #     /tmp/flow-{progress,kpi,context}-<scope>.json.new.* (atomic write 中間)
-  #     /tmp/codex-gate-<phase>-<scope>-<random>.txt (codex review log)
+  #     flow-{progress,kpi,context}-<scope>.json.new.* (atomic write 中間)
+  #     codex-gate-<phase>-<scope>-<random>.txt (codex review log)
   #   両 mode で残す:
-  #     /tmp/flow-<scope>.lock (state-io invariant)
+  #     flow-<scope>.lock (state-io invariant)
   local lock_file="$base/flow-${scope_key}.lock"
   # state-io 互換: lock file が無ければ作成 (state-io 側も touch ベースで作成する)
   : > "$lock_file" 2>/dev/null || true
@@ -276,7 +289,7 @@ cleanup_flow_state_files() {
         --arg now "$(date +%s)" \
         '{scope_key: $scope, branch: $branch, completed_at: ($now | tonumber), source: "cleanup_post_deploy(final)", archived: false}' \
         > "$base/flow-done-${scope_key}.json" 2>/dev/null; then
-      echo "WARNING: cleanup_flow_state_files: done sentinel 書き込み失敗 (/tmp 満杯 / 権限不足 等)、cleanup を中止 (KPI 未 archive、state 残置)" >&2
+      echo "WARNING: cleanup_flow_state_files: done sentinel 書き込み失敗 (flow state directory の容量不足 / 権限不足 等)、cleanup を中止 (KPI 未 archive、state 残置)" >&2
       rm -f "$base/flow-done-${scope_key}.json" 2>/dev/null
       return 0
     fi

--- a/.claude/lib/codex-gate.sh
+++ b/.claude/lib/codex-gate.sh
@@ -13,6 +13,13 @@
 
 set -euo pipefail
 
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  echo "ERROR: CLAUDE_PROJECT_DIR が未設定です (codex-gate.sh は project context から source してください)" >&2
+  return 1
+fi
+# shellcheck source=/dev/null
+source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"
+
 _run_codex() {
   if command -v codex >/dev/null 2>&1; then
     codex "$@"
@@ -82,13 +89,14 @@ _codex_gate_passed() {
 # 引数: $1 phase (P5/P8/P9), $2 scope_key
 # 戻り値: 0=PASS, 1=FAIL
 codex_gate_review() {
+  flow_state_dir_init || return 1
   local phase="$1"
   local scope_key="$2"
   local focus
   focus=$(_codex_phase_focus "$phase")
 
   CODEX_GATE_REASON=""
-  CODEX_GATE_OUTPUT=$(mktemp "/tmp/codex-gate-${phase}-${scope_key}-XXXXXX.txt")
+  CODEX_GATE_OUTPUT=$(mktemp "$FLOW_STATE_DIR/codex-gate-${phase}-${scope_key}-XXXXXX.txt")
 
   if ! _codex_available; then
     CODEX_GATE_REASON="codex CLI が利用できません (PATH にも mise にも見つかりません)"
@@ -119,6 +127,16 @@ codex_gate_review() {
   # ゲートが恒久 FAIL するため（2026-07-17 に実害を確認）。
   local final_output="${CODEX_GATE_OUTPUT}.final"
   : > "$final_output"  # 前回結果の残留による誤 PASS を防ぐ（fail-safe 判定の前提）
+  # ログはリダイレクトで直接ファイルへ書く。`| tee` + PIPESTATUS は bash 専用で、
+  # zsh (Claude の Bash ツールの実体) では PIPESTATUS が未定義 → set -u で即死する。
+  local exit_code
+  set +e
+  (
+    cd "$repo_root"
+    git diff --no-ext-diff origin/main...HEAD \
+      | _run_codex exec --skip-git-repo-check -s read-only \
+          -c 'model_reasoning_effort="high"' \
+          --output-last-message "$final_output" \
           "$prompt"
   ) > "$CODEX_GATE_OUTPUT" 2>&1
   exit_code=$?
@@ -159,13 +177,14 @@ codex_gate_max_p1_cycles() {
 
 # P2 plan ファイルに対する DDD レビュー。
 codex_gate_review_plan() {
+  flow_state_dir_init || return 1
   local plan_path="$1"
   local scope_key="$2"
   local focus
   focus=$(_codex_phase_focus "P2")
 
   CODEX_GATE_REASON=""
-  CODEX_GATE_OUTPUT=$(mktemp "/tmp/codex-gate-P2-${scope_key}-XXXXXX.txt")
+  CODEX_GATE_OUTPUT=$(mktemp "$FLOW_STATE_DIR/codex-gate-P2-${scope_key}-XXXXXX.txt")
 
   if ! _codex_available; then
     CODEX_GATE_REASON="codex CLI が利用できません"
@@ -223,10 +242,11 @@ codex_gate_review_plan() {
 }
 
 codex_gate_collect_new_findings() {
+  flow_state_dir_init || return 1
   local scope_key="$1"
   local seen_json
   seen_json=$(jq -r '.gate_findings_seen | join("\n")' \
-    "/tmp/flow-progress-${scope_key}.json" 2>/dev/null || echo "")
+    "$FLOW_STATE_DIR/flow-progress-${scope_key}.json" 2>/dev/null || echo "")
 
   grep -oE '[a-zA-Z0-9_./-]+:[0-9]+' "$CODEX_GATE_OUTPUT" 2>/dev/null \
     | sort -u \

--- a/.claude/lib/flow-state-dir.sh
+++ b/.claude/lib/flow-state-dir.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# flow / flow-x / flow-loop が共有する runtime state directory resolver。
+#
+# 明示 FLOW_STATE_DIR は信頼済み operator 入力として扱い、既存 path の permission
+# や ownership を変更しない。未指定時だけ secure default を作成・検証する。
+
+_flow_state_dir_error() {
+  echo "ERROR: flow state directory: $*" >&2
+  return 1
+}
+
+# GNU stat と BSD/macOS stat の差を吸収し、"<owner uid> <octal mode>" を返す。
+_flow_state_dir_stat() {
+  local target="$1"
+  local stat_output
+  if stat_output=$(stat -c '%u %a' "$target" 2>/dev/null); then
+    :
+  elif stat_output=$(stat -f '%u %Lp' "$target" 2>/dev/null); then
+    :
+  else
+    _flow_state_dir_error "stat に失敗しました: $target"
+    return 1
+  fi
+
+  local stat_uid stat_mode stat_extra
+  read -r stat_uid stat_mode stat_extra <<EOF
+$stat_output
+EOF
+  if [ -z "${stat_uid:-}" ] || [ -z "${stat_mode:-}" ] || [ -n "${stat_extra:-}" ]; then
+    _flow_state_dir_error "stat の出力を解釈できません: $target"
+    return 1
+  fi
+  case "$stat_uid" in
+    *[!0-9]*)
+      _flow_state_dir_error "stat owner が不正です: $target ($stat_uid)"
+      return 1
+      ;;
+  esac
+  case "$stat_mode" in
+    *[!0-7]*)
+      _flow_state_dir_error "stat mode が不正です: $target ($stat_mode)"
+      return 1
+      ;;
+  esac
+  printf '%s %s\n' "$stat_uid" "$stat_mode"
+}
+
+_flow_state_dir_normalize_mode() {
+  local normalized_mode="$1"
+  while [ "${normalized_mode#0}" != "$normalized_mode" ]; do
+    normalized_mode="${normalized_mode#0}"
+  done
+  printf '%s\n' "${normalized_mode:-0}"
+}
+
+_flow_state_dir_default() {
+  local runtime_base="${XDG_RUNTIME_DIR:-/tmp}"
+  local current_uid
+  current_uid=$(id -u) || {
+    _flow_state_dir_error "id -u に失敗しました"
+    return 1
+  }
+  printf '%s/ark-flow-%s\n' "${runtime_base%/}" "$current_uid"
+}
+
+# XDG_RUNTIME_DIR は明示された時だけ検証する。fallback の /tmp は sticky runtime
+# root として扱い、最終 user-specific directory を厳格検証する。
+_flow_state_dir_validate_xdg_runtime() {
+  local runtime_base="$1"
+  local current_uid="$2"
+  if [ -L "$runtime_base" ]; then
+    _flow_state_dir_error "XDG_RUNTIME_DIR が symlink です: $runtime_base"
+    return 1
+  fi
+  if [ ! -d "$runtime_base" ]; then
+    _flow_state_dir_error "XDG_RUNTIME_DIR が directory ではありません: $runtime_base"
+    return 1
+  fi
+
+  local stat_values stat_uid stat_mode mode_tail group_digit other_digit
+  stat_values=$(_flow_state_dir_stat "$runtime_base") || return 1
+  read -r stat_uid stat_mode <<EOF
+$stat_values
+EOF
+  if [ "$stat_uid" != "$current_uid" ]; then
+    _flow_state_dir_error \
+      "XDG_RUNTIME_DIR の owner が実行 user と一致しません: $runtime_base (owner=$stat_uid uid=$current_uid)"
+    return 1
+  fi
+
+  stat_mode=$(_flow_state_dir_normalize_mode "$stat_mode")
+  mode_tail=$(printf '%03d\n' "$stat_mode")
+  mode_tail="${mode_tail#"${mode_tail%???}"}"
+  group_digit="${mode_tail#?}"
+  group_digit="${group_digit%?}"
+  other_digit="${mode_tail#??}"
+  case "$group_digit$other_digit" in
+    *[2367]*)
+      _flow_state_dir_error \
+        "XDG_RUNTIME_DIR が group/other writable です: $runtime_base (mode=$stat_mode)"
+      return 1
+      ;;
+  esac
+}
+
+_flow_state_dir_validate_default() {
+  local candidate="$1"
+  local current_uid="$2"
+  if [ -L "$candidate" ]; then
+    _flow_state_dir_error "secure default が symlink です: $candidate"
+    return 1
+  fi
+  if [ ! -d "$candidate" ]; then
+    _flow_state_dir_error "secure default が directory ではありません: $candidate"
+    return 1
+  fi
+
+  local stat_values stat_uid stat_mode
+  stat_values=$(_flow_state_dir_stat "$candidate") || return 1
+  read -r stat_uid stat_mode <<EOF
+$stat_values
+EOF
+  stat_mode=$(_flow_state_dir_normalize_mode "$stat_mode")
+  if [ "$stat_uid" != "$current_uid" ]; then
+    _flow_state_dir_error \
+      "secure default の owner が実行 user と一致しません: $candidate (owner=$stat_uid uid=$current_uid)"
+    return 1
+  fi
+  if [ "$stat_mode" != "700" ]; then
+    _flow_state_dir_error \
+      "secure default の mode が 0700 ではありません: $candidate (mode=$stat_mode)"
+    return 1
+  fi
+}
+
+_flow_state_dir_warn_override() {
+  local override_dir="$1"
+  local current_uid="$2"
+  local warning_reason=""
+  if [ -L "$override_dir" ]; then
+    warning_reason="symlink"
+  elif [ ! -d "$override_dir" ]; then
+    warning_reason="directory ではない entry"
+  else
+    local stat_values stat_uid stat_mode
+    if ! stat_values=$(_flow_state_dir_stat "$override_dir" 2>/dev/null); then
+      warning_reason="stat 不能"
+    else
+      read -r stat_uid stat_mode <<EOF
+$stat_values
+EOF
+      stat_mode=$(_flow_state_dir_normalize_mode "$stat_mode")
+      if [ "$stat_uid" != "$current_uid" ] || [ "$stat_mode" != "700" ]; then
+        warning_reason="owner/mode が secure default 契約外 (owner=$stat_uid mode=$stat_mode)"
+      fi
+    fi
+  fi
+  if [ -n "$warning_reason" ]; then
+    echo "WARNING: FLOW_STATE_DIR override を検証せず使用します ($warning_reason): $override_dir" >&2
+  fi
+}
+
+flow_state_dir_init() {
+  if [ "${FLOW_STATE_DIR_INITIALIZED:-}" = "1" ]; then
+    if [ "${FLOW_STATE_DIR_SECURE_DEFAULT:-}" = "1" ]; then
+      _flow_state_dir_validate_default "$FLOW_STATE_DIR" "$(id -u)" || return 1
+    fi
+    return 0
+  fi
+
+  local current_uid
+  current_uid=$(id -u) || {
+    _flow_state_dir_error "id -u に失敗しました"
+    return 1
+  }
+
+  if [ -n "${FLOW_STATE_DIR:-}" ]; then
+    if [ ! -e "$FLOW_STATE_DIR" ] && [ ! -L "$FLOW_STATE_DIR" ]; then
+      mkdir -m 700 -p "$FLOW_STATE_DIR" || {
+        _flow_state_dir_error "FLOW_STATE_DIR override を作成できません: $FLOW_STATE_DIR"
+        return 1
+      }
+    fi
+    _flow_state_dir_warn_override "$FLOW_STATE_DIR" "$current_uid"
+    FLOW_STATE_DIR_INITIALIZED=1
+    FLOW_STATE_DIR_SECURE_DEFAULT=0
+    export FLOW_STATE_DIR FLOW_STATE_DIR_INITIALIZED FLOW_STATE_DIR_SECURE_DEFAULT
+    return 0
+  fi
+
+  if [ -n "${XDG_RUNTIME_DIR:-}" ]; then
+    _flow_state_dir_validate_xdg_runtime "$XDG_RUNTIME_DIR" "$current_uid" || return 1
+  fi
+
+  local candidate
+  candidate=$(_flow_state_dir_default) || return 1
+  if [ -L "$candidate" ]; then
+    _flow_state_dir_error "secure default が既存 symlink です: $candidate"
+    return 1
+  fi
+  mkdir -m 700 -p "$candidate" || {
+    _flow_state_dir_error "secure default を作成できません: $candidate"
+    return 1
+  }
+  _flow_state_dir_validate_default "$candidate" "$current_uid" || return 1
+
+  FLOW_STATE_DIR="$candidate"
+  FLOW_STATE_DIR_INITIALIZED=1
+  FLOW_STATE_DIR_SECURE_DEFAULT=1
+  export FLOW_STATE_DIR FLOW_STATE_DIR_INITIALIZED FLOW_STATE_DIR_SECURE_DEFAULT
+}

--- a/.claude/lib/state-io.sh
+++ b/.claude/lib/state-io.sh
@@ -17,6 +17,13 @@
 
 set -euo pipefail
 
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  echo "ERROR: CLAUDE_PROJECT_DIR が未設定です (state-io.sh は project context から source してください)" >&2
+  return 1
+fi
+# shellcheck source=/dev/null
+source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"
+
 # === 内部ヘルパー ===
 
 # work_id から SCOPE_KEY を計算する。
@@ -34,12 +41,12 @@ _flow_scope_key() {
 _flow_state_file() {
   local type="$1"
   local key="$2"
-  printf '/tmp/flow-%s-%s.json\n' "$type" "$key"
+  printf '%s/flow-%s-%s.json\n' "$FLOW_STATE_DIR" "$type" "$key"
 }
 
 _flow_lock_file() {
   local key="$1"
-  printf '/tmp/flow-%s.lock\n' "$key"
+  printf '%s/flow-%s.lock\n' "$FLOW_STATE_DIR" "$key"
 }
 
 _flow_gen_run_id() {
@@ -58,6 +65,7 @@ _flow_gen_run_id() {
 # state 3 ファイルを初期化する。
 # 引数: $1 work_id (issue-<N> or slug), $2 branch, $3 worktree_path, [$4 issue_number]
 flow_state_init() {
+  flow_state_dir_init || return 1
   local work_id="$1"
   local branch="$2"
   local worktree_path="$3"
@@ -172,6 +180,7 @@ flow_state_init() {
 # state JSON のフィールドを read する。
 # 引数: $1 type (progress|kpi|context), $2 jq_filter, $3 scope_key
 flow_state_read() {
+  flow_state_dir_init || return 1
   local type="$1"
   local filter="$2"
   local key="$3"
@@ -188,6 +197,7 @@ flow_state_read() {
 # state JSON のフィールドを atomic rename で update する。
 # 引数: $1 type, $2 jq_assign_expr, $3 scope_key
 flow_state_update() {
+  flow_state_dir_init || return 1
   local type="$1"
   local expr="$2"
   local key="$3"
@@ -212,6 +222,7 @@ flow_state_update() {
 
 # stale state を判定する。1h 経過 + owner_pid 死亡で stale。
 flow_state_is_stale() {
+  flow_state_dir_init || return 1
   local key="$1"
   local file lock
   file=$(_flow_state_file progress "$key")
@@ -237,6 +248,7 @@ flow_state_is_stale() {
 }
 
 flow_state_cleanup_stale() {
+  flow_state_dir_init || return 1
   local key="$1"
   local lock progress_file
   lock=$(_flow_lock_file "$key")
@@ -273,6 +285,7 @@ flow_state_cleanup_stale() {
 }
 
 flow_state_exists() {
+  flow_state_dir_init || return 1
   local key="$1"
   [ -f "$(_flow_state_file progress "$key")" ] \
     && [ -f "$(_flow_state_file kpi "$key")" ] \

--- a/.claude/lib/tests/test-cleanup.sh
+++ b/.claude/lib/tests/test-cleanup.sh
@@ -56,7 +56,9 @@ assert_file_present() {
 }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 CLEANUP_LIB="$SCRIPT_DIR/../cleanup.sh"
+export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
 
 # pre-flight: jq が無いと KPI archive のテストが意味を成さない
 if ! command -v jq >/dev/null 2>&1; then
@@ -71,7 +73,8 @@ source "$CLEANUP_LIB"
 
 # テスト用 tmpdir を確保 (本物の /tmp を汚さない)
 TMP_TEST_DIR=$(mktemp -d "/tmp/test-cleanup-flow-state.XXXXXX")
-trap 'rm -rf "$TMP_TEST_DIR"' EXIT
+LEGACY_SCOPE="cleanup-common-$$"
+trap 'rm -rf "$TMP_TEST_DIR"; rm -f "/tmp/flow-$LEGACY_SCOPE.lock"' EXIT
 
 # cleanup_flow_state_files が参照する base dir を CLEANUP_FLOW_STATE_DIR で差し替える
 export CLEANUP_FLOW_STATE_DIR="$TMP_TEST_DIR"
@@ -289,6 +292,43 @@ else
   PASSES=$((PASSES + 1))
   echo -e "${GREEN}PASS${NC}: cleanup_post_deploy は空 scope_key で fail-fast"
 fi
+
+echo ""
+echo "--- cleanup override priority: specific > common > secure default ---"
+COMMON_STATE_DIR="$TMP_TEST_DIR/common"
+SPECIFIC_STATE_DIR="$TMP_TEST_DIR/specific"
+mkdir -m 700 "$COMMON_STATE_DIR" "$SPECIFIC_STATE_DIR"
+
+unset CLEANUP_FLOW_STATE_DIR
+export FLOW_STATE_DIR="$COMMON_STATE_DIR"
+echo '{"phase":"done","branch":"feature/common"}' > "$COMMON_STATE_DIR/flow-progress-${LEGACY_SCOPE}.json"
+echo '{"scope":"common"}' > "$COMMON_STATE_DIR/flow-kpi-${LEGACY_SCOPE}.json"
+touch "$COMMON_STATE_DIR/flow-context-${LEGACY_SCOPE}.json" \
+  "$COMMON_STATE_DIR/codex-gate-P5-${LEGACY_SCOPE}-AAAAAA.txt" \
+  "$COMMON_STATE_DIR/flow-progress-${LEGACY_SCOPE}.json.new.123"
+cleanup_flow_state_files "$LEGACY_SCOPE" final
+assert_file_absent "CLEANUP 未指定時は FLOW_STATE_DIR の state を削除する" \
+  "$COMMON_STATE_DIR/flow-progress-${LEGACY_SCOPE}.json"
+assert_file_present "CLEANUP 未指定時は FLOW_STATE_DIR に done sentinel を作る" \
+  "$COMMON_STATE_DIR/flow-done-${LEGACY_SCOPE}.json"
+assert_file_present "CLEANUP 未指定時は FLOW_STATE_DIR に KPI history を作る" \
+  "$COMMON_STATE_DIR/flow-kpi-history.jsonl"
+assert_file_absent "CLEANUP 未指定時は FLOW_STATE_DIR の codex log を削除する" \
+  "$COMMON_STATE_DIR/codex-gate-P5-${LEGACY_SCOPE}-AAAAAA.txt"
+assert_file_absent "CLEANUP 未指定時は FLOW_STATE_DIR の atomic tmp を削除する" \
+  "$COMMON_STATE_DIR/flow-progress-${LEGACY_SCOPE}.json.new.123"
+
+PRIORITY_SCOPE="cleanup-priority-$$"
+export CLEANUP_FLOW_STATE_DIR="$SPECIFIC_STATE_DIR"
+echo '{"phase":"done","branch":"feature/specific"}' > "$SPECIFIC_STATE_DIR/flow-progress-${PRIORITY_SCOPE}.json"
+echo '{"scope":"specific"}' > "$SPECIFIC_STATE_DIR/flow-kpi-${PRIORITY_SCOPE}.json"
+touch "$SPECIFIC_STATE_DIR/flow-context-${PRIORITY_SCOPE}.json"
+echo '{"phase":"done","branch":"feature/common"}' > "$COMMON_STATE_DIR/flow-progress-${PRIORITY_SCOPE}.json"
+cleanup_flow_state_files "$PRIORITY_SCOPE" final
+assert_file_absent "両方指定時は CLEANUP_FLOW_STATE_DIR が優先される" \
+  "$SPECIFIC_STATE_DIR/flow-progress-${PRIORITY_SCOPE}.json"
+assert_file_present "限定 override 使用時は FLOW_STATE_DIR 側を処理しない" \
+  "$COMMON_STATE_DIR/flow-progress-${PRIORITY_SCOPE}.json"
 
 echo ""
 echo "========================================"

--- a/.claude/lib/tests/test-codex-gate-sentinel.sh
+++ b/.claude/lib/tests/test-codex-gate-sentinel.sh
@@ -16,11 +16,16 @@ GREEN='\033[0;32m'
 NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../codex-gate.sh"
 
 TMP_TEST_DIR=$(mktemp -d "/tmp/test-codex-gate-sentinel.XXXXXX")
-trap 'rm -rf "$TMP_TEST_DIR"' EXIT
+export FLOW_STATE_DIR="$TMP_TEST_DIR/state"
+mkdir -m 700 "$FLOW_STATE_DIR"
+COLLECT_SCOPE="codex-gate-collect-$$"
+trap 'rm -rf "$TMP_TEST_DIR"; rm -f "/tmp/flow-progress-$COLLECT_SCOPE.json"' EXIT
 
 # assert_gate <description> <expected: pass|fail> <file content...>
 assert_gate() {
@@ -82,6 +87,70 @@ assert_gate "GATE_PASS 無し・マーカー無しの本文のみは FAIL" fail 
 assert_gate "本文中の [P0] 引用は fail-safe で FAIL (誤 PASS しない)" fail \
 'このゲートは [P0] マーカーを検出します、という説明。
 GATE_PASS'
+
+echo ""
+echo "=== codex gate output / finding state directory ==="
+PLAN_FILE="$TMP_TEST_DIR/plan.md"
+printf '%s\n' '# test plan' > "$PLAN_FILE"
+_codex_available() { return 0; }
+_run_codex() {
+  local previous=""
+  local argument
+  for argument in "$@"; do
+    if [ "$previous" = "--output-last-message" ]; then
+      printf '%s\n' "GATE_PASS" > "$argument"
+      break
+    fi
+    previous="$argument"
+  done
+  # review gate は git diff を stdin で渡すため、実 codex と同様に最後まで消費する。
+  command cat >/dev/null || true
+  printf '%s\n' "stub codex log"
+}
+
+TESTS=$((TESTS + 1))
+if codex_gate_review_plan "$PLAN_FILE" "$COLLECT_SCOPE" >/dev/null 2>&1 \
+  && [ "${CODEX_GATE_OUTPUT#"$FLOW_STATE_DIR/"}" != "$CODEX_GATE_OUTPUT" ] \
+  && [ -f "$CODEX_GATE_OUTPUT" ] \
+  && [ -f "${CODEX_GATE_OUTPUT}.final" ]; then
+  PASSES=$((PASSES + 1))
+  echo -e "${GREEN}PASS${NC}: gate log と .final は FLOW_STATE_DIR 配下に作られる"
+else
+  FAILURES=$((FAILURES + 1))
+  echo -e "${RED}FAIL${NC}: gate log または .final が FLOW_STATE_DIR 配下に作られない"
+fi
+
+TESTS=$((TESTS + 1))
+if codex_gate_review "P5" "$COLLECT_SCOPE" >/dev/null 2>&1 \
+  && [ "${CODEX_GATE_OUTPUT#"$FLOW_STATE_DIR/"}" != "$CODEX_GATE_OUTPUT" ] \
+  && [ -f "$CODEX_GATE_OUTPUT" ] \
+  && [ -f "${CODEX_GATE_OUTPUT}.final" ]; then
+  PASSES=$((PASSES + 1))
+  echo -e "${GREEN}PASS${NC}: 通常 gate phase の log と .final も FLOW_STATE_DIR 配下に作られる"
+else
+  FAILURES=$((FAILURES + 1))
+  echo -e "${RED}FAIL${NC}: 通常 gate phase の log または .final が FLOW_STATE_DIR 配下に作られない"
+fi
+
+SEEN_MSG="src/seen.ts:10 existing finding"
+NEW_MSG="src/new.ts:20 new finding"
+SEEN_FP=$(_codex_fingerprint "src/seen.ts" "10" "$SEEN_MSG")
+printf '{"gate_findings_seen":["%s"]}\n' "$SEEN_FP" \
+  > "$FLOW_STATE_DIR/flow-progress-$COLLECT_SCOPE.json"
+CODEX_GATE_OUTPUT="$TMP_TEST_DIR/findings.txt"
+printf '%s\n%s\n' "$SEEN_MSG" "$NEW_MSG" > "$CODEX_GATE_OUTPUT"
+EXPECTED_NEW_FP=$(_codex_fingerprint "src/new.ts" "20" "$NEW_MSG")
+ACTUAL_NEW_FP=$(codex_gate_collect_new_findings "$COLLECT_SCOPE")
+TESTS=$((TESTS + 1))
+if [ "$ACTUAL_NEW_FP" = "$EXPECTED_NEW_FP" ]; then
+  PASSES=$((PASSES + 1))
+  echo -e "${GREEN}PASS${NC}: finding 重複判定は FLOW_STATE_DIR 配下の progress を読む"
+else
+  FAILURES=$((FAILURES + 1))
+  echo -e "${RED}FAIL${NC}: finding 重複判定が FLOW_STATE_DIR 配下の progress を読まない"
+  echo "  expected: $EXPECTED_NEW_FP"
+  echo "  actual:   $ACTUAL_NEW_FP"
+fi
 
 echo ""
 echo "========================================"

--- a/.claude/lib/tests/test-flow-state-dir.sh
+++ b/.claude/lib/tests/test-flow-state-dir.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# =============================================================================
+# flow state directory resolver の security contract / integration audit
+# =============================================================================
+set -uo pipefail
+
+TESTS=0
+PASSES=0
+FAILURES=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  TESTS=$((TESTS + 1))
+  if [ "$expected" = "$actual" ]; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+assert_success() {
+  local description="$1"
+  shift
+  TESTS=$((TESTS + 1))
+  if "$@"; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+  fi
+}
+
+assert_failure_reason() {
+  local description="$1"
+  local expected_reason="$2"
+  shift 2
+  local output rc
+  output=$("$@" 2>&1)
+  rc=$?
+  TESTS=$((TESTS + 1))
+  if [ "$rc" -ne 0 ] && printf '%s\n' "$output" | grep -q "$expected_reason"; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+    echo "  expected non-zero and diagnostic containing: $expected_reason"
+    echo "  rc: $rc"
+    echo "  output: $output"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+RESOLVER="$SCRIPT_DIR/../flow-state-dir.sh"
+
+if [ ! -f "$RESOLVER" ]; then
+  echo -e "${RED}FAIL${NC}: resolver が存在しない: $RESOLVER"
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$RESOLVER"
+
+TMP_TEST_DIR=$(mktemp -d "/tmp/test-flow-state-dir.XXXXXX")
+FALLBACK_DIR="/tmp/ark-flow-$(id -u)"
+trap 'rm -rf "$TMP_TEST_DIR"' EXIT
+
+REAL_STAT=$(command -v stat)
+
+run_default_init() {
+  env -u FLOW_STATE_DIR -u XDG_RUNTIME_DIR \
+    CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+    bash -c 'source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"; flow_state_dir_init >/dev/null'
+}
+
+run_xdg_init() {
+  local xdg_dir="$1"
+  env -u FLOW_STATE_DIR XDG_RUNTIME_DIR="$xdg_dir" \
+    CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+    bash -c 'source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"; flow_state_dir_init >/dev/null'
+}
+
+echo "=== secure default path / creation ==="
+unset FLOW_STATE_DIR XDG_RUNTIME_DIR
+assert_eq "XDG 未設定時の既定 path" \
+  "$FALLBACK_DIR" "$(_flow_state_dir_default)"
+assert_success "XDG 未設定時の既定 directory を初期化できる" run_default_init
+assert_eq "fallback directory mode は 0700" "700" "$("$REAL_STAT" -c '%a' "$FALLBACK_DIR")"
+
+XDG_OK="$TMP_TEST_DIR/xdg-ok"
+mkdir -m 700 "$XDG_OK"
+unset FLOW_STATE_DIR
+export XDG_RUNTIME_DIR="$XDG_OK"
+assert_eq "XDG 設定時の既定 path" \
+  "$XDG_OK/ark-flow-$(id -u)" "$(_flow_state_dir_default)"
+assert_success "XDG 配下に既定 directory を作成できる" run_xdg_init "$XDG_OK"
+assert_eq "XDG 配下の新規 directory mode は 0700" \
+  "700" "$("$REAL_STAT" -c '%a' "$XDG_OK/ark-flow-$(id -u)")"
+assert_success "既存 0700 directory は冪等に成功する" run_xdg_init "$XDG_OK"
+
+echo ""
+echo "=== fail-closed invariants ==="
+XDG_BAD_MODE="$TMP_TEST_DIR/xdg-bad-mode"
+mkdir -m 700 "$XDG_BAD_MODE"
+mkdir -m 755 "$XDG_BAD_MODE/ark-flow-$(id -u)"
+assert_failure_reason "既存 mode 0755 を拒否する" "mode" run_xdg_init "$XDG_BAD_MODE"
+
+XDG_SYMLINK="$TMP_TEST_DIR/xdg-symlink"
+XDG_SYMLINK_TARGET="$TMP_TEST_DIR/xdg-symlink-target"
+mkdir -m 700 "$XDG_SYMLINK" "$XDG_SYMLINK_TARGET"
+ln -s "$XDG_SYMLINK_TARGET" "$XDG_SYMLINK/ark-flow-$(id -u)"
+assert_failure_reason "既存 symlink を拒否する" "symlink" run_xdg_init "$XDG_SYMLINK"
+
+make_stat_stub() {
+  local stub_dir="$1"
+  local flavor="$2"
+  mkdir -p "$stub_dir"
+  if [ "$flavor" = "gnu" ]; then
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'if [ "${1:-}" = "-c" ]; then printf "%s %s\n" "$FLOW_TEST_STAT_UID" "$FLOW_TEST_STAT_MODE"; exit 0; fi' \
+      'exit 1' > "$stub_dir/stat"
+  elif [ "$flavor" = "bsd" ]; then
+    printf '%s\n' \
+      '#!/usr/bin/env bash' \
+      'if [ "${1:-}" = "-c" ]; then exit 1; fi' \
+      'if [ "${1:-}" = "-f" ]; then printf "%s %s\n" "$FLOW_TEST_STAT_UID" "$FLOW_TEST_STAT_MODE"; exit 0; fi' \
+      'exit 1' > "$stub_dir/stat"
+  else
+    printf '%s\n' '#!/usr/bin/env bash' 'exit 1' > "$stub_dir/stat"
+  fi
+  chmod 700 "$stub_dir/stat"
+}
+
+run_stubbed_default_init() {
+  local stub_dir="$1"
+  local uid="$2"
+  local mode="$3"
+  env -u FLOW_STATE_DIR -u XDG_RUNTIME_DIR \
+    PATH="$stub_dir:$PATH" \
+    FLOW_TEST_STAT_UID="$uid" \
+    FLOW_TEST_STAT_MODE="$mode" \
+    CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+    bash -c 'source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"; flow_state_dir_init >/dev/null'
+}
+
+GNU_STUB="$TMP_TEST_DIR/stat-gnu"
+BSD_STUB="$TMP_TEST_DIR/stat-bsd"
+ERROR_STUB="$TMP_TEST_DIR/stat-error"
+make_stat_stub "$GNU_STUB" gnu
+make_stat_stub "$BSD_STUB" bsd
+make_stat_stub "$ERROR_STUB" error
+
+assert_failure_reason "foreign UID を拒否する (root 権限不要 stub)" "owner" \
+  run_stubbed_default_init "$GNU_STUB" "$(( $(id -u) + 1 ))" 700
+assert_success "GNU stat 形式を受理する" \
+  run_stubbed_default_init "$GNU_STUB" "$(id -u)" 700
+assert_success "BSD stat 形式へ fallback できる" \
+  run_stubbed_default_init "$BSD_STUB" "$(id -u)" 700
+assert_failure_reason "stat 不能を拒否する" "stat" \
+  run_stubbed_default_init "$ERROR_STUB" "$(id -u)" 700
+
+XDG_UNSAFE="$TMP_TEST_DIR/xdg-unsafe"
+mkdir -m 770 "$XDG_UNSAFE"
+assert_failure_reason "明示 XDG_RUNTIME_DIR の group-writable mode を拒否する" \
+  "XDG_RUNTIME_DIR" run_xdg_init "$XDG_UNSAFE"
+
+XDG_LINK_TARGET="$TMP_TEST_DIR/xdg-link-target"
+XDG_LINK="$TMP_TEST_DIR/xdg-link"
+mkdir -m 700 "$XDG_LINK_TARGET"
+ln -s "$XDG_LINK_TARGET" "$XDG_LINK"
+assert_failure_reason "symlink の XDG_RUNTIME_DIR を拒否する" \
+  "XDG_RUNTIME_DIR" run_xdg_init "$XDG_LINK"
+
+OVERRIDE_INSECURE="$TMP_TEST_DIR/operator-override"
+mkdir -m 755 "$OVERRIDE_INSECURE"
+OVERRIDE_OUTPUT=$(FLOW_STATE_DIR="$OVERRIDE_INSECURE" \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" bash -c \
+  'source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"; flow_state_dir_init; printf "%s" "$FLOW_STATE_DIR"' \
+  2>&1)
+assert_eq "明示 FLOW_STATE_DIR は insecure mode でも拒否せず同じ path を使う" \
+  "$OVERRIDE_INSECURE" "$(printf '%s\n' "$OVERRIDE_OUTPUT" | tail -1)"
+assert_eq "明示 FLOW_STATE_DIR の mode を chmod で修復しない" \
+  "755" "$("$REAL_STAT" -c '%a' "$OVERRIDE_INSECURE")"
+assert_success "明示 FLOW_STATE_DIR が契約外なら security opt-out warning を出す" \
+  bash -c "printf '%s\n' \"\$1\" | grep -q 'WARNING: FLOW_STATE_DIR override'" _ "$OVERRIDE_OUTPUT"
+
+if command -v zsh >/dev/null 2>&1; then
+  ZSH_XDG="$TMP_TEST_DIR/xdg-zsh"
+  mkdir -m 700 "$ZSH_XDG"
+  assert_success "zsh でも secure default resolver が動く" \
+    env -u FLOW_STATE_DIR XDG_RUNTIME_DIR="$ZSH_XDG" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+      zsh -c 'source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"; flow_state_dir_init; [ "$FLOW_STATE_DIR" = "$XDG_RUNTIME_DIR/ark-flow-$(id -u)" ]'
+fi
+
+echo ""
+echo "=== SKILL snippets / production literal audit ==="
+assert_success "flow SKILL.md に /tmp/flow-* 直書きがない" \
+  bash -c "! grep -nE '/tmp/(flow-)' '$PROJECT_DIR/.claude/skills/flow/SKILL.md'"
+assert_success "flow-x SKILL.md に /tmp/flow-*・flowx-*・codex-* 直書きがない" \
+  bash -c "! grep -nE '/tmp/(flow-|flowx-|codex-)' '$PROJECT_DIR/.claude/skills/flow-x/SKILL.md'"
+assert_success "flow-loop SKILL.md に /tmp/flow-* 直書きがない" \
+  bash -c "! grep -nE '/tmp/(flow-)' '$PROJECT_DIR/.claude/skills/flow-loop/SKILL.md'"
+
+AUDIT_OUTPUT=$(rg -n '/tmp/(flow-|flowx-|codex-)' \
+  "$PROJECT_DIR"/.claude/lib/*.sh \
+  "$PROJECT_DIR"/.claude/skills/flow-loop/lib/*.sh \
+  "$PROJECT_DIR"/.claude/skills/flow/SKILL.md \
+  "$PROJECT_DIR"/.claude/skills/flow-x/SKILL.md \
+  "$PROJECT_DIR"/.claude/skills/flow-loop/SKILL.md 2>/dev/null || true)
+TESTS=$((TESTS + 1))
+if [ -z "$AUDIT_OUTPUT" ]; then
+  PASSES=$((PASSES + 1))
+  echo -e "${GREEN}PASS${NC}: production script / SKILL.md の flow/codex /tmp literal は 0 件"
+else
+  FAILURES=$((FAILURES + 1))
+  echo -e "${RED}FAIL${NC}: production script / SKILL.md に flow/codex /tmp literal が残存"
+  printf '%s\n' "$AUDIT_OUTPUT"
+fi
+
+echo ""
+echo "========================================"
+echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"
+echo "========================================"
+[ "$FAILURES" -eq 0 ]

--- a/.claude/lib/tests/test-zsh-compat.sh
+++ b/.claude/lib/tests/test-zsh-compat.sh
@@ -46,18 +46,53 @@ require_zsh
 # scope はテスト専用の一意な値にする (固定値 issue-9999 だと、万一同名の本番 run が
 # 進行中の場合にその state をテストが破壊するため。pid で衝突を避ける)
 SK="zshcompat-test-$$"
-cleanup_state() { rm -f /tmp/flow-progress-"$SK".json /tmp/flow-kpi-"$SK".json \
-  /tmp/flow-context-"$SK".json /tmp/flow-"$SK".lock /tmp/flow-progress-"$SK".json.new.* 2>/dev/null; }
+TMP_STATE=$(mktemp -d "/tmp/test-zsh-flow-state.XXXXXX")
+cleanup_state() {
+  rm -f "$TMP_STATE"/flow-progress-"$SK".json "$TMP_STATE"/flow-kpi-"$SK".json \
+    "$TMP_STATE"/flow-context-"$SK".json "$TMP_STATE"/flow-"$SK".lock \
+    "$TMP_STATE"/flow-progress-"$SK".json.new.* \
+    /tmp/flow-progress-"$SK".json /tmp/flow-kpi-"$SK".json \
+    /tmp/flow-context-"$SK".json /tmp/flow-"$SK".lock \
+    /tmp/flow-progress-"$SK".json.new.* 2>/dev/null
+}
+trap 'cleanup_state; rm -rf "$TMP_STATE"' EXIT
 cleanup_state
 phase_after_update=$(zsh -c "
   setopt aliases 2>/dev/null
   alias mv='mv -i'
+  export CLAUDE_PROJECT_DIR='$REPO_ROOT'
+  export FLOW_STATE_DIR='$TMP_STATE'
   source '$LIB_DIR/state-io.sh'
   sk=\$(flow_state_init '$SK' 'feature/$SK' /tmp/zshcompat-wt 2>/dev/null) || exit 7
   flow_state_update progress '.phase = \"P2\"' \"\$sk\" </dev/null 2>/dev/null
   flow_state_read progress '.phase' \"\$sk\"
 " 2>/dev/null)
 assert_eq "state-io: zsh の mv -i エイリアス下でも phase 更新が反映される" "P2" "$phase_after_update"
+assert_eq "state-io: progress は FLOW_STATE_DIR 配下に作られる" \
+  "yes" "$([ -f "$TMP_STATE/flow-progress-$SK.json" ] && echo yes || echo no)"
+assert_eq "state-io: kpi は FLOW_STATE_DIR 配下に作られる" \
+  "yes" "$([ -f "$TMP_STATE/flow-kpi-$SK.json" ] && echo yes || echo no)"
+assert_eq "state-io: context は FLOW_STATE_DIR 配下に作られる" \
+  "yes" "$([ -f "$TMP_STATE/flow-context-$SK.json" ] && echo yes || echo no)"
+assert_eq "state-io: scope lock は FLOW_STATE_DIR 配下に作られる" \
+  "yes" "$([ -f "$TMP_STATE/flow-$SK.lock" ] && echo yes || echo no)"
+assert_eq "state-io: atomic update の中間 file が残らない" \
+  "0" "$(find "$TMP_STATE" -maxdepth 1 -name '*.new.*' -type f | wc -l | tr -d ' ')"
+
+# deploy-watch は外部状態判定を stub し、context update の配置だけを integration 確認する。
+deploy_merge_sha="0123456789abcdef"
+deploy_context=$(zsh -c "
+  export CLAUDE_PROJECT_DIR='$REPO_ROOT'
+  export FLOW_STATE_DIR='$TMP_STATE'
+  source '$LIB_DIR/state-io.sh'
+  source '$LIB_DIR/deploy-watch.sh'
+  deploy_watch_has_target() { return 1; }
+  _deploy_watch_pm2_online() { return 1; }
+  deploy_watch_init '$SK' '$deploy_merge_sha'
+  flow_state_read context '.deploy_watch.merge_sha' '$SK'
+" 2>/dev/null)
+assert_eq "deploy-watch: context update は FLOW_STATE_DIR 配下の state を更新する" \
+  "$deploy_merge_sha" "$deploy_context"
 cleanup_state
 
 # -----------------------------------------------------------------------------

--- a/.claude/skills/flow-loop/SKILL.md
+++ b/.claude/skills/flow-loop/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash, PushNotification, Read, Edit, Write, Glob, Grep, Agent, Ski
 
 `/flow-x` の**外殻となる運転ループ**。1 作業の自走 (flow-x) を「バックログを回し続ける」に昇華する。
 
-- **原則 1: tick は何も待たない。** 毎回 state (`/tmp/flow-progress-*.json`) と外部状態 (PR Review・CI・CodeRabbit・deploy) を突き合わせ、シグナルが揃った run だけ前進させて終わる (冪等)。人間の判断は「AskUserQuestion への返答」ではなく「PR 上の状態」としてループが拾う。Monitor / CronCreate による run ごとのセッション内待機 (P7 / P12) も tick のポーリングに置き換わるため、**セッションを拘束しない**。
+- **原則 1: tick は何も待たない。** 毎回 state (`$FLOW_LOOP_RUNS_DIR/flow-progress-*.json`) と外部状態 (PR Review・CI・CodeRabbit・deploy) を突き合わせ、シグナルが揃った run だけ前進させて終わる (冪等)。人間の判断は「AskUserQuestion への返答」ではなく「PR 上の状態」としてループが拾う。Monitor / CronCreate による run ごとのセッション内待機 (P7 / P12) も tick のポーリングに置き換わるため、**セッションを拘束しない**。
 - **原則 2: 人間ゲートは不変。** P2.5 設計承認と P10 マージ確認の 2 つは廃止しない。待ち方だけが変わる (コメント「承認」`ok` `lgtm` `approve` /「修正: …」・PR Review・Close。検知仕様は flow-x「非同期ゲートモード」)。設計承認は **plan をコミットした draft PR** で取る (plan/spec は成果物としてコミットし作業の PR に含める)。**author 本人の PR は GitHub 仕様で Approve 不可・draft も Approve 不可**のため本人はコメントで判断する (ready 化後の merge-review はチームメンバーの PR Review でも可)。
 - **原則 3: run 単位の安全機構は置き換えず外側に重ねる。** flow-x の介入 2 段化・safety_level・iter 上限・pre-bash-guard はそのまま。flow-loop はブレーカー・kill switch を追加するだけ。
 
@@ -20,7 +20,7 @@ allowed-tools: Bash, PushNotification, Read, Edit, Write, Glob, Grep, Agent, Ski
 /flow-loop tick --dry-run  # 判定のみ。ラベル遷移 / push / PR 操作 / merge / 新規着手をしない
 /flow-loop tick --force    # active_hours (稼働時間帯) 外でも実行する
 /flow-loop status          # 読み取り専用ダッシュボード (run 一覧・ゲート状況・loop 設定)
-/flow-loop stop            # kill switch 設置 (touch /tmp/flow-loop-stop)
+/flow-loop stop            # resolved kill switch ($FLOW_LOOP_STOP) を設置
 /flow-loop start           # kill switch 撤去 + ブレーカーリセット (consecutive_halts=0)
 ```
 
@@ -40,7 +40,15 @@ source "$CLAUDE_PROJECT_DIR/.claude/skills/flow-loop/lib/loop.sh"
 flow_loop_init   # 冪等 (既存 loop.json は上書きしない)
 ```
 
-`/tmp/flow-loop.json` (run state・kpi 履歴と同じ /tmp 規約)。再起動で消えたら init が既定値で再生成する。**恒久化したい設定変更 (`wip_limit` / `pick_query` 等) は `lib/loop.sh` の既定値を PR で変える**。/tmp の loop.json 直接編集は一時的な調整用:
+`$FLOW_LOOP_JSON` (run state・kpi 履歴と同じ resolved runtime directory 規約)。再起動で消えたら init が既定値で再生成する。**恒久化したい設定変更 (`wip_limit` / `pick_query` 等) は `lib/loop.sh` の既定値を PR で変える**。resolved directory の loop.json 直接編集は一時的な調整用:
+
+kill switch を直接操作する場合も resolver を迂回しない:
+
+```bash
+source "$CLAUDE_PROJECT_DIR/.claude/skills/flow-loop/lib/loop.sh"
+touch "$FLOW_LOOP_STOP"    # stop
+rm -f "$FLOW_LOOP_STOP"    # start
+```
 
 | フィールド | 既定 | 意味 |
 | --- | --- | --- |
@@ -99,7 +107,7 @@ phase は flow-x の run state (`progress.phase`)。async モードで park す�
 ## 安全装置
 
 - **ブレーカー**: 連続 halt が 3 に達したら tick を拒否 (STEP 2)。同じ壁に無限に突撃しない。復帰は人間が原因を見てから `/flow-loop start`。
-- **kill switch**: `/flow-loop stop` (= `touch /tmp/flow-loop-stop`)。tick 冒頭で検知して即終了。ファイルを直接 touch してもよい (「停止指示も状態」)。
+- **kill switch**: `/flow-loop stop` (= `loop.sh` source 後に `touch "$FLOW_LOOP_STOP"`)。tick 冒頭で検知して即終了。ファイルを直接 touch する場合も resolved path を使う (「停止指示も状態」)。
 - **dry-run**: 初回導入時・pick_query 変更後は `--dry-run` で判定を確認してから実行する。
 - **run 単位の安全**: flow-x の介入 2 段化 (halt/warn)・safety_level 3 段階・iter 上限・DB スキーマ変更検出・pre-bash-guard (push 品質ゲート・PR コメント前 push マーカー) はそのまま効く。
 

--- a/.claude/skills/flow-loop/lib/loop.sh
+++ b/.claude/skills/flow-loop/lib/loop.sh
@@ -8,25 +8,36 @@
 #   flow_loop_lock && ... && flow_loop_unlock
 #
 # 設計判断:
-#   - run state (state-io.sh の /tmp/flow-{progress,kpi,context}-*.json) には依存せず、
+#   - run state (state-io.sh の flow-{progress,kpi,context}-*.json) には依存せず、
 #     progress ファイルの列挙と jq 読み取りのみで active run を数える (疎結合)。
-#   - loop 状態 (loop.json / metrics / kill switch) も state-io.sh と同じ /tmp 規約に置く
-#     (kpi 履歴の /tmp/flow-kpi-history.jsonl と同格)。再起動で消えたら init が既定値で
+#   - loop 状態 (loop.json / metrics / kill switch) も state-io.sh と同じ runtime
+#     directory 規約に置く (kpi 履歴と同格)。再起動で消えたら init が既定値で
 #     再生成する。恒久化したい設定変更 (wip_limit / pick_query 等) は本ファイルの既定値を
-#     PR で変える。/tmp の loop.json 直接編集は一時的な調整用。
+#     PR で変える。runtime directory の loop.json 直接編集は一時的な調整用。
 #   - パス解決に BASH_SOURCE を使わない。Claude の Bash ツールは実体が zsh のことがあり、
-#     zsh で source すると BASH_SOURCE が空になる (本ファイルは固定パス /tmp のみで完結)。
+#     zsh で source すると BASH_SOURCE が空になるため CLAUDE_PROJECT_DIR を使う。
 #   - tick 排他は mkdir の atomic 性を使う (flock ファイルと違い stale 回収を mtime で判定できる)。
 #   - pick は GitHub Issue のみ対応。pick_query は gh issue list --search 用の
 #     GitHub 検索構文で持つ。
 
 set -euo pipefail
 
-# loop 状態の配置先。テストでは一時ディレクトリに差し替える。
-: "${FLOW_LOOP_STATE_DIR:=/tmp}"
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  echo "ERROR: CLAUDE_PROJECT_DIR が未設定です (flow-loop loop.sh は project context から source してください)" >&2
+  return 1
+fi
+# shellcheck source=/dev/null
+source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"
 
-# run state (state-io.sh) の配置先。テストでは一時ディレクトリに差し替える。
-: "${FLOW_LOOP_RUNS_DIR:=/tmp}"
+# 限定 override が無い用途だけ共通 directory を解決する。
+if [ -z "${FLOW_LOOP_STATE_DIR:-}" ] || [ -z "${FLOW_LOOP_RUNS_DIR:-}" ]; then
+  flow_state_dir_init || return 1
+fi
+
+# loop 独自 state と run 走査は別々に限定 override 可能。空文字は未指定扱い。
+FLOW_LOOP_STATE_DIR="${FLOW_LOOP_STATE_DIR:-$FLOW_STATE_DIR}"
+FLOW_LOOP_RUNS_DIR="${FLOW_LOOP_RUNS_DIR:-$FLOW_STATE_DIR}"
+export FLOW_LOOP_STATE_DIR FLOW_LOOP_RUNS_DIR
 
 FLOW_LOOP_JSON="$FLOW_LOOP_STATE_DIR/flow-loop.json"
 FLOW_LOOP_LOCK="$FLOW_LOOP_STATE_DIR/flow-loop.lock"
@@ -113,7 +124,7 @@ flow_loop_lock() {
   now="$(date +%s)"
   # GNU (stat -c %Y) を先に試す。BSD 先行 (stat -f %m) にすると GNU stat では
   # -f がファイルシステムモードになり %m が「マウントポイント文字列」で成功してしまう
-  # (mtime に /tmp が入り算術式が爆発、stale 回収も永久に効かない) ため順序が重要。
+  # (mtime に mount path が入り算術式が爆発、stale 回収も永久に効かない) ため順序が重要。
   mtime="$(stat -c %Y "$FLOW_LOOP_LOCK" 2>/dev/null || stat -f %m "$FLOW_LOOP_LOCK" 2>/dev/null || echo "$now")"
   case "$mtime" in ''|*[!0-9]*) mtime="$now" ;; esac
   if { [ -n "$owner" ] && ! kill -0 "$owner" 2>/dev/null; } \
@@ -167,7 +178,8 @@ flow_loop_self_repo() {
 #   - self_repo 空 (repo 外で起動)        → 真 (絞り込みしない = 旧挙動)
 #   - context / worktree が解決できない    → 真 (permissive。active run は通常 worktree を持つ)
 #   - worktree が別 repo                   → 偽 (掴まない)
-# flow state は /tmp 共有のため、このフィルタが無いと他プロジェクトの run まで wip 算入・
+# flow state directory は複数 project で共有し得るため、このフィルタが無いと
+# 他プロジェクトの run まで wip 算入・
 # 走査・前進してしまう (クロスプロジェクト汚染。別 repo の PR を CI 判定/マージしかねない)。
 _flow_loop_run_in_self_repo() {
   local key="$1" self_repo="$2" ctx wt run_repo
@@ -278,7 +290,7 @@ flow_loop_pid_alive() {
 # ── 計測 (metrics) ──────────────────────────────────────────────
 # run のイベントを 1 行 JSON で metrics.jsonl へ追記する。
 # 記録点: pick (新規着手) / park (承認・監視待ち) / halt / merged (P11) / done (P12 terminal)。
-# 既存 KPI (/tmp/flow-kpi-*.json / flow-kpi-history.jsonl) とはレイヤが別:
+# 既存 KPI (flow-kpi-*.json / flow-kpi-history.jsonl) とはレイヤが別:
 # KPI は run 内の自走時間、metrics.jsonl は loop 視点のイベント列 (人間待ち内訳の集計用)。
 
 # append <work_id> <event> [<jq_object_expr>]

--- a/.claude/skills/flow-loop/lib/report.sh
+++ b/.claude/skills/flow-loop/lib/report.sh
@@ -9,7 +9,22 @@
 # 差し戻し修正に要した機械時間も直前 park からの区間に含まれるため、待ち時間はやや過大に出る (v1 の近似)。
 set -euo pipefail
 
-METRICS="${1:-${FLOW_LOOP_STATE_DIR:-/tmp}/flow-loop-metrics.jsonl}"
+REPORT_SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
+  CLAUDE_PROJECT_DIR="$(cd "$REPORT_SCRIPT_DIR/../../../.." && pwd)"
+  export CLAUDE_PROJECT_DIR
+fi
+# shellcheck source=/dev/null
+source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"
+
+if [ -n "${1:-}" ]; then
+  METRICS="$1"
+elif [ -n "${FLOW_LOOP_STATE_DIR:-}" ]; then
+  METRICS="$FLOW_LOOP_STATE_DIR/flow-loop-metrics.jsonl"
+else
+  flow_state_dir_init
+  METRICS="$FLOW_STATE_DIR/flow-loop-metrics.jsonl"
+fi
 [ -f "$METRICS" ] || { echo "metrics ファイルが見つかりません: $METRICS" >&2; exit 1; }
 
 jq -s -r '

--- a/.claude/skills/flow-loop/tests/test-loop.sh
+++ b/.claude/skills/flow-loop/tests/test-loop.sh
@@ -53,17 +53,76 @@ assert_rc() {
 }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 LOOP_LIB="$SCRIPT_DIR/../lib/loop.sh"
 
 TMP_STATE="$(mktemp -d)"
 TMP_RUNS="$(mktemp -d)"
-trap 'rm -rf "$TMP_STATE" "$TMP_RUNS"' EXIT
+TMP_XDG="$(mktemp -d)"
+trap 'rm -rf "$TMP_STATE" "$TMP_RUNS" "$TMP_XDG"' EXIT
+export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
 export FLOW_LOOP_STATE_DIR="$TMP_STATE"
 export FLOW_LOOP_RUNS_DIR="$TMP_RUNS"
 
 # shellcheck source=/dev/null
 source "$LOOP_LIB"
 set +e  # loop.sh の set -e をテストランナー側では解除 (FAIL しても継続する)
+
+echo "=== directory resolution / override priority ==="
+DEFAULT_XDG="$TMP_XDG/default"
+mkdir -m 700 "$DEFAULT_XDG"
+DEFAULT_RESULT=$(env -u FLOW_STATE_DIR -u FLOW_LOOP_STATE_DIR -u FLOW_LOOP_RUNS_DIR \
+  XDG_RUNTIME_DIR="$DEFAULT_XDG" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  bash -c '
+    source "$CLAUDE_PROJECT_DIR/.claude/skills/flow-loop/lib/loop.sh" || exit 1
+    expected="$XDG_RUNTIME_DIR/ark-flow-$(id -u)"
+    if [ "$FLOW_LOOP_STATE_DIR" != "$expected" ] || [ "$FLOW_LOOP_RUNS_DIR" != "$expected" ]; then
+      printf "%s|%s||\n" "$FLOW_LOOP_STATE_DIR" "$FLOW_LOOP_RUNS_DIR"
+      exit 0
+    fi
+    flow_loop_init || exit 2
+    flow_loop_lock || exit 3
+    [ -f "$FLOW_LOOP_LOCK/pid" ] || exit 4
+    flow_loop_unlock
+    touch "$FLOW_LOOP_STOP"
+    flow_loop_metrics_append issue-default park "{}" || exit 5
+    printf "%s|%s|%s|%s\n" "$FLOW_LOOP_STATE_DIR" "$FLOW_LOOP_RUNS_DIR" \
+      "$([ -f "$FLOW_LOOP_JSON" ] && echo json)" \
+      "$([ -f "$FLOW_LOOP_STOP" ] && [ -f "$FLOW_LOOP_METRICS" ] && echo artifacts)"
+  ' 2>/dev/null)
+EXPECTED_DEFAULT="$DEFAULT_XDG/ark-flow-$(id -u)"
+assert_eq "override 無しでは loop/run とも XDG secure default を使う" \
+  "$EXPECTED_DEFAULT|$EXPECTED_DEFAULT|json|artifacts" "$DEFAULT_RESULT"
+
+COMMON_DIR="$TMP_XDG/common"
+LIMITED_STATE_DIR="$TMP_XDG/limited-state"
+LIMITED_RUNS_DIR="$TMP_XDG/limited-runs"
+mkdir -m 700 "$COMMON_DIR" "$LIMITED_STATE_DIR" "$LIMITED_RUNS_DIR"
+PRIORITY_RESULT=$(FLOW_STATE_DIR="$COMMON_DIR" \
+  FLOW_LOOP_STATE_DIR="$LIMITED_STATE_DIR" FLOW_LOOP_RUNS_DIR="$LIMITED_RUNS_DIR" \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" bash -c '
+    source "$CLAUDE_PROJECT_DIR/.claude/skills/flow-loop/lib/loop.sh"
+    printf "%s|%s\n" "$FLOW_LOOP_STATE_DIR" "$FLOW_LOOP_RUNS_DIR"
+  ' 2>/dev/null)
+assert_eq "限定 override は共通 FLOW_STATE_DIR より優先される" \
+  "$LIMITED_STATE_DIR|$LIMITED_RUNS_DIR" "$PRIORITY_RESULT"
+
+COMMON_RESULT=$(FLOW_STATE_DIR="$COMMON_DIR" \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" bash -c '
+    unset FLOW_LOOP_STATE_DIR FLOW_LOOP_RUNS_DIR
+    source "$CLAUDE_PROJECT_DIR/.claude/skills/flow-loop/lib/loop.sh"
+    printf "%s|%s\n" "$FLOW_LOOP_STATE_DIR" "$FLOW_LOOP_RUNS_DIR"
+  ' 2>/dev/null)
+assert_eq "限定 override 未指定時は loop/run とも共通 FLOW_STATE_DIR を使う" \
+  "$COMMON_DIR|$COMMON_DIR" "$COMMON_RESULT"
+
+UNSAFE_XDG="$TMP_XDG/unsafe"
+mkdir -m 700 "$UNSAFE_XDG"
+mkdir -m 755 "$UNSAFE_XDG/ark-flow-$(id -u)"
+assert_rc "mode 0755 の自動既定候補では init が fail closed" 1 \
+  "env -u FLOW_STATE_DIR -u FLOW_LOOP_STATE_DIR -u FLOW_LOOP_RUNS_DIR XDG_RUNTIME_DIR='$UNSAFE_XDG' CLAUDE_PROJECT_DIR='$PROJECT_DIR' bash -c 'source \"\$CLAUDE_PROJECT_DIR/.claude/skills/flow-loop/lib/loop.sh\" || exit 1; expected=\"\$XDG_RUNTIME_DIR/ark-flow-\$(id -u)\"; [ \"\$FLOW_LOOP_STATE_DIR\" = \"\$expected\" ] || exit 0; flow_loop_init'"
+assert_rc "mode 0755 の自動既定候補では lock も fail closed" 1 \
+  "env -u FLOW_STATE_DIR -u FLOW_LOOP_STATE_DIR -u FLOW_LOOP_RUNS_DIR XDG_RUNTIME_DIR='$UNSAFE_XDG' CLAUDE_PROJECT_DIR='$PROJECT_DIR' bash -c 'source \"\$CLAUDE_PROJECT_DIR/.claude/skills/flow-loop/lib/loop.sh\" || exit 1; expected=\"\$XDG_RUNTIME_DIR/ark-flow-\$(id -u)\"; [ \"\$FLOW_LOOP_STATE_DIR\" = \"\$expected\" ] || exit 0; flow_loop_lock'"
 
 # --- init (冪等) ---
 flow_loop_init
@@ -219,7 +278,7 @@ assert_eq "metrics_tail が直近を返す" "done" "$(flow_loop_metrics_tail 1 |
 # (BASH_SOURCE 依存のパス解決だと zsh で空になり全機能が壊れる)
 if command -v zsh >/dev/null 2>&1; then
   ZTMP="$(mktemp -d)"
-  if zsh -c "export FLOW_LOOP_STATE_DIR='$ZTMP'; export FLOW_LOOP_RUNS_DIR='$TMP_RUNS'; \
+  if zsh -c "export CLAUDE_PROJECT_DIR='$PROJECT_DIR'; export FLOW_LOOP_STATE_DIR='$ZTMP'; export FLOW_LOOP_RUNS_DIR='$TMP_RUNS'; \
        source '$LOOP_LIB' \
        && flow_loop_init && flow_loop_lock && flow_loop_unlock \
        && [ \"\$(flow_loop_read '.wip_limit')\" = '2' ] \

--- a/.claude/skills/flow-loop/tests/test-report.sh
+++ b/.claude/skills/flow-loop/tests/test-report.sh
@@ -26,6 +26,7 @@ assert_true() {
 }
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
 REPORT="$SCRIPT_DIR/../lib/report.sh"
 
 TMPD="$(mktemp -d)"
@@ -57,6 +58,50 @@ assert_true "機械時間 30 分" 'echo "$OUT" | grep "issue-1t" | grep -qw "30"
 assert_true "待ち比率 40%" 'echo "$OUT" | grep "issue-1t" | grep -qw "40"'
 assert_true "done が無い run は集計に出ない" '! echo "$OUT" | grep -q "issue-2t"'
 assert_true "不在ファイルはエラー" '! bash "$REPORT" "$TMPD/nonexistent.jsonl"'
+
+write_minimal_metrics() {
+  local metrics_file="$1"
+  local ticket="$2"
+  mkdir -p "$(dirname "$metrics_file")"
+  printf '%s\n' \
+    "{\"ts\":100,\"ticket\":\"$ticket\",\"event\":\"pick\"}" \
+    "{\"ts\":160,\"ticket\":\"$ticket\",\"event\":\"done\"}" \
+    > "$metrics_file"
+}
+
+echo ""
+echo "=== metrics path priority ==="
+CLI_DIR="$TMPD/cli"
+LOOP_DIR="$TMPD/loop"
+COMMON_DIR="$TMPD/common"
+XDG_DIR="$TMPD/xdg"
+mkdir -m 700 "$CLI_DIR" "$LOOP_DIR" "$COMMON_DIR" "$XDG_DIR"
+write_minimal_metrics "$CLI_DIR/metrics.jsonl" "cli-ticket"
+write_minimal_metrics "$LOOP_DIR/flow-loop-metrics.jsonl" "loop-ticket"
+write_minimal_metrics "$COMMON_DIR/flow-loop-metrics.jsonl" "common-ticket"
+DEFAULT_DIR="$XDG_DIR/ark-flow-$(id -u)"
+mkdir -m 700 "$DEFAULT_DIR"
+write_minimal_metrics "$DEFAULT_DIR/flow-loop-metrics.jsonl" "default-ticket"
+
+PRIORITY_OUT=$(FLOW_LOOP_STATE_DIR="$LOOP_DIR" FLOW_STATE_DIR="$COMMON_DIR" \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" bash "$REPORT" "$CLI_DIR/metrics.jsonl")
+assert_true "CLI 第1引数が最優先" \
+  'echo "$PRIORITY_OUT" | grep -q "cli-ticket" && ! echo "$PRIORITY_OUT" | grep -q "loop-ticket"'
+
+LOOP_OUT=$(FLOW_LOOP_STATE_DIR="$LOOP_DIR" FLOW_STATE_DIR="$COMMON_DIR" \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" bash "$REPORT")
+assert_true "FLOW_LOOP_STATE_DIR は FLOW_STATE_DIR より優先" \
+  'echo "$LOOP_OUT" | grep -q "loop-ticket" && ! echo "$LOOP_OUT" | grep -q "common-ticket"'
+
+COMMON_OUT=$(env -u FLOW_LOOP_STATE_DIR FLOW_STATE_DIR="$COMMON_DIR" \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" bash "$REPORT")
+assert_true "限定 override 未指定時は FLOW_STATE_DIR を使う" \
+  'echo "$COMMON_OUT" | grep -q "common-ticket"'
+
+DEFAULT_OUT=$(env -u FLOW_LOOP_STATE_DIR -u FLOW_STATE_DIR \
+  XDG_RUNTIME_DIR="$XDG_DIR" bash "$REPORT")
+assert_true "全 override 未指定時は XDG secure default を使う" \
+  'echo "$DEFAULT_OUT" | grep -q "default-ticket"'
 
 echo ""
 echo "=== 結果: $PASSES/$TESTS PASS ==="

--- a/.claude/skills/flow-x/SKILL.md
+++ b/.claude/skills/flow-x/SKILL.md
@@ -88,8 +88,8 @@ flow-x を実運用で回して判明した、codex exec の安定運用に必�
 # 一時ファイル名には必ず ${SCOPE_KEY} を含める (flow-loop の WIP>1 で並行 run 同士の
 # 完了判定・ログが混線するのを防ぐ)。起動 pid は必ず記録する (停止は pid 指名で行う)
 nohup codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
-  -o "/tmp/codex-<phase>-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
-  "$(cat "/tmp/flowx-<phase>-prompt-${SCOPE_KEY}.md")" > "/tmp/codex-<phase>-${SCOPE_KEY}-run.log" 2>&1 &
+  -o "$FLOW_STATE_DIR/codex-<phase>-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
+  "$(cat "$FLOW_STATE_DIR/flowx-<phase>-prompt-${SCOPE_KEY}.md")" > "$FLOW_STATE_DIR/codex-<phase>-${SCOPE_KEY}-run.log" 2>&1 &
 CODEX_PID=$!
 flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 ```
@@ -105,7 +105,7 @@ flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 `ps` での codex プロセス検出は名前が安定せず当てにならない。Monitor は以下で張る:
 
 ```bash
-LOG="/tmp/codex-<phase>-${SCOPE_KEY}-run.log"; DONE="/tmp/codex-<phase>-${SCOPE_KEY}-last.txt"; prev=-1
+LOG="$FLOW_STATE_DIR/codex-<phase>-${SCOPE_KEY}-run.log"; DONE="$FLOW_STATE_DIR/codex-<phase>-${SCOPE_KEY}-last.txt"; prev=-1
 while true; do
   [ -s "$DONE" ] && { echo "CODEX_DONE"; break; }          # -o 完了ファイルが書かれた = 正常終了
   cur=$(wc -c < "$LOG" 2>/dev/null || echo 0)
@@ -165,8 +165,8 @@ codex が log 成長後に**プロセス消失・`-o` 未生成**で終わる事
 **P3 の detached 起動** (「codex 実行の運用知見」の invocation を流用し、待たずに park する):
 ```bash
 nohup codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
-  -o "/tmp/codex-p3-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
-  "$(cat "/tmp/flowx-impl-prompt-${SCOPE_KEY}.md")" > "/tmp/codex-p3-${SCOPE_KEY}-run.log" 2>&1 &
+  -o "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
+  "$(cat "$FLOW_STATE_DIR/flowx-impl-prompt-${SCOPE_KEY}.md")" > "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-run.log" 2>&1 &
 CODEX_PID=$!
 flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 flow_state_update progress '.gate = "codex-impl"' "$SCOPE_KEY"
@@ -198,6 +198,7 @@ source "$CLAUDE_PROJECT_DIR/.claude/lib/check-cr-threads.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/cleanup.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/ticket-source.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/worktree/setup-worktree.sh"
+flow_state_dir_init
 
 # 引数パース。state-io.sh は set -euo pipefail を有効化するので、
 # 未初期化変数を参照すると abort する。全変数を必ず初期化してから判定する。
@@ -317,14 +318,14 @@ SCOPE_KEY=$(flow_state_scope_key "$WORK_ID")
 #        された場合に state 不在 → 「新規 run」扱いで誤って P-1 から開始する事故を防ぐ。
 #        sentinel は scope_key + branch を JSON で持ち、branch が現在 branch と一致する
 #        場合のみ halt する (同 WORK_ID 別 branch は legitimate)。
-if [ -n "$SCOPE_KEY" ] && [ -f "/tmp/flow-done-${SCOPE_KEY}.json" ]; then
-  _SENTINEL_BRANCH=$(jq -r '.branch // ""' "/tmp/flow-done-${SCOPE_KEY}.json" 2>/dev/null)
+if [ -n "$SCOPE_KEY" ] && [ -f "$FLOW_STATE_DIR/flow-done-${SCOPE_KEY}.json" ]; then
+  _SENTINEL_BRANCH=$(jq -r '.branch // ""' "$FLOW_STATE_DIR/flow-done-${SCOPE_KEY}.json" 2>/dev/null)
   if [ -z "$_SENTINEL_BRANCH" ] || [ "$_SENTINEL_BRANCH" = "${_CURRENT_BRANCH:-}" ]; then
     if ! { [ "${MODE:-}" = "--resume" ] && flow_state_exists "$SCOPE_KEY"; }; then
       halt "STEP 0: scope $SCOPE_KEY (branch: ${_SENTINEL_BRANCH:-unknown}) は既に完了済み \
-(sentinel: /tmp/flow-done-${SCOPE_KEY}.json)。\
+(sentinel: $FLOW_STATE_DIR/flow-done-${SCOPE_KEY}.json)。\
 新しい flow run を始める場合は main worktree に戻り '/flow-x #NNN' を実行してください。\
-同じ branch で再実行したい場合は sentinel を削除 (rm /tmp/flow-done-${SCOPE_KEY}.json) してから再起動してください"
+同じ branch で再実行したい場合は sentinel を削除 (rm \"$FLOW_STATE_DIR/flow-done-${SCOPE_KEY}.json\") してから再起動してください"
     fi
   fi
 fi
@@ -342,11 +343,11 @@ fi
 if [ "${IN_FLOW_WORKTREE:-0}" = "1" ] && flow_state_exists "$SCOPE_KEY"; then
   _SAVED_BRANCH=$(flow_state_read progress '.branch' "$SCOPE_KEY")
   if [ -z "$_SAVED_BRANCH" ]; then
-    halt "STEP 0: state から branch を読み取れませんでした (state 破損の可能性): SCOPE_KEY=$SCOPE_KEY。state を削除 (rm /tmp/flow-{progress,kpi,context}-${SCOPE_KEY}.json) して再実行してください"
+    halt "STEP 0: state から branch を読み取れませんでした (state 破損の可能性): SCOPE_KEY=$SCOPE_KEY。state を削除 (rm \"$FLOW_STATE_DIR\"/flow-{progress,kpi,context}-${SCOPE_KEY}.json) して再実行してください"
   fi
   if [ "$_SAVED_BRANCH" != "$_CURRENT_BRANCH" ]; then
     halt "STEP 0: SCOPE_KEY ($SCOPE_KEY) は別 branch ($_SAVED_BRANCH) の state を保持しています。\
-古い branch の state を削除 (rm /tmp/flow-{progress,kpi,context}-${SCOPE_KEY}.json) してから再実行してください"
+古い branch の state を削除 (rm \"$FLOW_STATE_DIR\"/flow-{progress,kpi,context}-${SCOPE_KEY}.json) してから再実行してください"
   fi
 fi
 
@@ -473,8 +474,8 @@ flow_state_update progress '.phase = "P2"' "$SCOPE_KEY"
 PLAN_PATH="$WORKTREE_PATH/docs/superpowers/plans/<TODAY>-<WORK_ID>.md"
 # プロンプトはファイルに書いて渡す (shell escape 事故回避)
 nohup codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
-  -o "/tmp/codex-p2-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
-  "$(cat "/tmp/flowx-plan-prompt-${SCOPE_KEY}.md")" > "/tmp/codex-p2-${SCOPE_KEY}-run.log" 2>&1 &
+  -o "$FLOW_STATE_DIR/codex-p2-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
+  "$(cat "$FLOW_STATE_DIR/flowx-plan-prompt-${SCOPE_KEY}.md")" > "$FLOW_STATE_DIR/codex-p2-${SCOPE_KEY}-run.log" 2>&1 &
 CODEX_PID=$!
 flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 # Monitor で log 成長 + last.txt 生成を監視 (前節参照)。完了後:
@@ -558,8 +559,8 @@ plan は**成果物としてコミットし、作業の PR に含める** (CLAUD
 ```bash
 # 実装プロンプトをファイルに書いて渡す
 nohup codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
-  -o "/tmp/codex-p3-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
-  "$(cat "/tmp/flowx-impl-prompt-${SCOPE_KEY}.md")" > "/tmp/codex-p3-${SCOPE_KEY}-run.log" 2>&1 &
+  -o "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
+  "$(cat "$FLOW_STATE_DIR/flowx-impl-prompt-${SCOPE_KEY}.md")" > "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-run.log" 2>&1 &
 CODEX_PID=$!
 flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 # 対話モード: Monitor で log 成長 + 完了ファイルを監視 (前節「codex 実行の運用知見」)
@@ -886,7 +887,7 @@ tick (対話モードは cron、非同期モードは flow-loop) が実行する
 ### 12-3. terminal 後のフォロー
 
 - worktree はそのまま残す。ユーザーが結果を見て手動で `git worktree remove <path>` する。
-- **success / no-target** → `cleanup_post_deploy final`: 全 state を削除。削除前に kpi.json を `/tmp/flow-kpi-history.jsonl` に append するため KPI は履歴として永続化される。done sentinel (`/tmp/flow-done-<scope>.json`) が残り、STEP 0 が「完了済み」を検出できる。
+- **success / no-target** → `cleanup_post_deploy final`: 全 state を削除。削除前に kpi.json を `$FLOW_STATE_DIR/flow-kpi-history.jsonl` に append するため KPI は履歴として永続化される。done sentinel (`$FLOW_STATE_DIR/flow-done-<scope>.json`) が残り、STEP 0 が「完了済み」を検出できる。
 - **failure / timeout / poll-error** → `cleanup_post_deploy resumable`: state を**調査用に残置**する。terminal は `phase=done` を記録するため `--resume` での継続は STEP 0 で halt する。実際の re-deploy は**別 PR / 別 flow-x run** として開始する。
 
 ### 12-4. session 終了時の挙動 (対話モードのみ)
@@ -909,7 +910,7 @@ tick (対話モードは cron、非同期モードは flow-loop) が実行する
 ```bash
 /flow-x --kpi
 ```
-全 `/tmp/flow-kpi-*.json` (進行中 run) と `/tmp/flow-kpi-history.jsonl` (完了済み run、`cleanup_post_deploy final` で append される) を集計して以下の markdown table を出力:
+`$FLOW_STATE_DIR/flow-kpi-*.json` (進行中 run) と `$FLOW_STATE_DIR/flow-kpi-history.jsonl` (完了済み run、`cleanup_post_deploy final` で append される) を集計して以下の markdown table を出力:
 
 ```
 | Work | 最大連続 | 総自走率 | 初介入中央値 | 待機除外 | 状態 | deploy |

--- a/.claude/skills/flow/SKILL.md
+++ b/.claude/skills/flow/SKILL.md
@@ -62,6 +62,7 @@ source "$CLAUDE_PROJECT_DIR/.claude/lib/codex-gate.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/check-cr-threads.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/cleanup.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/worktree/setup-worktree.sh"
+flow_state_dir_init
 
 # 引数パース。state-io.sh / codex-gate.sh は set -euo pipefail を有効化するので、
 # 未初期化変数を参照すると abort する。MODE / FROM_PHASE / TARGET を必ず初期化してから判定する。
@@ -88,7 +89,7 @@ done
 # 通常 flow に進むと WORK_ID 空で flow_state_exists が偽になり P-1 を再走するので、
 # 早期 short-circuit する (codex review [P2] 指摘への対応)。
 if [ "${MODE:-}" = "--kpi" ]; then
-  # /tmp/flow-kpi-*.json を集計して markdown table を出して exit
+  # "$FLOW_STATE_DIR"/flow-kpi-*.json を集計して markdown table を出して exit
   # （実装本体は /flow --kpi セクション参照）
   exec_kpi_aggregation_and_exit
 fi
@@ -124,15 +125,15 @@ fi
 SCOPE_KEY=$(flow_state_scope_key "$WORK_ID")
 
 # done sentinel チェック。
-# cleanup_post_deploy "final" は state 削除後に /tmp/flow-done-<scope>.json を書く。
+# cleanup_post_deploy "final" は state 削除後に flow-done-<scope>.json を書く。
 # worktree は P12 後も残置されるので、state 不在 → 「新規 run」扱いで誤って P-1 から
 # 開始する事故を防ぐ。sentinel の branch が現在 branch と一致する場合のみ halt する。
-if [ -f "/tmp/flow-done-${SCOPE_KEY}.json" ]; then
-  _SENTINEL_BRANCH=$(jq -r '.branch // ""' "/tmp/flow-done-${SCOPE_KEY}.json" 2>/dev/null)
+if [ -f "$FLOW_STATE_DIR/flow-done-${SCOPE_KEY}.json" ]; then
+  _SENTINEL_BRANCH=$(jq -r '.branch // ""' "$FLOW_STATE_DIR/flow-done-${SCOPE_KEY}.json" 2>/dev/null)
   _CURRENT_BRANCH=$(git branch --show-current 2>/dev/null || echo "")
   if [ -z "$_SENTINEL_BRANCH" ] || [ "$_SENTINEL_BRANCH" = "$_CURRENT_BRANCH" ]; then
     if ! { [ "${MODE:-}" = "--resume" ] && flow_state_exists "$SCOPE_KEY"; }; then
-      halt "STEP 0: scope $SCOPE_KEY は既に完了済み (sentinel: /tmp/flow-done-${SCOPE_KEY}.json)。\
+      halt "STEP 0: scope $SCOPE_KEY は既に完了済み (sentinel: $FLOW_STATE_DIR/flow-done-${SCOPE_KEY}.json)。\
 再実行したい場合は sentinel を削除してから再起動してください"
     fi
   fi
@@ -547,7 +548,7 @@ if [ "$HAS_TARGET" != "true" ] || [ "$PM2_ONLINE" != "true" ]; then
   fi
   flow_state_update progress '.phase = "done"' "$SCOPE_KEY"
   # P12 terminal: state / codex log 回収。done sentinel を書き、KPI は
-  # /tmp/flow-kpi-history.jsonl に退避してから state を削除する (--kpi 集計と再起動阻害解消の両立)
+  # flow-kpi-history.jsonl に退避してから state を削除する (--kpi 集計と再起動阻害解消の両立)
   cleanup_post_deploy "$SCOPE_KEY" final || echo "WARNING: cleanup_post_deploy 失敗 (continue)" >&2
   echo "deploy 対象なし、P12 を no-target で finalize"
 else
@@ -602,7 +603,7 @@ cron が発火するたびに Claude が起き、上記 prompt の指示通り�
 ### 12-3. terminal 後のフォロー
 
 - worktree はそのまま残す。ユーザーが結果を見て手動で `git worktree remove <path>` する
-- **success / no-target** → `cleanup_post_deploy final`: 全 state を削除。削除前に kpi.json を `/tmp/flow-kpi-history.jsonl` に append するため KPI は履歴として永続化される。done sentinel (`/tmp/flow-done-<scope>.json`) が残り、STEP 0 が「完了済み」を検出できる
+- **success / no-target** → `cleanup_post_deploy final`: 全 state を削除。削除前に kpi.json を `$FLOW_STATE_DIR/flow-kpi-history.jsonl` に append するため KPI は履歴として永続化される。done sentinel (`$FLOW_STATE_DIR/flow-done-<scope>.json`) が残り、STEP 0 が「完了済み」を検出できる
 - **failure / timeout / poll-error** → `cleanup_post_deploy resumable`: state を**調査用に残置**。terminal は `phase=done` を記録するため `--resume` での継続は STEP 0 で halt する。実際の re-deploy は**別 PR / 別 flow run** として開始する
 
 ### 12-4. session 終了時の挙動
@@ -626,7 +627,7 @@ cron が発火するたびに Claude が起き、上記 prompt の指示通り�
 ```bash
 /flow --kpi
 ```
-全 `/tmp/flow-kpi-*.json` (進行中 run) と `/tmp/flow-kpi-history.jsonl` (完了済み run、`cleanup_post_deploy final` で append される) を集計して以下の markdown table を出力:
+`$FLOW_STATE_DIR/flow-kpi-*.json` (進行中 run) と `$FLOW_STATE_DIR/flow-kpi-history.jsonl` (完了済み run、`cleanup_post_deploy final` で append される) を集計して以下の markdown table を出力:
 
 ```
 | Work | 最大連続 | 総自走率 | 初介入中央値 | 待機除外 | 状態 | deploy |

--- a/docs/superpowers/plans/2026-07-24-issue-219.md
+++ b/docs/superpowers/plans/2026-07-24-issue-219.md
@@ -1,0 +1,577 @@
+# Issue #219: flow state をユーザー専用 runtime directory へ移す実装プラン
+
+> **実装担当者向け:** この文書は設計・実装順序だけを定める。各 Task は Red → Green → Refactor の順で進め、flow / flow-x / flow-loop の phase、gate、polling、cleanup の意味は変えない。
+
+**Goal:** flow / flow-x / flow-loop が作る state、lock、KPI、context、progress、metrics、codex log、done sentinel を、既定では `${XDG_RUNTIME_DIR:-/tmp}/ark-flow-$(id -u)` 配下へ集約し、別 OS user が事前配置した symlink を flow 実行ユーザー権限で辿れないようにする。
+
+**Issue:** GitHub Issue #219
+
+**Architecture:** 新規の `.claude/lib/flow-state-dir.sh` をパス解決と安全な初期化の唯一の正準にする。自動既定値だけは、作成後の directory が symlink でなく、実行 UID 所有かつ mode `0700` であることを GNU/BSD `stat` の両方で検証する。既存の個別 override は信頼済みの運用者入力として最優先で保持し、明示されなければ共通 `FLOW_STATE_DIR`、さらに無ければ安全な既定値へフォールバックする。各 source library は `CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh` を明示的に読み、zsh で壊れる `BASH_SOURCE` self-location を導入しない。ファイル名、JSON schema、lock 方式、atomic rename、phase/gate/polling は維持する。
+
+**対象環境:** Linux / Linux CI / macOS、bash / zsh
+
+---
+
+## 1. 調査で確認した現状
+
+### 1.1 実装上の配置先
+
+| 分類 | 現在の生成・参照箇所 | 現在のパス |
+| --- | --- | --- |
+| run state | `.claude/lib/state-io.sh` の `_flow_state_file` | `/tmp/flow-{progress,kpi,context}-<scope>.json` |
+| scope lock | `.claude/lib/state-io.sh` の `_flow_lock_file` | `/tmp/flow-<scope>.lock` |
+| atomic write 中間 | `.claude/lib/state-io.sh` | state と同じ directory の `*.new.$$` |
+| codex gate log / last message | `.claude/lib/codex-gate.sh` | `/tmp/codex-gate-<phase>-<scope>-XXXXXX.txt[.final]` |
+| finding 重複判定 | `.claude/lib/codex-gate.sh` | `/tmp/flow-progress-<scope>.json` を直接参照 |
+| done sentinel | `.claude/lib/cleanup.sh`、flow / flow-x の `SKILL.md` | `/tmp/flow-done-<scope>.json` |
+| KPI history / lock | `.claude/lib/cleanup.sh` | `/tmp/flow-kpi-history.jsonl`、`flow-kpi-history.lock` |
+| cleanup 対象 | `.claude/lib/cleanup.sh` | state、atomic tmp、codex gate log |
+| flow-x prompt / run log / last message | `.claude/skills/flow-x/SKILL.md` の起動 snippet | `/tmp/flowx-*-prompt-<scope>.md`、`/tmp/codex-*-<scope>-run.log`、`-last.txt` |
+| loop state / tmp | `.claude/skills/flow-loop/lib/loop.sh` | `/tmp/flow-loop.json[.$$.tmp]` |
+| loop lock directory | 同上 | `/tmp/flow-loop.lock/{pid}`、回収中は `.reclaim.$$` |
+| kill switch | 同上 | `/tmp/flow-loop-stop` |
+| loop metrics | 同上、`lib/report.sh` | `/tmp/flow-loop-metrics.jsonl` |
+| active run 走査 | 同上 | `/tmp/flow-progress-*.json` と対応する context |
+| KPI 集計 | flow / flow-x の `SKILL.md` | `/tmp/flow-kpi-*.json` と history |
+| deploy state | `.claude/lib/deploy-watch.sh` | 直書きはなく、`state-io.sh` の context を経由 |
+
+### 1.2 現在の override と既定値
+
+- `CLEANUP_FLOW_STATE_DIR`: cleanup の `base` だけを置換し、未指定時は `/tmp`。
+- `FLOW_LOOP_STATE_DIR`: loop.json、loop lock、kill switch、metrics を置換し、未指定時は `/tmp`。
+- `FLOW_LOOP_RUNS_DIR`: flow-loop が走査する run state directory を置換し、未指定時は `/tmp`。
+- `report.sh` の第1引数: metrics file そのものを最優先で指定可能。
+- `state-io.sh` と `codex-gate.sh` には共通 directory override がなく、`/tmp` を直接生成している。
+
+したがって `FLOW_STATE_DIR` を新しい共通 override として追加し、既存の3変数は削除・改名せず、より限定的な override として優先する。
+
+### 1.3 現在の lock と race 制御
+
+- scope lock は `: > "$lock_file"` または redirection `9>"$lock"` で file を作り、`flock` と同一 inode を保持するため cleanup 後も削除しない。
+- flow-loop lock は `mkdir "$FLOW_LOOP_LOCK"` の atomic 性を使う directory lock で、`pid`、mtime、atomic rename による stale reclaim を持つ。
+- state 更新は同一 directory 内の `*.new.$$` を `command mv` する。
+- 今回はこれらの方式を変更せず、親 directory の安全性だけを先に確立する。
+
+### 1.4 稼働中 run
+
+調査時点で `/tmp` に `flow-progress-issue-219.json`、`flow-context-issue-219.json`、`flow-progress-issue-248.json`、`flow-context-issue-248.json` など複数 run の state が存在する。これらを起動中に rename/copy すると、旧パスを保持する process と新パスを読む process が分裂する。旧 file は symlink である可能性も含むため、新実装が自動 import して信頼しない。
+
+---
+
+## 2. 6論点の結論
+
+### 2.1 ディレクトリ規約
+
+**採用:** 自動既定値を、末尾 slash なしの次の path に統一する。
+
+```text
+${XDG_RUNTIME_DIR:-/tmp}/ark-flow-$(id -u)
+```
+
+- `XDG_RUNTIME_DIR` が設定されている Linux desktop 等では、その配下へ user-specific directory を作る。
+- 多くの Linux CI と通常の macOS のように未設定なら `/tmp/ark-flow-<uid>` を使う。
+- macOS の `/tmp` が `/private/tmp` へ解決される実装差は許容し、文字列 realpath の一致を契約にしない。最終 directory の非 symlink・owner・mode を契約にする。
+- `/tmp` fallback でも UID namespace、mode `0700`、sticky `/tmp` によって別 OS user の事前配置・置換を拒否できる。
+- directory 名と配下の既存ファイル名は変えない。永続保存 directory ではなく、従来どおり再起動で消え得る runtime state とする。
+
+### 2.2 作成、検証、TOCTOU
+
+**採用:** `.claude/lib/flow-state-dir.sh` の初期化 helper が以下を一度に行い、成功した path だけを返す。
+
+1. `id -u` と `${XDG_RUNTIME_DIR:-/tmp}` から候補を組み立てる。
+2. 最終要素が既存 symlink なら、directory を指していても即時中断する。
+3. `mkdir -m 700 -p "$candidate"` を実行する。存在競合で他 user の entry が先に作られても、`-p` の成功だけでは信用しない。
+4. mkdir 後に再度 `lstat` 相当の `test -L` と `stat` を行う。
+5. GNU は `stat -c '%u %a'`、BSD/macOS は `stat -f '%u %Lp'` を使い、owner UID が `id -u` と一致し、permission が正確に `700` であることを確認する。
+6. directory でない、symlink、owner 不一致、`0700` 以外、stat 不能のいずれも具体的な path と理由を stderr に出し、非0で中断する。既存 entry を `chmod`、`chown`、削除して「修復」しない。
+
+`mkdir` は directory entry の作成を atomic に競争し、post-check が競争の勝者を検証する。fallback の `/tmp` は sticky directory であり、検証後の user-owned `0700` directory を別 user は rename/remove できない。`XDG_RUNTIME_DIR` が明示されている場合は、それ自体も symlink でない user-owned directory で、group/other に write 可能でないことを確認し、不正なら `/tmp` へ黙って fallback せず fail closed とする。同一 UID の悪意ある process と root は脅威モデル外である。
+
+### 2.3 移行
+
+**採用:** **新規 run から新既定値を使い、旧 `/tmp/flow-*` を起動時に自動移動・copy・fallback 読みしない。**
+
+理由:
+
+- rename は旧 path を使い続ける in-flight process から state を消す。
+- copy は同じ scope の state が二系統で更新され、phase、gate、KPI、cleanup が分裂する。
+- 旧 path の自動 import は、今回排除する symlink/owner 不明 file を新しい信頼領域へ持ち込む。
+
+rollout 手順:
+
+1. #219 実装を取り込む前から動いている #248/#219 等の session/process は、読み込み済みの旧コードと旧 `/tmp` state のまま完走させる。実装 branch からそれらの file を移動・削除しない。
+2. 更新後に旧 run を再開する必要がある場合だけ、その session に `FLOW_STATE_DIR=/tmp`、`CLEANUP_FLOW_STATE_DIR=/tmp`、`FLOW_LOOP_RUNS_DIR=/tmp` を明示し、flow-loop 自体も旧状態を継続する場合は `FLOW_LOOP_STATE_DIR=/tmp` も明示する。
+3. 明示 override は信頼済み operator 入力であり、自動既定値の `0700` 検証対象外とする。これは旧 run 完走用の一時的かつ意図的な security opt-out で、warning を出し、完了後に unset する。
+4. override なしの新規 run は常に新 directory へ入り、旧 `/tmp` file の存在に影響されない。
+
+これにより現在の run を見失わず、新実装が危険な旧 file を自動的に信用することもない。
+
+### 2.4 網羅
+
+**採用:** path の正準を `FLOW_STATE_DIR` に一本化し、次をすべて同じ directory から生成する。
+
+- progress / kpi / context と `*.new.$$`
+- scope lock
+- KPI history と history lock
+- done sentinel と sentinel `*.new.$$`
+- codex-gate log、`.final`
+- flow-x の prompt、run log、last-message/done file
+- flow-loop の loop.json、tmp、lock directory、pid、reclaim、kill switch、metrics
+- flow-loop の active run 走査先
+- flow / flow-x の KPI 集計、sentinel check、ユーザー向け削除例
+
+`deploy-watch.sh` は direct path を持たないため production code の変更は不要とし、`FLOW_STATE_DIR` を設定した integration test で context read/write が state-io 経由で同じ directory に入ることを確認する。最後に `rg` で production script と3つの `SKILL.md` を監査し、`/tmp/flow-...`、`/tmp/flowx-...`、`/tmp/codex-...` の直書きを0件にする。test harness 自身の衝突しない `mktemp -d` や、説明上の fallback `/tmp` 単体は対象外とする。
+
+### 2.5 後方互換と優先順位
+
+**採用:** 空文字は「未指定」と扱い、優先順位を次で固定する。
+
+| 利用箇所 | 優先順位（左が最優先） |
+| --- | --- |
+| state-io / codex-gate / flow / flow-x | 明示 `FLOW_STATE_DIR` → 安全な自動既定値 |
+| cleanup | 明示 `CLEANUP_FLOW_STATE_DIR` → 明示 `FLOW_STATE_DIR` → 安全な自動既定値 |
+| flow-loop 自身の state/lock/stop/metrics | 明示 `FLOW_LOOP_STATE_DIR` → 明示 `FLOW_STATE_DIR` → 安全な自動既定値 |
+| flow-loop の run 走査 | 明示 `FLOW_LOOP_RUNS_DIR` → 明示 `FLOW_STATE_DIR` → 安全な自動既定値 |
+| report metrics | CLI 第1引数 → `FLOW_LOOP_STATE_DIR` → `FLOW_STATE_DIR` → 安全な自動既定値 |
+
+既存 override を指定している運用の意味は変えない。override path を helper が勝手に chmod/chown しない。新規 `FLOW_STATE_DIR` は複数 component をまとめて hermetic に差し替えるための共通 override であり、既存のより限定的な変数が常に勝つ。
+
+### 2.6 テスト
+
+**採用:** 既存の shell test の assertion/counter 形式を踏襲し、実 filesystem と command stub の両方を使う。
+
+- 自動既定値が XDG 配下と `/tmp` fallback の双方で期待 path になり、mode `0700` で作られる。
+- 既存 symlink、foreign UID、mode `0755`、stat 不能を拒否する。foreign UID は root 権限に依存せず、owner/mode 取得 helper を test 内で stub して固定する。
+- mkdir 前後の競争を模した既存不正 entry を post-check で拒否する。
+- `FLOW_STATE_DIR` と既存の3 override、および report CLI 引数の優先順位を固定する。
+- state、cleanup、codex log、loop lock/metrics、deploy context が選択 directory の外へ出ないことを確認する。
+- static `rg` audit で対象 production file と `SKILL.md` に `/tmp` 直書きが残らないことを固定する。
+- bash と zsh の両方で resolver と既存 atomic update が動くことを確認する。
+
+---
+
+## 3. 影響範囲
+
+### 新規
+
+- `.claude/lib/flow-state-dir.sh`
+- `.claude/lib/tests/test-flow-state-dir.sh`
+
+### 変更
+
+- `.claude/lib/state-io.sh`
+- `.claude/lib/codex-gate.sh`
+- `.claude/lib/cleanup.sh`
+- `.claude/lib/tests/test-cleanup.sh`
+- `.claude/lib/tests/test-codex-gate-sentinel.sh`
+- `.claude/lib/tests/test-zsh-compat.sh`
+- `.claude/skills/flow-loop/lib/loop.sh`
+- `.claude/skills/flow-loop/lib/report.sh`
+- `.claude/skills/flow-loop/tests/test-loop.sh`
+- `.claude/skills/flow-loop/tests/test-report.sh`
+- `.claude/skills/flow-loop/SKILL.md`
+- `.claude/skills/flow/SKILL.md`
+- `.claude/skills/flow-x/SKILL.md`
+
+### 確認のみ
+
+- `.claude/lib/deploy-watch.sh` — path を直接作らず state-io に委譲済み。
+
+---
+
+## 4. 実装タスク
+
+## Task 1: secure directory resolver の契約を Red にする（2〜5分）
+
+**変更ファイル:**
+
+- Create: `.claude/lib/tests/test-flow-state-dir.sh`
+- Test target: `.claude/lib/flow-state-dir.sh`
+
+**テスト（RED）:**
+
+- XDG 未設定時の期待値が `/tmp/ark-flow-$(id -u)`、XDG 設定時が `$XDG_RUNTIME_DIR/ark-flow-$(id -u)` になる assertion を追加する。
+- 新規 directory が `0700`、既存 `0700` が冪等成功、既存 `0755`、symlink、foreign UID、stat error が非0になる assertion を追加する。
+- 対象 helper が未実装のため test が FAIL することを確認する。
+
+Run: `bash .claude/lib/tests/test-flow-state-dir.sh`
+
+Expected: FAIL。resolver/helper がまだ存在しない。
+
+**完了条件:**
+
+- OS と root 権限に依存しない Red case が揃い、失敗理由がどの security invariant か判別できる。
+
+## Task 2: secure directory resolver を Green にする（2〜5分）
+
+**変更ファイル:**
+
+- Create: `.claude/lib/flow-state-dir.sh`
+- Modify: `.claude/lib/tests/test-flow-state-dir.sh`
+
+**テスト（RED）:**
+
+- Task 1 の Red をそのまま用い、GNU/BSD stat の片方しか扱わない途中実装では対応する stub case が失敗することを確認する。
+
+**実装:**
+
+- 自動既定値の組み立て、`mkdir -m 700 -p`、pre/post symlink check、directory check、GNU/BSD owner/mode check、fail-closed 診断を小さい関数に分ける。
+- 自動既定値を選んだ場合だけ厳格検証する。明示 `FLOW_STATE_DIR` が未作成なら `0700` で作り、既存ならそのまま export する。既存の明示 path が自動既定値の invariant を満たさない場合は legacy/security opt-out warning を出すが、拒否・chmod・chown はしない。
+- consumer が helper をまだ source していなければ `CLAUDE_PROJECT_DIR` の固定 repo path から読み、未設定なら曖昧な相対 path を推測せず fail loud にする。standalone `report.sh` は実行 script の `$0` から同じ helper を読む。
+- zsh 特殊変数名、`BASH_SOURCE` self-location、素の `mv` を持ち込まない。
+
+Run: `bash .claude/lib/tests/test-flow-state-dir.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- Linux/macOS の stat 差を吸収し、競合後の不正 directory を信用せず、成功時に正準 `FLOW_STATE_DIR` が1つだけ決まる。
+
+## Task 3: state-io と deploy context を共通 directory へ切り替える（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/lib/state-io.sh`
+- Modify: `.claude/lib/tests/test-zsh-compat.sh`
+- Verify only: `.claude/lib/deploy-watch.sh`
+
+**テスト（RED）:**
+
+- `FLOW_STATE_DIR="$TMP_STATE"` で `flow_state_init` し、progress/kpi/context/scope lock と atomic update が `$TMP_STATE` 内だけに作られる test を追加する。
+- `deploy_watch_init` の外部依存を stub し、context 更新が同じ override directory に残る integration assertion を追加する。
+- 現状は `/tmp` 固定なので FAIL することを確認する。
+
+**実装:**
+
+- `_flow_state_file` と `_flow_lock_file` を `$FLOW_STATE_DIR` 起点にし、書込み前に resolver 初期化を必ず通す。
+- file basename、flock、lock inode を削除しない invariant、atomic rename、stale 判定を変えない。
+- zsh test の `/tmp/flow-*` cleanup を test専用 override directory に置換する。
+
+Run: `bash .claude/lib/tests/test-zsh-compat.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- state 3種、scope lock、中間 file、deploy-watch context が override directory 外へ出ず、bash/zsh の既存 update が回帰しない。
+
+## Task 4: codex-gate の log、last message、finding read を共通化する（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/lib/codex-gate.sh`
+- Modify: `.claude/lib/tests/test-codex-gate-sentinel.sh`
+
+**テスト（RED）:**
+
+- `FLOW_STATE_DIR="$TMP_STATE"` で codex command を stub し、gate log と `.final` が `$TMP_STATE` に作られる assertion を追加する。
+- `codex_gate_collect_new_findings` が override 配下の progress を読む assertion を追加する。
+- `/tmp` 固定の現状で FAIL することを確認する。
+
+**実装:**
+
+- 2箇所の `mktemp` template と finding 用 progress path を `$FLOW_STATE_DIR` 起点へ変更する。
+- PASS sentinel 判定、P0/P1 判定、codex invocation、cleanup 対象 basename は変えない。
+
+Run: `bash .claude/lib/tests/test-codex-gate-sentinel.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- gate phase に関係なく log、last-message、finding state が同じ選択 directory に入り、判定ロジックが不変である。
+
+## Task 5: cleanup の既存 override と共通既定値を接続する（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/lib/cleanup.sh`
+- Modify: `.claude/lib/tests/test-cleanup.sh`
+
+**テスト（RED）:**
+
+- `CLEANUP_FLOW_STATE_DIR` 未指定かつ `FLOW_STATE_DIR` 指定時に、state、done sentinel、KPI history/history lock、atomic tmp、codex gate log が共通 directory だけで処理される case を追加する。
+- 両方指定時は `CLEANUP_FLOW_STATE_DIR` が勝つ case を追加する。
+- 現状は共通 fallback を知らないため FAIL することを確認する。
+
+**実装:**
+
+- `base="${CLEANUP_FLOW_STATE_DIR:-$FLOW_STATE_DIR}"` の順に解決し、どちらも無い場合だけ secure default initializer を使う。
+- コメントと warning の `/tmp` 固有表現を「flow state directory」に直す。
+- final/resumable、sentinel 二段階 commit、KPI archive、scope whitelist、lock timeout、削除対象は変えない。
+
+Run: `bash .claude/lib/tests/test-cleanup.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- 新旧 override の優先順位が test で固定され、cleanup の対象と順序が従来と同一である。
+
+## Task 6: flow-loop の state、lock、run scan、metrics を共通化する（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/skills/flow-loop/lib/loop.sh`
+- Modify: `.claude/skills/flow-loop/tests/test-loop.sh`
+
+**テスト（RED）:**
+
+- override 無し + test用 XDG で loop.json、lock directory/pid/reclaim、stop、metrics が secure default に入る case を追加する。
+- `FLOW_LOOP_STATE_DIR > FLOW_STATE_DIR`、`FLOW_LOOP_RUNS_DIR > FLOW_STATE_DIR` の優先順位を別 directory で assertion する。
+- mode `0755` の自動既定候補で `flow_loop_init` / `flow_loop_lock` が fail closed になる case を追加する。
+
+**実装:**
+
+- loop state と run scan の既定を resolver の `FLOW_STATE_DIR` に変更し、既存2 override があれば最優先で保持する。
+- `mkdir -p` の直書きを、選択済み directory を準備する処理へ寄せる。
+- directory lock の mkdir atomic 性、pid 生存確認、mtime、rename reclaim、unlock ownership を変えない。
+
+Run: `bash .claude/skills/flow-loop/tests/test-loop.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- loop 独自 state と run state の分離 override を保ちつつ、未指定時だけ同じ安全 directory に収束し、lock 挙動が回帰しない。
+
+## Task 7: report の既定値と優先順位を固定する（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/skills/flow-loop/lib/report.sh`
+- Modify: `.claude/skills/flow-loop/tests/test-report.sh`
+
+**テスト（RED）:**
+
+- CLI file path、`FLOW_LOOP_STATE_DIR`、`FLOW_STATE_DIR`、自動既定値の4 case を追加し、優先順位を assertion する。
+- 現状 `FLOW_STATE_DIR` と secure default を知らない case が FAIL することを確認する。
+
+**実装:**
+
+- metrics 解決を `CLI > FLOW_LOOP_STATE_DIR > FLOW_STATE_DIR > secure default` にする。
+- 集計 jq、列、wait/machine の計算は変更しない。
+
+Run: `bash .claude/skills/flow-loop/tests/test-report.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- 引数ありの既存利用を壊さず、引数なしでも loop writer と同じ file を読む。
+
+## Task 8: flow の sentinel と KPI path 表記を置換する（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/skills/flow/SKILL.md`
+- Modify: `.claude/lib/tests/test-flow-state-dir.sh`
+
+**テスト（RED）:**
+
+- `SKILL.md` の実行 snippet と説明に `/tmp/flow-` が残っていない static assertion を追加する。
+- 現状の sentinel check、KPI 説明、集計説明で FAIL することを確認する。
+
+**実装:**
+
+- STEP 0 で確立した `$FLOW_STATE_DIR` を sentinel check、diagnostic、KPI 集計に使う。
+- progress/kpi/context は path を再構成できるが、可能な箇所は state-io helper を使い、正準を重複させない。
+- phase、resume 判定、terminal cleanup、KPI 算出は変えない。
+
+Run: `bash .claude/lib/tests/test-flow-state-dir.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- flow の命令例を実行しても flow 固有 file を `/tmp` 直下へ開かず、表示文も実パスと一致する。
+
+## Task 9: flow-x の prompt、codex log、done、KPI path を置換する（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/skills/flow-x/SKILL.md`
+- Modify: `.claude/lib/tests/test-flow-state-dir.sh`
+
+**テスト（RED）:**
+
+- `/tmp/flowx-`、`/tmp/codex-`、`/tmp/flow-` の static assertion を追加する。
+- 現状の同期/非同期 P2・P3 snippet、monitor snippet、sentinel、diagnostic、KPI 説明で FAIL することを確認する。
+
+**実装:**
+
+- prompt、`-run.log`、`-last.txt` をすべて `$FLOW_STATE_DIR` から生成し、LOG/DONE 監視も同じ変数を使う。
+- sentinel check、state 削除案内、KPI 集計を共通 directory に変更する。
+- detached pid、gate park、monitor の増分表示、codex options、phase 遷移は変えない。
+
+Run: `bash .claude/lib/tests/test-flow-state-dir.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- 同期/非同期の全 snippet が同じ directory を参照し、codex の完了検知 file と writer がずれない。
+
+## Task 10: flow-loop の操作例と説明を実装 path に合わせる（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/skills/flow-loop/SKILL.md`
+- Modify: `.claude/lib/tests/test-flow-state-dir.sh`
+
+**テスト（RED）:**
+
+- `/tmp/flow-progress-*`、`touch /tmp/flow-loop-stop`、`/tmp/flow-loop.json` が残らない static assertion を追加する。
+- 現状の原則、start/stop、状態、安全装置の説明で FAIL することを確認する。
+
+**実装:**
+
+- stop/start は `loop.sh` source 後の `$FLOW_LOOP_STOP` を使う例に変更し、state、metrics、active run の説明は resolved directory を示す。
+- tick の phase/gate table、WIP、breaker、polling cadence は変更しない。
+
+Run: `bash .claude/lib/tests/test-flow-state-dir.sh`
+
+Expected: PASS。
+
+**完了条件:**
+
+- operator が SKILL.md の例を copy/paste しても secure default/override を迂回しない。
+
+## Task 11: `/tmp` 直書き audit を repository test に固定する（2〜5分）
+
+**変更ファイル:**
+
+- Modify: `.claude/lib/tests/test-flow-state-dir.sh`
+
+**テスト（RED）:**
+
+- 次の production file 群を対象に `rg -n '/tmp/(flow-|flowx-|codex-)'` を実行し、hit があれば file:line を出して失敗する test を追加する。
+  - `.claude/lib/{state-io,codex-gate,cleanup,deploy-watch}.sh`
+  - `.claude/skills/flow/SKILL.md`
+  - `.claude/skills/flow-x/SKILL.md`
+  - `.claude/skills/flow-loop/SKILL.md`
+  - `.claude/skills/flow-loop/lib/{loop,report}.sh`
+- コメント、diagnostic、削除例も例外にせず対象にする。
+
+**実装:**
+
+- 残った literal を `$FLOW_STATE_DIR`、`$FLOW_LOOP_STATE_DIR`、`$FLOW_LOOP_RUNS_DIR` または basename 説明へ置換する。
+- resolver 内の `${XDG_RUNTIME_DIR:-/tmp}` と、test harness の secure `mktemp` は許容する。曖昧な全 `/tmp` whitelist は作らず、flow/codex 固有 basename の直書きだけを明確に禁止する。
+
+Run: `bash .claude/lib/tests/test-flow-state-dir.sh`
+
+Expected: PASS、audit hit 0件。
+
+**完了条件:**
+
+- state / lock / KPI / context / progress / metrics / codex log / done の直書き漏れを将来も CI 相当の shell test で検出できる。
+
+## Task 12: shell regression を全実行する（2〜5分）
+
+**変更ファイル:**
+
+- Verify only: 上記全変更ファイル
+
+**テスト（RED）:**
+
+- 個別 Task で Green にした test をまとめて実行し、source 順、環境変数残留、bash/zsh 差による suite 間の失敗があれば Red として扱う。
+
+Run:
+
+```bash
+bash .claude/lib/tests/test-flow-state-dir.sh
+bash .claude/lib/tests/test-cleanup.sh
+bash .claude/lib/tests/test-codex-gate-sentinel.sh
+bash .claude/lib/tests/test-zsh-compat.sh
+bash .claude/skills/flow-loop/tests/test-loop.sh
+bash .claude/skills/flow-loop/tests/test-report.sh
+```
+
+Expected: 全件 PASS。
+
+**完了条件:**
+
+- secure directory、override、cleanup、codex gate、loop、report、zsh の全回帰が単独・連続の双方で成功する。
+
+## Task 13: scope と差分品質を最終確認する（2〜5分）
+
+**変更ファイル:**
+
+- Verify only: 実装差分全体
+
+**テスト（RED）:**
+
+- `git diff --check`、path audit、変更 file 一覧のいずれかに違反があれば未完了とする。
+
+Run:
+
+```bash
+git diff --check
+rg -n '/tmp/(flow-|flowx-|codex-)' \
+  .claude/lib/state-io.sh \
+  .claude/lib/codex-gate.sh \
+  .claude/lib/cleanup.sh \
+  .claude/lib/deploy-watch.sh \
+  .claude/skills/flow/SKILL.md \
+  .claude/skills/flow-x/SKILL.md \
+  .claude/skills/flow-loop/SKILL.md \
+  .claude/skills/flow-loop/lib/loop.sh \
+  .claude/skills/flow-loop/lib/report.sh
+git diff --name-only origin/main...HEAD
+```
+
+Expected:
+
+- `git diff --check`: 出力なし。
+- `rg`: exit 1、出力なし。
+- 変更範囲: Section 3 の新規・変更 file のみ。`deploy-watch.sh` は test で不足が見つからない限り差分なし。
+
+**完了条件:**
+
+- file の置き場所以外の flow behavior、JSON schema、phase/gate/polling、GitHub 操作、deploy 動作に差分がない。
+
+---
+
+## 5. テスト戦略
+
+1. **resolver unit:** path 文字列、mkdir、owner、mode、symlink、GNU/BSD stat、競争後 post-check。
+2. **component integration:** state-io、codex-gate、cleanup、loop、report が同じ resolved directory と各 override を使う。
+3. **behavior regression:** state atomic update、cleanup final/resumable、KPI archive、sentinel、scope lock、loop directory lock、metrics 集計を既存 test で維持する。
+4. **shell compatibility:** bash/zsh の source と command alias の既存回帰を維持する。
+5. **static audit:** flow 固有 basename の `/tmp` 直書きを production script・SKILL.md の両方から排除する。
+6. **migration smoke:** legacy override を明示した test shell では旧 directory を参照し、unset した別 shell では secure default を参照することを確認し、同一 process 内で暗黙に混在させない。
+
+---
+
+## 6. ロールバック
+
+- 実装リリース前は、実装 commit を通常の `git revert` で戻す。旧 `/tmp` state は自動削除・移動しないため、rollback に data migration は不要。
+- リリース後に環境固有問題が出た場合は、まず user-owned `0700` directory を `FLOW_STATE_DIR` に明示して継続する。
+- 緊急に旧挙動へ戻す必要がある in-flight run だけ、Section 2.3 の4 override を `/tmp` に明示する。これは symlink 防御を外すため一時措置とし、共有 host の新規 run には使わない。
+- rollback しても新 directory 配下の file は勝手に旧 `/tmp` へ戻さない。必要な run は同じ override を指定して完走させ、手動 copy/rename はしない。
+
+---
+
+## 7. 非ゴール
+
+- flow / flow-x / flow-loop の phase、gate、WIP、breaker、polling 間隔、Cron/Monitor、通知、GitHub 操作、deploy 手順の変更。
+- state JSON schema、basename、scope key、KPI 算出、cleanup final/resumable の意味変更。
+- 稼働中の旧 `/tmp` state の自動移動、copy、削除、symlink 解決、所有権変更。
+- 明示 override の強制 `0700` 化。override は既存運用と legacy run のための信頼済み operator escape hatch とする。
+- XDG runtime state の永続化、再起動後の復元、複数 host 間共有。
+- flow と無関係な一般的な `/tmp` 利用、test harness の `mktemp`、他 skill の一時 file の全面 hardening。
+- `flock` や flow-loop directory lock を別 lock mechanism へ置換すること。
+
+---
+
+## 8. 完了条件チェック
+
+- [ ] override 未指定時、Linux/macOS とも `${XDG_RUNTIME_DIR:-/tmp}/ark-flow-$(id -u)` が選ばれる。
+- [ ] 自動既定 directory は `mkdir -m 700 -p` 後に non-symlink、self-owned、mode `0700` を post-check し、不一致を fail closed にする。
+- [ ] 新規 run は secure default、既存 in-flight run は明示 legacy override で見失わずに完走でき、自動 migration は行わない。
+- [ ] progress / kpi / context / locks / history / sentinel / atomic tmp / loop state / stop / metrics / codex prompt・log・last message の全 path が resolved directory 配下になる。
+- [ ] `CLEANUP_FLOW_STATE_DIR`、`FLOW_LOOP_STATE_DIR`、`FLOW_LOOP_RUNS_DIR` の既存利用が維持され、新規 `FLOW_STATE_DIR` との優先順位が test で固定される。
+- [ ] production script と flow / flow-x / flow-loop の `SKILL.md` に flow/codex file の `/tmp` 直書きが0件になる。
+- [ ] secure directory、owner/mode 拒否、override 優先、grep audit、bash/zsh、既存 shell regression がすべて PASS する。
+- [ ] `deploy-watch.sh` は state-io 経由で新 directory を使い、phase/gate/polling を含む flow behavior に変更がない。


### PR DESCRIPTION
## 概要

flow / flow-x / flow-loop の state・lock・KPI・context・codex ログ・done sentinel が予測可能な `/tmp/flow-*` を `>`/`>>` で開き **symlink を辿る**ため、マルチユーザーホストで別ユーザーが先にリンクを置くと任意ファイルの切り詰め・追記が可能（symlink/TOCTOU 攻撃）。これを塞ぐ。

## 実装

- **単一 resolver** `.claude/lib/flow-state-dir.sh`（211行）をパス解決と安全初期化の正準にする。各スクリプトは `${CLAUDE_PROJECT_DIR}/.claude/lib/flow-state-dir.sh` を明示 source（zsh で壊れる `BASH_SOURCE` self-location は不使用）
- **既定ディレクトリ** `${XDG_RUNTIME_DIR:-/tmp}/ark-flow-$(id -u)` を `mkdir -m 700`。作成後に **非 symlink・owner=自分・mode=0700 を GNU/BSD `stat` 両方で検証**し、不一致なら chmod/chown で「修復」せず **fail closed**
- **XDG_RUNTIME_DIR** が指定されているのに不正（symlink / 他人所有 / group・other writable）なら黙って `/tmp` に fallback せず fail closed
- **共通 override** `FLOW_STATE_DIR` を追加。既存の `CLEANUP_FLOW_STATE_DIR` / `FLOW_LOOP_STATE_DIR` / `FLOW_LOOP_RUNS_DIR` は**より限定的な override として常に優先**（後方互換）。override path は信頼済み operator 入力として検証せず warn のみ・chmod/chown しない
- **旧 `/tmp` state の自動移行はしない**（新規 run から新既定。in-flight run は旧パスで完走。更新後に旧 run を継続する場合のみ `FLOW_STATE_DIR=/tmp` 等を明示）
- 全パス（progress/kpi/context/`*.new.$$`・scope lock・KPI history/lock・done sentinel・codex-gate log/`.final`・flow-x prompt/run log/last-message・flow-loop loop.json/tmp/lock/pid/reclaim/kill switch/metrics・active run 走査・KPI 集計）を新ディレクトリから生成
- phase/gate/polling/atomic rename/lock 方式/cleanup の**挙動は不変**。変えたのは置き場所だけ

## 検証

- shell テスト: **6 スイート 178/178 PASS**（うち私が隔離環境で再確認: `test-flow-state-dir` 23/23、`test-loop` 63/63）
- resolver セキュリティレビュー: fail-closed・symlink/owner/mode 検証・TOCTOU（mkdir -m 700 → 再検証）を確認
- **rg audit**: production script + 3 SKILL.md に `/tmp/flow-`・`/tmp/flowx-`・`/tmp/codex-` の直書き **0件**
- bash / zsh 両対応・atomic update 確認

Closes #219
