### PR TITLE
図解編集 Phase A: 選択 state + 浮くコンテキストツールバー (#267)

### DIFF
--- a/docs/superpowers/plans/2026-07-25-issue-267.md
+++ b/docs/superpowers/plans/2026-07-25-issue-267.md
@@ -1,0 +1,631 @@
+# issue-267: 選択 state + 浮くコンテキストツールバー Implementation Plan
+
+**Goal:** graph node / edge の編集コントロールを hover 駆動から選択駆動の単一コンテキストツールバーへ置き換え、選択中はポインターが要素とツールバーの間を移動してもツールバーが消えないことを DOM test で保証する。
+
+**Issue:** #267「図解編集 Phase A: 選択 state + 浮くコンテキストツールバー」
+
+**親設計:** `docs/superpowers/specs/2026-07-25-diagram-smooth-editing-design.md`（承認済み）
+
+**Architecture:** `packages/server/src/lib/diagram-harness.ts` の単一注入文字列内に、semantic state として `selection = { kind: 'node' | 'edge' | null, id }` を1つだけ置く。クリック元の graph / DOM element は位置解決用の一時参照として selection とは分離する。`body` 直下に `data-ark-harness-ui` 付きの context toolbar root を1個だけ生成し、selection に応じて node / edge の内容を安全な DOM API で差し替える。toolbar は選択対象の `getBoundingClientRect()` を基準に `position: fixed` で上へ置き、上端に収まらなければ下へ fallback、左右は viewport 内へ clamp する。scroll / resize / graph 再描画は `requestAnimationFrame` で位置更新を coalesce する。
+
+**Tech Stack:** TypeScript / injected vanilla DOM・CSS・inline SVG / Vitest / Playwright
+
+---
+
+## 調査結果
+
+### 現行の selection と node 削除
+
+- `packages/server/src/lib/diagram-harness.ts:324-338` は `state = { model: null }` とは別に `selectedNodeId` を持つ。node / edge 共通の selection state はまだない。
+- `setSelectedNode()` と `attachNodeSelection()`（同ファイル `:2093-2125`）は node root に `tabindex` を足し、`pointerdown` / `click` / `focusin` で node を選択する。選択表示は `.ark-harness-node-selected` である。
+- `pointerdown` は contenteditable / input / textarea / select / button の実矩形内なら `preventDefault()` と root focus を避ける一方、後続 `click` は無条件に node を選択する。このため caret を置けるが、選択ロジックが2経路に分かれている。
+- 空白クリックによる解除と Escape による選択解除はない。Escape は現在 edge drag cancel だけに使われる。
+- `removeNode()`（`:2162-2212`）は node、incident edge、全 `groups[].nodes` の参照を同じ同期処理で除去し、同 id の graph 内外 projection、observer / map / active drag も掃除する。これは #243 の参照整合性契約としてそのまま再利用する。
+- `handleNodeDeleteKey()` は Delete / Backspace を node 削除へ接続し、contenteditable / form control 中は横取りしない。Phase A では edge selection にも対応する共通 selection delete handler へ一般化する。
+
+### kind picker と node hover affordance
+
+- kind 候補は authored CSS rule から `collectKindCandidates()` で収集し、固定 enum にしない。`updateNodeKind()` は allowlist を再検査して `node.kind`、`data-kind`、layout を同期する。この安全境界は再利用する。
+- 現在は node ごとに `attachKindPicker()`（`:2587-2614`）で wrapper / select / option を生成し、`kindPickers` 配列で同期する。
+- `.ark-harness-kind-picker` は node の上へ絶対配置され、`.ark-harness-graph-node:hover > .ark-harness-kind-picker`（`:156`）だけでも `opacity: 1; pointer-events: auto` になる。node 外へ出た picker へ向かうと node の `:hover` が切れるため、grace period のない主たる hover-gap である。
+- `attachNodeAffordanceHover()`（`:2037-2091`）にも 120ms の close timer があり、kind picker、graph drag handle、node connector をまとめて延命する。ただし純 CSS `:hover` 経路はこの timer と無関係に閉じる。
+- 同じ node hover controller は #243 の8方向 edge 作成アンカーも表示している。Phase B の作成 gesture を壊さないため、この controller、`AFFORDANCE_CLOSE_DELAY = 120`、connector の pointerenter / leave は残す。Phase A で除くのは controller の kind picker 参照と kind picker 用 CSS / DOM だけである。
+
+### edge control
+
+- edge の透明 wide-stroke hit target は `appendEdgeHitTarget()`（`:1087-1100`）で SVG ごとに描画され、現在は `pointerenter` で `activateEdgeControls()`、`pointerleave` で `scheduleEdgeControlsClose()` を呼ぶ。
+- edge ごとに `.ark-harness-edge-controls` root と3つの native select を生成し、`graph.edgeControlsById` へ保持する。root / select は hover / focus と 100ms `closeTimer` で表示を維持する。
+- `createEdgeOption()`、`edgeControlProperty()`、`syncEdgeSelect()`、`updateEdgeExt()` は allowlist、未知値 placeholder、安全な DOM API、即時 SVG 投影を実装済みである。これらを「選択 edge 1件の toolbar content」用に引数整理して再利用する。
+- `edgeControlBlockers()`、`edgePathAnchor()`、`placeEdgeSelect()`、`positionEdgeControls()`（`:1695-1847`）は3つの select を edge 周辺へ別々に置き、node / label / handle と6px gapを取る処理である。単一 toolbar の矩形配置へ置換できるため削除原資になる。
+- edge 自体には selection visual / keyboard selection がない。hit target の primary click を selection entry point にし、再描画のたびに edge main へ selected class を再投影する。
+
+### 「+ 行を追加」と行 control
+
+- `initEditing()` は node 所有の `ul` / `ol` を `listBindings` に集めるが、現在この配列は関数ローカルである。
+- `wireList()`（`:2746-2767`）は各 list の直後に常時表示の「+ 行を追加」を挿入し、`addField()` を呼ぶ。Phase A では binding を node id / 選択 projection から解決できる registry にし、常時 button の生成だけを撤去して toolbar の「+ 行」から同じ `addField()` を呼ぶ。
+- 現コードに常時表示の node delete button / edge delete button はない。既存 test も `.ark-harness-node-delete` / `.ark-harness-edge-delete` が0件であることを固定している。node は選択 + Delete、edge は endpoint を空白へ drag することで削除される。
+- 常時の「×」は field 行の削除 button（`attachRowControls()`）であり、semantic node / edge の削除とは別操作である。Phase A の toolbar は仕様どおり選択 node / edge 自体を削除する。field 行の reorder / delete を同じ button へ混ぜると selection state に row kind が必要になるため、行 handle / 行「×」は能力維持のため残す。field row chrome の整理は Phase C / D で別途扱う。
+
+### graph 再描画、複数 graph、scroll
+
+- `wireGraph()` は graph ごとに `nodesById`、`edgeMainById`、geometry / handle / connector map を持つ。edge SVG / hit target は `renderGraph()` のたびに作り直される。
+- `ResizeObserver` は graph container と node を監視し、window resize でも graph render を schedule する。選択中の edge anchor は古い SVG element を保持せず、選択元 graph の最新 `edgeMainById` から毎回引き直す必要がある。
+- model id は全 model entry で予約されるが、同じ semantic id の projection が複数 graph に存在する可能性は DOM 層で禁止されていない。semantic selection は `{ kind, id }` の1つを維持し、どの projection をクリックしたかを `selectionGraph` / anchor context として別に持つ。
+- `getBoundingClientRect()` は viewport 座標なので `body` 直下の fixed toolbar と座標系が一致する。window だけでなく nested scroll container の scroll にも追従するため、capture phase の `scroll` listener を使う。
+
+### submission cleanup と非還流
+
+- `buildSubmissionHtml()`（`:2809` 付近）は document clone から `[data-ark-harness-ui]` を丸ごと除去し、`ark-harness-*` class、temporary geometry、contenteditable / tabindex wrapper も掃除する。
+- context toolbar root と全 child に `markUi()` を通す。選択 visual class は既存の class cleanup で消えるため、submission HTML へ toolbar / selection の痕跡を残さない。
+- kind、cardinality、direction、layout / 座標は引き続き会話へ非還流である。node / edge の追加・削除だけを意味差分にする既存契約を使い、production `packages/server/src/lib/diagram-diff.ts` / `describeModelDiff` は変更しない。
+
+### 既存 test
+
+- `packages/server/src/lib/diagram-harness.test.ts` は注入文字列の layout、kind picker、edge control、CRUD、安全な DOM API、外部依存なし、`<128KiB` を検証する。旧 hover selector / per-edge control を期待する assertion は selection toolbar 契約へ置換が必要である。
+- `e2e/diagram-harness.spec.ts` は node selection + Delete cascade、edge control の3 select / allowlist / hover / 6px blocker、unknown ext、model 再適用、kind 候補 / unknown kind / geometry、clean submission を DOM assert している。これらの selector と操作開始点を「対象を click → 単一 toolbar」へ移す。
+- baseline として `pnpm --filter @ark/server test -- src/lib/diagram-harness.test.ts` を実行し、現ブランチでは 30 files / 521 tests が Green であることを確認済みである（現 script は引数の渡し方により server 全 Vitest を実行した）。実装時の targeted command は `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts` を使う。
+
+### 注入サイズ実測と差し引き
+
+- 現ブランチの guard fixture（graph 付き124 bytes HTML）に `injectHarness()` した UTF-8 サイズは **118,987 bytes**。注入 payload 自体は **118,863 bytes（116.1KiB）**。
+- guard は **131,072 bytes（128KiB）で固定**し、fixture 基準の現 headroom は **12,085 bytes**、payload 単体では **12,209 bytes** である。
+- 撤去見積りは **9〜11KiB**。内訳は、edge control の per-edge root / hover timer / active class / 3-control placement / blocker / sync map が約7〜9KiB、per-node kind wrapper / hover CSS / picker registry が約1〜2KiB、常時 add-row button / CSS と不要 state が約0.5KiBである。edge allowlist / option / update helper、node kind allowlist / update helper、`addField()` は残す。
+- 追加見積りは **10〜13KiB**。内訳は、selection / reconcile / visual が約3〜4KiB、単一 toolbar shell と node / edge content factory / action が約4〜5KiB、矩形配置 / fallback / scroll・resize follow が約2〜3KiB、event / accessibility glue が約1KiBである。
+- net は **-1〜+4KiB**、注入 payload は **117,839〜122,959 bytes**、guard fixture output は概ね **117,963〜123,083 bytes**を見込む。実装目標を fixture output **123,000 bytes前後以下**、guard headroom **約8KiB以上**とする。実測が 131,072 bytes以上なら threshold を変えず、旧 placement / per-element registry の残存や factory 重複を削る。
+
+---
+
+## 5論点の設計結論
+
+### 1. 選択の当たり判定と contenteditable 競合
+
+**採用:** node root と edge wide-stroke hit target を primary click の当たり判定にし、semantic state は常に1つの `selection = { kind, id }` で置換する。
+
+- node は `.ark-harness-graph-node` の listener で選択する。event target が contenteditable / form control の場合も node selection は更新するが、`preventDefault()`、root focus、caret 移動は行わない。したがって1 click で toolbar が出ても inline edit の focus / caret / text input は維持される。
+- node の非 editable 面を primary pointer で選んだ場合だけ default を抑止して root を `preventScroll` focus し、既存 keyboard delete を維持する。二重更新になる無条件 click / focusin 経路は整理する。
+- edge は `.ark-harness-edge-hit-target[data-ark-edge-id]` の click で選択する。endpoint rewire handle と node connector は既存どおり自分で propagation を止めるため、drag 開始を edge selection click と誤認しない。
+- toolbar 内、既存 harness UI、contenteditable / control 上の click は空白解除に数えない。node / edge / toolbar のいずれにも属さない primary click（graph 背景または body 背景）で解除する。
+- Escape は capture phase で扱い、toolbar の native select に focus があっても selection を解除する。active edge drag があれば同じ event で drag cleanup も行う。Delete / Backspace は従来どおり editable / select / button 中は横取りせず、selection が node なら `removeNode()`、edge なら `removeEdge()` を呼ぶ。
+- node 削除では incident edge と `groups[].nodes` を同一 synchronous mutation で除く既存 #243 契約を維持する。削除対象 selection は DOM / model mutation 前に clear し、stale toolbar を残さない。
+
+### 2. toolbar の位置算出、端 fallback、複数 graph / scroll
+
+**採用:** toolbar は `body` 直下に1個、`position: fixed` とし、選択 projection の viewport rect から配置する。
+
+1. node はクリック元 graph の最新 `nodesById.get(id)`、edge は最新 `edgeMainById.get(id)` を anchor にする。edge render で SVG が差し替わっても古い element を保持しない。
+2. toolbar を内容更新後に測り、gap 8pxで `top = anchor.top - toolbar.height - 8`、`left = anchor.left + (anchor.width - toolbar.width) / 2` を第一候補にする。
+3. 第一候補が viewport 上 margin 8pxを割る場合は `top = anchor.bottom + 8` へ fallback する。上下とも収まらない場合だけ viewport 内へ vertical clamp し、選択対象との重なりを最小化する。
+4. left は8pxから `innerWidth - toolbar.width - 8` の範囲へ clamp する。placement 結果を一時 `data-ark-toolbar-placement="above|below|clamped"` に置き、DOM test で分岐と実矩形を照合する。
+5. window resize、capture phase scroll、graph render、selected node / toolbar の ResizeObserver を1本の rAF schedulerへ集約する。listener ごとに同期 layout を繰り返さない。
+6. 複数 graph で同じ id projection があり得ても、最後にクリックした `selectionGraph` を位置 context として使う。semantic selection object 自体へ graph id や DOM reference は足さない。
+7. anchor が disconnected、model entry が消滅、選択元 graph で最新 projectionを解決できない場合は selection を clear する。model 直接編集後も同じ reconcile を通す。
+
+### 3. node / edge を出し分ける単一 component
+
+**採用:** `buildContextToolbar()` で root を1回だけ作り、`renderContextToolbar()` が root の child を安全な DOM API で差し替える。
+
+- root は `.ark-harness-context-toolbar`、`role="toolbar"`、`data-ark-harness-ui="1"` を持ち、非選択時は `hidden` にする。graph ごと / element ごとの toolbar root は作らない。
+- 選択中は `data-ark-selection-kind` / `data-ark-selection-id` を `setAttribute()` し、accessible label を現在の node / edge labelから `textContent` / attribute API で設定する。untrusted id / label を HTML や selectorへ連結しない。
+- node content は、kind native select、「+ 行」button、node 削除 button の順にする。kind 候補が0件なら disabled select + 固定「kind なし」optionを出す。候補外の現 kind は #241 と同じ disabled placeholderで保持する。
+- 「+ 行」はクリックした node projection 内にある owner binding の先頭 listを DOM 順で使う。binding が無ければ button を disabled にし、暗黙に list / fields UI を新造しない。複数 projectionがある場合もクリックした projection 内の listを優先する。
+- node 削除は `removeNode(selection.id)` を呼ぶ。field 行の「×」とは混ぜない。
+- edge content は from-cardinality、to-cardinality、方向の native select、edge 削除 button の順にする。値、label、unknown placeholder、update path は #242 の定数 / helper を共有する。
+- edge delete は既存 `removeEdge()` を呼ぶ。endpoint rewire の空白 drop 削除も後方互換として残す。
+- content factory の control event は toolbar root 内で propagation を止めるが、pointerleave / closeTimer は一切持たない。toolbar の表示条件は selection の有無だけである。
+
+### 4. hover / 常時表示の撤去範囲とサイズ
+
+**撤去するもの:**
+
+- `.ark-harness-kind-picker` wrapper、node ごとの picker attach / registry、`.ark-harness-graph-node:hover > .ark-harness-kind-picker`、`focus-within` / affordance-open による kind picker表示。
+- edge hit target の control 用 pointerenter / pointerleave。
+- `.ark-harness-edge-controls-active` / `:focus-within` CSS、per-edge controls root / map、100ms `closeTimer`、`activateEdgeControls()` / `scheduleEdgeControlsClose()` / `edgeControlsEngaged()`。
+- edge の3 selectを別々に配置する blocker / path fraction / fallback探索と `syncEdgeControls()`。
+- list ごとの `.ark-harness-add-row` DOM と CSS。`addField()` / list reorder / field row delete は残す。
+- `selectedNodeId` と node-only selection helper。共通 selection stateへ置換する。
+
+**残すもの:**
+
+- #243 の node connector / edge-create anchor 用 `attachNodeAffordanceHover()`、120ms grace、pointerenter / pointerleave / focusin / focusout。kind pickerだけを controller の affordance listから外す。
+- graph drag handle、edge endpoint rewire handle、edge hit targetそのもの、node palette。node paletteの撤去と新しい作成 gesture は Phase B である。
+- field row drag handle / field row delete。これは node / edge selection toolbarでは表せない field-level editingである。
+- #241 の kind candidate収集 / allowlist / update、#242 の edge ext allowlist / option / update、#243 の removeNode / removeEdge / addField。
+
+この境界により、Phase A が対象とする「編集 control の hover-gap」はゼロにしつつ、Phase B が引き継ぐ creation affordance と既存 field edit能力を壊さない。最終的な常時 chrome の掃除は Phase C / Dへ送る。
+
+### 5. 検証
+
+acceptance は screenshot / 目視ではなく DOM / model / bounding rect assertionで固定する。
+
+- 初期 / blank / Escapeでは toolbar root が hidden、node clickでは1個だけ visibleで node content、edge hit target clickでは同じ rootが edge contentへ変わる。
+- node / edge の selected classが排他的に付く。edge rerender後も selection visualと toolbarが同じ idへ再結合する。
+- toolbar rectは通常 anchor上、viewport上端 fixtureでは下へ fallbackし、左右 / 上下が viewport margin内にある。
+- 2 graph fixtureで第2 graphの要素を選び、nested scrollerを動かした後、同じ toolbar rootの rectが新しい anchor rectへ追従する。
+- **hover-gapゼロの機械検証:** node / edgeを選択後、Playwright mouseを対象外のgap経由で toolbar control中央へ移動し、旧 edge close 100ms / node grace 120msより長い250ms後も、同じ rootが visible、同じ selection id、controlが enabledであることを assertする。hover CSSの有無や screenshotではなく実DOM状態を判定する。
+- contenteditableをclickしても editableがfocusを保持し、keyboard inputがmodelへ反映され、selection toolbarも表示される。
+- node toolbarの kind / +行 / 削除、edge toolbarの3 select / 削除を操作し、既存の即時投影、unknown placeholder、安全性、非還流を維持する。
+- node削除後に node、incident edge、全 `groups[].nodes`参照、全projectionが同時に消え、非incident edge / group objectは残る。送信modelを既存 parser / diff testへ通し422相当の参照不整合を作らない。
+- clean submissionに context toolbar、select / option、selected class、`data-ark-harness-ui`が残らない。
+- guard fixtureを `Buffer.byteLength(..., "utf8")` で測り、**131,072未満**を維持する。threshold変更は禁止する。
+
+---
+
+## 変更範囲
+
+**Production:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+
+**Tests:**
+
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Modify: `e2e/diagram-harness.spec.ts`
+
+**Verify only（変更しない）:**
+
+- `packages/server/src/lib/diagram-diff.ts`
+- `packages/server/src/lib/diagram-diff.test.ts`
+- `packages/server/src/lib/diagram-model.ts`
+- `packages/server/src/lib/diagram-model.test.ts`
+- `packages/server/src/lib/diagram-file.ts`
+- `packages/server/src/lib/diagram-file.test.ts`
+
+model schema、production diff、MessageChannel payload、server submit、DB、React / web / desktop / mobile UI、既存 diagram artifact、承認済み spec は変更しない。
+
+---
+
+## Task 1: selection toolbar acceptance を E2E で Red にする
+
+**変更ファイル:**
+
+- Modify: `e2e/diagram-harness.spec.ts`
+
+**テスト（RED）:**
+
+```bash
+pnpm exec playwright test e2e/diagram-harness.spec.ts \
+  --project=chromium --grep "selection toolbar|hover-gap"
+```
+
+- [ ] **Step 1: selection toolbar 用 locator / rect helperを追加する（2〜5分）**
+
+  `contextToolbar(page)`、node / edge anchor rect、viewport margin内判定、toolbarがanchorの上または下にgap付きであることを判定するhelperを追加する。class名だけでなく `data-ark-selection-kind/id` と実 `getBoundingClientRect()` を読む。
+
+- [ ] **Step 2: 初期 hidden と node選択のRedを書く（2〜5分）**
+
+  初期は toolbar rootが1個かつhidden、nodeの非editable面をclickすると同じrootがvisibleになり、kind / +行 / node削除だけを持つことをassertする。選択nodeだけにselected classが付くことも固定する。
+
+- [ ] **Step 3: contenteditable競合回避のRedを書く（2〜5分）**
+
+  node label / fieldをclickし、editable自身がfocusを保持したままtoolbarがnode選択を示し、keyboard入力がcurrent modelへ反映されることをassertする。node rootへfocusを奪わないことを明示する。
+
+- [ ] **Step 4: edge選択と内容切替のRedを書く（2〜5分）**
+
+  wide-stroke hit targetをclickし、同じtoolbar rootがfrom-card / to-card / direction / edge削除へ差し替わり、node actionが消えることをassertする。node selected classが外れ、edge mainにselected classが付くことも固定する。
+
+- [ ] **Step 5: blank / Escape解除のRedを書く（2〜5分）**
+
+  graph背景clickとEscapeを別caseにし、toolbarがhidden、selection data属性とnode / edge selected classが消えることをassertする。toolbar selectへfocusした状態のEscapeも含める。
+
+- [ ] **Step 6: hover-gapゼロのRedを書く（2〜5分）**
+
+  nodeとedgeを別caseで選択し、mouseを対象外gapからtoolbar上へ実際に移動する。250ms後も同じtoolbar rootがvisible、selection id不変、対象controlが操作可能であることをassertする。
+
+- [ ] **Step 7: 上下fallback / viewport clampのRedを書く（2〜5分）**
+
+  viewport上端近くのnodeと通常位置のnodeを選び、`data-ark-toolbar-placement` とrect関係が一致することをassertする。左右端でもtoolbar rectが8px margin内に収まるcaseを加える。
+
+- [ ] **Step 8: 複数graph / nested scroll追従のRedを書く（2〜5分）**
+
+  2 graph fixtureの第2 graph node / edgeを選択し、toolbarが1個しかないことをassertする。nested scrollerをscrollし、poll後にtoolbar centerが最新anchor centerへ追従することをrectで比較する。
+
+- [ ] **Step 9: targeted E2Eが意図した理由でRedになることを確認する（2〜5分）**
+
+  commandを実行し、「context toolbar未生成」「edge selection未実装」「blank解除未実装」のいずれかで失敗することを確認する。browser起動失敗やfixture errorを仕様Redとして扱わない。
+
+**完了条件:** node / edge / blank / Escape / contenteditable / position / scroll / hover-gapのacceptanceがDOM assertionとして揃い、現行実装に対して意図どおりRedになる。
+
+---
+
+## Task 2: 注入契約と撤去契約を Vitest で Red にする
+
+**変更ファイル:**
+
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+
+**テスト（RED）:**
+
+```bash
+pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts
+```
+
+- [ ] **Step 1: node-only state assertionを共通selectionへ置換する（2〜5分）**
+
+  `selectedNodeId` / `setSelectedNode()`期待を外し、`selection`、set / clear / reconcile helper、node / edge kind分岐の注入を期待する。
+
+- [ ] **Step 2: 単一toolbar契約のRedを書く（2〜5分）**
+
+  context toolbar root、`role="toolbar"`、`data-ark-harness-ui`、selection data属性、node / edge content factory、hidden制御が注入されることを固定する。per graph / per edge rootを作るmapが無いこともassertする。
+
+- [ ] **Step 3: hover経路撤去のRedを書く（2〜5分）**
+
+  `.ark-harness-graph-node:hover > .ark-harness-kind-picker`、`scheduleEdgeControlsClose`、`activateEdgeControls`、`edgeControlsEngaged`、`.ark-harness-edge-controls-active` が注入されないことをassertする。
+
+- [ ] **Step 4: creation hover維持のGreen境界を書く（2〜5分）**
+
+  `AFFORDANCE_CLOSE_DELAY = 120`、`scheduleNodeAffordanceClose()`、node connectorのvisible class、anchor pointer handlersは引き続き注入されることをassertする。genericな「pointerenterが0件」は期待しない。
+
+- [ ] **Step 5:既存logic再利用のRedを書く（2〜5分）**
+
+  kind candidate / allowlist / `updateNodeKind()`、edge ext allowlist / `updateEdgeExt()`、`addField()`、`removeNode()` / `removeEdge()`、group ref filterが残り、toolbar actionから到達できることを文字列契約で固定する。
+
+- [ ] **Step 6: add-row常時描画撤去のRedを書く（2〜5分）**
+
+  `.ark-harness-add-row` と list直後へのbutton挿入が消え、node id / selected rootからlist bindingを引くregistryが注入されることを期待する。field row handle / `.ark-harness-delete`は残す。
+
+- [ ] **Step 7: size / safety guardを維持する（2〜5分）**
+
+  既存 `<128 * 1024`、外部resourceなし、`innerHTML` / `insertAdjacentHTML`なし、marker一意性を変更しない。context toolbarも `createElement` / `textContent` / `setAttribute` / `markUi`だけで作るassertionを足す。
+
+- [ ] **Step 8: targeted Vitestが意図した理由でRedになることを確認する（2〜5分）**
+
+  現行hover selector / per-edge controlが残り、context toolbarが無いことによるfailureを確認する。既存size guardやunrelated test failureなら先にbaseline問題を解消する。
+
+**完了条件:** 新selection / toolbarの存在、旧hover controlの不在、#243 creation hoverの維持、安全性、size上限が矛盾なく文字列契約化され、現行実装に対してRedになる。
+
+---
+
+## Task 3: 共通selection state machineと当たり判定を実装する
+
+**変更ファイル:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Test: `packages/server/src/lib/diagram-harness.test.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+**テスト（RED）:**
+
+```bash
+pnpm exec playwright test e2e/diagram-harness.spec.ts \
+  --project=chromium --grep "selection toolbar.*(node|edge|Escape|contenteditable)"
+```
+
+- [ ] **Step 1: semantic selection変数を導入する（2〜5分）**
+
+  `selectedNodeId`を `selection = { kind: null, id: null }`へ置換する。位置用に `selectionGraph` / selected projection contextを別変数にし、semantic stateへDOMを入れない。
+
+- [ ] **Step 2: set / clear / reconcile helperを実装する（2〜5分）**
+
+  kind / idをcurrent modelで検証し、同じselectionの再選択、node↔edge切替、stale id解除を一箇所に集約する。state変更後はvisual / toolbar render / position scheduleを必ず同じ順で呼ぶ。
+
+- [ ] **Step 3: node selection listenerを整理する（2〜5分）**
+
+  primary pointerだけを対象にし、contenteditable / form control上ではdefault / focusを奪わずselectionだけ更新する。非editable面では既存preventScroll focusを維持し、重複する無条件click / focusin更新を除く。
+
+- [ ] **Step 4: edge hit targetをselection entryへ変える（2〜5分）**
+
+  hover activate / close listenerを外し、primary clickでedgeを選択する。hit targetはwide strokeと `data-ark-harness-ui`を維持し、untrusted edge idをselectorへ連結しない。
+
+- [ ] **Step 5: blank click解除を実装する（2〜5分）**
+
+  document-level listenerでevent pathを判定し、node、edge hit target、toolbar、harness UI、editable control以外のblank primary clickだけ `clearSelection()`へ送る。
+
+- [ ] **Step 6: Escapeとselection deleteを共通化する（2〜5分）**
+
+  capture phase keydownでEscapeを受け、edge drag cancel後もselectionをclearする。Delete / Backspaceはeditable guardを維持し、nodeなら `removeNode()`、edgeなら `removeEdge()`を呼ぶ。
+
+- [ ] **Step 7: selected visualをnode / edgeへ投影する（2〜5分）**
+
+  node outlineを共通selectionからtoggleし、edge main用のselected stroke classを追加する。`renderGraph()`でedge mainを作るたびにselectionを再投影する。
+
+- [ ] **Step 8: node / edge / Escape / contenteditable caseをGreenにする（2〜5分）**
+
+  targeted E2EとVitestを実行し、toolbar content未実装によるRedを除いて、selection state、focus、selected visual、blank / Escape解除をGreenにする。
+
+**完了条件:** semantic selectionが1つになり、node root / edge hit target / blank / Escapeの遷移とcontenteditable競合回避がDOM testでGreen。edge rerender後もselected visualが復元される。
+
+---
+
+## Task 4: 単一toolbar shellと位置追従を実装する
+
+**変更ファイル:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Test: `e2e/diagram-harness.spec.ts`
+
+**テスト（RED）:**
+
+```bash
+pnpm exec playwright test e2e/diagram-harness.spec.ts \
+  --project=chromium --grep "selection toolbar.*(位置|fallback|scroll|hover-gap)"
+```
+
+- [ ] **Step 1: context toolbar CSSを追加する（2〜5分）**
+
+  fixed、最高位z-index、compact flex、8px gap、native select / button、selected visualをinline CSSへ追加する。外部font / icon / imageは使わない。
+
+- [ ] **Step 2: toolbar rootを1回だけ生成する（2〜5分）**
+
+  `buildContextToolbar()`でbody直下へrootをappendし、`role="toolbar"`、hidden、`markUi()`を設定する。graph / edgeごとのrootは作らない。
+
+- [ ] **Step 3: selection別renderの骨格を実装する（2〜5分）**
+
+  `renderContextToolbar()`で非選択時はchild / selection属性をclearしてhidden、選択時は同じrootを再利用してkind別factoryを呼ぶ。root内eventがblank解除へ伝播しないようにする。
+
+- [ ] **Step 4: anchor再解決helperを実装する（2〜5分）**
+
+  nodeはselection graphの `nodesById`、edgeは最新 `edgeMainById`からanchorを取る。disconnected / staleならreconcileし、別graphの同idへ勝手に飛ばない。
+
+- [ ] **Step 5: above / below / clamp配置を実装する（2〜5分）**
+
+  toolbar / anchor rectを測り、上8pxを第一候補、上端不足時は下、左右はviewportへclampする。実分岐を `data-ark-toolbar-placement`へ書く。
+
+- [ ] **Step 6: position schedulerを実装する（2〜5分）**
+
+  scroll capture、window resize、toolbar / selected node resize、graph renderからrAF schedulerを呼ぶ。1 frame中の重複requestを1回へcoalesceする。
+
+- [ ] **Step 7: graph cleanup時のobserver / listenerを整理する（2〜5分）**
+
+  selection切替で旧anchor observerを外し、新anchorだけを監視する。global listenerは初期化時に1回だけ登録し、renderごとに増やさない。
+
+- [ ] **Step 8: position / scroll / hover-gap testをGreenにする（2〜5分）**
+
+  通常上配置、上端fallback、左右clamp、2 graph nested scroll、250ms hover-gap assertionを通す。toolbar visibilityをpointerenter / leaveで変更するコードが無いこともVitestで確認する。
+
+**完了条件:** toolbar rootは常に1個で、selection中だけvisible。通常上、端で下fallback、複数graph / nested scroll / rerenderへ追従し、toolbarへポインターを移して250ms待っても消えない。
+
+---
+
+## Task 5: node用kind / +行 / 削除をtoolbarへ移す
+
+**変更ファイル:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Modify: `e2e/diagram-harness.spec.ts`
+
+**テスト（RED）:**
+
+```bash
+pnpm exec playwright test e2e/diagram-harness.spec.ts \
+  --project=chromium --grep "selection toolbar.*node|kind ピッカー|行を追加|node CRUD"
+```
+
+- [ ] **Step 1: list bindingをselectionから引けるregistryへする（2〜5分）**
+
+  `initEditing()`のbindingをnode idごとの配列として保持し、selected root内のlistをDOM順で解決するhelperを作る。bindingなしではnullを返す。
+
+- [ ] **Step 2:常時add-row button生成を外す（2〜5分）**
+
+  `wireList()`はdragover / drop / reorderだけをwireし、list直後のbutton挿入を止める。`.ark-harness-add-row` CSSを削除し、既存HTML上に常時buttonが0件であることをassertする。
+
+- [ ] **Step 3: toolbar「+ 行」を `addField()`へ接続する（2〜5分）**
+
+  selected rootのbindingがあるときだけenabledにし、clickで既存 `addField(listEl, nodeId)`を呼ぶ。追加fieldのopaque id、model entry、editable row、row reorder / delete controlは従来どおり生成する。
+
+- [ ] **Step 4: kind select factoryを単一toolbar向けに整理する（2〜5分）**
+
+  option生成、unknown current placeholder、aria-label、allowlist検査を再利用し、selected node1件だけを同期する。`kindPickers`配列とper-node `attachKindPicker()`は削除する。
+
+- [ ] **Step 5: kindなし / unknown kind境界を移植する（2〜5分）**
+
+  candidate 0件はdisabled「kind なし」、candidate外currentはdisabled placeholder、candidate選択時だけ `updateNodeKind()`を呼ぶ。untrusted current / candidateをtext / value APIだけで扱う。
+
+- [ ] **Step 6: node削除buttonを接続する（2〜5分）**
+
+  selection idをclick時にcurrent modelから再取得し、`removeNode()`を呼ぶ。selection clearを先に行い、node / incident edge / group refs / projectionを同期除去する。
+
+- [ ] **Step 7: kind pickerのhover DOM / CSSを撤去する（2〜5分）**
+
+  `.ark-harness-kind-picker` wrapper / transform / opacity / `:hover` / focus-within selectorを削除する。`attachNodeAffordanceHover()`のaffordance listからkind pickerだけを外し、connector graceは残す。
+
+- [ ] **Step 8: placement blockerの旧picker参照を外す（2〜5分）**
+
+  `nodePlacementBlockers()`から `.ark-harness-kind-picker`を外し、残すgraph drag handleだけをblockerにする。node paletteによる追加位置決定を壊さない。
+
+- [ ] **Step 9:既存kind / node CRUD E2Eをselection起点へ更新する（2〜5分）**
+
+  per-node pickerを直接探すtestを、node click後のcontext toolbar selectへ移す。候補順、unknown / hostile値、geometry再計算、model再適用、clean submission、node cascadeを同じ意味で維持する。
+
+- [ ] **Step 10: node action suiteとsize checkpointをGreenにする（2〜5分）**
+
+  targeted E2E / Vitestを実行し、注入fixture sizeも記録する。edge移行前の一時点でも131,072未満であることを確認し、超過時は次Taskへ進まずper-node残存codeを除く。
+
+**完了条件:** node選択中だけkind / +行 / node削除が単一toolbarに出る。常時add-rowとhover kind pickerは0件、既存kind安全性 / geometry / field追加 / node参照整合性はGreen、#243 connector hoverは維持される。
+
+---
+
+## Task 6: edge用3 select / 削除をtoolbarへ移し旧hover controlを撤去する
+
+**変更ファイル:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Modify: `e2e/diagram-harness.spec.ts`
+
+**テスト（RED）:**
+
+```bash
+pnpm exec playwright test e2e/diagram-harness.spec.ts \
+  --project=chromium --grep "selection toolbar.*edge|edge control|unknown edge ext"
+```
+
+- [ ] **Step 1: edge toolbar content factoryを実装する（2〜5分）**
+
+  from-card、to-card、directionの順にnative selectを1組だけ作り、最後にedge削除buttonを置く。role / property変換、option label、allowlistは既存定数を使う。
+
+- [ ] **Step 2: syncEdgeSelectをselection向けに整理する（2〜5分）**
+
+  per-edge controls object依存を外し、toolbar select / placeholderとcurrent edgeを受ける形にする。missing / hostile値のdisabled placeholderとforward表示fallbackを維持する。
+
+- [ ] **Step 3: edge ext updateを接続する（2〜5分）**
+
+  change時にselection idとcurrent model edgeを再取得し、`updateEdgeExt()`を呼ぶ。render後にtoolbar select、selected visual、positionを再同期する。
+
+- [ ] **Step 4: edge削除buttonを接続する（2〜5分）**
+
+  selectionをclearしてから既存 `removeEdge()`を呼び、対象main / label / cardinality / endpoint handleだけが消え、node / 他edgeが残ることをassertする。
+
+- [ ] **Step 5: hit targetのhover listenerを削除する（2〜5分）**
+
+  `pointerenter` / `pointerleave`によるactivate / schedule closeを取り除き、click selectionだけを残す。hit target geometryとpointer strokeは維持する。
+
+- [ ] **Step 6: per-edge root / timer / mapを削除する（2〜5分）**
+
+  `createEdgeControls()`、closeTimer、active class、`edgeControlsById`、`syncEdgeControls()`を削除し、`renderGraph()`からper-edge sync callを外す。
+
+- [ ] **Step 7:旧3-control placementを削除する（2〜5分）**
+
+  edge control専用のblocker収集、path fraction、法線候補、6px collision探索、unavailable classを削除する。単一toolbarのabove / below配置だけを残す。
+
+- [ ] **Step 8:旧edge control CSSを削除する（2〜5分）**
+
+  `.ark-harness-edge-controls`、active / focus-within / unavailable、absolute `.ark-harness-edge-control`を撤去し、context toolbar内select用CSSへ一本化する。
+
+- [ ] **Step 9:既存edge semantics E2Eをselection起点へ更新する（2〜5分）**
+
+  3 select / option / aria、即時cardinality / marker投影、unknown / hostile値、model直接編集後のstale edge除去、self-loop、clean submissionを、edge click後の単一toolbarで検証する。
+
+- [ ] **Step 10: edge action suiteとsize checkpointをGreenにする（2〜5分）**
+
+  targeted E2E / Vitestを実行し、旧 `.ark-harness-edge-controls` / timer / placement helper不在を確認する。guard fixtureを再実測し、131,072未満かつ目標123,000 bytes前後以下を確認する。
+
+**完了条件:** edge選択中だけ3 select / edge削除が単一toolbarに出る。旧edge hover / timer / per-edge controls / placementは注入から消え、allowlist、unknown値、安全性、即時投影、非還流、endpoint rewire / drag削除はGreen。
+
+---
+
+## Task 7: stale selection・submission・全回帰を閉じる
+
+**変更ファイル:**
+
+- Modify: `packages/server/src/lib/diagram-harness.ts`
+- Modify: `packages/server/src/lib/diagram-harness.test.ts`
+- Modify: `e2e/diagram-harness.spec.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.ts`
+- Verify only: `packages/server/src/lib/diagram-diff.test.ts`
+
+**テスト（RED）:**
+
+```bash
+pnpm exec playwright test e2e/diagram-harness.spec.ts \
+  --project=chromium --grep "selection toolbar.*(stale|削除|submission)"
+```
+
+- [ ] **Step 1: model直接編集後のreconcile Redを追加する（2〜5分）**
+
+  選択中node / edgeをmodel panel適用で消すcaseを作り、toolbar hidden、selected classなし、stale actionなしをassertする。idが残る場合は同じrootをcurrent値へ同期する。
+
+- [ ] **Step 2: node削除参照整合性をtoolbar操作で固定する（2〜5分）**
+
+  group memberかつself / normal incident edgeを持つnodeをtoolbarから削除し、node、incident edge、全 `groups[].nodes`参照、graph内外projectionが同じtick後に消えることをassertする。group object / 非incident edgeは残す。
+
+- [ ] **Step 3: clean submission Redを追加する（2〜5分）**
+
+  node / edgeを選択したままsubmitし、HTMLにcontext toolbar、selection data属性、selected class、toolbar select / option、`data-ark-harness-ui`が無いことをassertする。semantic authored DOM / `data-kind`は残す。
+
+- [ ] **Step 4:非還流契約を固定する（2〜5分）**
+
+  kind / cardinality / direction変更だけなら `describeModelDiff()` は `[]`、node / edge削除は既存意味差分だけになることを既存testで確認する。production `diagram-diff.ts`は編集しない。
+
+- [ ] **Step 5: stale reconcile / cleanupを実装する（2〜5分）**
+
+  model panel apply、removeNode / removeEdge、unregister / render、anchor disconnectを同じreconcile helperへ接続する。cleanupのために別selection stateやtimerを増やさない。
+
+- [ ] **Step 6: targeted unit / E2Eを実行する（2〜5分）**
+
+  ```bash
+  pnpm --filter @ark/server exec vitest run \
+    src/lib/diagram-harness.test.ts src/lib/diagram-diff.test.ts
+  pnpm exec playwright test e2e/diagram-harness.spec.ts \
+    --project=chromium --grep "selection toolbar|hover-gap|node CRUD|edge control|kind ピッカー"
+  ```
+
+  新旧selectorを更新したsuiteがGreenで、旧behaviorを意図せずskipしていないことをtest count / grep結果で確認する。
+
+- [ ] **Step 7: diagram harness全E2Eを実行する（2〜5分）**
+
+  ```bash
+  pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium
+  ```
+
+  overlap、LR / TB、SCC、group-aware layout、drag / rewire / create、kind、field、clean submissionを含む全fileをGreenにする。browser infrastructure failureを目視確認で代替しない。
+
+- [ ] **Step 8: build / static checkを実行する（2〜5分）**
+
+  ```bash
+  pnpm --filter @ark/server build
+  pnpm check
+  git diff --check
+  ```
+
+  esbuild artifactでもguard、安全なinline script、CSP契約が同じであることを確認する。
+
+- [ ] **Step 9:最終注入sizeと変更境界を監査する（2〜5分）**
+
+  guard fixture output / payloadをUTF-8で記録し、131,072未満を確認する。`git diff -- packages/server/src/lib/diagram-diff.ts`が空で、production変更が `diagram-harness.ts`だけ、test変更が指定2fileだけであることを確認する。
+
+**完了条件:** stale selection、node参照整合性、clean submission、非還流、size、全diagram harness回帰、build / static checkがGreen。production diff / model / submit contractは無変更で、hover-gapゼロが250msのDOM assertionで機械検証される。
+
+---
+
+## テスト戦略まとめ
+
+| 層 | 検証内容 | 目視依存 |
+| --- | --- | --- |
+| Vitest injection contract | semantic selection、単一toolbar、旧hover経路不在、creation hover維持、安全DOM API、外部resourceなし、marker一意、`<128KiB` | なし |
+| Playwright selection | node / edge hit、排他selection visual、blank / Escape、contenteditable focus、node / edge content切替 | なし |
+| Playwright geometry | anchor上配置、上端below fallback、viewport clamp、複数graph、nested scroll / resize / rerender追従 | なし |
+| Playwright hover-gap | 対象外gap経由でtoolbarへmouse移動し、250ms後も同root / selection / controlがvisible | なし |
+| Playwright actions | kind、+行、node / edge削除、cardinality / direction、unknown / hostile値、即時投影 | なし |
+| Integrity / persistence | node + incident edge + group refs同期削除、clean submission、非還流、既存意味差分 | なし |
+| Existing regressions | overlap、LR / TB、SCC、group、drag / rewire / create、field reorder / delete、palette | なし |
+| Human review | 見た目の余白 / 色は参考確認のみでacceptance判定に使わない | 任意 |
+
+hover-gap testはCSS selectorの不在だけで終えない。旧timerの100 / 120msを超える250msを実際のpointer移動後に待ち、toolbar rootの `hidden`、bounding box、selection属性、control disabled状態をassertする。これにより「触りに行くと消える」を操作経路として再現し、原理的にselection以外では閉じないことを固定する。
+
+---
+
+## 影響範囲
+
+- graph node / edgeのclick、focus、Delete / Backspace、Escape、blank clickのevent routingが変わる。
+- kind / edge ext / field add / semantic deleteのmodel mutationは既存helperを共有し、値の意味や保存形式は変わらない。
+- per-node kind selectとper-edge 3 selectが、document全体で選択中の1組へ減る。大きいgraphほどDOM node / listener数は減る。
+- toolbar位置更新のためglobal scroll capture / resize listenerとselected anchor observerが増えるが、rAFで1 frame 1回へcoalesceし、非選択時は測定しない。
+- edge SVG再描画後にselection anchor / visualを再結合する処理が増える。edge geometry / marker / cardinality描画自体は変えない。
+- node palette、graph drag、node connector edge作成、endpoint rewire、field reorder / row delete、bottom toolbarは維持する。
+- submission clone、MessageChannel、server parser、conversation diff、DB、mobileには影響しない。
+
+---
+
+## ロールバック
+
+- model schema、migration、保存済みHTMLの一括変換がないため、feature commitの `diagram-harness.ts` と対応test変更をrevertすれば現行のper-node kind picker / per-edge hover controlsへ戻せる。データ修復は不要である。
+- rollback時も #241 / #242 / #243 のmodel更新helper、node cascade cleanup、edge endpoint dragは既存形へ戻るため、保存済みkind / edge ext /構造は有効である。
+- 問題がposition followだけに限られても、size guardやhover-gap acceptanceを無効化して出荷しない。selection toolbar全体をrevertするか、testをRedに保ったままposition helperを修正する。
+- `<128KiB`超過時はthreshold引上げ、外部script化、test skipへ逃げず、旧per-element control / placementの残存とfactory重複を削減する。収まらなければ実装を止めてplanを再見積りする。
+
+---
+
+## 制約・非ゴール
+
+- 注入後HTMLは **131,072 bytes未満**。guard thresholdは変更禁止。現在118,987 bytes / fixture headroom 12,085 bytesである。
+- CDN、font、image、stylesheet、external script、Worker、WASM、Blob URL、network fetchを追加しない。inline CSS / Unicode /既存inline SVGだけを使う。
+- production `diagram-diff.ts` / `describeModelDiff`、model schema、submission payload、DB、server routeを変更しない。
+- kind、cardinality、direction、layout、座標の非還流契約を変更しない。node / edge構造削除だけが既存どおり還流する。
+- mobile編集UIは対象外。desktop / PC board paneの既存harnessだけを扱う。
+- Phase Bの「hover方向handleから空白dropでnode + edge作成」、node palette撤去、作成kind記憶は非ゴール。既存node connector作成を壊さず残す。
+- Phase Cのmodel JSON debug送り、送信buttonの変更時表示、bottom toolbar /残存chrome掃除は非ゴール。
+- Phase Dの最終行Enter追加、追加keyboard shortcut、transition、発見性、undo / redo、磨き込みは非ゴール。
+- graph drag handle、field row handle / deleteをselection toolbarへ移すことは非ゴール。Phase A selection kindはnode / edgeだけであり、row selectionを追加しない。
+- toolbarのcollision回避は選択対象とviewport端を対象にする。任意のauthored floating UI、全node / labelとの組合せ最適化、矢印付きpopover、portal framework導入は非ゴール。
+
+---
+
+## 未確定事項・実装時 stop condition
+
+- 実装判断として未確定事項はない。複数listを持つnodeは「クリックしたprojection内の先頭owner list」、listなしは「+行disabled」とする。別のlist chooserが必要ならselection model / toolbar仕様の拡張になるため別Issueにする。
+- 同一semantic idが複数graphへ投影される場合は、最後にclickしたgraphをposition contextにする。selection object自体へgraph idを増やさない。この契約で操作対象が曖昧になる実図が見つかった場合は、model id一意性 / projection semanticsの設計判断として実装を止める。
+- edge pathのrectが幅0または高さ0でも有限ならcenter anchorとして扱う。browserが非有限rectを返す、またはselected edgeがrender後に解決不能ならtoolbarを推測位置へ残さずselectionをclearする。
+- field row「×」の常時表示をこのPhaseで消す要求が追加された場合、node削除buttonとの意味衝突を解くrow selection / focused-row action設計が必要であるため、現在のnode / edge selectionへ暗黙に混ぜずplanを再承認する。
+- guard fixture outputが131,072 bytes以上、または目標123,000 bytes前後を大きく超える場合は、thresholdを変更せず実装を止め、旧edge placement / picker registryの残存とtoolbar factory重複を監査する。
+- production `diagram-diff.ts`、model schema、submission payload、外部resourceの変更が必要になった場合はPhase Aの信頼境界外なので実装を止め、人間の設計レビューへ戻す。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -596,6 +596,53 @@ function edgeSemanticsHtml(diagramModel: unknown = edgeSemanticsModel): string {
   </body></html>`);
 }
 
