### PR TITLE
ci: bump-claude-code の cron を 01:00 UTC へ移す

### DIFF
--- a/.claude/skills/build-deploy/SKILL.md
+++ b/.claude/skills/build-deploy/SKILL.md
@@ -14,7 +14,7 @@ CLAUDE.mdのデプロイ手順に従い、以下を **順番通りに** 実行�
 pnpm install --frozen-lockfile
 ```
 
-毎晩の bump-claude-code ワークフローによる同梱 `@anthropic-ai/claude-code` の更新は、
+毎日の bump-claude-code ワークフローによる同梱 `@anthropic-ai/claude-code` の更新は、
 install で初めて node_modules に反映される。省略すると稼働中の Ark が旧バージョンの
 claude を配り続ける。失敗した場合はエラー内容を報告して停止する。
 

--- a/.github/workflows/bump-claude-code.yml
+++ b/.github/workflows/bump-claude-code.yml
@@ -1,6 +1,6 @@
 name: Bump Claude Code
 
-# 同梱依存 @anthropic-ai/claude-code の新しい npm リリースを毎晩検知し、
+# 同梱依存 @anthropic-ai/claude-code の新しい npm リリースを毎日検知し、
 # バージョンを引き上げる PR を作成する。マージ前の検証は「in-job 品質ゲート」
 # （verify ジョブ内で実行する pnpm check + pnpm build）で行い、緑なら squash マージする。
 # 新版が無ければ何もしない。
@@ -19,8 +19,13 @@ name: Bump Claude Code
 # マージ後の main への push で ci.yml が事後検証（backstop）として走る。
 
 on:
+  # 実行時刻は upstream の npm 公開時刻より「後ろ」に置く。公開は概ね 19:00-21:00 UTC に
+  # 集中しており、旧設定の 18:00 UTC 起動では GitHub のスケジュール遅延（実測 +50〜85 分）
+  # を加味しても公開の直前に走って空振りし、取り込みが翌サイクル送り = 実質1日遅れになって
+  # いた（2.1.216/217/218/220 が約20〜23時間遅れ）。01:00 UTC なら前日の公開分を同一
+  # サイクルで拾える。
   schedule:
-    - cron: "0 18 * * *" # 18:00 UTC = 03:00 JST
+    - cron: "0 1 * * *" # 01:00 UTC = 10:00 JST
   workflow_dispatch:
 
 # 既定は最小権限。各ジョブが必要な権限だけを個別に付与する。
@@ -183,12 +188,12 @@ jobs:
             exit 1
           fi
           # ResolvedVersion が両 importer とも厳密に LATEST であること。
-          # 検出〜install の時間差で別の新版が解決された場合はここで fail（翌晩クリーン再試行 = self-healing）。
+          # 検出〜install の時間差で別の新版が解決された場合はここで fail（翌日クリーン再試行 = self-healing）。
           ver_lines=$(grep -A2 "$anchor" pnpm-lock.yaml | grep 'version:' | sed -E 's/^[[:space:]]*version:[[:space:]]*//' || true)
           ver_count=$(printf '%s\n' "$ver_lines" | grep -c . || true)
           uniq_ver=$(printf '%s\n' "$ver_lines" | sort -u)
           if [ "$ver_count" != "2" ] || [ "$uniq_ver" != "$LATEST" ]; then
-            echo "::error::ResolvedVersion が LATEST と不一致 (count=$ver_count uniq=$uniq_ver expected= 2 x $LATEST)。検出後に別版が公開された可能性。中止（翌晩再試行）。"
+            echo "::error::ResolvedVersion が LATEST と不一致 (count=$ver_count uniq=$uniq_ver expected= 2 x $LATEST)。検出後に別版が公開された可能性。中止（翌日再試行）。"
             exit 1
           fi
       - name: Snapshot trusted manifests (before any lifecycle script runs)
@@ -301,7 +306,7 @@ jobs:
           branch="chore/bump-claude-code-$LATEST"
           url=$(gh pr create --base main --head "$branch" \
             --title "chore(deps): bump @anthropic-ai/claude-code to $LATEST" \
-            --body "npm latest \`$LATEST\` へ自動追従（\`$CURRENT\` → \`$LATEST\`）。毎晩の bump-claude-code ワークフローが作成しました。マージ前検証は in-job 品質ゲート（pnpm check + build）で実施済みです。")
+            --body "npm latest \`$LATEST\` へ自動追従（\`$CURRENT\` → \`$LATEST\`）。毎日の bump-claude-code ワークフローが作成しました。マージ前検証は in-job 品質ゲート（pnpm check + build）で実施済みです。")
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Check base freshness (TOCTOU guard)
         id: freshness

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ mainブランチをpullした後は、以下の手順で **順番通りに** ビ
 
 ```bash
 # 1. 依存関係をインストール
-#    毎晩の bump-claude-code ワークフローによる同梱 @anthropic-ai/claude-code の
+#    毎日の bump-claude-code ワークフローによる同梱 @anthropic-ai/claude-code の
 #    更新は install で初めて node_modules に反映される。省略すると稼働中の Ark が
 #    旧バージョンの claude を配り続ける
 pnpm install --frozen-lockfile


### PR DESCRIPTION
## 背景

毎日の bump ワークフローは動作自体は正常（直近10回すべて success、現在 `^2.1.220` = npm latest に追従済み）だが、**cron 時刻が upstream の npm 公開時刻とほぼ競合していて、ほぼ毎回1日遅れで取り込んでいる**。

`cron: "0 18 * * *"` に対し GitHub のスケジュール遅延で実際の起動は 18:49〜19:24 UTC。一方 npm の公開は概ね 19:00〜21:00 UTC。つまり**公開の30〜60分前に走って空振りし、翌サイクルで拾う**という形になっていた。

| version | npm 公開 (UTC) | マージ (UTC) | 遅れ |
|---|---|---|---|
| 2.1.216 | 7/20 20:19 | 7/21 19:04 | 約23h |
| 2.1.217 | 7/21 19:55 | 7/22 18:58 | 約23h |
| 2.1.218 | 7/22 19:55 | 7/23 18:59 | 約23h |
| 2.1.219 | 7/24 16:11 | 7/24 19:12 | 約3h ✅ |
| 2.1.220 | 7/24 23:11 | 7/25 18:53 | 約20h |

自動化5件のうち4件が1日遅れ。同サイクルで拾えたのは公開が早かった 2.1.219 のみ。

## 変更

`0 18 * * *`（03:00 JST）→ `0 1 * * *`（10:00 JST）。

公開時刻より後ろに置くことで、上表の全バージョンが同一サイクルで拾える。直近の公開実績（2.1.213 の 22:26 UTC、2.1.214 の 00:13 UTC、2.1.215 の 00:53 UTC を含む）も 01:00 UTC 起動なら取りこぼさない。

併せて、実行時刻が深夜でなくなるため「毎晩 / 翌晩」という表現を「毎日 / 翌日」に揃えた（ワークフローのコメント・PR 本文テンプレート・CLAUDE.md・build-deploy スキル）。ロジックの変更は無し。

## 影響

- スケジュール以外の挙動（detect の不変条件検証、verify の隔離、artifact 改ざん検証、TOCTOU ガード）は一切変更なし
- 日次1回という頻度も変更なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * デプロイ手順における Claude Code の更新タイミングに関する説明を、毎晩から毎日へ更新しました。
  * 依存関係更新後の注意事項を追加しました。

* **保守性の改善**
  * 自動更新の実行時刻と検証時のエラーメッセージを見直し、更新処理の状況をより正確に案内できるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->