### PR TITLE
デプロイ経路すべてに pnpm install を追加し claude-code の postinstall を許可する

### DIFF
--- a/.claude/lib/deploy-watch.sh
+++ b/.claude/lib/deploy-watch.sh
@@ -3,16 +3,18 @@
 # flow P12: ark の **ローカル pm2 デプロイ** を実行・監視するヘルパー。
 #
 # ark には GitHub Actions の deploy workflow が無く、main ブランチを pull した後に
-# `pkill -f ttyd && pnpm build && pm2 restart claude-code-ark` で再起動する運用 (CLAUDE.md 参照)。
+# `pnpm install --frozen-lockfile && pnpm build && pkill -x ttyd && pm2 restart claude-code-ark`
+# で再起動する運用 (CLAUDE.md 参照)。install を省略すると、毎晩の bump-claude-code による
+# 同梱 @anthropic-ai/claude-code の更新が node_modules に反映されない。
 # 本ヘルパーは P11 のマージ完了後に呼ばれ、以下を行う:
 #
 #   1. deploy 対象パス変更を検出 (packages/server/src/, packages/web/, packages/shared/src/, packages/server/ecosystem.config.cjs, package.json)
 #      → 変更が無ければ no-target finalize
 #   2. pm2 で claude-code-ark プロセスが稼働しているかを判定
 #      → 稼働していなければ "pnpm dev で動いている" とみなして no-target finalize
-#   3. 稼働している場合は `pkill -f ttyd && pnpm build && pm2 restart claude-code-ark` を実行
+#   3. 稼働している場合は `pnpm install --frozen-lockfile && pnpm build && pkill -x ttyd && pm2 restart claude-code-ark` を実行
 #   4. 30 秒間隔で最大 5 回、health check (HTTP 200 on http://localhost:<PORT>/) を実施
-#      → 成功で success、5 回連続失敗で failure、build/restart 失敗で failure
+#      → 成功で success、5 回連続失敗で failure、install/build/restart 失敗で failure
 #
 # 利用想定:
 #   source "$CLAUDE_PROJECT_DIR/.claude/lib/deploy-watch.sh"