+function selectionToolbarPositionHtml(): string {
+  const positionModel = {
+    version: 1,
+    nodes: [
+      {
+        id: "top-left",
+        label: "Top left",
+        kind: "entity",
+        ext: { x: 0, y: 0 },
+      },
+      {
+        id: "lower-right",
+        label: "Lower right",
+        kind: "entity",
+        ext: { x: 690, y: 180 },
+      },
+      {
+        id: "shared",
+        label: "Shared",
+        kind: "entity",
+        ext: { x: 120, y: 210 },
+      },
+    ],
+    edges: [],
+    groups: [],
+  };
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .position-graph { width: 840px; height: 360px; background: #f8fafc; }
+    .position-node { box-sizing: border-box; width: 150px; height: 72px; padding: 12px; border: 1px solid #64748b; background: white; }
+    .position-scroller { width: 520px; height: 140px; overflow: auto; margin-top: 24px; }
+    .position-spacer { height: 180px; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(positionModel)}</script>
+    <div class="position-graph" data-ark-container="graph">
+      <section class="position-node" data-model-id="top-left">Top left</section>
+      <section class="position-node" data-model-id="lower-right">Lower right</section>
+    </div>
+    <div class="position-scroller">
+      <div class="position-spacer"></div>
+      <div class="position-graph" data-ark-container="graph">
+        <section class="position-node" data-model-id="shared">Shared</section>
+      </div>
+    </div>
+  </body></html>`);
+}
+
 async function openDiagram(page: Page, diagramModel: unknown = model) {
   const errors: string[] = [];
   page.on("pageerror", error => errors.push(error.message));
@@ -769,6 +816,127 @@ async function requiredBoundingBox(locator: Locator) {
   return box;
 }
 
+function contextToolbar(page: Page) {
+  return page.locator("body > .ark-harness-context-toolbar");
+}
+
+function selectedNodeAnchor(page: Page, id: string) {
+  return page.locator(
+    `.ark-harness-graph-node[data-model-id="${id}"].ark-harness-node-selected`
+  );
+}
+
+function selectedEdgeAnchor(page: Page, id: string) {
+  return page.locator(
+    `.ark-harness-edge-main[data-ark-edge-id="${id}"].ark-harness-edge-selected`
+  );
+}
+
+async function selectNode(page: Page, id: string) {
+  const node = page
+    .locator(`.ark-harness-graph-node[data-model-id="${id}"]`)
+    .first();
+  await node.dispatchEvent("pointerdown", { button: 0 });
+  await node.dispatchEvent("click", { button: 0 });
+  await expect(contextToolbar(page)).toHaveAttribute(
+    "data-ark-selection-id",
+    id
+  );
+  return contextToolbar(page);
+}
+
+async function selectEdge(page: Page, id: string) {
+  await page
+    .locator(`.ark-harness-edge-hit-target[data-ark-edge-id="${id}"]`)
+    .first()
+    .dispatchEvent("click", { button: 0 });
+  await expect(contextToolbar(page)).toHaveAttribute(
+    "data-ark-selection-id",
+    id
+  );
+  return contextToolbar(page);
+}
+
+async function expectContextToolbarPlacement(
+  page: Page,
+  anchor: Locator,
+  expected?: "above" | "below" | "clamped"
+) {
+  const toolbar = contextToolbar(page);
+  await expect(toolbar).toHaveAttribute(
+    "data-ark-toolbar-placement",
+    /above|below|clamped/
+  );
+  await expect
+    .poll(async () => {
+      const [toolbarBox, anchorBox, placement] = await Promise.all([
+        requiredBoundingBox(toolbar),
+        requiredBoundingBox(anchor),
+        toolbar.getAttribute("data-ark-toolbar-placement"),
+      ]);
+      if (placement === "above") {
+        return (
+          anchorBox.y - (toolbarBox.y + toolbarBox.height) >= 7 &&
+          Math.abs(
+            toolbarBox.x +
+              toolbarBox.width / 2 -
+              (anchorBox.x + anchorBox.width / 2)
+          ) <= Math.max(toolbarBox.width / 2, 8)
+        );
+      }
+      if (placement === "below") {
+        return toolbarBox.y - (anchorBox.y + anchorBox.height) >= 7;
+      }
+      return placement === "clamped";
+    })
+    .toBe(true);
+  const [toolbarBox, anchorBox, placement, viewport] = await Promise.all([
+    requiredBoundingBox(toolbar),
+    requiredBoundingBox(anchor),
+    toolbar.getAttribute("data-ark-toolbar-placement"),
+    page.evaluate(() => ({ width: innerWidth, height: innerHeight })),
+  ]);
+  expect(toolbarBox.x).toBeGreaterThanOrEqual(8);
+  expect(toolbarBox.y).toBeGreaterThanOrEqual(8);
+  expect(toolbarBox.x + toolbarBox.width).toBeLessThanOrEqual(
+    viewport.width - 8
+  );
+  expect(toolbarBox.y + toolbarBox.height).toBeLessThanOrEqual(
+    viewport.height - 8
+  );
+  if (expected) expect(placement).toBe(expected);
+  if (placement === "above") {
+    expect(
+      anchorBox.y - (toolbarBox.y + toolbarBox.height)
+    ).toBeGreaterThanOrEqual(7);
+  } else if (placement === "below") {
+    expect(
+      toolbarBox.y - (anchorBox.y + anchorBox.height)
+    ).toBeGreaterThanOrEqual(7);
+  }
+}
+
+async function moveAcrossToolbarGap(
+  page: Page,
+  anchor: Locator,
+  control: Locator
+) {
+  const [anchorBox, toolbarBox, controlBox] = await Promise.all([
+    requiredBoundingBox(anchor),
+    requiredBoundingBox(contextToolbar(page)),
+    requiredBoundingBox(control),
+  ]);
+  const gapY =
+    toolbarBox.y + toolbarBox.height <= anchorBox.y
+      ? (toolbarBox.y + toolbarBox.height + anchorBox.y) / 2
+      : (anchorBox.y + anchorBox.height + toolbarBox.y) / 2;
+  await page.mouse.move(anchorBox.x + anchorBox.width / 2, gapY);
+  await page.mouse.move(
+    controlBox.x + controlBox.width / 2,
+    controlBox.y + controlBox.height / 2
+  );
+}
+
 function expectBoxToContain(
   container: { x: number; y: number; width: number; height: number },
   member: { x: number; y: number; width: number; height: number }
@@ -866,6 +1034,288 @@ function expectNoOverlaps(
   }
 }
 
+test("selection toolbar: node・contenteditable・edge・解除を単一 root で扱う", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  const toolbar = contextToolbar(page);
+  await expect(toolbar).toHaveCount(1);
+  await expect(toolbar).toBeHidden();
+  await expect(toolbar).toHaveAttribute("role", "toolbar");
+  await toolbar.evaluate(element => {
+    (element as HTMLElement & { __arkIdentity?: string }).__arkIdentity =
+      "selection-toolbar";
+  });
+
+  const order = page.locator('.ark-harness-graph-node[data-model-id="order"]');
+  await order.click({ position: { x: 8, y: 36 } });
+  await expect(toolbar).toBeVisible();
+  await expect(toolbar).toHaveAttribute("data-ark-selection-kind", "node");
+  await expect(toolbar).toHaveAttribute("data-ark-selection-id", "order");
+  await expect(selectedNodeAnchor(page, "order")).toHaveCount(1);
+  await expect(toolbar.locator("select.ark-harness-kind-select")).toHaveCount(
+    1
+  );
+  await expect(toolbar.getByRole("button", { name: "行を追加" })).toHaveCount(
+    1
+  );
+  await expect(
+    toolbar.getByRole("button", { name: "Order を削除" })
+  ).toHaveCount(1);
+  await expect(toolbar.locator("[data-ark-edge-control]")).toHaveCount(0);
+
+  const editable = order.locator(
+    'li[data-model-id="order_id"] .ark-harness-text'
+  );
+  await editable.click();
+  await expect(editable).toBeFocused();
+  await expect(toolbar).toHaveAttribute("data-ark-selection-id", "order");
+  await page.keyboard.insertText("-edited");
+  expect(
+    (await readCurrentModel(page)).nodes
+      .find(node => node.id === "order")
+      ?.fields?.find(field => field.id === "order_id")?.label
+  ).toContain("-edited");
+
+  const hitTarget = page.locator(
+    '.ark-harness-edge-hit-target[data-ark-edge-id="e_order_owner"]'
+  );
+  await hitTarget.click({ force: true });
+  await expect(toolbar).toBeVisible();
+  await expect(toolbar).toHaveAttribute("data-ark-selection-kind", "edge");
+  await expect(toolbar).toHaveAttribute(
+    "data-ark-selection-id",
+    "e_order_owner"
+  );
+  await expect(
+    toolbar.evaluate(
+      element =>
+        (element as HTMLElement & { __arkIdentity?: string }).__arkIdentity
+    )
+  ).resolves.toBe("selection-toolbar");
+  await expect(selectedNodeAnchor(page, "order")).toHaveCount(0);
+  await expect(selectedEdgeAnchor(page, "e_order_owner")).toHaveCount(1);
+  await expect(toolbar.locator("[data-ark-edge-control]")).toHaveCount(3);
+  await expect(toolbar.locator("select.ark-harness-kind-select")).toHaveCount(
+    0
+  );
+  await expect(
+    toolbar.getByRole("button", { name: "owned by を削除" })
+  ).toHaveCount(1);
+
+  await toolbar.locator('select[data-ark-edge-control="from-card"]').focus();
+  await page.keyboard.press("Escape");
+  await expect(toolbar).toBeHidden();
+  await expect(toolbar).not.toHaveAttribute("data-ark-selection-kind");
+  await expect(toolbar).not.toHaveAttribute("data-ark-selection-id");
+  await expect(selectedEdgeAnchor(page, "e_order_owner")).toHaveCount(0);
+
+  await order.click({ position: { x: 8, y: 36 } });
+  await page
+    .locator('[data-ark-container="graph"]')
+    .click({ position: { x: 820, y: 500 } });
+  await expect(toolbar).toBeHidden();
+  await expect(selectedNodeAnchor(page, "order")).toHaveCount(0);
+});
+
+test("selection toolbar hover-gap: node と edge から gap 経由で移動しても 250ms 後まで維持する", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  const toolbar = contextToolbar(page);
+  const order = page.locator('.ark-harness-graph-node[data-model-id="order"]');
+
+  await order.click({ position: { x: 8, y: 36 } });
+  const nodeControl = toolbar.getByRole("button", { name: "行を追加" });
+  await moveAcrossToolbarGap(page, order, nodeControl);
+  await page.waitForTimeout(250);
+  await expect(toolbar).toBeVisible();
+  await expect(toolbar).toHaveAttribute("data-ark-selection-id", "order");
+  await expect(nodeControl).toBeEnabled();
+
+  const hitTarget = page.locator(
+    '.ark-harness-edge-hit-target[data-ark-edge-id="e_order_owner"]'
+  );
+  await hitTarget.click({ force: true });
+  const edgeAnchor = selectedEdgeAnchor(page, "e_order_owner");
+  const edgeControl = toolbar.locator(
+    'select[data-ark-edge-control="from-card"]'
+  );
+  await moveAcrossToolbarGap(page, edgeAnchor, edgeControl);
+  await page.waitForTimeout(250);
+  await expect(toolbar).toBeVisible();
+  await expect(toolbar).toHaveAttribute(
+    "data-ark-selection-id",
+    "e_order_owner"
+  );
+  await expect(edgeControl).toBeEnabled();
+});
+
+test("selection toolbar: anchor 上配置・上端 fallback・viewport clamp を実矩形で保証する", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 860, height: 720 });
+  await page.setContent(selectionToolbarPositionHtml());
+
+  const topLeft = page.locator(
+    '.ark-harness-graph-node[data-model-id="top-left"]'
+  );
+  await topLeft.click({ position: { x: 8, y: 30 } });
+  await expectContextToolbarPlacement(page, topLeft, "below");
+
+  const lowerRight = page.locator(
+    '.ark-harness-graph-node[data-model-id="lower-right"]'
+  );
+  await lowerRight.click({ position: { x: 8, y: 30 } });
+  await expectContextToolbarPlacement(page, lowerRight, "above");
+});
+
+test("selection toolbar: 複数 graph の選択元と nested scroll 後の最新 anchor に追従する", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 900, height: 720 });
+  await page.setContent(selectionToolbarPositionHtml());
+  const scroller = page.locator(".position-scroller");
+  await scroller.evaluate(element => {
+    element.scrollTop = 230;
+  });
+  const shared = page
+    .locator('[data-ark-container="graph"]')
+    .nth(1)
+    .locator('.ark-harness-graph-node[data-model-id="shared"]');
+  await shared.click({ position: { x: 8, y: 30 } });
+  const toolbar = contextToolbar(page);
+  await expect(toolbar).toHaveCount(1);
+  await expect(toolbar).toHaveAttribute("data-ark-selection-id", "shared");
+  const before = await requiredBoundingBox(toolbar);
+
+  await scroller.evaluate(element => {
+    element.scrollTop += 40;
+  });
+  await expect
+    .poll(async () => Math.round((await requiredBoundingBox(toolbar)).y))
+    .not.toBe(Math.round(before.y));
+  await expectContextToolbarPlacement(page, shared);
+});
+
+test("selection toolbar node action: +行と削除を既存 field・参照整合性へ接続する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  const toolbar = await selectNode(page, "order");
+  await expect(page.locator(".ark-harness-add-row")).toHaveCount(0);
+  const before = (await readCurrentModel(page)).nodes.find(
+    node => node.id === "order"
+  )?.fields?.length;
+  await toolbar.getByRole("button", { name: "行を追加" }).click();
+  const afterAdd = await readCurrentModel(page);
+  const orderAfterAdd = afterAdd.nodes.find(node => node.id === "order");
+  expect(orderAfterAdd?.fields).toHaveLength((before || 0) + 1);
+  expect(orderAfterAdd?.fields?.at(-1)?.id).toMatch(/^field-/);
+  await expect(
+    page.locator(
+      '.ark-harness-graph-node[data-model-id="order"] li[data-model-id]'
+    )
+  ).toHaveCount((before || 0) + 1);
+
+  await toolbar.getByRole("button", { name: "Order を削除" }).click();
+  await expect(toolbar).toBeHidden();
+  await expect(
+    page.locator('.ark-harness-graph-node[data-model-id="order"]')
+  ).toHaveCount(0);
+  await expect(page.locator('[data-ark-edge-id="e_order_user"]')).toHaveCount(
+    0
+  );
+  const afterDelete = await readCurrentModel(page);
+  expect(afterDelete.nodes.some(node => node.id === "order")).toBe(false);
+  expect(afterDelete.edges.some(edge => edge.id === "e_order_user")).toBe(
+    false
+  );
+  expect(
+    afterDelete.groups.find(group => group.id === "ordering-context")?.nodes
+  ).toEqual(["user"]);
+  expect(
+    afterDelete.groups.find(group => group.id === "cross-graph-context")?.nodes
+  ).toEqual(["external"]);
+});
+
+test("selection toolbar edge action: rerender 後も選択を復元して対象 edge だけ削除する", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  const toolbar = await selectEdge(page, "e_order_owner");
+  await toolbar
+    .locator('select[data-ark-edge-control="direction"]')
+    .selectOption("both");
+  await expect(selectedEdgeAnchor(page, "e_order_owner")).toHaveCount(1);
+  await expect(toolbar).toHaveAttribute(
+    "data-ark-selection-id",
+    "e_order_owner"
+  );
+  await toolbar.getByRole("button", { name: "owned by を削除" }).click();
+  await expect(toolbar).toBeHidden();
+  await expect(page.locator('[data-ark-edge-id="e_order_owner"]')).toHaveCount(
+    0
+  );
+  await expect(
+    page.locator('.ark-harness-edge-main[data-ark-edge-id="e_account_user"]')
+  ).toHaveCount(1);
+  expect((await readCurrentModel(page)).edges.map(edge => edge.id)).toEqual([
+    "e_account_user",
+  ]);
+});
+
+test("selection toolbar stale・submission: model 直接削除で解除し選択痕跡を送信しない", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  await connectSubmissionPort(page);
+  const toolbar = await selectNode(page, "order");
+  const nextModel = structuredClone(model);
+  nextModel.nodes = nextModel.nodes.filter(node => node.id !== "order");
+  nextModel.edges = nextModel.edges.filter(
+    edge => edge.from !== "order" && edge.to !== "order"
+  );
+  nextModel.groups = nextModel.groups.map(group => ({
+    ...group,
+    nodes: group.nodes.filter(id => id !== "order"),
+  }));
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  await page.locator(".ark-harness-textarea").fill(JSON.stringify(nextModel));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+  await expect(toolbar).toBeHidden();
+  await expect(page.locator(".ark-harness-node-selected")).toHaveCount(0);
+  await expect(page.locator(".ark-harness-edge-selected")).toHaveCount(0);
+
+  await selectNode(page, "user");
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const html = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { html: string };
+        }
+      ).arkHarnessSubmission?.html || ""
+  );
+  expect(html).not.toContain("ark-harness-context-toolbar");
+  expect(html).not.toContain("data-ark-selection-kind");
+  expect(html).not.toContain("data-ark-selection-id");
+  expect(html).not.toContain("ark-harness-node-selected");
+  expect(html).not.toContain("ark-harness-edge-selected");
+  expect(html).not.toContain("data-ark-harness-ui");
+  expect(html).toContain('data-kind="entity"');
+});
+
 test("node CRUD: palette から安全な projection を重ならず追加して再編集できる", async ({
   page,
 }) => {
@@ -911,7 +1361,11 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
   await expect(
     projection.locator(`span[data-model-id="${added.id}"]`)
   ).toHaveText("新しいノード");
-  await expect(projection.locator(".ark-harness-kind-picker")).toHaveCount(1);
+  await expect(projection.locator(".ark-harness-kind-picker")).toHaveCount(0);
+  await selectNode(page, added.id);
+  await expect(
+    contextToolbar(page).locator("select.ark-harness-kind-select")
+  ).toHaveValue("event");
   await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(1);
   await expect(
     firstGraph.locator(
@@ -2376,16 +2830,14 @@ test("cardinality・方向・type を edge SVG に安全に投影する", async 
   expect(errors).toEqual([]);
 });
 
-test("edge ごとに3つの native edge control と allowlist を表示する", async ({
+test("edge 選択時に単一 toolbar へ3つの native control と allowlist を表示する", async ({
   page,
 }) => {
   const errors = await openEdgeSemanticsDiagram(page);
-  const graph = page.locator('[data-ark-container="graph"]');
-  const controls = graph.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
-  );
+  const controls = await selectEdge(page, "e_order_owner");
 
   await expect(controls.locator("select")).toHaveCount(3);
+  await expect(page.locator(".ark-harness-edge-controls")).toHaveCount(0);
   for (const [role, name, expected] of [
     ["from-card", /owned by.*始点 cardinality.*one/, edgeControlOptions.from],
     [
@@ -2420,80 +2872,31 @@ test("edge ごとに3つの native edge control と allowlist を表示する", 
   expect(errors).toEqual([]);
 });
 
-test("edge control は hover・focus で表示され6px gapで重ならない", async ({
+test("edge control は選択中だけ単一 toolbar に表示し hover では切り替わらない", async ({
   page,
 }) => {
   await openEdgeSemanticsDiagram(page);
-  const graph = page.locator('[data-ark-container="graph"]');
-  const controls = graph.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
+  const controls = await selectEdge(page, "e_order_owner");
+  const rootIdentity = await controls.evaluate(element => {
+    (element as HTMLElement & { __edgeToolbar?: boolean }).__edgeToolbar = true;
+    return true;
+  });
+  await page
+    .locator('.ark-harness-edge-hit-target[data-ark-edge-id="e_account_user"]')
+    .hover({ force: true });
+  await page.waitForTimeout(250);
+  await expect(controls).toHaveAttribute(
+    "data-ark-selection-id",
+    "e_order_owner"
   );
-  const hitTarget = graph.locator(
-    '.ark-harness-edge-hit-target[data-ark-edge-id="e_order_owner"]'
-  );
-
-  await expect(controls).toHaveCSS("opacity", "0");
-  await expect(controls).toHaveCSS("pointer-events", "none");
-  await hitTarget.hover({ force: true });
-  await expect(controls).toHaveCSS("opacity", "1");
-  await controls.locator("select").first().hover();
-  await expect(controls).toHaveCSS("opacity", "1");
-
-  const secondHitTarget = graph.locator(
-    '.ark-harness-edge-hit-target[data-ark-edge-id="e_account_user"]'
-  );
-  await secondHitTarget.hover({ force: true });
-  await expect(controls).toHaveCSS("opacity", "0");
   await controls.locator("select").first().focus();
-  await expect(controls).toHaveCSS("opacity", "1");
-
-  const blockers = [
-    graph.locator(
-      'text[data-ark-edge-id="e_order_owner"].ark-harness-edge-label'
-    ),
-    graph.locator(
-      '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="from"]'
-    ),
-    graph.locator(
-      '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"][data-ark-edge-end="to"]'
-    ),
-    graph.locator('.ark-harness-graph-node[data-model-id="order"]'),
-    graph.locator('.ark-harness-graph-node[data-model-id="user"]'),
-    graph.locator('.ark-harness-graph-node[data-model-id="account"]'),
-  ];
-  const controlBoxes = await controls.locator("select").evaluateAll(elements =>
-    elements.map(element => {
-      const rect = element.getBoundingClientRect();
-      return {
-        left: rect.left,
-        top: rect.top,
-        right: rect.right,
-        bottom: rect.bottom,
-      };
-    })
+  await expect(controls.locator("select").first()).toBeFocused();
+  expect(rootIdentity).toBeTruthy();
+  await selectEdge(page, "e_account_user");
+  await expect(controls).toHaveAttribute(
+    "data-ark-selection-id",
+    "e_account_user"
   );
-  const blockerBoxes = await Promise.all(
-    blockers.map(async blocker => {
-      const box = await requiredBoundingBox(blocker);
-      return {
-        left: box.x,
-        top: box.y,
-        right: box.x + box.width,
-        bottom: box.y + box.height,
-      };
-    })
-  );
-  for (let index = 0; index < controlBoxes.length; index += 1) {
-    const control = controlBoxes[index];
-    for (const blocker of [...blockerBoxes, ...controlBoxes.slice(0, index)]) {
-      expect(
-        control.right + 6 <= blocker.left ||
-          blocker.right + 6 <= control.left ||
-          control.bottom + 6 <= blocker.top ||
-          blocker.bottom + 6 <= control.top
-      ).toBe(true);
-    }
-  }
 });
 
 test("edge cardinality・edge direction control を即時投影し非還流で保存する", async ({
@@ -2503,9 +2906,7 @@ test("edge cardinality・edge direction control を即時投影し非還流で�
   const errors = await openEdgeSemanticsDiagram(page, initialModel);
   await connectSubmissionPort(page);
   const graph = page.locator('[data-ark-container="graph"]');
-  const controls = graph.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
-  );
+  const controls = await selectEdge(page, "e_order_owner");
   const main = graph.locator(
     '.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
   );
@@ -2610,9 +3011,7 @@ test("unknown edge ext は allowlist placeholder と forward fallback で安全�
   hostileExt.direction = '<script src="https://example.invalid/x.js">';
   const errors = await openEdgeSemanticsDiagram(page, hostileModel);
   const graph = page.locator('[data-ark-container="graph"]');
-  const controls = graph.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
-  );
+  const controls = await selectEdge(page, "e_order_owner");
   const main = graph.locator(
     '.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
   );
@@ -2687,14 +3086,12 @@ test("unknown edge ext は allowlist placeholder と forward fallback で安全�
   expect(errors).toEqual([]);
 });
 
-test("モデル直接編集後の edge control を current model と同期して stale group を除去する", async ({
+test("モデル直接編集後の edge toolbar を current model と同期して stale selection を除去する", async ({
   page,
 }) => {
   const errors = await openEdgeSemanticsDiagram(page);
   const graph = page.locator('[data-ark-container="graph"]');
-  const ownerControls = graph.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
-  );
+  const ownerControls = await selectEdge(page, "e_order_owner");
   await ownerControls
     .locator('select[data-ark-edge-control="direction"]')
     .focus();
@@ -2723,10 +3120,9 @@ test("モデル直接編集後の edge control を current model と同期して
     .getByRole("button", { name: "反映", exact: true })
     .evaluate(element => (element as HTMLButtonElement).click());
 
-  await expect(ownerControls).toHaveCount(0);
-  const legacyControls = graph.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_account_user"]'
-  );
+  await expect(ownerControls).toBeHidden();
+  await expect(ownerControls).not.toHaveAttribute("data-ark-selection-id");
+  const legacyControls = await selectEdge(page, "e_account_user");
   await expect(
     legacyControls.locator('select[data-ark-edge-control="from-card"]')
   ).toHaveValue("many");
@@ -2775,17 +3171,14 @@ test("カーディナリティ 5 語彙を self-loop にも投影する", async 
     await expect(main).toHaveAttribute("marker-end", /url\(.+\)/);
     await expect(primitive.locator("line")).toHaveCount(lineCount);
     await expect(primitive.locator("circle")).toHaveCount(circleCount);
+    const controls = await selectEdge(page, "e_order_owner");
     await expect(
-      page.locator(
-        '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"] select[data-ark-edge-control="from-card"]'
-      )
+      controls.locator('select[data-ark-edge-control="from-card"]')
     ).toHaveValue(cardinality);
   }
 
   const graph = page.locator('[data-ark-container="graph"]');
-  const controls = graph.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
-  );
+  const controls = await selectEdge(page, "e_order_owner");
   await expect(controls.locator("select")).toHaveCount(3);
   await controls
     .locator('select[data-ark-edge-control="to-card"]')
@@ -2813,41 +3206,12 @@ test("カーディナリティ 5 語彙を self-loop にも投影する", async 
       'path.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
     )
   ).not.toHaveAttribute("marker-end", /.+/);
-  expect(
-    await graph.evaluate(container => {
-      const selects = [
-        ...container.querySelectorAll(
-          '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"] select'
-        ),
-      ];
-      const blockers = [
-        container.querySelector(
-          'text.ark-harness-edge-label[data-ark-edge-id="e_order_owner"]'
-        ),
-        ...container.querySelectorAll(
-          '.ark-harness-edge-handle[data-ark-edge-id="e_order_owner"]'
-        ),
-        container.querySelector(
-          '.ark-harness-graph-node[data-model-id="order"]'
-        ),
-      ].filter((element): element is Element => element !== null);
-      const separated = (left: Element, right: Element) => {
-        const a = left.getBoundingClientRect();
-        const b = right.getBoundingClientRect();
-        return (
-          a.right + 6 <= b.left ||
-          b.right + 6 <= a.left ||
-          a.bottom + 6 <= b.top ||
-          b.bottom + 6 <= a.top
-        );
-      };
-      return selects.every(
-        (select, index) =>
-          blockers.every(blocker => separated(select, blocker)) &&
-          selects.slice(0, index).every(other => separated(select, other))
-      );
-    })
-  ).toBe(true);
+  await expect(controls).toBeVisible();
+  await expect(controls).toHaveAttribute(
+    "data-ark-selection-id",
+    "e_order_owner"
+  );
+  await expect(controls.locator("select").first()).toBeEnabled();
   expect(errors).toEqual([]);
 });
 
@@ -2899,9 +3263,7 @@ test("edge 終点を張り替えて記号と clean HTML を同期する", async 
   await openEdgeSemanticsDiagram(page);
   await connectSubmissionPort(page);
   const graph = page.locator('[data-ark-container="graph"]');
-  const controls = graph.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_order_owner"]'
-  );
+  const controls = await selectEdge(page, "e_order_owner");
   await controls
     .locator('select[data-ark-edge-control="from-card"]')
     .selectOption("zero-or-one");
@@ -3508,9 +3870,8 @@ test("kind 候補は authored CSS rule を宣言順かつ重複なしで収集�
 }) => {
   await page.setContent(kindCandidateHtml());
 
-  const picker = page.getByRole("combobox", {
-    name: /Candidate.*quoted/,
-  });
+  const toolbar = await selectNode(page, "candidate");
+  const picker = toolbar.getByRole("combobox", { name: /Candidate.*quoted/ });
   await expect(picker).toHaveCount(1);
   expect(await picker.locator("option").allTextContents()).toEqual([
     "quoted",
@@ -3526,7 +3887,7 @@ test("kind 候補は authored CSS rule を宣言順かつ重複なしで収集�
   await expect(picker.locator("option", { hasText: "comment" })).toHaveCount(0);
 });
 
-test("kind 候補が無い図ではピッカーを付けず既存編集 UI を維持する", async ({
+test("kind 候補が無い図では disabled toolbar select と既存編集 UI を維持する", async ({
   page,
 }) => {
   await page.setContent(invalidCoordinateHtml());
@@ -3537,9 +3898,14 @@ test("kind 候補が無い図ではピッカーを付けず既存編集 UI を�
   await expect(
     graph.locator('[data-model-id="valid_a"].ark-harness-editable')
   ).toHaveAttribute("contenteditable", "true");
+  const toolbar = await selectNode(page, "valid_a");
+  await expect(
+    toolbar.locator("select.ark-harness-kind-select")
+  ).toBeDisabled();
+  await expect(toolbar.locator("select option")).toHaveText("kind なし");
 });
 
-test("kind ピッカーは候補外の現在値を保持し候補選択時だけ更新する", async ({
+test("kind toolbar は候補外の現在値を保持し候補選択時だけ更新する", async ({
   page,
 }) => {
   const boundaryModel = structuredClone(model);
@@ -3549,7 +3915,8 @@ test("kind ピッカーは候補外の現在値を保持し候補選択時だけ
   const order = page.locator(
     '[data-ark-container="graph"] > section[data-model-id="order"]'
   );
-  const picker = order.locator("select.ark-harness-kind-select");
+  const toolbar = await selectNode(page, "order");
+  const picker = toolbar.locator("select.ark-harness-kind-select");
   const current = picker.locator("option").first();
   await expect(order).toHaveAttribute("data-kind", "legacy-kind");
   await expect(picker).toHaveValue("legacy-kind");
@@ -3569,7 +3936,7 @@ test("kind ピッカーは候補外の現在値を保持し候補選択時だけ
   await expect(picker.locator("option")).toHaveCount(3);
 });
 
-test("kind ピッカーは untrusted 値を text と value だけで扱う", async ({
+test("kind toolbar は untrusted 値を text と value だけで扱う", async ({
   page,
 }) => {
   const requests: string[] = [];
@@ -3581,7 +3948,8 @@ test("kind ピッカーは untrusted 値を text と value だけで扱う", asy
   const root = page.locator(
     '[data-ark-container="graph"] > [data-model-id="unsafe"]'
   );
-  const picker = root.locator("select.ark-harness-kind-select");
+  const toolbar = await selectNode(page, "unsafe");
+  const picker = toolbar.locator("select.ark-harness-kind-select");
   const options = picker.locator("option");
   await expect(options).toHaveCount(2);
   await expect(options.nth(0)).toBeDisabled();
@@ -3605,14 +3973,15 @@ test("kind ピッカーは untrusted 値を text と value だけで扱う", asy
   expect(requests).toEqual([]);
 });
 
-test("モデル直接編集後に kind ピッカーと方向表示を再同期する", async ({
+test("モデル直接編集後に kind toolbar と方向表示を再同期する", async ({
   page,
 }) => {
   await openDiagram(page);
   const order = page.locator(
     '[data-ark-container="graph"] > section[data-model-id="order"]'
   );
-  const picker = order.locator("select.ark-harness-kind-select");
+  const toolbar = await selectNode(page, "order");
+  const picker = toolbar.locator("select.ark-harness-kind-select");
   const editButton = page.getByRole("button", {
     name: "モデル JSON を直接編集する",
   });
@@ -3656,7 +4025,7 @@ test("モデル直接編集後に kind ピッカーと方向表示を再同期�
   ).toBeVisible();
 });
 
-test("kind ピッカーで CSS 候補を選び投影・geometry・保存へ同期する", async ({
+test("kind toolbar で CSS 候補を選び投影・geometry・保存へ同期する", async ({
   page,
 }) => {
   await openDiagram(page);
@@ -3665,24 +4034,25 @@ test("kind ピッカーで CSS 候補を選び投影・geometry・保存へ同�
   const graph = page.locator('[data-ark-container="graph"]');
   const order = graph.locator(':scope > section[data-model-id="order"]');
   const user = graph.locator(':scope > section[data-model-id="user"]');
-  const orderPickerWrapper = order.locator(".ark-harness-kind-picker");
-  const orderPicker = order.locator("select.ark-harness-kind-select");
-  const userPicker = user.locator("select.ark-harness-kind-select");
+  const toolbar = await selectNode(page, "order");
+  const orderPicker = toolbar.locator("select.ark-harness-kind-select");
 
   await expect(orderPicker).toHaveCount(1);
-  await expect(userPicker).toHaveCount(1);
   await expect(orderPicker).toHaveAccessibleName(/Order.*aggregate/);
-  await expect(userPicker).toHaveAccessibleName(/User.*entity/);
   expect(await orderPicker.locator("option").allTextContents()).toEqual([
     "aggregate",
     "entity",
     "event",
   ]);
+  await selectNode(page, "user");
+  const userPicker = toolbar.locator("select.ark-harness-kind-select");
+  await expect(userPicker).toHaveAccessibleName(/User.*entity/);
   expect(await userPicker.locator("option").allTextContents()).toEqual([
     "aggregate",
     "entity",
     "event",
   ]);
+  await selectNode(page, "order");
   await expect(
     graph.locator(
       '[data-ark-group] select, h2[data-model-id="order"] select, li select, .ark-harness-edge-layer select'
@@ -3692,19 +4062,7 @@ test("kind ピッカーで CSS 候補を選び投影・geometry・保存へ同�
     page.locator('body > section[data-model-id="external"] select')
   ).toHaveCount(0);
 
-  await expect(orderPickerWrapper).toHaveCSS("opacity", "0");
-  const beforeHoverBox = await requiredBoundingBox(order);
-  await order.hover();
-  await expect(orderPickerWrapper).toHaveCSS("opacity", "1");
-  const [hoverBox, pickerBox, titleBox, dragHandleBox] = await Promise.all([
-    requiredBoundingBox(order),
-    requiredBoundingBox(orderPicker),
-    requiredBoundingBox(order.locator('h2[data-model-id="order"]')),
-    requiredBoundingBox(order.locator(".ark-harness-graph-handle")),
-  ]);
-  expect(hoverBox).toEqual(beforeHoverBox);
-  expect(boxesOverlap(pickerBox, titleBox)).toBe(false);
-  expect(boxesOverlap(pickerBox, dragHandleBox)).toBe(false);
+  await expectContextToolbarPlacement(page, order);
 
   const beforeModel = structuredClone(model);
   const beforeBox = await requiredBoundingBox(order);
@@ -4546,7 +4904,10 @@ test("kind 変更と node・edge・field・list 編集を同じ送信 model に�
   await connectSubmissionPort(page);
 
   const order = page.locator('section[data-model-id="order"]');
-  await order.locator("select.ark-harness-kind-select").selectOption("event");
+  const nodeToolbar = await selectNode(page, "order");
+  await nodeToolbar
+    .locator("select.ark-harness-kind-select")
+    .selectOption("event");
   await expect(order).toHaveAttribute("data-kind", "event");
   await page.evaluate(
     () =>
@@ -4554,9 +4915,7 @@ test("kind 変更と node・edge・field・list 編集を同じ送信 model に�
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       })
   );
-  const edgeControls = page.locator(
-    '.ark-harness-edge-controls[data-ark-edge-id="e_order_user"]'
-  );
+  const edgeControls = await selectEdge(page, "e_order_user");
   await edgeControls
     .locator('select[data-ark-edge-control="from-card"]')
     .selectOption("zero-or-many");

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -69,6 +69,79 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
+  it("node / edge 共通 selection と単一 context toolbar の契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain("var selection = { kind: null, id: null };");
+    expect(out).toContain("var selectionGraph = null;");
+    expect(out).toContain("function setSelection(");
+    expect(out).toContain("function clearSelection(");
+    expect(out).toContain("function reconcileSelection(");
+    expect(out).toContain("function renderSelectionVisuals(");
+    expect(out).toContain("function buildContextToolbar(");
+    expect(out).toContain("function renderContextToolbar(");
+    expect(out).toContain("function scheduleContextToolbarPosition(");
+    expect(out).toContain("ark-harness-context-toolbar");
+    expect(out).toContain('setAttribute("role", "toolbar")');
+    expect(out).toContain('setAttribute("data-ark-selection-kind"');
+    expect(out).toContain('setAttribute("data-ark-selection-id"');
+    expect(out).toContain("data-ark-toolbar-placement");
+    expect(out).toContain("document.body.appendChild(contextToolbar)");
+    expect(out).not.toContain("selectedNodeId");
+    expect(out).not.toContain("function setSelectedNode(");
+    expect(out).not.toContain("edgeControlsById: new Map()");
+  });
+
+  it("selection toolbar から node / edge action の既存安全境界へ到達する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain("function renderNodeToolbar(");
+    expect(out).toContain("function renderEdgeToolbar(");
+    expect(out).toContain("function collectKindCandidates(");
+    expect(out).toContain("function updateNodeKind(");
+    expect(out).toContain("kindCandidates.indexOf(value) === -1");
+    expect(out).toContain("function updateEdgeExt(");
+    expect(out).toContain("CARDINALITY_VALUES.indexOf(value)");
+    expect(out).toContain("DIRECTION_VALUES.indexOf(direction)");
+    expect(out).toContain("function addField(");
+    expect(out).toContain("function removeNode(");
+    expect(out).toContain("function removeEdge(");
+    expect(out).toContain("group.nodes = group.nodes.filter");
+    expect(out).toContain("var listBindingsByNode = new Map();");
+    expect(out).toContain("function selectedListBinding(");
+    expect(out).not.toContain("ark-harness-add-row");
+  });
+
+  it("selection toolbar は hover close 経路を持たず creation hover だけを維持する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).not.toContain(
+      ".ark-harness-graph-node:hover > .ark-harness-kind-picker"
+    );
+    expect(out).not.toContain("ark-harness-kind-picker");
+    expect(out).not.toContain("function scheduleEdgeControlsClose(");
+    expect(out).not.toContain("function activateEdgeControls(");
+    expect(out).not.toContain("function edgeControlsEngaged(");
+    expect(out).not.toContain("ark-harness-edge-controls-active");
+    expect(out).not.toContain("function positionEdgeControls(");
+    expect(out).toContain("var AFFORDANCE_CLOSE_DELAY = 120");
+    expect(out).toContain("function scheduleNodeAffordanceClose(");
+    expect(out).toContain("ark-harness-node-connectors-visible");
+    expect(out).toContain('anchor.addEventListener("pointerdown"');
+  });
+
   it("依存なし auto layout と注入サイズの契約を満たす", () => {
     const out = injectHarness(
       page(
@@ -183,8 +256,8 @@ describe("injectHarness", () => {
     expect(out).toContain('document.createElement("option")');
     expect(out).toContain("option.textContent =");
     expect(out).toContain("markUi(option)");
-    expect(out).toContain("function syncEdgeControls(");
-    expect(out).toContain("edgeControlsById: new Map()");
+    expect(out).toContain("function syncEdgeSelect(");
+    expect(out).toContain("function renderEdgeToolbar(");
     expect(out).toContain("data-ark-harness-ui");
   });
 
@@ -256,7 +329,7 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
-  it("authored CSS 由来の kind picker 契約を注入する", () => {
+  it("authored CSS 由来の kind toolbar 契約を注入する", () => {
     const out = injectHarness(
       page(
         '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
@@ -269,18 +342,13 @@ describe("injectHarness", () => {
     expect(out).toContain("style:not([data-ark-harness-ui])");
     expect(out).toContain("rule.selectorText");
     expect(out).toContain("new Set()");
-    expect(out).toContain("ark-harness-kind-picker");
-    expect(out).toContain("transform: translateY(calc(-100% - .25rem))");
-    expect(out).toContain("opacity: 0; pointer-events: none");
-    expect(out).toContain(
-      ".ark-harness-graph-node:focus-within > .ark-harness-kind-picker"
-    );
-    expect(out).toContain("opacity: 1; pointer-events: auto");
+    expect(out).toContain("ark-harness-context-toolbar");
+    expect(out).not.toContain("ark-harness-kind-picker");
     expect(out).toContain('document.createElement("select")');
     expect(out).toContain('document.createElement("option")');
     expect(out).toContain("option.textContent = value");
     expect(out).toContain("option.value = value");
-    expect(out).toContain("function syncKindPicker(");
+    expect(out).toContain("function syncKindSelect(");
     expect(out).toContain("function updateNodeKind(");
     expect(out).toContain("getNode(state.model, id)");
     expect(out).toContain("kindCandidates.indexOf(value) === -1");
@@ -330,16 +398,16 @@ describe("injectHarness", () => {
     expect(out).toContain("function setEdgeDeletePending(");
     expect(out).toContain('drag.mode === "rewire" && !candidate');
     expect(out).toContain("離すと edge を削除");
-    expect(out).toContain("function setSelectedNode(");
+    expect(out).toContain("function setSelection(");
     expect(out).toContain('root.addEventListener("pointerdown"');
-    expect(out).toContain("editableControl.getBoundingClientRect()");
+    expect(out).toContain("if (isEditableControlTarget(event.target)) return;");
     expect(out).toContain("event.preventDefault()");
     expect(out).toContain("root.focus({ preventScroll: true })");
-    expect(out).toContain("function handleNodeDeleteKey(");
+    expect(out).toContain("function handleSelectionKey(");
     expect(out).toContain('event.key !== "Delete"');
     expect(out).toContain('event.key !== "Backspace"');
     expect(out).toContain("target.isContentEditable");
-    expect(out).not.toContain("ark-harness-node-delete");
+    expect(out).toContain("ark-harness-node-delete");
     expect(out).not.toContain("ark-harness-edge-delete-visible");
     expect(out).not.toContain(".ark-harness-edge-hit {");
     expect(out).not.toContain("function syncEdgeDeleteControls(");

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -134,12 +134,6 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-handle { cursor: grab; }
 .ark-harness-handle:hover { background: rgba(255,255,255,.08); color: #d7dee8; }
 .ark-harness-delete:hover { background: rgba(248,113,113,.2); color: #f87171; }
-.ark-harness-add-row {
-  display: inline-block; margin: .35rem 0 1.5rem; padding: .3rem .6rem;
-  border: 1px dashed #333947; border-radius: 6px; background: transparent; color: #8b93a7;
-  font-size: 11.5px; cursor: pointer;
-}
-.ark-harness-add-row:hover { border-color: #38bdf8; color: #38bdf8; }
 [data-ark-container="graph"] { position: relative; }
 [data-ark-container="graph"].ark-harness-graph-layout {
   min-width: var(--ark-harness-graph-min-width); min-height: var(--ark-harness-graph-min-height);
@@ -147,16 +141,6 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-graph-group { position: absolute; z-index: 0; }
 .ark-harness-graph-node {
   position: absolute; left: var(--ark-harness-graph-x); top: var(--ark-harness-graph-y); z-index: 2;
-}
-.ark-harness-kind-picker {
-  position: absolute; top: 0; right: .25rem; z-index: 4;
-  transform: translateY(calc(-100% - .25rem));
-  opacity: 0; pointer-events: none; transition: opacity .12s ease;
-}
-.ark-harness-graph-node:hover > .ark-harness-kind-picker,
-.ark-harness-graph-node.ark-harness-node-affordance-open > .ark-harness-kind-picker,
-.ark-harness-graph-node:focus-within > .ark-harness-kind-picker {
-  opacity: 1; pointer-events: auto;
 }
 .ark-harness-kind-select {
   appearance: auto; max-width: 9rem; min-width: 4.5rem; padding: .18rem .25rem;
@@ -217,30 +201,10 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   opacity: 0; pointer-events: none;
 }
 .ark-harness-edge-dragging .ark-harness-node-anchor { pointer-events: none !important; }
-.ark-harness-edge-controls {
-  position: absolute; inset: 0; z-index: 4; opacity: 0; pointer-events: none;
-  transition: opacity .1s ease;
-}
-.ark-harness-edge-controls.ark-harness-edge-controls-active,
-.ark-harness-edge-controls:focus-within {
-  opacity: 1;
-}
 .ark-harness-edge-control {
-  position: absolute; transform: translate(-50%, -50%); box-sizing: border-box;
-  width: 108px; min-width: 0; padding: 2px 3px;
+  box-sizing: border-box; min-width: 108px; padding: 2px 3px;
   border: 1px solid rgba(100,116,139,.65); border-radius: 4px;
   background: rgba(255,255,255,.97); color: #334155; font: 10px/1.2 sans-serif;
-  pointer-events: none;
-}
-.ark-harness-edge-controls.ark-harness-edge-controls-active .ark-harness-edge-control,
-.ark-harness-edge-controls:focus-within .ark-harness-edge-control {
-  pointer-events: auto;
-}
-.ark-harness-edge-controls-unavailable {
-  opacity: 0 !important; pointer-events: none !important;
-}
-.ark-harness-edge-controls-unavailable .ark-harness-edge-control {
-  pointer-events: none !important;
 }
 .ark-harness-edge-preview {
   position: absolute; inset: 0; width: 100%; height: 100%; overflow: visible; pointer-events: none;
@@ -270,6 +234,25 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-graph-node.ark-harness-node-selected {
   outline: 2px solid #0ea5b7; outline-offset: 3px;
 }
+.ark-harness-edge-main.ark-harness-edge-selected {
+  stroke: #0ea5b7; stroke-width: 3;
+}
+.ark-harness-context-toolbar {
+  position: fixed; z-index: 2147483647; display: flex; align-items: center; gap: .35rem;
+  box-sizing: border-box; max-width: calc(100vw - 16px); padding: .35rem;
+  border: 1px solid rgba(100,116,139,.55); border-radius: 7px;
+  background: rgba(255,255,255,.98); color: #334155;
+  box-shadow: 0 4px 14px rgba(15,23,42,.22); font: 11px/1.2 sans-serif;
+}
+.ark-harness-context-toolbar[hidden] { display: none; }
+.ark-harness-context-toolbar button {
+  appearance: none; border: 1px solid rgba(100,116,139,.55); border-radius: 4px;
+  background: #fff; color: #334155; padding: .25rem .45rem; font: inherit; cursor: pointer;
+}
+.ark-harness-context-toolbar button:disabled,
+.ark-harness-context-toolbar select:disabled { opacity: .45; cursor: not-allowed; }
+.ark-harness-context-toolbar .ark-harness-node-delete,
+.ark-harness-context-toolbar .ark-harness-edge-delete { color: #b91c1c; }
 .ark-harness-graph-dragging { z-index: 3; }
 body { padding-bottom: var(--ark-harness-toolbar-height, 3.4rem) !important; }
 </style>`;
@@ -329,10 +312,14 @@ const RAW_HARNESS_JS = `(function () {
   var graphs = [];
   var graphSequence = 0;
   var kindCandidates = [];
-  var kindPickers = [];
   var reservedModelIds = new Set();
   var generatedIdCounter = 0;
-  var selectedNodeId = null;
+  var selection = { kind: null, id: null };
+  var selectionGraph = null;
+  var contextToolbar = null;
+  var toolbarPositionFrame = null;
+  var selectionResizeObserver = null;
+  var listBindingsByNode = new Map();
   var statusEl = null;
   var sendBtn = null;
   var layoutDirectionBtn = null;
@@ -1059,6 +1046,7 @@ const RAW_HARNESS_JS = `(function () {
   function removeEdge(edgeId) {
     var edge = getEdge(state.model, edgeId);
     if (!edge) return;
+    if (selection.kind === "edge" && selection.id === edgeId) clearSelection();
     if (edgeDrag && edgeDrag.mode === "rewire" && edgeDrag.edgeId === edgeId) {
       finishEdgeDrag(null, false);
     }
@@ -1090,11 +1078,10 @@ const RAW_HARNESS_JS = `(function () {
     hitTarget.setAttribute("data-ark-edge-id", edge.id);
     setEdgeGeometryAttributes(hitTarget, geometry);
     markUi(hitTarget);
-    hitTarget.addEventListener("pointerenter", function () {
-      activateEdgeControls(graph, edge.id);
-    });
-    hitTarget.addEventListener("pointerleave", function () {
-      scheduleEdgeControlsClose(graph, edge.id);
+    hitTarget.addEventListener("click", function (event) {
+      if (event.button !== 0) return;
+      event.stopPropagation();
+      setSelection("edge", edge.id, graph);
     });
     graph.svg.appendChild(hitTarget);
   }
@@ -1251,8 +1238,8 @@ const RAW_HARNESS_JS = `(function () {
       appendEdgeHitTarget(graph, edge, geometry);
     });
     syncEdgeHandles(graph, edges);
-    syncEdgeControls(graph, edges);
     syncNodeConnectors(graph);
+    reconcileSelection();
   }
 
   function scheduleGraphRender(graph) {
@@ -1575,83 +1562,17 @@ const RAW_HARNESS_JS = `(function () {
     ["pointerdown", "click", "keydown"].forEach(function (type) {
       select.addEventListener(type, function (event) { event.stopPropagation(); });
     });
-    select.addEventListener("focus", function () {
-      activateEdgeControls(graph, edgeId);
-    });
     select.addEventListener("change", function (event) {
       event.stopPropagation();
+      if (selection.kind !== "edge" || selection.id !== edgeId ||
+          selectionGraph !== graph) return;
       var property = edgeControlProperty(select.getAttribute("data-ark-edge-control"));
       if (property) updateEdgeExt(graph, edgeId, property, select.value);
     });
     return select;
   }
 
-  function createEdgeControls(graph, edge) {
-    var root = document.createElement("div");
-    root.className = "ark-harness-edge-controls";
-    root.setAttribute("data-ark-edge-id", edge.id);
-    markUi(root);
-    var controls = {
-      root: root,
-      selects: {},
-      placeholders: {},
-      closeTimer: null
-    };
-    ["from-card", "direction", "to-card"].forEach(function (role) {
-      var select = createEdgeSelect(graph, edge.id, role);
-      controls.selects[role] = select;
-      root.appendChild(select);
-    });
-    root.addEventListener("pointerenter", function () {
-      activateEdgeControls(graph, edge.id);
-    });
-    root.addEventListener("pointerleave", function () {
-      scheduleEdgeControlsClose(graph, edge.id);
-    });
-    graph.handleLayer.appendChild(root);
-    return controls;
-  }
-
-  function clearEdgeControlsClose(controls) {
-    if (controls.closeTimer === null) return;
-    window.clearTimeout(controls.closeTimer);
-    controls.closeTimer = null;
-  }
-
-  function edgeControlsEngaged(controls) {
-    if (controls.root.contains(document.activeElement)) return true;
-    var roles = ["from-card", "direction", "to-card"];
-    for (var i = 0; i < roles.length; i++) {
-      if (controls.selects[roles[i]].matches(":hover")) return true;
-    }
-    return false;
-  }
-
-  function activateEdgeControls(graph, edgeId) {
-    graph.edgeControlsById.forEach(function (controls, currentId) {
-      clearEdgeControlsClose(controls);
-      if (currentId === edgeId) {
-        controls.root.classList.add("ark-harness-edge-controls-active");
-      } else {
-        controls.root.classList.remove("ark-harness-edge-controls-active");
-      }
-    });
-  }
-
-  function scheduleEdgeControlsClose(graph, edgeId) {
-    var controls = graph.edgeControlsById.get(edgeId);
-    if (!controls) return;
-    clearEdgeControlsClose(controls);
-    controls.closeTimer = window.setTimeout(function () {
-      controls.closeTimer = null;
-      if (!edgeControlsEngaged(controls)) {
-        controls.root.classList.remove("ark-harness-edge-controls-active");
-      }
-    }, 100);
-  }
-
-  function syncEdgeSelect(controls, role, edge) {
-    var select = controls.selects[role];
+  function syncEdgeSelect(select, role, edge) {
     var property = edgeControlProperty(role);
     var raw = isRecordObject(edge.ext) ? edge.ext[property] : undefined;
     var allowed = role === "direction"
@@ -1665,18 +1586,10 @@ const RAW_HARNESS_JS = `(function () {
         ? "\\u4E0D\\u6B63\\u5024\\u30FB\\u8868\\u793A\\u306F forward"
         : "\\u4E0D\\u6B63\\u5024";
     if (current === null) {
-      if (!controls.placeholders[role]) {
-        controls.placeholders[role] = createEdgePlaceholder(placeholderText);
-        select.insertBefore(controls.placeholders[role], select.firstChild);
-      } else {
-        controls.placeholders[role].textContent = placeholderText;
-      }
+      var placeholder = createEdgePlaceholder(placeholderText);
+      select.insertBefore(placeholder, select.firstChild);
       select.value = "__ark_invalid__";
     } else {
-      if (controls.placeholders[role]) {
-        controls.placeholders[role].remove();
-        controls.placeholders[role] = null;
-      }
       select.value = current;
     }
     select.disabled = false;
@@ -1690,184 +1603,6 @@ const RAW_HARNESS_JS = `(function () {
     var label = name + " \\u306E" + roleLabel + "\\uFF08\\u73FE\\u5728 " + currentLabel + "\\uFF09";
     select.setAttribute("aria-label", label);
     select.setAttribute("title", label);
-  }
-
-  function domRectangle(element, containerRect) {
-    var rect = element.getBoundingClientRect();
-    return {
-      x: rect.left - containerRect.left,
-      y: rect.top - containerRect.top,
-      width: rect.width,
-      height: rect.height
-    };
-  }
-
-  function findEdgeLabel(graph, edgeId) {
-    var labels = graph.svg.querySelectorAll(".ark-harness-edge-label");
-    for (var i = 0; i < labels.length; i++) {
-      if (labels[i].getAttribute("data-ark-edge-id") === edgeId) return labels[i];
-    }
-    return null;
-  }
-
-  function edgeControlBlockers(graph, edgeId, containerRect) {
-    var blockers = [];
-    var label = findEdgeLabel(graph, edgeId);
-    if (label) blockers.push(domRectangle(label, containerRect));
-    ["from", "to"].forEach(function (end) {
-      var handle = graph.edgeHandlesByKey.get(edgeId + ":" + end);
-      if (handle) blockers.push(domRectangle(handle, containerRect));
-    });
-    graph.nodesById.forEach(function (node) {
-      blockers.push(domRectangle(node, containerRect));
-    });
-    return blockers;
-  }
-
-  function edgePathAnchor(main, fraction) {
-    var length = main.getTotalLength();
-    if (!Number.isFinite(length) || length <= 0) return null;
-    var offset = Math.max(0.5, Math.min(2, length / 20));
-    var distance = length * fraction;
-    var before = main.getPointAtLength(Math.max(0, distance - offset));
-    var after = main.getPointAtLength(Math.min(length, distance + offset));
-    var dx = after.x - before.x;
-    var dy = after.y - before.y;
-    var tangentLength = Math.sqrt(dx * dx + dy * dy);
-    if (!Number.isFinite(tangentLength) || tangentLength <= 0) return null;
-    var point = main.getPointAtLength(distance);
-    return {
-      x: point.x,
-      y: point.y,
-      tx: dx / tangentLength,
-      ty: dy / tangentLength
-    };
-  }
-
-  function controlRectangle(center, size) {
-    return {
-      x: center.x - size.width / 2,
-      y: center.y - size.height / 2,
-      width: size.width,
-      height: size.height
-    };
-  }
-
-  function placeEdgeSelect(select, anchor, blockers, edgeBox) {
-    var measured = select.getBoundingClientRect();
-    var size = { width: measured.width, height: measured.height };
-    if (!Number.isFinite(size.width) || !Number.isFinite(size.height) ||
-        size.width <= 0 || size.height <= 0) return null;
-    var nx = -anchor.ty;
-    var ny = anchor.tx;
-    var distances = [32, 56, 84, 112, 140, 168, 196];
-    var shifts = [0, -48, 48, -96, 96, -144, 144];
-    for (var i = 0; i < distances.length; i++) {
-      for (var signIndex = 0; signIndex < 2; signIndex++) {
-        var sign = signIndex === 0 ? 1 : -1;
-        for (var j = 0; j < shifts.length; j++) {
-          var center = {
-            x: anchor.x + nx * distances[i] * sign + anchor.tx * shifts[j],
-            y: anchor.y + ny * distances[i] * sign + anchor.ty * shifts[j]
-          };
-          var candidate = controlRectangle(center, size);
-          var blocked = blockers.some(function (blocker) {
-            return rectanglesCollide(candidate, blocker, 6);
-          });
-          if (blocked) continue;
-          select.style.left = center.x + "px";
-          select.style.top = center.y + "px";
-          return candidate;
-        }
-      }
-    }
-    var fallbackXs = [
-      edgeBox.x + edgeBox.width / 2,
-      edgeBox.x,
-      edgeBox.x + edgeBox.width,
-      edgeBox.x - size.width - 6,
-      edgeBox.x + edgeBox.width + size.width + 6
-    ];
-    for (var row = 0; row < 6; row++) {
-      for (var sideIndex = 0; sideIndex < 2; sideIndex++) {
-        for (var xIndex = 0; xIndex < fallbackXs.length; xIndex++) {
-          var fallbackCenter = {
-            x: fallbackXs[xIndex],
-            y: sideIndex === 0
-              ? edgeBox.y - size.height / 2 - 6 - row * (size.height + 6)
-              : edgeBox.y + edgeBox.height + size.height / 2 + 6 +
-                row * (size.height + 6)
-          };
-          var fallback = controlRectangle(fallbackCenter, size);
-          var fallbackBlocked = blockers.some(function (blocker) {
-            return rectanglesCollide(fallback, blocker, 6);
-          });
-          if (fallbackBlocked) continue;
-          select.style.left = fallbackCenter.x + "px";
-          select.style.top = fallbackCenter.y + "px";
-          return fallback;
-        }
-      }
-    }
-    return null;
-  }
-
-  function positionEdgeControls(graph, edge, controls) {
-    var main = graph.edgeMainById.get(edge.id);
-    if (!main) {
-      controls.root.classList.add("ark-harness-edge-controls-unavailable");
-      ["from-card", "direction", "to-card"].forEach(function (role) {
-        controls.selects[role].disabled = true;
-      });
-      return;
-    }
-    var containerRect = graph.container.getBoundingClientRect();
-    var blockers = edgeControlBlockers(graph, edge.id, containerRect);
-    var edgeBox = domRectangle(main, containerRect);
-    var placements = [
-      { role: "from-card", fraction: 0.2 },
-      { role: "direction", fraction: 0.5 },
-      { role: "to-card", fraction: 0.8 }
-    ];
-    for (var i = 0; i < placements.length; i++) {
-      var placement = placements[i];
-      var anchor = edgePathAnchor(main, placement.fraction);
-      var rectangle = anchor &&
-        placeEdgeSelect(controls.selects[placement.role], anchor, blockers, edgeBox);
-      if (!rectangle) {
-        controls.root.classList.add("ark-harness-edge-controls-unavailable");
-        ["from-card", "direction", "to-card"].forEach(function (role) {
-          controls.selects[role].disabled = true;
-        });
-        return;
-      }
-      blockers.push(rectangle);
-    }
-    controls.root.classList.remove("ark-harness-edge-controls-unavailable");
-  }
-
-  function syncEdgeControls(graph, edges) {
-    var activeIds = new Set();
-    edges.forEach(function (edge) {
-      if (!graph.edgeGeometryById.has(edge.id)) return;
-      activeIds.add(edge.id);
-      var controls = graph.edgeControlsById.get(edge.id);
-      if (!controls) {
-        controls = createEdgeControls(graph, edge);
-        graph.edgeControlsById.set(edge.id, controls);
-      }
-      controls.root.setAttribute("data-ark-edge-id", edge.id);
-      syncEdgeSelect(controls, "from-card", edge);
-      syncEdgeSelect(controls, "direction", edge);
-      syncEdgeSelect(controls, "to-card", edge);
-      positionEdgeControls(graph, edge, controls);
-    });
-    graph.edgeControlsById.forEach(function (controls, edgeId) {
-      if (activeIds.has(edgeId)) return;
-      clearEdgeControlsClose(controls);
-      if (controls.root.parentNode) controls.root.parentNode.removeChild(controls.root);
-      graph.edgeControlsById.delete(edgeId);
-    });
   }
 
   function finishGraphDrag(event) {
@@ -2074,7 +1809,6 @@ const RAW_HARNESS_JS = `(function () {
       });
     });
     var affordances = [
-      root.querySelector(".ark-harness-kind-picker"),
       root.querySelector(".ark-harness-graph-handle"),
       connectors
     ];
@@ -2090,16 +1824,289 @@ const RAW_HARNESS_JS = `(function () {
     graph.nodeAffordancesById.set(id, controller);
   }
 
-  function setSelectedNode(id) {
-    selectedNodeId = id && getNode(state.model, id) ? id : null;
+  function selectionEntry() {
+    if (selection.kind === "node") return getNode(state.model, selection.id);
+    if (selection.kind === "edge") return getEdge(state.model, selection.id);
+    return null;
+  }
+
+  function selectionAnchor() {
+    if (!selectionGraph || graphs.indexOf(selectionGraph) === -1) return null;
+    if (selection.kind === "node") {
+      return selectionGraph.nodesById.get(selection.id) || null;
+    }
+    if (selection.kind === "edge") {
+      return selectionGraph.edgeMainById.get(selection.id) || null;
+    }
+    return null;
+  }
+
+  function renderSelectionVisuals() {
     graphs.forEach(function (graph) {
       graph.nodesById.forEach(function (root, nodeId) {
         root.classList.toggle(
           "ark-harness-node-selected",
-          nodeId === selectedNodeId
+          selection.kind === "node" && graph === selectionGraph &&
+            nodeId === selection.id
+        );
+      });
+      graph.edgeMainById.forEach(function (main, edgeId) {
+        main.classList.toggle(
+          "ark-harness-edge-selected",
+          selection.kind === "edge" && graph === selectionGraph &&
+            edgeId === selection.id
         );
       });
     });
+  }
+
+  function clearToolbarChildren() {
+    if (!contextToolbar) return;
+    while (contextToolbar.firstChild) {
+      contextToolbar.removeChild(contextToolbar.firstChild);
+    }
+  }
+
+  function syncKindSelect(select, node) {
+    var current = typeof node.kind === "string" ? node.kind : "";
+    if (kindCandidates.indexOf(current) === -1) {
+      var currentOption = createKindOption(current);
+      currentOption.textContent = current || "kind \\u306A\\u3057";
+      currentOption.disabled = true;
+      select.insertBefore(currentOption, select.firstChild);
+    }
+    select.value = current;
+    var name = (typeof node.label === "string" && node.label) || node.id;
+    var label = name + " \\u306E kind\\uFF08\\u73FE\\u5728 " +
+      (current || "\\u306A\\u3057") + "\\uFF09";
+    select.setAttribute("aria-label", label);
+    select.title = label;
+  }
+
+  function selectedListBinding() {
+    if (selection.kind !== "node" || !selectionGraph) return null;
+    var root = selectionGraph.nodesById.get(selection.id);
+    var bindings = listBindingsByNode.get(selection.id) || [];
+    for (var i = 0; i < bindings.length; i++) {
+      if (bindings[i].listEl.isConnected && root.contains(bindings[i].listEl)) {
+        return bindings[i];
+      }
+    }
+    return null;
+  }
+
+  function renderNodeToolbar(node) {
+    var graph = selectionGraph;
+    var root = graph && graph.nodesById.get(node.id);
+    var select = document.createElement("select");
+    select.className = "ark-harness-kind-select";
+    markUi(select);
+    if (kindCandidates.length === 0) {
+      var none = createKindOption("");
+      none.textContent = "kind \\u306A\\u3057";
+      select.appendChild(none);
+      select.disabled = true;
+    } else {
+      kindCandidates.forEach(function (value) {
+        select.appendChild(createKindOption(value));
+      });
+      syncKindSelect(select, node);
+    }
+    select.addEventListener("change", function (event) {
+      event.stopPropagation();
+      if (selection.kind === "node" && selection.id === node.id &&
+          selectionGraph === graph && root) {
+        updateNodeKind(graph, root, select.value);
+      }
+    });
+    contextToolbar.appendChild(select);
+
+    var binding = selectedListBinding();
+    var add = createButton(
+      "+ \\u884C",
+      "ark-harness-node-add-field",
+      "\\u884C\\u3092\\u8FFD\\u52A0"
+    );
+    add.disabled = !binding;
+    add.addEventListener("click", function () {
+      if (selection.kind !== "node" || selection.id !== node.id) return;
+      var current = selectedListBinding();
+      if (current) addField(current.listEl, current.ownerNodeId);
+    });
+    contextToolbar.appendChild(add);
+
+    var name = (typeof node.label === "string" && node.label) || node.id;
+    var del = createButton(
+      "\\u524A\\u9664",
+      "ark-harness-node-delete",
+      name + " \\u3092\\u524A\\u9664"
+    );
+    del.addEventListener("click", function () {
+      if (selection.kind !== "node" || selection.id !== node.id) return;
+      clearSelection();
+      removeNode(node.id);
+    });
+    contextToolbar.appendChild(del);
+  }
+
+  function renderEdgeToolbar(edge) {
+    var graph = selectionGraph;
+    ["from-card", "to-card", "direction"].forEach(function (role) {
+      var select = createEdgeSelect(graph, edge.id, role);
+      syncEdgeSelect(select, role, edge);
+      contextToolbar.appendChild(select);
+    });
+    var name = (typeof edge.label === "string" && edge.label) || edge.id;
+    var del = createButton(
+      "\\u524A\\u9664",
+      "ark-harness-edge-delete",
+      name + " \\u3092\\u524A\\u9664"
+    );
+    del.addEventListener("click", function () {
+      if (selection.kind !== "edge" || selection.id !== edge.id) return;
+      clearSelection();
+      removeEdge(edge.id);
+    });
+    contextToolbar.appendChild(del);
+  }
+
+  function renderContextToolbar() {
+    if (!contextToolbar) return;
+    clearToolbarChildren();
+    contextToolbar.removeAttribute("data-ark-selection-kind");
+    contextToolbar.removeAttribute("data-ark-selection-id");
+    contextToolbar.removeAttribute("data-ark-toolbar-placement");
+    var entry = selectionEntry();
+    if (!entry) {
+      contextToolbar.hidden = true;
+      return;
+    }
+    contextToolbar.hidden = false;
+    contextToolbar.setAttribute("data-ark-selection-kind", selection.kind);
+    contextToolbar.setAttribute("data-ark-selection-id", selection.id);
+    var name = (typeof entry.label === "string" && entry.label) || entry.id;
+    contextToolbar.setAttribute(
+      "aria-label",
+      name + " \\u306E\\u30B3\\u30F3\\u30C6\\u30AD\\u30B9\\u30C8\\u30C4\\u30FC\\u30EB\\u30D0\\u30FC"
+    );
+    if (selection.kind === "node") renderNodeToolbar(entry);
+    if (selection.kind === "edge") renderEdgeToolbar(entry);
+  }
+
+  function observeSelectionAnchor(anchor) {
+    if (!selectionResizeObserver) return;
+    selectionResizeObserver.disconnect();
+    if (anchor) selectionResizeObserver.observe(anchor);
+    if (contextToolbar && !contextToolbar.hidden) {
+      selectionResizeObserver.observe(contextToolbar);
+    }
+  }
+
+  function positionContextToolbar() {
+    toolbarPositionFrame = null;
+    if (!contextToolbar || contextToolbar.hidden) return;
+    var anchor = selectionAnchor();
+    if (!anchor || !anchor.isConnected) {
+      clearSelection();
+      return;
+    }
+    var anchorRect = anchor.getBoundingClientRect();
+    var toolbarRect = contextToolbar.getBoundingClientRect();
+    if (!finiteNumber(anchorRect.left) || !finiteNumber(anchorRect.top) ||
+        !finiteNumber(toolbarRect.width) || !finiteNumber(toolbarRect.height) ||
+        toolbarRect.width <= 0 || toolbarRect.height <= 0) {
+      clearSelection();
+      return;
+    }
+    var margin = 8;
+    var top = anchorRect.top - toolbarRect.height - margin;
+    var placement = "above";
+    if (top < margin) {
+      top = anchorRect.bottom + margin;
+      placement = "below";
+    }
+    if (top + toolbarRect.height > window.innerHeight - margin) {
+      top = Math.max(
+        margin,
+        Math.min(top, window.innerHeight - toolbarRect.height - margin)
+      );
+      placement = "clamped";
+    }
+    var left = anchorRect.left +
+      (anchorRect.width - toolbarRect.width) / 2;
+    left = Math.max(
+      margin,
+      Math.min(left, window.innerWidth - toolbarRect.width - margin)
+    );
+    contextToolbar.style.left = left + "px";
+    contextToolbar.style.top = top + "px";
+    contextToolbar.setAttribute("data-ark-toolbar-placement", placement);
+    observeSelectionAnchor(anchor);
+  }
+
+  function scheduleContextToolbarPosition() {
+    if (toolbarPositionFrame !== null || !contextToolbar ||
+        contextToolbar.hidden) return;
+    toolbarPositionFrame = window.requestAnimationFrame(positionContextToolbar);
+  }
+
+  function clearSelection() {
+    selection = { kind: null, id: null };
+    selectionGraph = null;
+    if (selectionResizeObserver) selectionResizeObserver.disconnect();
+    renderSelectionVisuals();
+    renderContextToolbar();
+  }
+
+  function setSelection(kind, id, graph) {
+    var valid = kind === "node"
+      ? getNode(state.model, id)
+      : kind === "edge"
+        ? getEdge(state.model, id)
+        : null;
+    if (!valid || graphs.indexOf(graph) === -1) {
+      clearSelection();
+      return;
+    }
+    selection = { kind: kind, id: id };
+    selectionGraph = graph;
+    renderSelectionVisuals();
+    renderContextToolbar();
+    scheduleContextToolbarPosition();
+  }
+
+  function reconcileSelection() {
+    if (!selectionEntry()) {
+      clearSelection();
+      return;
+    }
+    var anchor = selectionAnchor();
+    if (!anchor || !anchor.isConnected) {
+      clearSelection();
+      return;
+    }
+    renderSelectionVisuals();
+    renderContextToolbar();
+    scheduleContextToolbarPosition();
+  }
+
+  function buildContextToolbar() {
+    contextToolbar = document.createElement("div");
+    contextToolbar.className = "ark-harness-context-toolbar";
+    contextToolbar.setAttribute("role", "toolbar");
+    contextToolbar.hidden = true;
+    markUi(contextToolbar);
+    ["pointerdown", "click"].forEach(function (type) {
+      contextToolbar.addEventListener(type, function (event) {
+        event.stopPropagation();
+      });
+    });
+    document.body.appendChild(contextToolbar);
+    if (typeof ResizeObserver !== "undefined") {
+      selectionResizeObserver = new ResizeObserver(
+        scheduleContextToolbarPosition
+      );
+    }
   }
 
   function attachNodeSelection(root, id) {
@@ -2109,19 +2116,22 @@ const RAW_HARNESS_JS = `(function () {
     }
     root.addEventListener("pointerdown", function (event) {
       if (event.button !== 0 || isInsideHarnessUi(event.target)) return;
-      var editableControl = event.target && event.target.closest &&
-        event.target.closest('[contenteditable="true"], input, textarea, select, button');
-      if (editableControl) {
-        var editableRect = editableControl.getBoundingClientRect();
-        if (event.clientX >= editableRect.left && event.clientX <= editableRect.right &&
-            event.clientY >= editableRect.top && event.clientY <= editableRect.bottom) return;
-      }
+      if (isEditableControlTarget(event.target)) return;
       event.preventDefault();
-      setSelectedNode(id);
+      var graph = graphs.find(function (entry) {
+        return entry.nodesById.get(id) === root;
+      });
+      setSelection("node", id, graph);
       root.focus({ preventScroll: true });
     });
-    root.addEventListener("click", function () { setSelectedNode(id); });
-    root.addEventListener("focusin", function () { setSelectedNode(id); });
+    root.addEventListener("click", function (event) {
+      if (event.button !== 0 || isInsideHarnessUi(event.target) ||
+          !isEditableControlTarget(event.target)) return;
+      var graph = graphs.find(function (entry) {
+        return entry.nodesById.get(id) === root;
+      });
+      setSelection("node", id, graph);
+    });
   }
 
   function registerGraphNode(graph, root, node) {
@@ -2129,7 +2139,6 @@ const RAW_HARNESS_JS = `(function () {
     graph.nodesById.set(node.id, root);
     root.classList.add("ark-harness-graph-node");
     attachNodeSelection(root, node.id);
-    attachKindPicker(graph, root);
     attachGraphHandle(graph, root, node);
     attachNodeConnectors(graph, root);
     attachNodeAffordanceHover(graph, root, node.id);
@@ -2148,11 +2157,6 @@ const RAW_HARNESS_JS = `(function () {
     var affordance = graph.nodeAffordancesById.get(id);
     clearNodeAffordanceClose(affordance);
     graph.nodeAffordancesById.delete(id);
-    kindPickers = kindPickers.filter(function (picker) {
-      if (picker.root !== root) return true;
-      if (picker.select.parentNode) picker.select.parentNode.remove();
-      return false;
-    });
     if (graphDrag && graphDrag.graph === graph &&
         graphDrag.el.getAttribute("data-model-id") === id) {
       finishGraphDrag(null);
@@ -2194,7 +2198,7 @@ const RAW_HARNESS_JS = `(function () {
       (edgeDrag.mode === "create" && edgeDrag.sourceId === id) ||
       (edgeDrag.mode === "rewire" && incidentIds.has(edgeDrag.edgeId))
     )) finishEdgeDrag(null, false);
-    if (selectedNodeId === id) selectedNodeId = null;
+    if (selection.kind === "node" && selection.id === id) clearSelection();
 
     state.model.nodes = state.model.nodes.filter(function (entry) {
       return entry.id !== id;
@@ -2211,13 +2215,16 @@ const RAW_HARNESS_JS = `(function () {
     graphs.forEach(function (graph) { scheduleGraphRender(graph); });
   }
 
-  function handleNodeDeleteKey(event) {
+  function handleSelectionKey(event) {
     if ((event.key !== "Delete" && event.key !== "Backspace") ||
-        !selectedNodeId || graphDrag || edgeDrag ||
+        !selection.id || graphDrag || edgeDrag ||
         isEditableControlTarget(event.target)) return;
     event.preventDefault();
     event.stopPropagation();
-    removeNode(selectedNodeId);
+    var selected = { kind: selection.kind, id: selection.id };
+    clearSelection();
+    if (selected.kind === "node") removeNode(selected.id);
+    if (selected.kind === "edge") removeEdge(selected.id);
   }
 
   function authoredClassName(root) {
@@ -2274,9 +2281,7 @@ const RAW_HARNESS_JS = `(function () {
     graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(add);
     graph.edgeHandlesByKey.forEach(add);
     graph.nodesById.forEach(function (nodeRoot) {
-      nodeRoot.querySelectorAll(
-        ".ark-harness-kind-picker, .ark-harness-graph-handle"
-      ).forEach(add);
+      nodeRoot.querySelectorAll(".ark-harness-graph-handle").forEach(add);
     });
     return blockers;
   }
@@ -2406,7 +2411,6 @@ const RAW_HARNESS_JS = `(function () {
       edgeHandlesByKey: new Map(),
       nodeConnectorsById: new Map(),
       nodeAffordancesById: new Map(),
-      edgeControlsById: new Map(),
       positionsById: new Map(),
       layoutExtent: { width: null, height: null },
       resizeObserver: null,
@@ -2431,21 +2435,33 @@ const RAW_HARNESS_JS = `(function () {
     containers.forEach(function (container) { graphs.push(wireGraph(container)); });
     window.addEventListener("resize", function () {
       graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+      scheduleContextToolbarPosition();
     });
+    window.addEventListener("scroll", scheduleContextToolbarPosition, true);
     window.addEventListener("pointerup", function (event) {
       finishEdgeDrag(event, true);
     });
     window.addEventListener("pointercancel", function (event) {
       finishEdgeDrag(event, false);
     });
+    window.addEventListener("click", function (event) {
+      if (event.button !== 0) return;
+      var target = event.target;
+      if (!target || isInsideHarnessUi(target) ||
+          target.closest(".ark-harness-graph-node") ||
+          target.closest(".ark-harness-edge-hit-target") ||
+          isEditableControlTarget(target)) return;
+      clearSelection();
+    });
     window.addEventListener("keydown", function (event) {
       if (event.key === "Escape") {
         if (edgeDrag) event.preventDefault();
         finishEdgeDrag(null, false);
+        clearSelection();
         return;
       }
-      handleNodeDeleteKey(event);
-    });
+      handleSelectionKey(event);
+    }, true);
   }
 
   function findEntry(model, id) {
@@ -2539,40 +2555,6 @@ const RAW_HARNESS_JS = `(function () {
     return option;
   }
 
-  function syncKindPicker(picker) {
-    var id = picker.root.getAttribute("data-model-id");
-    var node = id && getNode(state.model, id);
-    if (!node) {
-      picker.select.disabled = true;
-      return;
-    }
-    picker.select.disabled = false;
-    var current = typeof node.kind === "string" ? node.kind : "";
-    if (kindCandidates.indexOf(current) === -1) {
-      if (!picker.currentOption) {
-        picker.currentOption = createKindOption(current);
-        picker.currentOption.disabled = true;
-        picker.select.insertBefore(picker.currentOption, picker.select.firstChild);
-      } else {
-        picker.currentOption.textContent = current || "kind なし";
-        picker.currentOption.value = current;
-      }
-    } else if (picker.currentOption) {
-      picker.currentOption.remove();
-      picker.currentOption = null;
-    }
-    picker.select.value = current;
-    var name = (typeof node.label === "string" && node.label) || node.id;
-    var currentLabel = current || "なし";
-    var label = name + " の kind（現在 " + currentLabel + "）";
-    picker.select.setAttribute("aria-label", label);
-    picker.select.title = label;
-  }
-
-  function syncKindPickers() {
-    kindPickers.forEach(function (picker) { syncKindPicker(picker); });
-  }
-
   function updateNodeKind(graph, root, value) {
     var id = root.getAttribute("data-model-id");
     if (!id || kindCandidates.indexOf(value) === -1) return;
@@ -2580,37 +2562,8 @@ const RAW_HARNESS_JS = `(function () {
     if (!node) return;
     node.kind = value;
     syncNodeKinds();
-    syncKindPickers();
+    renderContextToolbar();
     scheduleGraphRender(graph);
-  }
-
-  function attachKindPicker(graph, root) {
-    if (kindCandidates.length === 0) return;
-    var wrapper = document.createElement("span");
-    wrapper.className = "ark-harness-kind-picker";
-    markUi(wrapper);
-    var select = document.createElement("select");
-    select.className = "ark-harness-kind-select";
-    markUi(select);
-    kindCandidates.forEach(function (value) {
-      select.appendChild(createKindOption(value));
-    });
-    var picker = {
-      root: root,
-      select: select,
-      currentOption: null
-    };
-    ["pointerdown", "click", "keydown"].forEach(function (type) {
-      select.addEventListener(type, function (event) { event.stopPropagation(); });
-    });
-    select.addEventListener("change", function (event) {
-      event.stopPropagation();
-      updateNodeKind(graph, root, select.value);
-    });
-    wrapper.appendChild(select);
-    root.appendChild(wrapper);
-    kindPickers.push(picker);
-    syncKindPicker(picker);
   }
 
   function markUi(el) {
@@ -2758,22 +2711,23 @@ const RAW_HARNESS_JS = `(function () {
       e.preventDefault();
       syncFieldOrder(listEl, ownerNodeId);
     });
-
-    var addBtn = createButton("+ 行を追加", "ark-harness-add-row", "行を追加");
-    addBtn.addEventListener("click", function () {
-      addField(listEl, ownerNodeId);
-    });
-    listEl.insertAdjacentElement("afterend", addBtn);
   }
 
   function initEditing() {
     var model = state.model;
     var listBindings = [];
+    listBindingsByNode = new Map();
     var listEls = document.querySelectorAll("ul, ol");
     listEls.forEach(function (listEl) {
       if (isInsideHarnessUi(listEl)) return;
       var ownerNodeId = findOwnerNodeId(model, listEl);
-      if (ownerNodeId) listBindings.push({ listEl: listEl, ownerNodeId: ownerNodeId });
+      if (ownerNodeId) {
+        var binding = { listEl: listEl, ownerNodeId: ownerNodeId };
+        listBindings.push(binding);
+        var owned = listBindingsByNode.get(ownerNodeId) || [];
+        owned.push(binding);
+        listBindingsByNode.set(ownerNodeId, owned);
+      }
     });
 
     listBindings.forEach(function (binding) {
@@ -2917,8 +2871,8 @@ const RAW_HARNESS_JS = `(function () {
         state.model = parsed;
         reserveCurrentModelIds();
         syncNodeKinds();
-        syncKindPickers();
         syncLayoutDirectionButton();
+        reconcileSelection();
         graphs.forEach(function (graph) { scheduleGraphRender(graph); });
         error.style.display = "none";
         panel.style.display = "none";
@@ -3072,6 +3026,7 @@ const RAW_HARNESS_JS = `(function () {
       kindCandidates = collectKindCandidates();
       buildToolbar();
       initEditing();
+      buildContextToolbar();
       initGraphs();
     } catch (e) {
       console.error("[ark-harness] 初期化に失敗しました", e);


### PR DESCRIPTION
## 概要（図解編集 draw.io 化 Phase A）

「ホバーで出てくる項目に触ろうとすると消える（最悪の UX）」を**構造的に解消**する。設計 spec（#266）の第1フェーズ。

hover 駆動をやめ**選択駆動**へ:
- **選択 state**（`selection={kind:'node'|'edge'|null,id}`）+ **body 直下に単一の浮くコンテキストツールバー**（`position:fixed`・選択要素の上に配置・上端で下へ fallback・左右 clamp・scroll/resize/graph 再描画を rAF で追従）
- **toolbar は選択している間ずっと表示**（pointerleave/closeTimer を一切持たない）→ **hover-gap が原理的に起きない**
- node 選択 = kind ▾/+行/削除、edge 選択 = from-card ▾/to-card ▾/方向 ▾/削除。#241/#242/「+行」の既存ロジックを流用
- 主犯だった kind ピッカーの純 CSS `:hover`（`.ark-harness-graph-node:hover > .ark-harness-kind-picker`）と per-edge hover コントロール・常時 add-row button を撤去

非選択時キャンバスは無地。#243 の作成アンカー（hover）は Phase B で使うため残置。

## 検証（目視でなく DOM assert）

- **hover-gap ゼロの機械検証**: 選択後 mouse を gap 経由で toolbar control 中央へ移動し、旧 grace（100/120ms）より長い **250ms 後も visible・同 selection id・enabled**（node/edge 両方）
- 初期/blank/Escape で hidden・node/edge click で内容が変わる・contenteditable click で編集 focus 維持
- 削除で node/incident edge/`groups[].nodes` 同期除去（参照整合性・422 回避）
- clean submission に toolbar/selection の痕跡なし
- E2E **62 PASS**・対象 Vitest 19・全 unit **681 PASS**・`pnpm check`/`build`/`git diff --check` PASS
- **注入後 116,856 bytes**（guard 131,072・余裕 14,216。撤去が追加を上回り縮小・threshold 変更なし）
- production `diagram-diff.ts`/`describeModelDiff` 不変（非還流契約維持）・モバイル非対象
- **実機プレビューで動作確認済み**（選択→ツールバー→触っても消えない・空白/Escape で解除・Delete cascade）

## フェーズ

spec 2026-07-25 の Phase A。B（作成ジェスチャ）/C（クロム掃除）/D（磨き込み）は #268-270。

Closes #267


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ノードやエッジを選択すると、操作項目をまとめたコンテキストツールバーを表示するようになりました。
  - ツールバーから種類の変更、行の追加、エッジ設定、削除を行えます。
  - `Delete` / `Backspace`、`Escape`、画面外クリックで選択を解除できます。
  - スクロールや複数のグラフでも、ツールバーが選択対象に追従します。

- **テスト**
  - 選択、削除、位置調整、編集内容の同期などの動作確認を拡充しました。

- **ドキュメント**
  - 選択ツールバー機能の実装計画を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->