### PR TITLE
図解編集 Phase B: 接続ドラッグで新ノード生成 + 構造引き継ぎ (#268)

### DIFF
--- a/docs/superpowers/plans/2026-07-27-issue-268.md
+++ b/docs/superpowers/plans/2026-07-27-issue-268.md
@@ -1,0 +1,119 @@
+# issue-268: hover→方向ハンドル→ドラッグで繋がった新ノード作成 Implementation Plan
+
+親設計: `docs/superpowers/specs/2026-07-25-diagram-smooth-editing-design.md`（#266）の **Phase B**（柱2: 作成）。
+Phase A（#267, 選択 state + 浮くツールバー）の基盤に乗る。
+
+## ゴール（最重要）
+
+既存ノードの周縁ハンドル（#243 のアンカー）から:
+- **空白へドラッグして離す → 「新ノード + そこへの edge」を一気に作成**（新規挙動）
+- **既存ノードへ drop → edge のみ**（#243 の既存挙動を維持）
+
+差し引きの原資として **ノードパレット（graph/kind select +「+ノード」）を撤去**する。注入後 `<128KiB`（131072）維持。
+
+## 調査結果（実在するコードの地図）
+
+すべて `packages/server/src/lib/diagram-harness.ts`（単一注入文字列、3080 行）。
+
+### 作成ジェスチャは既に半分ある（#243）
+- `startCreateEdgeDrag(graph, nodeEl, anchor, event)` @1699 — アンカー pointerdown で `edgeDrag = { mode:"create", sourceId, graph, ... }` を張る。
+- アンカーは `attachNodeConnectors(graph, root)` @1726 が8方向（top-left..left）に生成。各アンカーの pointerup → `finishEdgeDrag(event, true)`。
+- `finishEdgeDrag(event, commit)` @1392 が drop を解決する。**ここが Phase B の中心的な変更点**。現状:
+  - `candidate = edgeDropCandidateAtPointer(drag, event)`（既存ノード上なら node、空白なら `null`）
+  - create モードで `candidate && explicitSelfDrop` → **edge を push**（@1410-1422、既存ノード drop）
+  - create モードで **`!candidate`（空白 drop）は現状ノーオペ**（rewire の `!candidate` だけ removeEdge）
+- `edgeDropCandidateAtPointer` / `findEdgeDropCandidate` @1256 — pointer 座標→候補ノード。
+- id 生成: `generateUniqueModelId("node"|"edge")` @~352（crypto.randomUUID / getRandomValues、衝突回避済み）。
+
+### ノード生成の既存ロジック（流用元）
+- `addNode(graph, kind)` @2329 — node `{ id, label:"新しいノード", ext:{x,y} }`（+ kind）を作り、`createNodeProjection`→append→`findNodePlacement(graph, root)` @2289 で **auto 座標**を ext に入れて push→`registerGraphNode`→render。失敗時はロールバック（model から除去・unregister・projection.remove）。**呼び出し元はノードパレットのみ**（撤去後は dead になるので下記のとおり流用へ作り替える）。
+
+### 撤去対象（差し引きの原資）
+- `buildNodePalette()` @2912-2952（graph select + kind select +「+ノード」）
+- `createPaletteSelect(labelText, className)` @2893-2911（**buildNodePalette 専用**。`createKindOption` @2550 は toolbar 側 @1873/1905/1911 でも使うので残す）
+- `buildToolbar` 内の `bar.appendChild(buildNodePalette())` @2979
+- CSS: `.ark-harness-node-palette` @96、`.ark-harness-palette-label` @100、`.ark-harness-palette-select` @101。撤去後に無参照化する `ark-harness-graph-select` / `ark-harness-palette-kind-select` / `ark-harness-add-node` は専用 CSS を持たない（確認済み）ので追加削除は不要。
+
+### selection と lastKind
+- `selection = { kind, id }` @317、toolbar の kind picker（Phase A）は @1873-1911 付近で kind select を持ち change で node.kind を更新する。**「直近に選んだ kind」を保持する状態は未実装** → 追加する。
+
+### サイズ実測基準
+- Phase A 出荷時点で **注入後 116,856 bytes / guard 131,072（余裕 14,216）**。撤去 ≈ 追加で中立の見込み。guard 閾値（`128 * 1024`, test @157/@215）は**変更しない**。
+
+## 設計結論
+
+### 1. 空白 drop → 新ノード + edge（`finishEdgeDrag` に分岐追加）
+`finishEdgeDrag` の create モードに、`commit && drag.didDrag && !candidate` の分岐を足す:
+1. source が生存（`getNode(state.model, drag.sourceId)` かつ `drag.graph.nodesById.get(sourceId)` 一致）を確認。無ければ何もしない。
+2. drop 点を **graph-local 座標**へ変換（`drag.graph.container.getBoundingClientRect()` 基準。`nodeAnchorPoint` @1690 と同じ考え方）。
+3. kind = `lastKind` が `kindCandidates` に含まれればそれ、無ければ `kindCandidates[0]`（候補ゼロなら kind 無し）。
+4. **新ノードを pin 生成**（下記 helper）。drop 点を新ノードの**中心**とみなし、projection の実測サイズから top-left を出して `ext.x/y` に入れる（`>= 0` にクランプ）。= その要素だけ manual 固定、auto 要素は #248 で避ける。
+5. edge を生成: `edgeId = generateUniqueModelId("edge")`; `state.model.edges.push({ id: edgeId, from: drag.sourceId, to: newNode.id })`。
+6. **原子性**: 新ノード生成に失敗、または edge id 生成に失敗したら、既に push した新ノード/projection を**ロールバック**して `updateStatus(..., "...作成できませんでした")`。中途半端な「edge なしの浮きノード」を残さない。
+7. 最後に全 graph を `scheduleGraphRender`。
+
+### 2. ノード生成 helper（`addNode` を作り替える）
+`addNode(graph, kind)` を `createNodeInGraph(graph, kind, point)` に一般化する（`point`: graph-local 座標 `{x,y}` または `null`）:
+- `point === null` → 従来どおり `findNodePlacement` で auto 配置（既存挙動）。
+- `point` あり → その点を**中心**として projection 実測サイズから top-left を算出し `ext.x/y` に固定（pin）。`findNodePlacement` は呼ばない。
+- どちらも push→register→project→（失敗時ロールバック）は既存 addNode のロジックをそのまま流用。返り値は生成した node（失敗時 `null`）。
+- パレット撤去で addNode の唯一の呼び出し元が消えるため、この作り替えでコードは純減方向。
+
+### 3. lastKind の保持
+- モジュールスコープに `var lastKind = null;` を追加。
+- toolbar の node kind picker（Phase A, @1873-1911 付近）の change ハンドラで、選んだ kind を `lastKind` に代入（`kindCandidates` に含まれる値のみ）。
+- 新ノードを kind 付きで作った場合も `lastKind` を更新（次の作成に引き継ぐ）。
+
+### 4. パレット撤去
+「撤去対象」の 5 箇所（関数2・呼び出し1・CSS3）を削除。toolbar は Phase C で更に最小化するが、本 Phase では**パレットだけ**外す（レイアウト方向トグル・変更送信ボタンは残す）。
+
+## 変更範囲
+- `packages/server/src/lib/diagram-harness.ts`（唯一の本体変更）
+- `packages/server/src/lib/diagram-harness.test.ts`（注入契約・撤去契約の Vitest）
+- `e2e/diagram-harness.spec.ts`（作成ジェスチャの E2E）
+
+production `diagram-diff.ts` / `describeModelDiff` は**変更しない**（node/edge 追加は #243 契約で還流するが、それは既存の挙動で本 Phase は差分ロジックを触らない）。
+
+## Task 1: 作成ジェスチャ acceptance を E2E で Red にする
+`e2e/diagram-harness.spec.ts` に追加:
+- ノードのアンカーから**空白へ pointer drag → drop** で `model.nodes` が1増え、`model.edges` が1増える（from = source id、to = 新ノード id）。新ノードは `ext.x/y` を持つ（pin）。source ノードはそのまま。
+- ノードのアンカーから**既存ノードへ drop** で edge のみ1増（node は増えない）= #243 の回帰を維持。
+- 空白 drop で作られた**新ノードだけ** ext を持ち、レイアウトが overlap を作らない（既存 overlap assert を流用）。
+- パレット撤去の確認: `.ark-harness-add-node` / `.ark-harness-node-palette` が DOM に存在しない。
+（#243 / Phase A の pointer drag ヘルパを流用。drag は `didDrag` 閾値を越える距離を動かす。）
+
+## Task 2: 注入契約・撤去契約を Vitest で Red にする
+`diagram-harness.test.ts`:
+- 既存 `Buffer.byteLength(out,"utf8") < 128*1024` を維持（閾値変更禁止）。
+- 注入文字列に `ark-harness-node-palette` / `buildNodePalette` が**含まれない**ことを assert（撤去の固定）。
+- `buildSubmissionHtml` 後の提出 HTML に palette / toolbar / selection の痕跡が無いことを既存 assert で維持。
+
+## Task 3: `createNodeInGraph` 一般化 + lastKind（GREEN）
+設計 §2/§3 を実装。単体で `pnpm check`。
+
+## Task 4: `finishEdgeDrag` 空白 drop 分岐（GREEN）
+設計 §1 を実装。原子ロールバック含む。Task 1 の E2E を GREEN に。
+
+## Task 5: パレット撤去（GREEN・純減）
+設計 §4。撤去後 `pnpm check` / 提出 HTML 契約 / サイズ。
+
+## Task 6: 全回帰を閉じる
+- `pnpm exec playwright test e2e/diagram-harness.spec.ts --project=chromium --workers=1`
+- `pnpm --filter @ark/server exec vitest run src/lib/diagram-harness.test.ts`
+- `pnpm vitest run`（全 unit）
+- `pnpm check` / `pnpm build` / `git diff --check`
+- **注入後サイズ実測 <131072**（guard fixture を injectHarness して Buffer.byteLength、余裕もログ）。
+
+## 検証（目視でなくDOM assert）
+- 空白 drop で node+edge が model に増える / 既存ノード drop で edge のみ。
+- pin: drag/drop した新ノードだけ `ext.x/y`、auto ノードには付かない。
+- 参照整合: 生成失敗時にロールバックし孤立ノード/孤立 edge を残さない。
+- パレットが DOM から消えている・注入文字列から消えている。
+- `<128KiB` guard・既存 E2E（overlap/LR/TB/SCC）不変。
+
+## 制約・非ゴール
+- 注入後 `<128KiB` 維持。guard 閾値は触らない。超えたら実装を削る。
+- 非還流契約・production `diagram-diff.ts` / `describeModelDiff` 不変。モバイル非対象。外部リソース禁止。
+- crypto で安全 id 生成（#243 踏襲）。参照整合性・422 回避。
+- Phase C（クロム掃除: 生 JSON debug 送り・変更送信最小化・下部ツールバー最小化）/ Phase D（磨き込み）を混ぜない。**本 Phase で撤去するのはノードパレットのみ**。
+- 承認済み spec は変更しない。push はしない。git hook のバイパスはしない。

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -727,7 +727,10 @@ const crudModel: DiagramModel = {
   },
 };
 