@@ -63,12 +65,15 @@ _DEPLOY_WATCH_PATHS=(
 DEPLOY_WATCH_MAX_FIRES=${DEPLOY_WATCH_MAX_FIRES:-5}                  # 30 秒 × 5 = 2.5 分
 DEPLOY_WATCH_TICK_INTERVAL=${DEPLOY_WATCH_TICK_INTERVAL:-30}         # 30 秒間隔
 DEPLOY_WATCH_MAX_POLL_FAILURES=${DEPLOY_WATCH_MAX_POLL_FAILURES:-5}
-DEPLOY_WATCH_MAX_WALL_SECONDS=${DEPLOY_WATCH_MAX_WALL_SECONDS:-180}  # 3 分
+# wall cap は init からの経過秒で判定される (初回 tick の install/build/restart 時間も含む)。
+# install (最大 120s) + build (最大 120s) + restart (最大 30s) が収まるよう 5 分とする
+DEPLOY_WATCH_MAX_WALL_SECONDS=${DEPLOY_WATCH_MAX_WALL_SECONDS:-300}  # 5 分
 
-# pnpm build / pm2 restart の個別タイムアウト (秒)。
+# pnpm install / pnpm build / pm2 restart の個別タイムアウト (秒)。
 # これを超えるとコマンドが kill され failure として扱われる。
-# 設定しないと build/restart のハングで P12 が wall-clock cap に到達できず無限待機になる
+# 設定しないと install/build/restart のハングで P12 が wall-clock cap に到達できず無限待機になる
 # (codex review [P1] 指摘)。
+DEPLOY_WATCH_INSTALL_TIMEOUT=${DEPLOY_WATCH_INSTALL_TIMEOUT:-120}
 DEPLOY_WATCH_BUILD_TIMEOUT=${DEPLOY_WATCH_BUILD_TIMEOUT:-120}
 DEPLOY_WATCH_RESTART_TIMEOUT=${DEPLOY_WATCH_RESTART_TIMEOUT:-30}
 
@@ -203,8 +208,8 @@ deploy_watch_set_cron_id() {
   flow_state_update context ".deploy_watch.cron_id = \"$cron_id\"" "$scope_key"
 }
 
-# main worktree で `pkill -f ttyd && pnpm build && pm2 restart claude-code-ark` を実行する。
-# 戻り値: 0=成功, 1=失敗 (build / restart いずれか)
+# main worktree で `pnpm install --frozen-lockfile && pnpm build && pkill -x ttyd && pm2 restart claude-code-ark` を実行する。
+# 戻り値: 0=成功, 1=失敗 (install / build / restart いずれか)
 # 出力: stdout/stderr に build / restart のログを残す
 # 副作用: context.deploy_watch.deploy_started_at / deploy_completed_at を更新
 deploy_watch_run_pm2_deploy() {
@@ -221,17 +226,28 @@ deploy_watch_run_pm2_deploy() {
   started_at=$(date +%s)
   flow_state_update context ".deploy_watch.deploy_started_at = $started_at" "$scope_key"
 
-  echo "[deploy-watch] pkill -f ttyd"
-  pkill -f ttyd || true  # ttyd プロセス無しは正常
-
-  # pnpm build / pm2 restart はハング可能性があるため timeout で囲む。
+  # pnpm install / pnpm build / pm2 restart はハング可能性があるため timeout で囲む。
   # cap 内に終わらないと kill され、tick は terminal=failure を返す
   # (codex review [P1] 指摘への対応)。
+  # install を省略すると毎晩の bump-claude-code による同梱 claude の更新が
+  # node_modules に反映されず、古いバージョンを配り続ける。
+  echo "[deploy-watch] cd $main_root && timeout ${DEPLOY_WATCH_INSTALL_TIMEOUT}s pnpm install --frozen-lockfile"
+  if ! (cd "$main_root" && timeout "${DEPLOY_WATCH_INSTALL_TIMEOUT}s" pnpm install --frozen-lockfile 2>&1); then
+    echo "ERROR: pnpm install に失敗または ${DEPLOY_WATCH_INSTALL_TIMEOUT}s でタイムアウト" >&2
+    return 1
+  fi
+
   echo "[deploy-watch] cd $main_root && timeout ${DEPLOY_WATCH_BUILD_TIMEOUT}s pnpm build"
   if ! (cd "$main_root" && timeout "${DEPLOY_WATCH_BUILD_TIMEOUT}s" pnpm build 2>&1); then
     echo "ERROR: pnpm build に失敗または ${DEPLOY_WATCH_BUILD_TIMEOUT}s でタイムアウト" >&2
     return 1
   fi
+
+  # ttyd の kill は restart の直前に行い、build 中のターミナル断を避ける。
+  # -f はコマンドライン部分一致で無関係プロセス (例: ttyd-manager.ts を開いたエディタ)
+  # を巻き込みうるため、プロセス名完全一致の -x を使う。
+  echo "[deploy-watch] pkill -x ttyd"
+  pkill -x ttyd || true  # ttyd プロセス無し / 他ユーザー所有で kill 不可は正常
 
   echo "[deploy-watch] timeout ${DEPLOY_WATCH_RESTART_TIMEOUT}s pm2 restart $DEPLOY_WATCH_PM2_APP"
   if ! timeout "${DEPLOY_WATCH_RESTART_TIMEOUT}s" pm2 restart "$DEPLOY_WATCH_PM2_APP" 2>&1; then
@@ -325,12 +341,12 @@ deploy_watch_tick() {
   local deploy_completed_at
   deploy_completed_at=$(flow_state_read context '.deploy_watch.deploy_completed_at' "$scope_key")
   if [ "$deploy_completed_at" = "null" ] || [ -z "$deploy_completed_at" ]; then
-    echo "[deploy-watch] 初回 tick: pkill ttyd → pnpm build → pm2 restart 実行"
+    echo "[deploy-watch] 初回 tick: pnpm install → pnpm build → pkill ttyd → pm2 restart 実行"
     if ! deploy_watch_run_pm2_deploy "$scope_key"; then
       DEPLOY_WATCH_RESULT="failure"
-      DEPLOY_WATCH_DETAIL='{"reason":"pnpm build または pm2 restart 失敗"}'
+      DEPLOY_WATCH_DETAIL='{"reason":"pnpm install / pnpm build または pm2 restart 失敗"}'
       flow_state_update context '.deploy_watch.result = "failure"' "$scope_key"
-      printf '[deploy-watch] FAILURE: build/restart 失敗\n'
+      printf '[deploy-watch] FAILURE: install/build/restart 失敗\n'
       printf 'RESULT=failure CRON_ID=%s FIRES=%s\n' "${cron_id:-null}" "$fires"
       return 0
     fi

--- a/.claude/skills/build-deploy/SKILL.md
+++ b/.claude/skills/build-deploy/SKILL.md
@@ -8,13 +8,15 @@ allowed-tools: Bash
 
 CLAUDE.mdのデプロイ手順に従い、以下を **順番通りに** 実行する。
 
-### 1. ttydプロセスをkill
+### 1. 依存関係をインストール
 
 ```bash
-pkill -f ttyd
+pnpm install --frozen-lockfile
 ```
 
-エラーは無視してよい（ttydが起動していない場合）。
+毎晩の bump-claude-code ワークフローによる同梱 `@anthropic-ai/claude-code` の更新は、
+install で初めて node_modules に反映される。省略すると稼働中の Ark が旧バージョンの
+claude を配り続ける。失敗した場合はエラー内容を報告して停止する。
 
 ### 2. ビルド
 
@@ -24,21 +26,34 @@ pnpm build
 
 失敗した場合はエラー内容を報告して停止する。
 
-### 3. pm2で再起動
+### 3. ttydプロセスをkill（再起動の直前に実行）
+
+```bash
+pkill -x ttyd
+```
+
+エラーは無視してよい（ttydが起動していない場合）。
+
+### 4. pm2で再起動
 
 ```bash
 pm2 restart claude-code-ark
 ```
 
-### 4. 結果報告
+### 5. 反映確認と結果報告
 
-- 成功: 「ビルド&デプロイ完了」と報告
+```bash
+packages/server/node_modules/.bin/claude --version
+```
+
+- 成功: 同梱 claude のバージョンを添えて「ビルド&デプロイ完了」と報告
 - 失敗: エラー内容を表示
 
 ## 注意
 
-- `pkill -f ttyd` を省略するとttydのポート(7680〜)が競合し、ターミナルが表示されなくなる
-- 3つのコマンドは必ず上記の順番で実行すること
+- `pkill -x ttyd` を省略するとttydのポート(7680〜)が競合し、ターミナルが表示されなくなる。kill は pm2 restart の直前に行う（`-f` はコマンドライン文字列に "ttyd" を含む無関係なプロセスへ誤マッチしうるため `-x` を使う）
+- コマンドは必ず上記の順番で実行すること
+- `@anthropic-ai/claude-code` の postinstall（native binary の配置）はルート `package.json` の `pnpm.onlyBuiltDependencies` で許可している。install 後に `claude native binary not installed` が出る場合はこの許可が外れていないか確認する
 
 ## pm2 の env 汚染に注意 (pm2 start / --update-env 時)
 

--- a/.claude/skills/flow-x/SKILL.md
+++ b/.claude/skills/flow-x/SKILL.md
@@ -825,9 +825,9 @@ flow_state_update progress '.phase = "P12"' "$SCOPE_KEY"
 
 ---
 
-## P12: pm2 deploy 監視 (30 秒間隔・最大 3 分)
+## P12: pm2 deploy 監視 (30 秒間隔・最大 5 分)
 
-ark の本番デプロイは `pkill -f ttyd && pnpm build && pm2 restart claude-code-ark`。
+ark の本番デプロイは `pnpm install --frozen-lockfile && pnpm build && pkill -x ttyd && pm2 restart claude-code-ark`。
 判定・tick の仕様は flow P12 と同一 (deploy-watch.sh の has_target / pm2_online 判定)。
 
 | 条件 | 動作 |

--- a/.claude/skills/flow/SKILL.md
+++ b/.claude/skills/flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: flow
-description: ark 用の自走期間最大化型自律実装 skill。worktree 作成 → plan (codex DDD) → 実装 (TDD) → ローカル検証 → push 前 codex review → push → CI/CodeRabbit 監視 → 自律修正 → マージ前 codex review → マージ確認 (人間) → cleanup → pm2 deploy 監視 (30 秒間隔・最大 3 分) を 1 セッション内で連続実行する。GitHub Issue 連携 (#NNN) または slug ベースの両方に対応。worktree は P11 で削除せず、deploy 結果を確認したユーザーが手動で削除する運用。
+description: ark 用の自走期間最大化型自律実装 skill。worktree 作成 → plan (codex DDD) → 実装 (TDD) → ローカル検証 → push 前 codex review → push → CI/CodeRabbit 監視 → 自律修正 → マージ前 codex review → マージ確認 (人間) → cleanup → pm2 deploy 監視 (30 秒間隔・最大 5 分) を 1 セッション内で連続実行する。GitHub Issue 連携 (#NNN) または slug ベースの両方に対応。worktree は P11 で削除せず、deploy 結果を確認したユーザーが手動で削除する運用。
 disable-model-invocation: true
 allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, Skill, AskUserQuestion, Monitor, CronCreate, CronDelete, CronList, PushNotification, WebSearch, WebFetch
 argument-hint: [#<issue> | <slug>] [--resume | --from PHASE | --dry-run | --plan-only | --kpi]
@@ -504,7 +504,7 @@ cleanup_issue_close_hint "$ISSUE_NUMBER_FROM_STATE"
 P11 完了直前に、`progress.warnings` に蓄積した警告をまとめて `AskUserQuestion` で表示 (1 回のみ)。
 
 ### 11-2. KPI 集計 (`end_at` は記録しない)
-P11 完了時点では `kpi.end_at` を書かない。P12 (deploy 監視) が最大 3 分動く可能性があるため、
+P11 完了時点では `kpi.end_at` を書かない。P12 (deploy 監視) が最大 5 分動く可能性があるため、
 ここで end_at を記録すると KPI が deploy 待機を含まず短く出る。
 **`end_at` は P12 terminal (success/failure/timeout/poll-error/no-target) で記録する。**
 
@@ -515,9 +515,9 @@ flow_state_update progress '.phase = "P12"' "$SCOPE_KEY"
 
 ---
 
-## P12: pm2 deploy 監視 (30 秒間隔・最大 3 分)
+## P12: pm2 deploy 監視 (30 秒間隔・最大 5 分)
 
-ark の本番デプロイは `pkill -f ttyd && pnpm build && pm2 restart claude-code-ark`。
+ark の本番デプロイは `pnpm install --frozen-lockfile && pnpm build && pkill -x ttyd && pm2 restart claude-code-ark`。
 P12 では以下の判定で動作を分ける:
 
 | 条件 | 動作 |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,7 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 
 ## 自走実装（flow / flow-x / flow-loop）
 
-- **`/flow #NNN`（または slug）**: Claude が plan/実装し codex がレビューゲート (P2/P5/P8/P9) を担う自走 skill。worktree 作成 → plan → 実装 (TDD) → ローカル検証 → push → CI/CodeRabbit 監視 → 自律修正 → マージ確認 (人間) → cleanup → pm2 deploy 監視 (P12: 30 秒間隔・最大 3 分) を 1 セッションで実行。worktree は `<repo-parent>/ark-<sanitized-branch>/` に作られ、P11 では削除しない（deploy 確認後にユーザーが手動 `git worktree remove`）
+- **`/flow #NNN`（または slug）**: Claude が plan/実装し codex がレビューゲート (P2/P5/P8/P9) を担う自走 skill。worktree 作成 → plan → 実装 (TDD) → ローカル検証 → push → CI/CodeRabbit 監視 → 自律修正 → マージ確認 (人間) → cleanup → pm2 deploy 監視 (P12: 30 秒間隔・最大 5 分) を 1 セッションで実行。worktree は `<repo-parent>/ark-<sanitized-branch>/` に作られ、P11 では削除しない（deploy 確認後にユーザーが手動 `git worktree remove`）
 - **`/flow-x #NNN`**: flow の役割逆転版。**codex が plan 立案と実装** (`codex exec --dangerously-bypass-approvals-and-sandbox`)、**Claude がレビュー** (P2/P5/P8/P9)。**P2.5 設計承認ゲート**（人間が plan を承認してから実装へ）を持ち、plan は成果物としてコミットする。`--async-gates` で待ちを park に変える非同期モードになる
 - **運転ループ `/flow-loop`**: `/flow-x` の外殻。自分アサインの open Issue を WIP 上限 (既定 2) 内で自動 pick し `/flow-x --async-gates` で回す冪等な `tick` を提供する。人間ゲートは **P2.5 設計承認**と **P10 マージ確認**の 2 つで廃止せず、判断を **GitHub PR 上のシグナル** (コメント「承認」`ok` `lgtm` /「修正: <指示>」/ Close。author 本人の PR は GitHub 仕様で Approve 不可のためコメントで判断) として非同期に検知する。設計承認は plan をコミットした draft PR で取る。P7 (CI/CodeRabbit) / P12 (deploy) のセッション内待機 (Monitor/CronCreate) も tick のポーリングに置き換わるため、セッションを拘束しない。安全装置: サーキットブレーカー (連続 halt 3 で停止)・kill switch・`--dry-run`・日次 pick 予算・`active_hours`。loop に処理させない Issue は GitHub ラベル `loop-exclude` で pick 対象から外す。常駐運用は `/loop 30m /flow-loop tick`。詳細は `.claude/skills/flow-loop/SKILL.md`
 
@@ -115,20 +115,30 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 mainブランチをpullした後は、以下の手順で **順番通りに** ビルド・再起動する：
 
 ```bash
-# 1. 古いttydプロセスをkill
-#    ttydは各セッションごとに独立プロセスで起動しており、
-#    サーバー再起動時に同じポートを確保できずEADDRINUSEになるため、
-#    必ず先にkillする
-pkill -f ttyd
+# 1. 依存関係をインストール
+#    毎晩の bump-claude-code ワークフローによる同梱 @anthropic-ai/claude-code の
+#    更新は install で初めて node_modules に反映される。省略すると稼働中の Ark が
+#    旧バージョンの claude を配り続ける
+pnpm install --frozen-lockfile
 
 # 2. ビルド
 pnpm build
 
-# 3. pm2で再起動（サーバー起動時にttydも自動で再起動される）
+# 3. 古いttydプロセスをkill（再起動の直前に実行）
+#    ttydは各セッションごとに独立プロセスで起動しており、
+#    サーバー再起動時に同じポートを確保できずEADDRINUSEになるため、
+#    必ず再起動前にkillする。-f だとコマンドライン文字列に "ttyd" を含む
+#    無関係なプロセスに誤マッチしうるため、プロセス名一致の -x を使う
+pkill -x ttyd
+
+# 4. pm2で再起動（サーバー起動時にttydも自動で再起動される）
 pm2 restart claude-code-ark
 ```
 
-**注意**: `pkill -f ttyd` を省略するとttydのポート(7680〜)が競合し、ターミナルが表示されなくなる。
+**注意**:
+
+- `pkill -x ttyd` を省略するとttydのポート(7680〜)が競合し、ターミナルが表示されなくなる
+- `@anthropic-ai/claude-code` の postinstall（native binary の配置）はルート `package.json` の `pnpm.onlyBuiltDependencies` で許可している。リストから外すと install 後も `claude native binary not installed` で起動できなくなる
 
 ## 一般規約
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
       "better-sqlite3",
       "esbuild",
       "@tailwindcss/oxide",
-      "electron"
+      "electron",
+      "@anthropic-ai/claude-code"
     ]
   }
 }


### PR DESCRIPTION
## 背景

毎晩の bump-claude-code ワークフロー（18:00 UTC）は正常に動いており、main は npm latest の 2.1.219 に追従済み。しかし**デプロイ手順（CLAUDE.md / build-deploy skill / flow P12 の deploy-watch.sh）のいずれにも `pnpm install` が無かった**ため、node_modules が更新されず、稼働中の Ark は 2.1.217 の同梱 claude を配り続けていた（本番実機で確認）。

さらに、install を足すだけでは不十分なことも実機で確認した: pnpm v10 は `pnpm.onlyBuiltDependencies` に無い依存のビルドスクリプトをブロックするため、claude-code の postinstall（native binary の配置）が走らず `Error: claude native binary not installed` で起動不能になる。

## 変更内容

- **CLAUDE.md / build-deploy skill**: デプロイ手順に `pnpm install --frozen-lockfile` を追加。skill には同梱 claude のバージョン確認ステップも追加
- **`.claude/lib/deploy-watch.sh`（flow P12 自動デプロイ）**: install ステップを追加（codex review P1 指摘）。install(120s)+build(120s)+restart(30s) が収まるよう wall cap を 3 分 → 5 分に拡大し、flow / flow-x / CLAUDE.md の P12 記述も追従
- **ttyd kill の堅牢化**: `pkill -f`（部分一致。`ttyd-manager.ts` を開いたエディタ等に誤マッチしうる）→ `pkill -x`（プロセス名完全一致）に変更し、実行位置を pm2 restart の直前に移動（build 中のターミナル断を回避）
- **root package.json**: `pnpm.onlyBuiltDependencies` に `@anthropic-ai/claude-code` を追加

## 検証

- 本番で install → postinstall → check → build → restart を実施し、同梱 claude が 2.1.219 で起動・HTTP 200 を確認済み
- `bash -n` で deploy-watch.sh の構文確認、`.claude/lib/tests/test-zsh-compat.sh` 6/6 pass
- worktree で `pnpm install --frozen-lockfile`（lockfile 整合性）と `pnpm check` を確認
- codex review: 初回 P1 1件（deploy-watch.sh の install 欠落）→ 対応後 GATE PASS