### PR TITLE
fix: モバイル真っ白を修正（外部Google Fontsをセルフホスト化） (#262)

### DIFF
--- a/packages/web/index.html
+++ b/packages/web/index.html
@@ -7,21 +7,10 @@
       content="width=device-width, initial-scale=1.0, maximum-scale=1, viewport-fit=cover"
     />
     <title>Ark</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
   </head>
 
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <script
-      defer
-      src="%VITE_ANALYTICS_ENDPOINT%/umami"
-      data-website-id="%VITE_ANALYTICS_WEBSITE_ID%"
-    ></script>
   </body>
 </html>

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@ark/shared": "workspace:*",
+    "@fontsource/inter": "^5.3.0",
+    "@fontsource/jetbrains-mono": "^5.3.0",
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,5 +1,24 @@
+import "@fontsource/inter/400.css";
+import "@fontsource/inter/500.css";
+import "@fontsource/inter/600.css";
+import "@fontsource/inter/700.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+import "@fontsource/jetbrains-mono/600.css";
+import "@fontsource/jetbrains-mono/700.css";
 import { createRoot } from "react-dom/client";
 import App from "./App";
 import "./index.css";
+
+const analyticsEndpoint = import.meta.env.VITE_ANALYTICS_ENDPOINT;
+const analyticsWebsiteId = import.meta.env.VITE_ANALYTICS_WEBSITE_ID;
+
+if (analyticsEndpoint && analyticsWebsiteId) {
+  const script = document.createElement("script");
+  script.defer = true;
+  script.src = `${analyticsEndpoint}/umami`;
+  script.dataset.websiteId = analyticsWebsiteId;
+  document.head.appendChild(script);
+}
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,12 @@ importers:
       '@ark/shared':
         specifier: workspace:*
         version: link:../shared
+      '@fontsource/inter':
+        specifier: ^5.3.0
+        version: 5.3.0
+      '@fontsource/jetbrains-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.75.0(react@19.2.5))
@@ -841,6 +847,12 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@fontsource/inter@5.3.0':
+    resolution: {integrity: sha512-RofMylZmjlJEfELXeNHFWBRcSs75rGU/6bV2S2jfnvv/3rPXPGe0LgUJTklcHZ9lM4OZmAVFhcJPnACfb91A3g==}
+
+  '@fontsource/jetbrains-mono@5.3.0':
+    resolution: {integrity: sha512-fqDfB5I9f1p1TV486aUgB9t8zP84P0O1FtQR5Ol9vjwPy+S+EIGlVYm1cvj2W5shcZMTg2nZFdVMoH5wFu8a1A==}
 
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -5367,6 +5379,10 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@fontsource/inter@5.3.0': {}
+
+  '@fontsource/jetbrains-mono@5.3.0': {}
 
   '@gar/promisify@1.1.3': {}
 


### PR DESCRIPTION
## 概要（hotfix）

モバイルでアプリが**真っ白**になる本番バグを修正する。

## 根本原因（再現で確定）

`packages/web/index.html` が**外部 Google Fonts スタイルシート**（`fonts.googleapis.com`）を読み込んでおり、`<link rel="stylesheet">` は**レンダリングブロッキング**。モバイル回線（セルラー・Google が遅い/届かない網・Cloudflare Tunnel 経由の遅いクライアント等）でこのリクエストがハングすると、スタイルシート待ちで **React が mount する前に画面が白いまま**になる。

headless 再現:
- Google Fonts 到達可 → `#root` 描画（innerHTML ≈ 18,932）
- `fonts.googleapis.com` / `fonts.gstatic.com` をハング → **`#root` 空（=白画面）**

「再発性・モバイル固有・PC/fresh 再現は正常・モバイルはハードリロード不可」の全証拠と整合。

## 修正

- **Inter / JetBrains Mono を `@fontsource` でセルフホスト**（woff2 をローカル bundle）、index.html の外部 `<link>` / `preconnect` を除去。図解ハーネスが CSP で外部リソースを禁止しているのと同じ「外部依存ゼロ」原則に揃えた。CSS の family 参照とシステムフォント fallback はそのまま
- 副次: 未展開だった analytics script（`%VITE_ANALYTICS_ENDPOINT%` → 404）を、**env（endpoint + website-id）が両方定義されているときだけ `main.tsx` で動的注入**するよう変更。未定義時は script を出さない

## 検証

- **修正の実証**（原因究明と同じ fonts-blocked 条件で再実行）: 修正前 root=0（白画面）→ **修正後 root=34,378（0.5s で描画）**、外部フォント request **0 件**
- `dist/index.html` に `fonts.googleapis.com` / `fonts.gstatic.com` / `%VITE_ANALYTICS` を含まない（grep 確認）
- woff2 44個がローカル bundle
- `pnpm check` / `pnpm build`: PASS
- unit: **46 files / 678 tests PASS**
- `pnpm-lock.yaml` 差分は `@fontsource/inter` + `@fontsource/jetbrains-mono` の追加のみ

Closes #262


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Inter と JetBrains Mono フォントをアプリ内で読み込むようになり、表示の一貫性が向上しました。
  * 分析機能の読み込み方法を見直し、設定に応じて計測を実行できるようになりました。
  * 外部フォントおよび分析スクリプトの直接読み込みを削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->