-function crudDiagramHtml(diagramModel: DiagramModel = crudModel): string {
+function crudDiagramHtml(
+  diagramModel: DiagramModel = crudModel,
+  setup = ""
+): string {
   return injectHarness(`<!doctype html><html><head><style>
     body { margin: 0; }
     .crud-graph { width: 760px; min-height: 420px; background: #f8fafc; }
@@ -746,6 +749,7 @@ function crudDiagramHtml(diagramModel: DiagramModel = crudModel): string {
       <section class="crud-node" data-model-id="crud-other"><span data-model-id="crud-other">Other graph</span></section>
     </div>
     <aside data-model-id="crud-a">duplicate projection</aside>
+    ${setup}
   </body></html>`);
 }
 
@@ -814,6 +818,29 @@ async function requiredBoundingBox(locator: Locator) {
   expect(box).not.toBeNull();
   if (!box) throw new Error("要素の bounding box がありません");
   return box;
+}
+
+async function dragNodeAnchorToPoint(
+  page: Page,
+  graph: Locator,
+  sourceId: string,
+  anchorPosition: string,
+  point: { x: number; y: number }
+) {
+  await graph.locator(`[data-model-id="${sourceId}"]`).first().hover();
+  const anchorBox = await requiredBoundingBox(
+    graph.locator(
+      `.ark-harness-node-connectors[data-ark-node-id="${sourceId}"] ` +
+        `.ark-harness-node-anchor[data-ark-anchor-position="${anchorPosition}"]`
+    )
+  );
+  await page.mouse.move(
+    anchorBox.x + anchorBox.width / 2,
+    anchorBox.y + anchorBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(point.x, point.y, { steps: 5 });
+  await page.mouse.up();
 }
 
 function contextToolbar(page: Page) {
@@ -1316,47 +1343,64 @@ test("selection toolbar stale・submission: model 直接削除で解除し選択
   expect(html).toContain('data-kind="entity"');
 });
 
-test("node CRUD: palette から安全な projection を重ならず追加して再編集できる", async ({
+test("node CRUD: anchor から空白へ drag して pin node と edge を原子的に追加する", async ({
   page,
 }) => {
   const errors: string[] = [];
   page.on("pageerror", error => errors.push(error.message));
-  await page.setContent(crudDiagramHtml());
-
-  const palette = page.locator(".ark-harness-node-palette");
-  await expect(palette.getByLabel("配置先")).toHaveText(/graph 1/);
-  await expect(palette.getByLabel("kind")).toHaveText(/entity/);
-  await expect(palette.getByLabel("kind").locator("option")).toHaveText([
-    "entity",
-    "event",
-  ]);
-  await expect(palette.locator("input")).toHaveCount(0);
-  await expect(palette.getByText(/group|cardinality/i)).toHaveCount(0);
-
-  await palette.getByLabel("配置先").selectOption("0");
-  await palette.getByLabel("kind").selectOption("event");
-  const initialEdgeCount = (await readCurrentModel(page)).edges.length;
-  await palette.getByRole("button", { name: "ノードを追加" }).click();
+  const connectDragModel = structuredClone(crudModel);
+  connectDragModel.nodes.forEach(node => {
+    delete node.ext;
+  });
+  await page.setContent(crudDiagramHtml(connectDragModel));
 
   const firstGraph = page.locator('[data-ark-container="graph"]').first();
+  const sourceBefore = structuredClone(
+    connectDragModel.nodes.find(node => node.id === "crud-b")
+  );
+  const initial = await readCurrentModel(page);
+  const graphBox = await requiredBoundingBox(firstGraph);
+  const drop = {
+    x: graphBox.x + graphBox.width - 20,
+    y: graphBox.y + graphBox.height - 20,
+  };
+  await dragNodeAnchorToPoint(page, firstGraph, "crud-b", "bottom", drop);
+
   await expect(firstGraph.locator(".ark-harness-graph-node")).toHaveCount(4);
+  await expect(page.locator(".ark-harness-add-node")).toHaveCount(0);
+  await expect(page.locator(".ark-harness-node-palette")).toHaveCount(0);
   const current = await readCurrentModel(page);
   const added = current.nodes.find(
-    node => !crudModel.nodes.some(old => old.id === node.id)
+    node => !connectDragModel.nodes.some(old => old.id === node.id)
   );
   expect(added).toBeDefined();
-  expect(added).toMatchObject({ label: "新しいノード", kind: "event" });
+  expect(added).toMatchObject({ label: "新しいノード", kind: "entity" });
   expect(added?.id).toMatch(/^node-/);
   expect(added?.id).not.toContain("新しいノード");
   expect(Number.isInteger((added?.ext as { x?: number })?.x)).toBe(true);
   expect(Number.isInteger((added?.ext as { y?: number })?.y)).toBe(true);
-  expect(current.edges).toHaveLength(initialEdgeCount);
+  expect(current.nodes).toHaveLength(initial.nodes.length + 1);
+  expect(current.edges).toHaveLength(initial.edges.length + 1);
+  expect(current.nodes.find(node => node.id === "crud-b")).toEqual(
+    sourceBefore
+  );
+  expect(
+    current.nodes.filter(node => {
+      const ext = node.ext as { x?: unknown; y?: unknown } | undefined;
+      return Number.isFinite(ext?.x) && Number.isFinite(ext?.y);
+    })
+  ).toEqual([added]);
   if (!added) throw new Error("追加 node がありません");
+  const addedEdge = current.edges.find(
+    edge => !connectDragModel.edges.some(old => old.id === edge.id)
+  );
+  expect(addedEdge).toMatchObject({ from: "crud-b", to: added.id });
+  expect(addedEdge?.id).toMatch(/^edge-/);
 
   const projection = firstGraph
     .locator(`[data-model-id="${added.id}"]`)
     .first();
-  await expect(projection).toHaveAttribute("data-kind", "event");
+  await expect(projection).toHaveAttribute("data-kind", "entity");
   await expect(projection).toHaveClass(/crud-node/);
   await expect(
     projection.locator(`span[data-model-id="${added.id}"]`)
@@ -1365,7 +1409,7 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
   await selectNode(page, added.id);
   await expect(
     contextToolbar(page).locator("select.ark-harness-kind-select")
-  ).toHaveValue("event");
+  ).toHaveValue("entity");
   await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(1);
   await expect(
     firstGraph.locator(
@@ -1376,6 +1420,12 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
   await expect(projection.locator(".ark-harness-node-delete")).toHaveCount(0);
 
   const newBox = await requiredBoundingBox(projection);
+  expect((added.ext as { x: number }).x).toBe(
+    Math.max(0, Math.round(drop.x - graphBox.x - newBox.width / 2))
+  );
+  expect((added.ext as { y: number }).y).toBe(
+    Math.max(0, Math.round(drop.y - graphBox.y - newBox.height / 2))
+  );
   const oldBoxes = await firstGraph
     .locator(".ark-harness-graph-node")
     .evaluateAll(
@@ -1404,6 +1454,54 @@ test("node CRUD: palette から安全な projection を重ならず追加して�
       ?.label
   ).toBe("追加済み");
   expect(errors).toEqual([]);
+});
+
+test("node CRUD: node/edge ID 生成失敗時は projection と model を原子的に戻す", async ({
+  page,
+}) => {
+  const setup =
+    '<script>Object.defineProperty(window.crypto, "randomUUID", ' +
+    '{ configurable: true, value: function () { return "fixed"; } });</script>';
+  const scenarios = [
+    {
+      name: "node ID",
+      model: {
+        ...structuredClone(crudModel),
+        nodes: [
+          ...structuredClone(crudModel.nodes),
+          { id: "node-fixed", label: "予約済み node ID" },
+        ],
+      },
+    },
+    {
+      name: "edge ID",
+      model: {
+        ...structuredClone(crudModel),
+        edges: [
+          ...structuredClone(crudModel.edges),
+          { id: "edge-fixed", from: "crud-a", to: "crud-b" },
+        ],
+      },
+    },
+  ] satisfies { name: string; model: DiagramModel }[];
+
+  for (const scenario of scenarios) {
+    await page.setContent(crudDiagramHtml(scenario.model, setup));
+    const graph = page.locator('[data-ark-container="graph"]').first();
+    const graphBox = await requiredBoundingBox(graph);
+    await dragNodeAnchorToPoint(page, graph, "crud-b", "bottom", {
+      x: graphBox.x + graphBox.width - 20,
+      y: graphBox.y + graphBox.height - 20,
+    });
+
+    expect(await readCurrentModel(page), scenario.name).toEqual(scenario.model);
+    await expect(graph.locator(":scope > .ark-harness-graph-node")).toHaveCount(
+      3
+    );
+    await expect(page.locator(".ark-harness-status")).toHaveText(
+      "ノードと edge を作成できませんでした"
+    );
+  }
 });
 
 test("node CRUD: node 削除を対象 projection・incident edge・group 参照だけに限定する", async ({
@@ -1632,11 +1730,6 @@ test("edge CRUD: click・微小移動・source drop・Escape を無視し明確�
     '.ark-harness-node-connectors[data-ark-node-id="crud-b"]'
   );
   const target = graph.locator('[data-model-id="crud-d"]').first();
-  const otherGraphTarget = page
-    .locator('[data-ark-container="graph"]')
-    .nth(1)
-    .locator('[data-model-id="crud-other"]')
-    .first();
 
   const dragCreate = async (drop: Locator) => {
     await source.hover();
@@ -1758,9 +1851,6 @@ test("edge CRUD: click・微小移動・source drop・Escape を無視し明確�
     graph.locator(`path.ark-harness-edge-main[data-ark-edge-id="${self?.id}"]`)
   ).toHaveCount(1);
 
-  const beforeInvalid = current.edges.length;
-  await dragCreate(otherGraphTarget);
-  expect((await readCurrentModel(page)).edges).toHaveLength(beforeInvalid);
   await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
   await expect(graph.locator(".ark-harness-edge-drop-indicator")).toHaveCount(
     0
@@ -1839,13 +1929,20 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
 }) => {
   await page.setContent(crudDiagramHtml());
   await connectSubmissionPort(page);
-  await page.locator(".ark-harness-palette-kind-select").selectOption("event");
-  await page.getByRole("button", { name: "ノードを追加" }).click();
+  const graph = page.locator('[data-ark-container="graph"]').first();
+  const toolbar = await selectNode(page, "crud-b");
+  await toolbar.locator("select.ark-harness-kind-select").selectOption("event");
+  const graphBox = await requiredBoundingBox(graph);
+  await dragNodeAnchorToPoint(page, graph, "crud-b", "bottom", {
+    x: graphBox.x + graphBox.width - 20,
+    y: graphBox.y + graphBox.height - 20,
+  });
   const current = await readCurrentModel(page);
   const added = current.nodes.find(
     node => !crudModel.nodes.some(old => old.id === node.id)
   );
   if (!added) throw new Error("追加 node がありません");
+  expect(added.kind).toBe("event");
 
   await page
     .getByRole("button", { name: "変更を親フレームへ送信する" })
@@ -1876,6 +1973,7 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   expect(submission.html).not.toContain("--ark-harness-graph-x");
   expect(describeModelDiff(crudModel, submission.model)).toEqual([
     "新しいノード を追加",
+    "B から 新しいノード への関連を追加",
   ]);
 });
 
@@ -1909,7 +2007,7 @@ test("レイアウト方向を LR から TB へ切り替えて再配置・保存
     await toolbar
       .locator("button")
       .evaluateAll(buttons => buttons.map(button => button.textContent))
-  ).toEqual(["方向: LR", "+ ノード", "モデルを直接編集", "変更を送る"]);
+  ).toEqual(["方向: LR", "モデルを直接編集", "変更を送る"]);
   expect(
     await directionButton.evaluate(
       (button, editButton) =>

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -4172,6 +4172,43 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   expect(
     (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
   ).not.toHaveProperty("kind");
+  await expect(label).toHaveCount(1);
+  await expect(list).toHaveCount(1);
+  await expect(list.locator(":scope > li")).toHaveCount(1);
+  await expect(addFieldButton).toBeEnabled();
+
+  const beforeKindless = await readCurrentModel(page);
+  await dragNodeAnchorToPoint(page, graph, added.id, "bottom", {
+    x: graphBox.x + 100,
+    y: graphBox.y + graphBox.height - 60,
+  });
+  const afterKindless = await readCurrentModel(page);
+  const kindless = afterKindless.nodes.find(
+    node => !beforeKindless.nodes.some(old => old.id === node.id)
+  );
+  expect(kindless).toBeDefined();
+  expect(kindless).not.toHaveProperty("kind");
+  if (!kindless) throw new Error("kind なし node がありません");
+
+  const kindlessProjection = graph
+    .locator(`[data-model-id="${kindless.id}"]`)
+    .first();
+  expect(await kindlessProjection.evaluate(element => element.tagName)).toBe(
+    "SECTION"
+  );
+  await expect(kindlessProjection).toHaveClass(/(^|\s)entity(\s|$)/);
+  await expect(kindlessProjection).not.toHaveAttribute("data-kind", /.*/);
+  await expect(kindlessProjection.locator(":scope > h2")).toHaveCount(0);
+  await expect(kindlessProjection.locator(":scope > ul")).toHaveCount(0);
+  const kindlessLabel = kindlessProjection.locator(
+    `:scope > span[data-model-id="${kindless.id}"]`
+  );
+  await expect(kindlessLabel).toHaveCount(1);
+  await expect(kindlessLabel).toHaveText("新しいノード");
+  const kindlessToolbar = await selectNode(page, kindless.id);
+  await expect(
+    kindlessToolbar.getByRole("button", { name: "行を追加" })
+  ).toBeDisabled();
 });
 
 test("kind 候補が無い図では disabled toolbar select と既存編集 UI を維持する", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1730,6 +1730,11 @@ test("edge CRUD: click・微小移動・source drop・Escape を無視し明確�
     '.ark-harness-node-connectors[data-ark-node-id="crud-b"]'
   );
   const target = graph.locator('[data-model-id="crud-d"]').first();
+  const otherGraphTarget = page
+    .locator('[data-ark-container="graph"]')
+    .nth(1)
+    .locator('[data-model-id="crud-other"]')
+    .first();
 
   const dragCreate = async (drop: Locator) => {
     await source.hover();
@@ -1851,6 +1856,17 @@ test("edge CRUD: click・微小移動・source drop・Escape を無視し明確�
     graph.locator(`path.ark-harness-edge-main[data-ark-edge-id="${self?.id}"]`)
   ).toHaveCount(1);
 
+  const beforeInvalid = await readCurrentModel(page);
+  const beforeInvalidDomNodes = await page
+    .locator(".ark-harness-graph-node")
+    .count();
+  await dragCreate(otherGraphTarget);
+  const afterInvalid = await readCurrentModel(page);
+  expect(afterInvalid.nodes).toHaveLength(beforeInvalid.nodes.length);
+  expect(afterInvalid.edges).toHaveLength(beforeInvalid.edges.length);
+  await expect(page.locator(".ark-harness-graph-node")).toHaveCount(
+    beforeInvalidDomNodes
+  );
   await expect(graph.locator(".ark-harness-edge-preview")).toHaveCount(0);
   await expect(graph.locator(".ark-harness-edge-drop-indicator")).toHaveCount(
     0

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -188,12 +188,14 @@ function modelKindCandidateHtml(): string {
         id: "model-kind-source",
         label: "Source",
         kind: "entity",
+        fields: [{ id: "model-kind-source-id", label: "id" }],
         ext: { x: 30, y: 40 },
       },
       {
         id: "model-kind-peer",
         label: "Peer",
         kind: "entity",
+        fields: [{ id: "model-kind-peer-id", label: "id" }],
         ext: { x: 260, y: 40 },
       },
     ],
@@ -203,12 +205,21 @@ function modelKindCandidateHtml(): string {
   return injectHarness(`<!doctype html><html><head><style>
     body { margin: 0; }
     .model-kind-graph { width: 640px; height: 360px; background: #f8fafc; }
-    .model-kind-node { box-sizing: border-box; width: 150px; min-height: 72px; padding: 12px; border: 1px solid #64748b; background: white; }
+    .entity { box-sizing: border-box; width: 180px; min-height: 72px; border: 1px solid #64748b; background: white; }
+    .entity h2 { margin: 0; padding: 8px 12px; background: #dbeafe; font-size: 16px; }
+    .entity h2::before { content: "▤"; margin-right: 6px; }
+    .entity ul { margin: 0; padding: 8px 12px 8px 32px; }
   </style></head><body>
     <script id="ark-diagram-model" type="application/json">${JSON.stringify(candidateModel)}</script>
     <div class="model-kind-graph" data-ark-container="graph">
-      <section class="model-kind-node" data-model-id="model-kind-source">Source</section>
-      <section class="model-kind-node" data-model-id="model-kind-peer">Peer</section>
+      <section class="entity" data-model-id="model-kind-source">
+        <h2 class="entity-title" data-model-id="model-kind-source">Source</h2>
+        <ul><li data-model-id="model-kind-source-id">id</li></ul>
+      </section>
+      <section class="entity" data-model-id="model-kind-peer">
+        <h2 class="entity-title" data-model-id="model-kind-peer">Peer</h2>
+        <ul><li data-model-id="model-kind-peer-id">id</li></ul>
+      </section>
     </div>
   </body></html>`);
 }
@@ -1445,9 +1456,13 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
     .first();
   await expect(projection).toHaveAttribute("data-kind", "entity");
   await expect(projection).toHaveClass(/crud-node/);
-  await expect(
-    projection.locator(`span[data-model-id="${added.id}"]`)
-  ).toHaveText("新しいノード");
+  const projectionLabel = projection.locator(
+    `:scope > span[data-model-id="${added.id}"]`
+  );
+  await expect(projectionLabel).toHaveText("新しいノード");
+  expect(await projectionLabel.evaluate(element => element.tagName)).toBe(
+    "SPAN"
+  );
   await expect(projection.locator(".ark-harness-kind-picker")).toHaveCount(0);
   await selectNode(page, added.id);
   await expect(
@@ -4116,7 +4131,15 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   expect(added).toMatchObject({ label: "新しいノード", kind: "entity" });
   if (!added) throw new Error("追加 node がありません");
   const projection = graph.locator(`[data-model-id="${added.id}"]`).first();
+  expect(await projection.evaluate(element => element.tagName)).toBe("SECTION");
+  await expect(projection).toHaveClass(/(^|\s)entity(\s|$)/);
   await expect(projection).toHaveAttribute("data-kind", "entity");
+  const label = projection.locator(`:scope > h2[data-model-id="${added.id}"]`);
+  await expect(label).toHaveCount(1);
+  expect(await label.evaluate(element => element.tagName)).toBe("H2");
+  await expect(label).toHaveClass(/(^|\s)entity-title(\s|$)/);
+  await expect(label).toHaveAttribute("data-model-id", added.id);
+  await expect(label).toHaveText("新しいノード");
 
   const addedToolbar = await selectNode(page, added.id);
   const addedPicker = addedToolbar.locator("select.ark-harness-kind-select");

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -214,11 +214,11 @@ function modelKindCandidateHtml(): string {
     <div class="model-kind-graph" data-ark-container="graph">
       <section class="entity" data-model-id="model-kind-source">
         <h2 class="entity-title" data-model-id="model-kind-source">Source</h2>
-        <ul><li data-model-id="model-kind-source-id">id</li></ul>
+        <ul class="entity-fields"><li data-model-id="model-kind-source-id">id</li></ul>
       </section>
       <section class="entity" data-model-id="model-kind-peer">
         <h2 class="entity-title" data-model-id="model-kind-peer">Peer</h2>
-        <ul><li data-model-id="model-kind-peer-id">id</li></ul>
+        <ul class="entity-fields"><li data-model-id="model-kind-peer-id">id</li></ul>
       </section>
     </div>
   </body></html>`);
@@ -1468,6 +1468,10 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   await expect(
     contextToolbar(page).locator("select.ark-harness-kind-select")
   ).toHaveValue("entity");
+  await expect(projection.locator(":scope > ul")).toHaveCount(0);
+  await expect(
+    contextToolbar(page).getByRole("button", { name: "行を追加" })
+  ).toBeDisabled();
   await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(1);
   await expect(
     firstGraph.locator(
@@ -4142,6 +4146,25 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   await expect(label).toHaveText("新しいノード");
 
   const addedToolbar = await selectNode(page, added.id);
+  const list = projection.locator(":scope > ul");
+  await expect(list).toHaveCount(1);
+  expect(await list.evaluate(element => element.tagName)).toBe("UL");
+  await expect(list).toHaveClass(/(^|\s)entity-fields(\s|$)/);
+  await expect(list.locator(":scope > li")).toHaveCount(0);
+  const addFieldButton = addedToolbar.getByRole("button", {
+    name: "行を追加",
+  });
+  await expect(addFieldButton).toBeEnabled();
+  await addFieldButton.click();
+  await expect(list.locator(":scope > li")).toHaveCount(1);
+  const afterAdd = await readCurrentModel(page);
+  const addedAfterField = afterAdd.nodes.find(node => node.id === added.id);
+  expect(addedAfterField?.fields).toHaveLength(1);
+  expect(addedAfterField?.fields?.[0]).toMatchObject({
+    label: "新しい項目",
+  });
+  expect(addedAfterField?.fields?.[0]?.id).toMatch(/^field-/);
+
   const addedPicker = addedToolbar.locator("select.ark-harness-kind-select");
   await addedPicker.selectOption("");
   await expect(addedPicker).toHaveValue("");

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1456,6 +1456,49 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   expect(errors).toEqual([]);
 });
 
+test("node CRUD: kind なしを選ぶと node から kind を除去し drag 作成にも引き継ぐ", async ({
+  page,
+}) => {
+  await page.setContent(crudDiagramHtml());
+
+  const graph = page.locator('[data-ark-container="graph"]').first();
+  const source = graph.locator('[data-model-id="crud-b"]').first();
+  const toolbar = await selectNode(page, "crud-b");
+  const picker = toolbar.locator("select.ark-harness-kind-select");
+  const none = picker.locator('option[value=""]');
+  await expect(none).toHaveText("kind なし");
+  await expect(none).toBeEnabled();
+  expect(await picker.locator("option").allTextContents()).toEqual([
+    "kind なし",
+    "entity",
+    "event",
+  ]);
+
+  await picker.selectOption("");
+  await expect(picker).toHaveValue("");
+  await expect(source).not.toHaveAttribute("data-kind", /.*/);
+  const cleared = await readCurrentModel(page);
+  expect(cleared.nodes.find(node => node.id === "crud-b")).not.toHaveProperty(
+    "kind"
+  );
+
+  const graphBox = await requiredBoundingBox(graph);
+  await dragNodeAnchorToPoint(page, graph, "crud-b", "bottom", {
+    x: graphBox.x + graphBox.width - 20,
+    y: graphBox.y + graphBox.height - 20,
+  });
+  const current = await readCurrentModel(page);
+  const added = current.nodes.find(
+    node => !crudModel.nodes.some(old => old.id === node.id)
+  );
+  expect(added).toBeDefined();
+  expect(added).not.toHaveProperty("kind");
+  if (!added) throw new Error("追加 node がありません");
+  await expect(
+    graph.locator(`[data-model-id="${added.id}"]`).first()
+  ).not.toHaveAttribute("data-kind", /.*/);
+});
+
 test("node CRUD: node/edge ID 生成失敗時は projection と model を原子的に戻す", async ({
   page,
 }) => {
@@ -3988,13 +4031,14 @@ test("kind 候補は authored CSS rule を宣言順かつ重複なしで収集�
   const picker = toolbar.getByRole("combobox", { name: /Candidate.*quoted/ });
   await expect(picker).toHaveCount(1);
   expect(await picker.locator("option").allTextContents()).toEqual([
+    "kind なし",
     "quoted",
     "single",
     "unquoted",
     "nested",
     "escaped&kind",
   ]);
-  await expect(picker.locator("option")).toHaveCount(5);
+  await expect(picker.locator("option")).toHaveCount(6);
   await expect(
     picker.locator("option", { hasText: "declaration" })
   ).toHaveCount(0);
@@ -4031,13 +4075,18 @@ test("kind toolbar は候補外の現在値を保持し候補選択時だけ更�
   );
   const toolbar = await selectNode(page, "order");
   const picker = toolbar.locator("select.ark-harness-kind-select");
-  const current = picker.locator("option").first();
+  const none = picker.locator("option").first();
+  const current = picker.locator("option").nth(1);
   await expect(order).toHaveAttribute("data-kind", "legacy-kind");
   await expect(picker).toHaveValue("legacy-kind");
+  await expect(none).toBeEnabled();
+  await expect(none).toHaveText("kind なし");
+  await expect(none).toHaveAttribute("value", "");
   await expect(current).toBeDisabled();
   await expect(current).toHaveText("legacy-kind");
   await expect(current).toHaveAttribute("value", "legacy-kind");
   expect(await picker.locator("option").allTextContents()).toEqual([
+    "kind なし",
     "legacy-kind",
     "aggregate",
     "entity",
@@ -4047,7 +4096,7 @@ test("kind toolbar は候補外の現在値を保持し候補選択時だけ更�
   await picker.selectOption("entity");
   await expect(order).toHaveAttribute("data-kind", "entity");
   await expect(picker).toHaveValue("entity");
-  await expect(picker.locator("option")).toHaveCount(3);
+  await expect(picker.locator("option")).toHaveCount(4);
 });
 
 test("kind toolbar は untrusted 値を text と value だけで扱う", async ({
@@ -4065,12 +4114,15 @@ test("kind toolbar は untrusted 値を text と value だけで扱う", async (
   const toolbar = await selectNode(page, "unsafe");
   const picker = toolbar.locator("select.ark-harness-kind-select");
   const options = picker.locator("option");
-  await expect(options).toHaveCount(2);
-  await expect(options.nth(0)).toBeDisabled();
-  await expect(options.nth(0)).toHaveText(currentKind);
-  await expect(options.nth(0)).toHaveAttribute("value", currentKind);
-  await expect(options.nth(1)).toHaveText(candidateKind);
-  await expect(options.nth(1)).toHaveAttribute("value", candidateKind);
+  await expect(options).toHaveCount(3);
+  await expect(options.nth(0)).toBeEnabled();
+  await expect(options.nth(0)).toHaveText("kind なし");
+  await expect(options.nth(0)).toHaveAttribute("value", "");
+  await expect(options.nth(1)).toBeDisabled();
+  await expect(options.nth(1)).toHaveText(currentKind);
+  await expect(options.nth(1)).toHaveAttribute("value", currentKind);
+  await expect(options.nth(2)).toHaveText(candidateKind);
+  await expect(options.nth(2)).toHaveAttribute("value", candidateKind);
   await expect(
     page.locator(
       "img, script:not(#ark-diagram-model):not(#ark-diagram-harness), [onerror], [onload]"
@@ -4129,7 +4181,7 @@ test("モデル直接編集後に kind toolbar と方向表示を再同期する
   await expect(order).toHaveAttribute("data-kind", "custom-kind");
   await expect(picker).toHaveValue("custom-kind");
   await expect(picker).toHaveAccessibleName(/Order.*custom-kind/);
-  const current = picker.locator("option").first();
+  const current = picker.locator("option").nth(1);
   await expect(current).toBeDisabled();
   await expect(current).toHaveText("custom-kind");
   await expect(
@@ -4154,6 +4206,7 @@ test("kind toolbar で CSS 候補を選び投影・geometry・保存へ同期す
   await expect(orderPicker).toHaveCount(1);
   await expect(orderPicker).toHaveAccessibleName(/Order.*aggregate/);
   expect(await orderPicker.locator("option").allTextContents()).toEqual([
+    "kind なし",
     "aggregate",
     "entity",
     "event",
@@ -4162,6 +4215,7 @@ test("kind toolbar で CSS 候補を選び投影・geometry・保存へ同期す
   const userPicker = toolbar.locator("select.ark-harness-kind-select");
   await expect(userPicker).toHaveAccessibleName(/User.*entity/);
   expect(await userPicker.locator("option").allTextContents()).toEqual([
+    "kind なし",
     "aggregate",
     "entity",
     "event",

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -148,7 +148,17 @@ function invalidCoordinateHtml(): string {
 function kindCandidateHtml(): string {
   const candidateModel = {
     version: 1,
-    nodes: [{ id: "candidate", label: "Candidate", kind: "quoted" }],
+    nodes: [
+      { id: "candidate", label: "Candidate", kind: "quoted" },
+      { id: "css-duplicate", label: "CSS duplicate", kind: "single" },
+      { id: "model-only", label: "Model only", kind: "model-only" },
+      {
+        id: "model-only-duplicate",
+        label: "Model only duplicate",
+        kind: "model-only",
+      },
+      { id: "empty-kind", label: "Empty kind", kind: "" },
+    ],
     edges: [],
     groups: [],
   };
@@ -166,6 +176,39 @@ function kindCandidateHtml(): string {
     <script id="ark-diagram-model" type="application/json">${JSON.stringify(candidateModel)}</script>
     <div data-ark-container="graph">
       <section data-model-id="candidate">Candidate</section>
+    </div>
+  </body></html>`);
+}
+
+function modelKindCandidateHtml(): string {
+  const candidateModel = {
+    version: 1,
+    nodes: [
+      {
+        id: "model-kind-source",
+        label: "Source",
+        kind: "entity",
+        ext: { x: 30, y: 40 },
+      },
+      {
+        id: "model-kind-peer",
+        label: "Peer",
+        kind: "entity",
+        ext: { x: 260, y: 40 },
+      },
+    ],
+    edges: [],
+    groups: [],
+  };
+  return injectHarness(`<!doctype html><html><head><style>
+    body { margin: 0; }
+    .model-kind-graph { width: 640px; height: 360px; background: #f8fafc; }
+    .model-kind-node { box-sizing: border-box; width: 150px; min-height: 72px; padding: 12px; border: 1px solid #64748b; background: white; }
+  </style></head><body>
+    <script id="ark-diagram-model" type="application/json">${JSON.stringify(candidateModel)}</script>
+    <div class="model-kind-graph" data-ark-container="graph">
+      <section class="model-kind-node" data-model-id="model-kind-source">Source</section>
+      <section class="model-kind-node" data-model-id="model-kind-peer">Peer</section>
     </div>
   </body></html>`);
 }
@@ -4022,7 +4065,7 @@ test("node.kind を data-kind へ同期して色とアイコンを区別する",
   ).toHaveAttribute("contenteditable", "true");
 });
 
-test("kind 候補は authored CSS rule を宣言順かつ重複なしで収集する", async ({
+test("kind 候補は CSS を先に model node のみを後に重複なしで収集する", async ({
   page,
 }) => {
   await page.setContent(kindCandidateHtml());
@@ -4037,12 +4080,52 @@ test("kind 候補は authored CSS rule を宣言順かつ重複なしで収集�
     "unquoted",
     "nested",
     "escaped&kind",
+    "model-only",
   ]);
-  await expect(picker.locator("option")).toHaveCount(6);
+  await expect(picker.locator("option")).toHaveCount(7);
   await expect(
     picker.locator("option", { hasText: "declaration" })
   ).toHaveCount(0);
   await expect(picker.locator("option", { hasText: "comment" })).toHaveCount(0);
+});
+
+test("model node だけに kind がある図でも picker・drag 作成・kind なしを利用できる", async ({
+  page,
+}) => {
+  await page.setContent(modelKindCandidateHtml());
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const toolbar = await selectNode(page, "model-kind-source");
+  const picker = toolbar.locator("select.ark-harness-kind-select");
+  await expect(picker).toBeEnabled();
+  expect(await picker.locator("option").allTextContents()).toEqual([
+    "kind なし",
+    "entity",
+  ]);
+
+  const initial = await readCurrentModel(page);
+  const graphBox = await requiredBoundingBox(graph);
+  await dragNodeAnchorToPoint(page, graph, "model-kind-source", "bottom", {
+    x: graphBox.x + graphBox.width - 20,
+    y: graphBox.y + graphBox.height - 20,
+  });
+  const current = await readCurrentModel(page);
+  const added = current.nodes.find(
+    node => !initial.nodes.some(old => old.id === node.id)
+  );
+  expect(added).toMatchObject({ label: "新しいノード", kind: "entity" });
+  if (!added) throw new Error("追加 node がありません");
+  const projection = graph.locator(`[data-model-id="${added.id}"]`).first();
+  await expect(projection).toHaveAttribute("data-kind", "entity");
+
+  const addedToolbar = await selectNode(page, added.id);
+  const addedPicker = addedToolbar.locator("select.ark-harness-kind-select");
+  await addedPicker.selectOption("");
+  await expect(addedPicker).toHaveValue("");
+  await expect(projection).not.toHaveAttribute("data-kind", /.*/);
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
+  ).not.toHaveProperty("kind");
 });
 
 test("kind 候補が無い図では disabled toolbar select と既存編集 UI を維持する", async ({
@@ -4063,7 +4146,7 @@ test("kind 候補が無い図では disabled toolbar select と既存編集 UI �
   await expect(toolbar.locator("select option")).toHaveText("kind なし");
 });
 
-test("kind toolbar は候補外の現在値を保持し候補選択時だけ更新する", async ({
+test("kind toolbar は model のみの現在値を CSS 候補の後へ追加して更新できる", async ({
   page,
 }) => {
   const boundaryModel = structuredClone(model);
@@ -4076,27 +4159,27 @@ test("kind toolbar は候補外の現在値を保持し候補選択時だけ更�
   const toolbar = await selectNode(page, "order");
   const picker = toolbar.locator("select.ark-harness-kind-select");
   const none = picker.locator("option").first();
-  const current = picker.locator("option").nth(1);
+  const current = picker.locator("option").last();
   await expect(order).toHaveAttribute("data-kind", "legacy-kind");
   await expect(picker).toHaveValue("legacy-kind");
   await expect(none).toBeEnabled();
   await expect(none).toHaveText("kind なし");
   await expect(none).toHaveAttribute("value", "");
-  await expect(current).toBeDisabled();
+  await expect(current).toBeEnabled();
   await expect(current).toHaveText("legacy-kind");
   await expect(current).toHaveAttribute("value", "legacy-kind");
   expect(await picker.locator("option").allTextContents()).toEqual([
     "kind なし",
-    "legacy-kind",
     "aggregate",
     "entity",
     "event",
+    "legacy-kind",
   ]);
 
   await picker.selectOption("entity");
   await expect(order).toHaveAttribute("data-kind", "entity");
   await expect(picker).toHaveValue("entity");
-  await expect(picker.locator("option")).toHaveCount(4);
+  await expect(picker.locator("option")).toHaveCount(5);
 });
 
 test("kind toolbar は untrusted 値を text と value だけで扱う", async ({
@@ -4118,11 +4201,12 @@ test("kind toolbar は untrusted 値を text と value だけで扱う", async (
   await expect(options.nth(0)).toBeEnabled();
   await expect(options.nth(0)).toHaveText("kind なし");
   await expect(options.nth(0)).toHaveAttribute("value", "");
-  await expect(options.nth(1)).toBeDisabled();
-  await expect(options.nth(1)).toHaveText(currentKind);
-  await expect(options.nth(1)).toHaveAttribute("value", currentKind);
-  await expect(options.nth(2)).toHaveText(candidateKind);
-  await expect(options.nth(2)).toHaveAttribute("value", candidateKind);
+  await expect(options.nth(1)).toBeEnabled();
+  await expect(options.nth(1)).toHaveText(candidateKind);
+  await expect(options.nth(1)).toHaveAttribute("value", candidateKind);
+  await expect(options.nth(2)).toBeEnabled();
+  await expect(options.nth(2)).toHaveText(currentKind);
+  await expect(options.nth(2)).toHaveAttribute("value", currentKind);
   await expect(
     page.locator(
       "img, script:not(#ark-diagram-model):not(#ark-diagram-harness), [onerror], [onload]"

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -373,9 +373,11 @@ describe("injectHarness", () => {
     expect(out).toContain("reservedModelIds");
     expect(out).toContain("function collectModelIds(");
     expect(out).toContain("function generateUniqueModelId(");
-    expect(out).toContain("ark-harness-node-palette");
+    expect(out).not.toContain("ark-harness-node-palette");
+    expect(out).not.toContain("buildNodePalette");
+    expect(out).not.toContain("createPaletteSelect");
     expect(out).toContain("function registerGraphNode(");
-    expect(out).toContain("function addNode(");
+    expect(out).toContain("function createNodeInGraph(");
     expect(out).toContain("function removeNode(");
     expect(out).toContain("group.nodes = group.nodes.filter");
     expect(out).toContain('mode: "create"');

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -107,7 +107,7 @@ describe("injectHarness", () => {
     expect(out).toContain("function renderEdgeToolbar(");
     expect(out).toContain("function collectKindCandidates(");
     expect(out).toContain("function updateNodeKind(");
-    expect(out).toContain("kindCandidates.indexOf(value) === -1");
+    expect(out).toContain("value && kindCandidates.indexOf(value) === -1");
     expect(out).toContain("function updateEdgeExt(");
     expect(out).toContain("CARDINALITY_VALUES.indexOf(value)");
     expect(out).toContain("DIRECTION_VALUES.indexOf(direction)");
@@ -351,8 +351,12 @@ describe("injectHarness", () => {
     expect(out).toContain("function syncKindSelect(");
     expect(out).toContain("function updateNodeKind(");
     expect(out).toContain("getNode(state.model, id)");
-    expect(out).toContain("kindCandidates.indexOf(value) === -1");
+    expect(out).toContain("value && kindCandidates.indexOf(value) === -1");
     expect(out).toContain("node.kind = value");
+    expect(out).toContain("else delete node.kind");
+    expect(out).toContain('var none = createKindOption("")');
+    expect(out).toContain('lastKind === ""');
+    expect(out).toContain("lastKind = kind;");
     expect(out).toContain("syncNodeKinds();");
     expect(out).toContain("scheduleGraphRender(graph);");
     expect(out).toContain('el.setAttribute("data-kind", node.kind)');

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -381,6 +381,9 @@ describe("injectHarness", () => {
     expect(out).toContain(
       'var id = template && template.getAttribute("data-model-id")'
     );
+    expect(out).toContain("var matched = false");
+    expect(out).toContain("matched = true");
+    expect(out.match(/if \(matched && id\)/g)).toHaveLength(2);
     expect(out).toContain('template.querySelectorAll("[data-model-id]")');
     expect(out).toContain('candidate.getAttribute("data-model-id") !== id');
     expect(out).toContain("isInsideHarnessUi(candidate)");

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -371,6 +371,32 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
+  it("node projection に authored label のタグと class を複製する契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><section class="entity" data-model-id="node"><h2 class="title" data-model-id="node">Node</h2></section></div>'
+      )
+    );
+
+    expect(out).toContain(
+      'var id = template && template.getAttribute("data-model-id")'
+    );
+    expect(out).toContain('template.querySelectorAll("[data-model-id]")');
+    expect(out).toContain('candidate.getAttribute("data-model-id") !== id');
+    expect(out).toContain("isInsideHarnessUi(candidate)");
+    expect(out).toContain('candidate.hasAttribute("data-ark-container")');
+    expect(out).toContain('candidate.hasAttribute("data-ark-group")');
+    expect(out).toContain("/^(H1|H2|H3|H4|H5|H6|SPAN|DIV|P|STRONG|HEADER)$/");
+    expect(out).toContain("labelTag: labelTag");
+    expect(out).toContain(
+      "labelClassName: labelEl ? authoredClassName(labelEl) :"
+    );
+    expect(out).toContain("document.createElement(template.labelTag)");
+    expect(out).toContain(
+      "if (template.labelClassName) label.className = template.labelClassName"
+    );
+  });
+
   it("node / edge CRUD と参照整合性の契約を注入する", () => {
     const out = injectHarness(
       page(

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -329,7 +329,7 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
-  it("authored CSS 由来の kind toolbar 契約を注入する", () => {
+  it("authored CSS と model node 由来の kind toolbar 契約を注入する", () => {
     const out = injectHarness(
       page(
         '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
@@ -342,6 +342,10 @@ describe("injectHarness", () => {
     expect(out).toContain("style:not([data-ark-harness-ui])");
     expect(out).toContain("rule.selectorText");
     expect(out).toContain("new Set()");
+    expect(out).toContain("state.model && Array.isArray(state.model.nodes)");
+    expect(out).toContain('typeof value === "string" && value');
+    expect(out).toContain("!seen.has(value)");
+    expect(out).toContain("values.push(value)");
     expect(out).toContain("ark-harness-context-toolbar");
     expect(out).not.toContain("ark-harness-kind-picker");
     expect(out).toContain('document.createElement("select")');

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -371,10 +371,10 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
-  it("node projection に authored label のタグと class を複製する契約を注入する", () => {
+  it("node projection に authored label と空 list の構造を複製する契約を注入する", () => {
     const out = injectHarness(
       page(
-        '<div data-ark-container="graph"><section class="entity" data-model-id="node"><h2 class="title" data-model-id="node">Node</h2></section></div>'
+        '<div data-ark-container="graph"><section class="entity" data-model-id="node"><h2 class="title" data-model-id="node">Node</h2><ul class="fields"><li data-model-id="field">Field</li></ul></section></div>'
       )
     );
 
@@ -395,6 +395,19 @@ describe("injectHarness", () => {
     expect(out).toContain(
       "if (template.labelClassName) label.className = template.labelClassName"
     );
+    expect(out).toContain('template.querySelectorAll("ul, ol")');
+    expect(out).toContain("findOwnerNodeId(state.model, candidate) === id");
+    expect(out).toContain(
+      "listTag: listEl ? listEl.tagName.toLowerCase() : null"
+    );
+    expect(out).toContain(
+      "listClassName: listEl ? authoredClassName(listEl) :"
+    );
+    expect(out).toContain("document.createElement(template.listTag)");
+    expect(out).toContain(
+      "if (template.listClassName) list.className = template.listClassName"
+    );
+    expect(out).toContain("return { root: root, label: label, list: list }");
   });
 
   it("node / edge CRUD と参照整合性の契約を注入する", () => {
@@ -413,6 +426,11 @@ describe("injectHarness", () => {
     expect(out).toContain("function registerGraphNode(");
     expect(out).toContain("function createNodeInGraph(");
     expect(out).toContain("function removeNode(");
+    expect(out).toContain("listBindingsByNode.delete(id)");
+    expect(out).toContain(
+      "owned.push({ listEl: projection.list, ownerNodeId: node.id })"
+    );
+    expect(out).toContain("wireList(projection.list, node.id)");
     expect(out).toContain("group.nodes = group.nodes.filter");
     expect(out).toContain('mode: "create"');
     expect(out).toContain('mode: "rewire"');

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -1415,9 +1415,11 @@ const RAW_HARNESS_JS = `(function () {
           x: event.clientX - graphRect.left,
           y: event.clientY - graphRect.top
         };
-        var kind = kindCandidates.indexOf(lastKind) !== -1
-          ? lastKind
-          : kindCandidates[0] || "";
+        var kind = lastKind === ""
+          ? ""
+          : kindCandidates.indexOf(lastKind) !== -1
+            ? lastKind
+            : kindCandidates[0] || "";
         var previousLastKind = lastKind;
         var newNode = createNodeInGraph(drag.graph, kind, point);
         if (!newNode) {
@@ -1906,11 +1908,11 @@ const RAW_HARNESS_JS = `(function () {
 
   function syncKindSelect(select, node) {
     var current = typeof node.kind === "string" ? node.kind : "";
-    if (kindCandidates.indexOf(current) === -1) {
+    if (current && kindCandidates.indexOf(current) === -1) {
       var currentOption = createKindOption(current);
-      currentOption.textContent = current || "kind \\u306A\\u3057";
+      currentOption.textContent = current;
       currentOption.disabled = true;
-      select.insertBefore(currentOption, select.firstChild);
+      select.insertBefore(currentOption, select.children[1] || null);
     }
     select.value = current;
     var name = (typeof node.label === "string" && node.label) || node.id;
@@ -1944,6 +1946,9 @@ const RAW_HARNESS_JS = `(function () {
       select.appendChild(none);
       select.disabled = true;
     } else {
+      var none = createKindOption("");
+      none.textContent = "kind \\u306A\\u3057";
+      select.appendChild(none);
       kindCandidates.forEach(function (value) {
         select.appendChild(createKindOption(value));
       });
@@ -2396,7 +2401,7 @@ const RAW_HARNESS_JS = `(function () {
         throw new Error("node registration failed");
       }
       wireEditableLeaf(projection.label, null);
-      if (kind) lastKind = kind;
+      lastKind = kind;
       graphs.forEach(function (entry) { scheduleGraphRender(entry); });
       return node;
     } catch (error) {
@@ -2603,10 +2608,11 @@ const RAW_HARNESS_JS = `(function () {
 
   function updateNodeKind(graph, root, value) {
     var id = root.getAttribute("data-model-id");
-    if (!id || kindCandidates.indexOf(value) === -1) return;
+    if (!id || value && kindCandidates.indexOf(value) === -1) return;
     var node = getNode(state.model, id);
     if (!node) return;
-    node.kind = value;
+    if (value) node.kind = value;
+    else delete node.kind;
     lastKind = value;
     syncNodeKinds();
     renderContextToolbar();

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -1393,6 +1393,20 @@ const RAW_HARNESS_JS = `(function () {
     if (commit && drag.didDrag && drag.mode === "rewire" && !candidate) {
       removeEdge(drag.edgeId);
     } else if (commit && drag.didDrag && drag.mode === "create" && !candidate) {
+      var overOtherGraph = graphs.some(function (entry) {
+        if (entry === drag.graph) return false;
+        var rect = entry.container.getBoundingClientRect();
+        return event.clientX >= rect.left && event.clientX <= rect.right &&
+          event.clientY >= rect.top && event.clientY <= rect.bottom;
+      });
+      if (overOtherGraph) {
+        removeEdgeDragUi(drag);
+        if (drag.handle.hasPointerCapture(drag.pointerId)) {
+          drag.handle.releasePointerCapture(drag.pointerId);
+        }
+        graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+        return;
+      }
       var blankSource = getNode(state.model, drag.sourceId);
       var blankSourceEl = drag.graph.nodesById.get(drag.sourceId);
       if (blankSource && blankSourceEl) {

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2252,6 +2252,7 @@ const RAW_HARNESS_JS = `(function () {
     )) finishEdgeDrag(null, false);
     if (selection.kind === "node" && selection.id === id) clearSelection();
 
+    listBindingsByNode.delete(id);
     state.model.nodes = state.model.nodes.filter(function (entry) {
       return entry.id !== id;
     });
@@ -2322,11 +2323,22 @@ const RAW_HARNESS_JS = `(function () {
       /^(H1|H2|H3|H4|H5|H6|SPAN|DIV|P|STRONG|HEADER)$/.test(labelEl.tagName)
       ? labelEl.tagName.toLowerCase()
       : null;
+    var listEl = null;
+    if (id) {
+      template.querySelectorAll("ul, ol").forEach(function (candidate) {
+        if (!listEl && !isInsideHarnessUi(candidate) &&
+            findOwnerNodeId(state.model, candidate) === id) {
+          listEl = candidate;
+        }
+      });
+    }
     return {
       tag: tag,
       className: template ? authoredClassName(template) : "",
       labelTag: labelTag,
-      labelClassName: labelEl ? authoredClassName(labelEl) : ""
+      labelClassName: labelEl ? authoredClassName(labelEl) : "",
+      listTag: listEl ? listEl.tagName.toLowerCase() : null,
+      listClassName: listEl ? authoredClassName(listEl) : ""
     };
   }
 
@@ -2347,7 +2359,13 @@ const RAW_HARNESS_JS = `(function () {
     if (template.labelClassName) label.className = template.labelClassName;
     label.textContent = node.label;
     root.appendChild(label);
-    return { root: root, label: label };
+    var list = null;
+    if (template.listTag) {
+      list = document.createElement(template.listTag);
+      if (template.listClassName) list.className = template.listClassName;
+      root.appendChild(list);
+    }
+    return { root: root, label: label, list: list };
   }
 
   function nodePlacementBlockers(graph, excluded) {
@@ -2439,6 +2457,12 @@ const RAW_HARNESS_JS = `(function () {
         throw new Error("node registration failed");
       }
       wireEditableLeaf(projection.label, null);
+      if (projection.list) {
+        var owned = listBindingsByNode.get(node.id) || [];
+        owned.push({ listEl: projection.list, ownerNodeId: node.id });
+        listBindingsByNode.set(node.id, owned);
+        wireList(projection.list, node.id);
+      }
       lastKind = kind;
       graphs.forEach(function (entry) { scheduleGraphRender(entry); });
       return node;

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2290,10 +2290,14 @@ const RAW_HARNESS_JS = `(function () {
 
   function projectionTemplate(graph, kind) {
     var template = null;
+    var matched = false;
     graph.nodesById.forEach(function (root, id) {
       if (template) return;
       var node = getNode(state.model, id);
-      if (kind && node && node.kind === kind) template = root;
+      if (kind && node && node.kind === kind) {
+        template = root;
+        matched = true;
+      }
     });
     if (!template) {
       graph.nodesById.forEach(function (root) {
@@ -2305,7 +2309,7 @@ const RAW_HARNESS_JS = `(function () {
       : "article";
     var id = template && template.getAttribute("data-model-id");
     var labelEl = null;
-    if (id) {
+    if (matched && id) {
       template.querySelectorAll("[data-model-id]").forEach(function (candidate) {
         if (labelEl || candidate === template ||
             candidate.getAttribute("data-model-id") !== id ||
@@ -2324,7 +2328,7 @@ const RAW_HARNESS_JS = `(function () {
       ? labelEl.tagName.toLowerCase()
       : null;
     var listEl = null;
-    if (id) {
+    if (matched && id) {
       template.querySelectorAll("ul, ol").forEach(function (candidate) {
         if (!listEl && !isInsideHarnessUi(candidate) &&
             findOwnerNodeId(state.model, candidate) === id) {

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -93,15 +93,6 @@ const HARNESS_STYLE = `<style data-ark-harness-ui="1">
 .ark-harness-btn:hover { background: #232732; }
 .ark-harness-btn:disabled { opacity: .45; cursor: not-allowed; }
 .ark-harness-layout-direction { min-width: 5.5rem; }
-.ark-harness-node-palette {
-  display: flex; align-items: center; flex-wrap: wrap; gap: .35rem;
-  padding: .2rem .35rem; border: 1px solid #2a2f3a; border-radius: 6px;
-}
-.ark-harness-palette-label { display: flex; align-items: center; gap: .25rem; color: #aab1c1; }
-.ark-harness-palette-select {
-  appearance: auto; max-width: 9rem; padding: .2rem .3rem;
-  border: 1px solid #333947; border-radius: 4px; background: #1b1e27; color: #e6e8ee;
-}
 .ark-harness-btn-primary { background: #0ea5b7; border-color: #0ea5b7; color: #05201f; font-weight: 600; }
 .ark-harness-btn-primary:hover { background: #14b8c9; }
 .ark-harness-btn-primary:disabled { background: #1b1e27; border-color: #333947; color: #8b93a7; }
@@ -312,6 +303,7 @@ const RAW_HARNESS_JS = `(function () {
   var graphs = [];
   var graphSequence = 0;
   var kindCandidates = [];
+  var lastKind = null;
   var reservedModelIds = new Set();
   var generatedIdCounter = 0;
   var selection = { kind: null, id: null };
@@ -1400,6 +1392,37 @@ const RAW_HARNESS_JS = `(function () {
       drag.leftSource;
     if (commit && drag.didDrag && drag.mode === "rewire" && !candidate) {
       removeEdge(drag.edgeId);
+    } else if (commit && drag.didDrag && drag.mode === "create" && !candidate) {
+      var blankSource = getNode(state.model, drag.sourceId);
+      var blankSourceEl = drag.graph.nodesById.get(drag.sourceId);
+      if (blankSource && blankSourceEl) {
+        var graphRect = drag.graph.container.getBoundingClientRect();
+        var point = {
+          x: event.clientX - graphRect.left,
+          y: event.clientY - graphRect.top
+        };
+        var kind = kindCandidates.indexOf(lastKind) !== -1
+          ? lastKind
+          : kindCandidates[0] || "";
+        var previousLastKind = lastKind;
+        var newNode = createNodeInGraph(drag.graph, kind, point);
+        if (!newNode) {
+          updateStatus(!!submitPort, "ノードと edge を作成できませんでした");
+        } else {
+          var newEdgeId = generateUniqueModelId("edge");
+          if (newEdgeId) {
+            state.model.edges.push({
+              id: newEdgeId,
+              from: blankSource.id,
+              to: newNode.id
+            });
+          } else {
+            removeNode(newNode.id);
+            lastKind = previousLastKind;
+            updateStatus(!!submitPort, "ノードと edge を作成できませんでした");
+          }
+        }
+      }
     } else if (commit && drag.didDrag && candidate && explicitSelfDrop) {
       if (drag.mode === "rewire") {
         var currentEdge = getEdge(state.model, drag.edgeId);
@@ -2326,16 +2349,16 @@ const RAW_HARNESS_JS = `(function () {
       : { x: Math.round(maximumRight + config.rankSpacing), y: Math.round(maximumBottom + config.nodeSpacing) };
   }
 
-  function addNode(graph, kind) {
+  function createNodeInGraph(graph, kind, point) {
     if (!graph || graphs.indexOf(graph) === -1) {
       updateStatus(!!submitPort, "配置先 graph を解決できませんでした");
-      return;
+      return null;
     }
-    if (kind && kindCandidates.indexOf(kind) === -1) return;
+    if (kind && kindCandidates.indexOf(kind) === -1) return null;
     var id = generateUniqueModelId("node");
     if (!id) {
       updateStatus(!!submitPort, "一意な ID を生成できませんでした");
-      return;
+      return null;
     }
     var node = { id: id, label: "新しいノード", ext: { x: 0, y: 0 } };
     if (kind) node.kind = kind;
@@ -2345,7 +2368,13 @@ const RAW_HARNESS_JS = `(function () {
     projection.root.style.setProperty("--ark-harness-graph-x", "0px");
     projection.root.style.setProperty("--ark-harness-graph-y", "0px");
     try {
-      var position = findNodePlacement(graph, projection.root);
+      var rect = projection.root.getBoundingClientRect();
+      var position = point === null
+        ? findNodePlacement(graph, projection.root)
+        : {
+            x: Math.max(0, Math.round(point.x - (rect.width || 160) / 2)),
+            y: Math.max(0, Math.round(point.y - (rect.height || 64) / 2))
+          };
       node.ext.x = position.x;
       node.ext.y = position.y;
       state.model.nodes.push(node);
@@ -2353,7 +2382,9 @@ const RAW_HARNESS_JS = `(function () {
         throw new Error("node registration failed");
       }
       wireEditableLeaf(projection.label, null);
+      if (kind) lastKind = kind;
       graphs.forEach(function (entry) { scheduleGraphRender(entry); });
+      return node;
     } catch (error) {
       state.model.nodes = state.model.nodes.filter(function (entry) {
         return entry.id !== id;
@@ -2361,6 +2392,7 @@ const RAW_HARNESS_JS = `(function () {
       unregisterGraphNode(graph, id);
       projection.root.remove();
       updateStatus(!!submitPort, "ノードを追加できませんでした");
+      return null;
     }
   }
 
@@ -2561,6 +2593,7 @@ const RAW_HARNESS_JS = `(function () {
     var node = getNode(state.model, id);
     if (!node) return;
     node.kind = value;
+    lastKind = value;
     syncNodeKinds();
     renderContextToolbar();
     scheduleGraphRender(graph);
@@ -2890,67 +2923,6 @@ const RAW_HARNESS_JS = `(function () {
     return panel;
   }
 
-  function createPaletteSelect(labelText, className) {
-    var label = document.createElement("label");
-    label.className = "ark-harness-palette-label";
-    markUi(label);
-    var text = document.createElement("span");
-    text.textContent = labelText;
-    markUi(text);
-    var select = document.createElement("select");
-    select.className = "ark-harness-palette-select " + className;
-    select.setAttribute("aria-label", labelText);
-    markUi(select);
-    ["pointerdown", "click", "keydown"].forEach(function (type) {
-      select.addEventListener(type, function (event) { event.stopPropagation(); });
-    });
-    label.appendChild(text);
-    label.appendChild(select);
-    return { label: label, select: select };
-  }
-
-  function buildNodePalette() {
-    var palette = document.createElement("div");
-    palette.className = "ark-harness-node-palette";
-    markUi(palette);
-    var graphChoice = createPaletteSelect("配置先", "ark-harness-graph-select");
-    document.querySelectorAll('[data-ark-container="graph"]').forEach(function (_, index) {
-      var option = document.createElement("option");
-      option.value = String(index);
-      option.textContent = "graph " + (index + 1);
-      markUi(option);
-      graphChoice.select.appendChild(option);
-    });
-    var kindChoice = createPaletteSelect("kind", "ark-harness-palette-kind-select");
-    if (kindCandidates.length === 0) {
-      var none = document.createElement("option");
-      none.value = "";
-      none.textContent = "kind なし";
-      markUi(none);
-      kindChoice.select.appendChild(none);
-    } else {
-      kindCandidates.forEach(function (value) {
-        kindChoice.select.appendChild(createKindOption(value));
-      });
-    }
-    var add = createButton(
-      "+ ノード",
-      "ark-harness-btn ark-harness-btn-secondary ark-harness-add-node",
-      "ノードを追加"
-    );
-    add.addEventListener("click", function () {
-      var graphIndex = Number(graphChoice.select.value);
-      var graph = Number.isInteger(graphIndex) ? graphs[graphIndex] : null;
-      var kind = kindChoice.select.value;
-      if (kind && kindCandidates.indexOf(kind) === -1) return;
-      addNode(graph, kind);
-    });
-    palette.appendChild(graphChoice.label);
-    palette.appendChild(kindChoice.label);
-    palette.appendChild(add);
-    return palette;
-  }
-
   function syncToolbarHeight(bar) {
     var update = function () {
       var height = Math.ceil(bar.getBoundingClientRect().height);
@@ -2976,7 +2948,6 @@ const RAW_HARNESS_JS = `(function () {
       syncLayoutDirectionButton();
       layoutDirectionBtn.addEventListener("click", toggleLayoutDirection);
       bar.appendChild(layoutDirectionBtn);
-      bar.appendChild(buildNodePalette());
     }
 
     var editModelBtn = createButton("モデルを直接編集", "ark-harness-btn ark-harness-btn-secondary", "モデル JSON を直接編集する");

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -458,6 +458,16 @@ const RAW_HARNESS_JS = `(function () {
       }
       if (rules) collectKindRules(rules, seen, values);
     });
+    var nodes = state.model && Array.isArray(state.model.nodes)
+      ? state.model.nodes
+      : [];
+    nodes.forEach(function (node) {
+      var value = node && node.kind;
+      if (typeof value === "string" && value && !seen.has(value)) {
+        seen.add(value);
+        values.push(value);
+      }
+    });
     return values;
   }
 

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2302,7 +2302,32 @@ const RAW_HARNESS_JS = `(function () {
     var tag = template && /^(ARTICLE|SECTION|DIV)$/.test(template.tagName)
       ? template.tagName.toLowerCase()
       : "article";
-    return { tag: tag, className: template ? authoredClassName(template) : "" };
+    var id = template && template.getAttribute("data-model-id");
+    var labelEl = null;
+    if (id) {
+      template.querySelectorAll("[data-model-id]").forEach(function (candidate) {
+        if (labelEl || candidate === template ||
+            candidate.getAttribute("data-model-id") !== id ||
+            isInsideHarnessUi(candidate) ||
+            candidate.hasAttribute("data-ark-container") ||
+            candidate.hasAttribute("data-ark-group")) return;
+        var nested = candidate.querySelectorAll("[data-model-id]");
+        for (var i = 0; i < nested.length; i++) {
+          if (nested[i].getAttribute("data-model-id") === id) return;
+        }
+        labelEl = candidate;
+      });
+    }
+    var labelTag = labelEl &&
+      /^(H1|H2|H3|H4|H5|H6|SPAN|DIV|P|STRONG|HEADER)$/.test(labelEl.tagName)
+      ? labelEl.tagName.toLowerCase()
+      : null;
+    return {
+      tag: tag,
+      className: template ? authoredClassName(template) : "",
+      labelTag: labelTag,
+      labelClassName: labelEl ? authoredClassName(labelEl) : ""
+    };
   }
 
   function createNodeProjection(graph, node) {
@@ -2312,11 +2337,14 @@ const RAW_HARNESS_JS = `(function () {
       : template.tag === "div"
         ? document.createElement("div")
         : document.createElement("article");
-    var label = document.createElement("span");
+    var label = template.labelTag
+      ? document.createElement(template.labelTag)
+      : document.createElement("span");
     root.setAttribute("data-model-id", node.id);
     label.setAttribute("data-model-id", node.id);
     if (node.kind) root.setAttribute("data-kind", node.kind);
     if (template.className) root.className = template.className;
+    if (template.labelClassName) label.className = template.labelClassName;
     label.textContent = node.label;
     root.appendChild(label);
     return { root: root, label: label };


### PR DESCRIPTION
## 概要

draw.io スムーズ編集リデザイン（#266）の **Phase B（#268）**。ノードのハンドルから空白へドラッグして「**繋がった新ノード**」を一気に生成できるようにし、旧ノードパレットを撤去した。構造化ノード（ER entity 等、見た目が class + 内部 DOM で決まる図）では、**同じ kind の既存ノードに一致したときだけ**テンプレの構造（ヘッダ `<h2>` + 属性リスト `<ul>`）を引き継ぐ。

## 変更（コミット単位）

- `711e170` 図解ハンドルの空白ドロップで接続ノードを作成（`finishEdgeDrag` に空白ドロップ分岐 + `createNodeInGraph`）
- `5425afc` 別グラフへの接続ドラッグをキャンセル（誤配置ガード）
- `13a6bf0` 選択可能な「kindなし」+ ドラッグ作成の kind 決定
- `6e0ff4c` モデル由来の kind 候補を union（CSS ルール ∪ node.kind）
- `9e73721` 新規ノードにラベル構造（ヘッダ）を引き継ぐ
- `abf1b54` 新規ノードへ空の属性リストを引き継ぎ「+ 行」を有効化
- `90bbb7b` 同じ kind のノードだけ構造を引き継ぐ（kindなしは素の箱・行追加不可）

## 挙動

- entity 作成（同 kind 一致）→ ヘッダ + 空の属性リスト、`+ 行` で行追加可
- kindなし作成（一致なし）→ 素の箱（`<section class="entity"><span>`・`<ul>` 無し・`+ 行` disabled）
- kind 切替は非破壊（構造・行データを保持）

## テスト

- E2E 65 passed / harness unit 20 passed / 全 unit 682 passed
- `pnpm check` / `pnpm build` / `git diff --check` PASS
- 注入後ハーネス 119,065 bytes < 128KiB guard（131,072）
- 非還流契約・production `diagram-diff.ts` / `describeModelDiff` 不変

## Plan

`docs/superpowers/plans/2026-07-27-issue-268.md`（設計成果物としてコミット済み）

Closes #268


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ノードのコネクターから空白へドラッグして、新しいノードとエッジを同時に作成できるようになりました。
  * 新規ノードはドラッグ先の位置に配置され、直前に選択した種別を引き継ぎます。
  * 既存ノードから利用可能な種別も選択候補に表示されます。
* **改善**
  * ノード追加パレットを廃止し、より直接的な操作でノードを作成できるようにしました。
  * 無効なドラッグ操作やID生成失敗時に、画面とデータが不整合にならないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->