### PR TITLE
図解編集: note を独立 kind に追加し接続ドラッグ/向き編集を安定化

### DIFF
--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1323,7 +1323,7 @@ test("selection toolbar node action: +行と削除を既存 field・参照整合
   ).toEqual(["external"]);
 });
 
-test("selection toolbar edge action: 向き反転で from/to と cardinality を入替え2回で元に戻る", async ({
+test("selection toolbar edge action: 向き反転で direction だけを切替え2回で元に戻る", async ({
   page,
 }) => {
   await openEdgeSemanticsDiagram(page);
@@ -1345,28 +1345,27 @@ test("selection toolbar edge action: 向き反転で from/to と cardinality を
   });
 
   await reverse.click();
-  expect(
-    (await readCurrentModel(page)).edges.find(
-      edge => edge.id === "e_order_owner"
-    )
-  ).toMatchObject({
-    from: "user",
-    to: "order",
+  const reversed = (await readCurrentModel(page)).edges.find(
+    edge => edge.id === "e_order_owner"
+  );
+  expect(reversed).toMatchObject({
+    from: "order",
+    to: "user",
     ext: {
-      from_card: "zero-or-many",
-      to_card: "one",
-      direction: "forward",
+      from_card: "one",
+      to_card: "zero-or-many",
+      direction: "reverse",
     },
   });
   await expect(
     toolbar.locator('select[data-ark-edge-control="from-card"]')
-  ).toHaveValue("zero-or-many");
-  await expect(
-    toolbar.locator('select[data-ark-edge-control="to-card"]')
   ).toHaveValue("one");
   await expect(
+    toolbar.locator('select[data-ark-edge-control="to-card"]')
+  ).toHaveValue("zero-or-many");
+  await expect(
     toolbar.locator('select[data-ark-edge-control="direction"]')
-  ).toHaveValue("forward");
+  ).toHaveValue("reverse");
   await expect(toolbar).toHaveAttribute(
     "data-ark-selection-id",
     "e_order_owner"
@@ -1377,7 +1376,9 @@ test("selection toolbar edge action: 向き反転で from/to と cardinality を
     edge => edge.id === "e_order_owner"
   );
   expect(restored).toEqual(original);
-  expect(restored?.ext).toMatchObject({ direction: "forward" });
+  await expect(
+    toolbar.locator('select[data-ark-edge-control="direction"]')
+  ).toHaveValue("forward");
   await expect(selectedEdgeAnchor(page, "e_order_owner")).toHaveCount(1);
 });
 
@@ -1515,7 +1516,7 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   const addedEdge = current.edges.find(
     edge => !connectDragModel.edges.some(old => old.id === edge.id)
   );
-  expect(addedEdge).toMatchObject({ from: added.id, to: "crud-b" });
+  expect(addedEdge).toMatchObject({ from: "crud-b", to: added.id });
   expect(addedEdge?.id).toMatch(/^edge-/);
 
   const projection = firstGraph
@@ -1595,23 +1596,18 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   expect(errors).toEqual([]);
 });
 
-test("node CRUD: 空白への接続 drag は anchor の方向に応じて新 node を edge の始点・終点にする", async ({
+test("node CRUD: 空白への接続 drag はどの anchor でも新 node を edge の終点にする", async ({
   page,
 }) => {
   const directionalModel = structuredClone(crudModel);
   directionalModel.edges = [];
-  const scenarios = [
-    { anchor: "top", newNodeEnd: "to" },
-    { anchor: "bottom", newNodeEnd: "from" },
-    { anchor: "left", newNodeEnd: "to" },
-    { anchor: "right", newNodeEnd: "from" },
-  ] as const;
+  const anchors = ["top", "bottom", "left", "right"] as const;
 
-  for (const scenario of scenarios) {
+  for (const anchor of anchors) {
     await page.setContent(crudDiagramHtml(directionalModel));
     const graph = page.locator('[data-ark-container="graph"]').first();
     const graphBox = await requiredBoundingBox(graph);
-    await dragNodeAnchorToPoint(page, graph, "crud-b", scenario.anchor, {
+    await dragNodeAnchorToPoint(page, graph, "crud-b", anchor, {
       x: graphBox.x + graphBox.width - 20,
       y: graphBox.y + graphBox.height - 20,
     });
@@ -1620,17 +1616,15 @@ test("node CRUD: 空白への接続 drag は anchor の方向に応じて新 nod
     const addedNode = current.nodes.find(
       node => !directionalModel.nodes.some(old => old.id === node.id)
     );
-    expect(addedNode, scenario.anchor).toBeDefined();
-    if (!addedNode)
-      throw new Error(`${scenario.anchor}: 追加 node がありません`);
+    expect(addedNode, anchor).toBeDefined();
+    if (!addedNode) throw new Error(`${anchor}: 追加 node がありません`);
     const addedEdge = current.edges.find(
       edge => !directionalModel.edges.some(old => old.id === edge.id)
     );
-    expect(addedEdge, scenario.anchor).toMatchObject(
-      scenario.newNodeEnd === "from"
-        ? { from: addedNode.id, to: "crud-b" }
-        : { from: "crud-b", to: addedNode.id }
-    );
+    expect(addedEdge, anchor).toMatchObject({
+      from: "crud-b",
+      to: addedNode.id,
+    });
   }
 });
 
@@ -2225,7 +2219,7 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   expect(submission.html).not.toContain("--ark-harness-graph-x");
   expect(describeModelDiff(crudModel, submission.model)).toEqual([
     "新しいノード を追加",
-    "新しいノード から B への関連を追加",
+    "B から 新しいノード への関連を追加",
   ]);
 });
 

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1382,6 +1382,25 @@ test("selection toolbar edge action: 向き反転で direction だけを切替�
   await expect(selectedEdgeAnchor(page, "e_order_owner")).toHaveCount(1);
 });
 
+test("selection toolbar edge action: both は向き反転を無効化し forward は有効にする", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  const toolbar = await selectEdge(page, "e_order_owner");
+  const reverse = toolbar.getByRole("button", {
+    name: "owned by の向きを反転",
+  });
+  const direction = toolbar.locator(
+    'select[data-ark-edge-control="direction"]'
+  );
+
+  await expect(direction).toHaveValue("forward");
+  await expect(reverse).toBeEnabled();
+  await direction.selectOption("both");
+  await expect(direction).toHaveValue("both");
+  await expect(reverse).toBeDisabled();
+});
+
 test("selection toolbar edge action: rerender 後も選択を復元して対象 edge だけ削除する", async ({
   page,
 }) => {
@@ -4346,6 +4365,52 @@ test("authored entity と note を往復して label・fields・noteText を独�
   expect(submission.html).toContain("設計メモ\n2行目");
   expect(submission.html).not.toContain("contenteditable");
   expect(submission.html).not.toContain("data-placeholder");
+});
+
+test("モデル直接編集後の note 入力を現行モデルへ反映して送信する", async ({
+  page,
+}) => {
+  await page.setContent(modelKindCandidateHtml());
+  await connectSubmissionPort(page);
+
+  const source = page.locator(
+    '.ark-harness-graph-node[data-model-id="model-kind-source"]'
+  );
+  const toolbar = await selectNode(page, "model-kind-source");
+  await toolbar.locator("select.ark-harness-kind-select").selectOption("note");
+  const note = source.locator(":scope > [data-ark-harness-note]");
+  await note.fill("適用前のメモ");
+
+  await page
+    .getByRole("button", { name: "モデル JSON を直接編集する" })
+    .click();
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+
+  const currentNote = source.locator(":scope > [data-ark-harness-note]");
+  await expect(currentNote).toHaveText("適用前のメモ");
+  await currentNote.fill("適用後のメモ\n2行目");
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel };
+        }
+      ).arkHarnessSubmission
+  );
+
+  expect(
+    submission?.model.nodes.find(node => node.id === "model-kind-source")
+      ?.noteText
+  ).toBe("適用後のメモ\n2行目");
 });
 
 test("model node だけに entity がある図でも note picker・往復・drag 作成を利用できる", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1468,10 +1468,10 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   await expect(
     contextToolbar(page).locator("select.ark-harness-kind-select")
   ).toHaveValue("entity");
-  await expect(projection.locator(":scope > ul")).toHaveCount(0);
+  await expect(projection.locator(":scope > ul")).toHaveCount(1);
   await expect(
     contextToolbar(page).getByRole("button", { name: "行を追加" })
-  ).toBeDisabled();
+  ).toBeEnabled();
   await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(1);
   await expect(
     firstGraph.locator(
@@ -1518,7 +1518,7 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   expect(errors).toEqual([]);
 });
 
-test("node CRUD: kind なしを選ぶと node から kind を除去し drag 作成にも引き継ぐ", async ({
+test("node CRUD: note を選ぶと独立本文を投影し drag 作成にも引き継ぐ", async ({
   page,
 }) => {
   await page.setContent(crudDiagramHtml());
@@ -1527,22 +1527,28 @@ test("node CRUD: kind なしを選ぶと node から kind を除去し drag 作�
   const source = graph.locator('[data-model-id="crud-b"]').first();
   const toolbar = await selectNode(page, "crud-b");
   const picker = toolbar.locator("select.ark-harness-kind-select");
-  const none = picker.locator('option[value=""]');
-  await expect(none).toHaveText("kind なし");
-  await expect(none).toBeEnabled();
+  const noteOption = picker.locator('option[value="note"]');
+  await expect(noteOption).toHaveText("note");
+  await expect(noteOption).toBeEnabled();
   expect(await picker.locator("option").allTextContents()).toEqual([
-    "kind なし",
+    "note",
     "entity",
     "event",
   ]);
 
-  await picker.selectOption("");
-  await expect(picker).toHaveValue("");
-  await expect(source).not.toHaveAttribute("data-kind", /.*/);
-  const cleared = await readCurrentModel(page);
-  expect(cleared.nodes.find(node => node.id === "crud-b")).not.toHaveProperty(
-    "kind"
-  );
+  await picker.selectOption("note");
+  await expect(picker).toHaveValue("note");
+  await expect(source).toHaveAttribute("data-kind", "note");
+  const sourceNote = source.locator(":scope > [data-ark-harness-note]");
+  await expect(sourceNote).toHaveCount(1);
+  await expect(sourceNote).toHaveAttribute("contenteditable", "true");
+  await expect(
+    source.locator(":scope > span, :scope > h2, :scope > ul")
+  ).toHaveCount(0);
+  await sourceNote.fill("1行目\n2行目");
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === "crud-b")
+  ).toMatchObject({ kind: "note", noteText: "1行目\n2行目", label: "B" });
 
   const graphBox = await requiredBoundingBox(graph);
   await dragNodeAnchorToPoint(page, graph, "crud-b", "bottom", {
@@ -1554,11 +1560,16 @@ test("node CRUD: kind なしを選ぶと node から kind を除去し drag 作�
     node => !crudModel.nodes.some(old => old.id === node.id)
   );
   expect(added).toBeDefined();
-  expect(added).not.toHaveProperty("kind");
+  expect(added).toMatchObject({ kind: "note", noteText: "" });
   if (!added) throw new Error("追加 node がありません");
   const projection = graph.locator(`[data-model-id="${added.id}"]`).first();
-  await expect(projection).not.toHaveAttribute("data-kind", /.*/);
-  await expect(projection.locator(":scope > ul")).toHaveCount(0);
+  await expect(projection).toHaveAttribute("data-kind", "note");
+  await expect(
+    projection.locator(":scope > [data-ark-harness-note]")
+  ).toHaveCount(1);
+  await expect(
+    projection.locator(":scope > h2, :scope > span, :scope > ul")
+  ).toHaveCount(0);
   const addedToolbar = await selectNode(page, added.id);
   await expect(
     addedToolbar.getByRole("button", { name: "行を追加" })
@@ -4097,7 +4108,7 @@ test("kind 候補は CSS を先に model node のみを後に重複なしで収�
   const picker = toolbar.getByRole("combobox", { name: /Candidate.*quoted/ });
   await expect(picker).toHaveCount(1);
   expect(await picker.locator("option").allTextContents()).toEqual([
-    "kind なし",
+    "note",
     "quoted",
     "single",
     "unquoted",
@@ -4112,10 +4123,12 @@ test("kind 候補は CSS を先に model node のみを後に重複なしで収�
   await expect(picker.locator("option", { hasText: "comment" })).toHaveCount(0);
 });
 
-test("authored 先頭 entity を kind なしから戻すと h2 と内容を復元する", async ({
+test("authored entity と note を往復して label・fields・noteText を独立保持する", async ({
   page,
 }) => {
   await page.setContent(modelKindCandidateHtml());
+  await connectSubmissionPort(page);
+  const beforeModel = await readCurrentModel(page);
 
   const graph = page.locator('[data-ark-container="graph"]');
   const authoredNodes = graph.locator(":scope > section.entity");
@@ -4130,20 +4143,33 @@ test("authored 先頭 entity を kind なしから戻すと h2 と内容を復�
   const picker = toolbar.locator("select.ark-harness-kind-select");
   const fields = [{ id: "model-kind-source-id", label: "id" }];
 
-  await picker.selectOption("");
-  await expect(source).not.toHaveAttribute("data-kind", /.*/);
-  await expect(
-    source.locator(':scope > span[data-model-id="model-kind-source"]')
-  ).toHaveText("Source");
+  await picker.selectOption("note");
+  await expect(source).toHaveAttribute("data-kind", "note");
+  const note = source.locator(":scope > [data-ark-harness-note]");
+  await expect(note).toHaveCount(1);
+  await expect(note).toHaveAttribute("contenteditable", "true");
   await expect(
     source.locator(':scope > h2[data-model-id="model-kind-source"]')
   ).toHaveCount(0);
+  await expect(source.locator(":scope > ul")).toHaveCount(0);
+  await note.fill("設計メモ\n2行目");
+  expect(
+    (await readCurrentModel(page)).nodes.find(
+      node => node.id === "model-kind-source"
+    )
+  ).toMatchObject({
+    kind: "note",
+    label: "Source",
+    fields,
+    noteText: "設計メモ\n2行目",
+  });
 
   await picker.selectOption("entity");
   await expect(source).toHaveAttribute("data-kind", "entity");
   await expect(
     source.locator(':scope > span[data-model-id="model-kind-source"]')
   ).toHaveCount(0);
+  await expect(note).toHaveCount(0);
   await expect(
     source.locator(':scope > h2[data-model-id="model-kind-source"]')
   ).toHaveText("Source");
@@ -4155,15 +4181,63 @@ test("authored 先頭 entity を kind なしから戻すと h2 と内容を復�
     kind: "entity",
     label: "Source",
     fields,
+    noteText: "設計メモ\n2行目",
   });
   await expect(
     source.locator(
       ':scope > ul > li[data-model-id="model-kind-source-id"] .ark-harness-text'
     )
   ).toHaveText("id");
+
+  await picker.selectOption("note");
+  await expect(source.locator(":scope > h2, :scope > ul")).toHaveCount(0);
+  await expect(source.locator(":scope > [data-ark-harness-note]")).toHaveText(
+    "設計メモ\n2行目"
+  );
+  expect(
+    (await readCurrentModel(page)).nodes.find(
+      node => node.id === "model-kind-source"
+    )
+  ).toMatchObject({
+    kind: "note",
+    label: "Source",
+    fields,
+    noteText: "設計メモ\n2行目",
+  });
+
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const submission = await page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel; html: string };
+        }
+      ).arkHarnessSubmission
+  );
+  if (!submission) throw new Error("submission がありません");
+  expect(describeModelDiff(beforeModel, submission.model)).toEqual([]);
+  expect(
+    submission.model.nodes.find(node => node.id === "model-kind-source")
+  ).toMatchObject({
+    kind: "note",
+    label: "Source",
+    fields,
+    noteText: "設計メモ\n2行目",
+  });
+  expect(submission.html).toContain('data-kind="note"');
+  expect(submission.html).toContain("設計メモ\n2行目");
+  expect(submission.html).not.toContain("contenteditable");
 });
 
-test("model node だけに kind がある図でも picker・drag 作成・kind なしを利用できる", async ({
+test("model node だけに entity がある図でも note picker・往復・drag 作成を利用できる", async ({
   page,
 }) => {
   await page.setContent(modelKindCandidateHtml());
@@ -4173,7 +4247,7 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   const picker = toolbar.locator("select.ark-harness-kind-select");
   await expect(picker).toBeEnabled();
   expect(await picker.locator("option").allTextContents()).toEqual([
-    "kind なし",
+    "note",
     "entity",
   ]);
 
@@ -4223,48 +4297,37 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   if (!addedField) throw new Error("追加 field がありません");
 
   const addedPicker = addedToolbar.locator("select.ark-harness-kind-select");
-  await addedPicker.selectOption("");
-  await expect(addedPicker).toHaveValue("");
-  await expect(projection).not.toHaveAttribute("data-kind", /.*/);
+  await addedPicker.selectOption("note");
+  await expect(addedPicker).toHaveValue("note");
+  await expect(projection).toHaveAttribute("data-kind", "note");
   await expect(label).toHaveCount(0);
-  const kindlessLabelAfterSwitch = projection.locator(
-    `:scope > span[data-model-id="${added.id}"]`
-  );
-  await expect(kindlessLabelAfterSwitch).toHaveCount(1);
-  await expect(kindlessLabelAfterSwitch).toHaveText("新しいノード");
-  await expect(kindlessLabelAfterSwitch).toHaveAttribute(
-    "contenteditable",
-    "true"
-  );
-  const kindlessAfterSwitch = (await readCurrentModel(page)).nodes.find(
+  await expect(list).toHaveCount(0);
+  const note = projection.locator(":scope > [data-ark-harness-note]");
+  await expect(note).toHaveCount(1);
+  await expect(note).toHaveAttribute("contenteditable", "true");
+  await expect(note).toHaveText("");
+  const noteAfterSwitch = (await readCurrentModel(page)).nodes.find(
     node => node.id === added.id
   );
-  expect(kindlessAfterSwitch).not.toHaveProperty("kind");
-  expect(kindlessAfterSwitch?.fields).toEqual([addedField]);
-  await expect(list).toHaveCount(1);
-  await expect(
-    list.locator(
-      `:scope > li[data-model-id="${addedField.id}"] .ark-harness-text`
-    )
-  ).toHaveText(addedField.label);
-  await expect(addFieldButton).toBeEnabled();
-
-  await kindlessLabelAfterSwitch.fill("切替後のラベル");
-  expect(
-    (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
-      ?.label
-  ).toBe("切替後のラベル");
+  expect(noteAfterSwitch).toMatchObject({
+    kind: "note",
+    label: "新しいノード",
+    fields: [addedField],
+    noteText: "",
+  });
+  await expect(addFieldButton).toBeDisabled();
+  await note.fill("自由記述\n複数行");
 
   await addedPicker.selectOption("entity");
   await expect(addedPicker).toHaveValue("entity");
   await expect(projection).toHaveAttribute("data-kind", "entity");
-  await expect(kindlessLabelAfterSwitch).toHaveCount(0);
+  await expect(note).toHaveCount(0);
   const entityLabelAfterSwitch = projection.locator(
     `:scope > h2[data-model-id="${added.id}"]`
   );
   await expect(entityLabelAfterSwitch).toHaveCount(1);
   await expect(entityLabelAfterSwitch).toHaveClass(/(^|\s)entity-title(\s|$)/);
-  await expect(entityLabelAfterSwitch).toHaveText("切替後のラベル");
+  await expect(entityLabelAfterSwitch).toHaveText("新しいノード");
   await expect(entityLabelAfterSwitch).toHaveAttribute(
     "contenteditable",
     "true"
@@ -4273,77 +4336,71 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
     (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
   ).toMatchObject({
     kind: "entity",
-    label: "切替後のラベル",
+    label: "新しいノード",
     fields: [addedField],
+    noteText: "自由記述\n複数行",
   });
+  const restoredList = projection.locator(":scope > ul.entity-fields");
   await expect(
-    list.locator(
+    restoredList.locator(
       `:scope > li[data-model-id="${addedField.id}"] .ark-harness-text`
     )
   ).toHaveText(addedField.label);
 
-  await addedPicker.selectOption("");
-  await expect(addedPicker).toHaveValue("");
-  await expect(projection).not.toHaveAttribute("data-kind", /.*/);
+  await addedPicker.selectOption("note");
+  await expect(addedPicker).toHaveValue("note");
+  await expect(projection).toHaveAttribute("data-kind", "note");
   await expect(entityLabelAfterSwitch).toHaveCount(0);
+  await expect(restoredList).toHaveCount(0);
   await expect(
-    projection.locator(`:scope > span[data-model-id="${added.id}"]`)
-  ).toHaveText("切替後のラベル");
+    projection.locator(":scope > [data-ark-harness-note]")
+  ).toHaveText("自由記述\n複数行");
   expect(
     (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
-      ?.fields
-  ).toEqual([addedField]);
+  ).toMatchObject({
+    kind: "note",
+    label: "新しいノード",
+    fields: [addedField],
+    noteText: "自由記述\n複数行",
+  });
 
-  const beforeKindless = await readCurrentModel(page);
+  const beforeNote = await readCurrentModel(page);
   await dragNodeAnchorToPoint(page, graph, added.id, "bottom", {
     x: graphBox.x + 100,
     y: graphBox.y + graphBox.height - 60,
   });
-  const afterKindless = await readCurrentModel(page);
-  const kindless = afterKindless.nodes.find(
-    node => !beforeKindless.nodes.some(old => old.id === node.id)
+  const afterNote = await readCurrentModel(page);
+  const createdNote = afterNote.nodes.find(
+    node => !beforeNote.nodes.some(old => old.id === node.id)
   );
-  expect(kindless).toBeDefined();
-  expect(kindless).not.toHaveProperty("kind");
-  if (!kindless) throw new Error("kind なし node がありません");
+  expect(createdNote).toMatchObject({
+    kind: "note",
+    noteText: "",
+    label: "新しいノード",
+  });
+  if (!createdNote) throw new Error("note node がありません");
 
-  const kindlessProjection = graph
-    .locator(`[data-model-id="${kindless.id}"]`)
+  const noteProjection = graph
+    .locator(`[data-model-id="${createdNote.id}"]`)
     .first();
-  expect(await kindlessProjection.evaluate(element => element.tagName)).toBe(
+  expect(await noteProjection.evaluate(element => element.tagName)).toBe(
     "SECTION"
   );
-  await expect(kindlessProjection).toHaveClass(/(^|\s)entity(\s|$)/);
-  await expect(kindlessProjection).not.toHaveAttribute("data-kind", /.*/);
-  await expect(kindlessProjection.locator(":scope > h2")).toHaveCount(0);
-  const kindlessLabel = kindlessProjection.locator(
-    `:scope > span[data-model-id="${kindless.id}"]`
-  );
-  await expect(kindlessLabel).toHaveCount(1);
-  await expect(kindlessLabel).toHaveText("新しいノード");
-  const kindlessList = kindlessProjection.locator(":scope > ul");
-  await expect(kindlessList).toHaveCount(1);
-  await expect(kindlessList).toHaveClass(/(^|\s)entity-fields(\s|$)/);
-  await expect(kindlessList.locator(":scope > li")).toHaveCount(0);
-  const kindlessToolbar = await selectNode(page, kindless.id);
-  const kindlessAddFieldButton = kindlessToolbar.getByRole("button", {
-    name: "行を追加",
-  });
-  await expect(kindlessAddFieldButton).toBeEnabled();
-  await kindlessAddFieldButton.click();
-  await expect(kindlessList.locator(":scope > li")).toHaveCount(1);
-  const afterKindlessAdd = await readCurrentModel(page);
-  const kindlessAfterField = afterKindlessAdd.nodes.find(
-    node => node.id === kindless.id
-  );
-  expect(kindlessAfterField?.fields).toHaveLength(1);
-  expect(kindlessAfterField?.fields?.[0]).toMatchObject({
-    label: "新しい項目",
-  });
-  expect(kindlessAfterField?.fields?.[0]?.id).toMatch(/^field-/);
+  await expect(noteProjection).toHaveClass(/(^|\s)entity(\s|$)/);
+  await expect(noteProjection).toHaveAttribute("data-kind", "note");
+  await expect(
+    noteProjection.locator(":scope > [data-ark-harness-note]")
+  ).toHaveCount(1);
+  await expect(
+    noteProjection.locator(":scope > h2, :scope > span, :scope > ul")
+  ).toHaveCount(0);
+  const noteToolbar = await selectNode(page, createdNote.id);
+  await expect(
+    noteToolbar.getByRole("button", { name: "行を追加" })
+  ).toBeDisabled();
 });
 
-test("kind 候補が無い図では disabled toolbar select と既存編集 UI を維持する", async ({
+test("flat 図の authored kindless node は note を選ぶまで従来投影を維持する", async ({
   page,
 }) => {
   await page.setContent(invalidCoordinateHtml());
@@ -4354,11 +4411,20 @@ test("kind 候補が無い図では disabled toolbar select と既存編集 UI �
   await expect(
     graph.locator('[data-model-id="valid_a"].ark-harness-editable')
   ).toHaveAttribute("contenteditable", "true");
+  const root = graph.locator('[data-model-id="valid_a"]');
+  await expect(root).not.toHaveAttribute("data-kind", /.*/);
+  await expect(root).toContainText("Valid A");
+  await expect(root.locator(":scope > [data-ark-harness-note]")).toHaveCount(0);
   const toolbar = await selectNode(page, "valid_a");
-  await expect(
-    toolbar.locator("select.ark-harness-kind-select")
-  ).toBeDisabled();
-  await expect(toolbar.locator("select option")).toHaveText("kind なし");
+  const picker = toolbar.locator("select.ark-harness-kind-select");
+  await expect(picker).toBeEnabled();
+  await expect(picker.locator("option")).toHaveText("note");
+  await expect(root).not.toHaveAttribute("data-kind", /.*/);
+
+  await picker.selectOption("note");
+  await expect(root).toHaveAttribute("data-kind", "note");
+  await expect(root.locator(":scope > [data-ark-harness-note]")).toHaveCount(1);
+  await expect(root.locator(":scope > [data-model-id]")).toHaveCount(0);
 });
 
 test("kind toolbar は model のみの現在値を CSS 候補の後へ追加して更新できる", async ({
@@ -4373,18 +4439,18 @@ test("kind toolbar は model のみの現在値を CSS 候補の後へ追加し�
   );
   const toolbar = await selectNode(page, "order");
   const picker = toolbar.locator("select.ark-harness-kind-select");
-  const none = picker.locator("option").first();
+  const note = picker.locator("option").first();
   const current = picker.locator("option").last();
   await expect(order).toHaveAttribute("data-kind", "legacy-kind");
   await expect(picker).toHaveValue("legacy-kind");
-  await expect(none).toBeEnabled();
-  await expect(none).toHaveText("kind なし");
-  await expect(none).toHaveAttribute("value", "");
+  await expect(note).toBeEnabled();
+  await expect(note).toHaveText("note");
+  await expect(note).toHaveAttribute("value", "note");
   await expect(current).toBeEnabled();
   await expect(current).toHaveText("legacy-kind");
   await expect(current).toHaveAttribute("value", "legacy-kind");
   expect(await picker.locator("option").allTextContents()).toEqual([
-    "kind なし",
+    "note",
     "aggregate",
     "entity",
     "event",
@@ -4414,8 +4480,8 @@ test("kind toolbar は untrusted 値を text と value だけで扱う", async (
   const options = picker.locator("option");
   await expect(options).toHaveCount(3);
   await expect(options.nth(0)).toBeEnabled();
-  await expect(options.nth(0)).toHaveText("kind なし");
-  await expect(options.nth(0)).toHaveAttribute("value", "");
+  await expect(options.nth(0)).toHaveText("note");
+  await expect(options.nth(0)).toHaveAttribute("value", "note");
   await expect(options.nth(1)).toBeEnabled();
   await expect(options.nth(1)).toHaveText(candidateKind);
   await expect(options.nth(1)).toHaveAttribute("value", candidateKind);
@@ -4505,7 +4571,7 @@ test("kind toolbar で CSS 候補を選び投影・geometry・保存へ同期す
   await expect(orderPicker).toHaveCount(1);
   await expect(orderPicker).toHaveAccessibleName(/Order.*aggregate/);
   expect(await orderPicker.locator("option").allTextContents()).toEqual([
-    "kind なし",
+    "note",
     "aggregate",
     "entity",
     "event",
@@ -4514,7 +4580,7 @@ test("kind toolbar で CSS 候補を選び投影・geometry・保存へ同期す
   const userPicker = toolbar.locator("select.ark-harness-kind-select");
   await expect(userPicker).toHaveAccessibleName(/User.*entity/);
   expect(await userPicker.locator("option").allTextContents()).toEqual([
-    "kind なし",
+    "note",
     "aggregate",
     "entity",
     "event",

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1556,9 +1556,13 @@ test("node CRUD: kind なしを選ぶと node から kind を除去し drag 作�
   expect(added).toBeDefined();
   expect(added).not.toHaveProperty("kind");
   if (!added) throw new Error("追加 node がありません");
+  const projection = graph.locator(`[data-model-id="${added.id}"]`).first();
+  await expect(projection).not.toHaveAttribute("data-kind", /.*/);
+  await expect(projection.locator(":scope > ul")).toHaveCount(0);
+  const addedToolbar = await selectNode(page, added.id);
   await expect(
-    graph.locator(`[data-model-id="${added.id}"]`).first()
-  ).not.toHaveAttribute("data-kind", /.*/);
+    addedToolbar.getByRole("button", { name: "行を追加" })
+  ).toBeDisabled();
 });
 
 test("node CRUD: node/edge ID 生成失敗時は projection と model を原子的に戻す", async ({
@@ -4164,18 +4168,42 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
     label: "新しい項目",
   });
   expect(addedAfterField?.fields?.[0]?.id).toMatch(/^field-/);
+  const addedField = addedAfterField?.fields?.[0];
+  if (!addedField) throw new Error("追加 field がありません");
 
   const addedPicker = addedToolbar.locator("select.ark-harness-kind-select");
   await addedPicker.selectOption("");
   await expect(addedPicker).toHaveValue("");
   await expect(projection).not.toHaveAttribute("data-kind", /.*/);
-  expect(
-    (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
-  ).not.toHaveProperty("kind");
+  const kindlessAfterSwitch = (await readCurrentModel(page)).nodes.find(
+    node => node.id === added.id
+  );
+  expect(kindlessAfterSwitch).not.toHaveProperty("kind");
+  expect(kindlessAfterSwitch?.fields).toEqual([addedField]);
   await expect(label).toHaveCount(1);
   await expect(list).toHaveCount(1);
-  await expect(list.locator(":scope > li")).toHaveCount(1);
+  await expect(
+    list.locator(
+      `:scope > li[data-model-id="${addedField.id}"] .ark-harness-text`
+    )
+  ).toHaveText(addedField.label);
   await expect(addFieldButton).toBeEnabled();
+
+  await addedPicker.selectOption("entity");
+  await expect(addedPicker).toHaveValue("entity");
+  await expect(projection).toHaveAttribute("data-kind", "entity");
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
+  ).toMatchObject({ kind: "entity", fields: [addedField] });
+  await expect(
+    list.locator(
+      `:scope > li[data-model-id="${addedField.id}"] .ark-harness-text`
+    )
+  ).toHaveText(addedField.label);
+
+  await addedPicker.selectOption("");
+  await expect(addedPicker).toHaveValue("");
+  await expect(projection).not.toHaveAttribute("data-kind", /.*/);
 
   const beforeKindless = await readCurrentModel(page);
   await dragNodeAnchorToPoint(page, graph, added.id, "bottom", {
@@ -4199,16 +4227,31 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   await expect(kindlessProjection).toHaveClass(/(^|\s)entity(\s|$)/);
   await expect(kindlessProjection).not.toHaveAttribute("data-kind", /.*/);
   await expect(kindlessProjection.locator(":scope > h2")).toHaveCount(0);
-  await expect(kindlessProjection.locator(":scope > ul")).toHaveCount(0);
   const kindlessLabel = kindlessProjection.locator(
     `:scope > span[data-model-id="${kindless.id}"]`
   );
   await expect(kindlessLabel).toHaveCount(1);
   await expect(kindlessLabel).toHaveText("新しいノード");
+  const kindlessList = kindlessProjection.locator(":scope > ul");
+  await expect(kindlessList).toHaveCount(1);
+  await expect(kindlessList).toHaveClass(/(^|\s)entity-fields(\s|$)/);
+  await expect(kindlessList.locator(":scope > li")).toHaveCount(0);
   const kindlessToolbar = await selectNode(page, kindless.id);
-  await expect(
-    kindlessToolbar.getByRole("button", { name: "行を追加" })
-  ).toBeDisabled();
+  const kindlessAddFieldButton = kindlessToolbar.getByRole("button", {
+    name: "行を追加",
+  });
+  await expect(kindlessAddFieldButton).toBeEnabled();
+  await kindlessAddFieldButton.click();
+  await expect(kindlessList.locator(":scope > li")).toHaveCount(1);
+  const afterKindlessAdd = await readCurrentModel(page);
+  const kindlessAfterField = afterKindlessAdd.nodes.find(
+    node => node.id === kindless.id
+  );
+  expect(kindlessAfterField?.fields).toHaveLength(1);
+  expect(kindlessAfterField?.fields?.[0]).toMatchObject({
+    label: "新しい項目",
+  });
+  expect(kindlessAfterField?.fields?.[0]?.id).toMatch(/^field-/);
 });
 
 test("kind 候補が無い図では disabled toolbar select と既存編集 UI を維持する", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -4175,12 +4175,21 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   await addedPicker.selectOption("");
   await expect(addedPicker).toHaveValue("");
   await expect(projection).not.toHaveAttribute("data-kind", /.*/);
+  await expect(label).toHaveCount(0);
+  const kindlessLabelAfterSwitch = projection.locator(
+    `:scope > span[data-model-id="${added.id}"]`
+  );
+  await expect(kindlessLabelAfterSwitch).toHaveCount(1);
+  await expect(kindlessLabelAfterSwitch).toHaveText("新しいノード");
+  await expect(kindlessLabelAfterSwitch).toHaveAttribute(
+    "contenteditable",
+    "true"
+  );
   const kindlessAfterSwitch = (await readCurrentModel(page)).nodes.find(
     node => node.id === added.id
   );
   expect(kindlessAfterSwitch).not.toHaveProperty("kind");
   expect(kindlessAfterSwitch?.fields).toEqual([addedField]);
-  await expect(label).toHaveCount(1);
   await expect(list).toHaveCount(1);
   await expect(
     list.locator(
@@ -4189,12 +4198,33 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   ).toHaveText(addedField.label);
   await expect(addFieldButton).toBeEnabled();
 
+  await kindlessLabelAfterSwitch.fill("切替後のラベル");
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
+      ?.label
+  ).toBe("切替後のラベル");
+
   await addedPicker.selectOption("entity");
   await expect(addedPicker).toHaveValue("entity");
   await expect(projection).toHaveAttribute("data-kind", "entity");
+  await expect(kindlessLabelAfterSwitch).toHaveCount(0);
+  const entityLabelAfterSwitch = projection.locator(
+    `:scope > h2[data-model-id="${added.id}"]`
+  );
+  await expect(entityLabelAfterSwitch).toHaveCount(1);
+  await expect(entityLabelAfterSwitch).toHaveClass(/(^|\s)entity-title(\s|$)/);
+  await expect(entityLabelAfterSwitch).toHaveText("切替後のラベル");
+  await expect(entityLabelAfterSwitch).toHaveAttribute(
+    "contenteditable",
+    "true"
+  );
   expect(
     (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
-  ).toMatchObject({ kind: "entity", fields: [addedField] });
+  ).toMatchObject({
+    kind: "entity",
+    label: "切替後のラベル",
+    fields: [addedField],
+  });
   await expect(
     list.locator(
       `:scope > li[data-model-id="${addedField.id}"] .ark-harness-text`
@@ -4204,6 +4234,14 @@ test("model node だけに kind がある図でも picker・drag 作成・kind �
   await addedPicker.selectOption("");
   await expect(addedPicker).toHaveValue("");
   await expect(projection).not.toHaveAttribute("data-kind", /.*/);
+  await expect(entityLabelAfterSwitch).toHaveCount(0);
+  await expect(
+    projection.locator(`:scope > span[data-model-id="${added.id}"]`)
+  ).toHaveText("切替後のラベル");
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
+      ?.fields
+  ).toEqual([addedField]);
 
   const beforeKindless = await readCurrentModel(page);
   await dragNodeAnchorToPoint(page, graph, added.id, "bottom", {

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -4235,6 +4235,7 @@ test("authored entity と note を往復して label・fields・noteText を独�
   expect(submission.html).toContain('data-kind="note"');
   expect(submission.html).toContain("設計メモ\n2行目");
   expect(submission.html).not.toContain("contenteditable");
+  expect(submission.html).not.toContain("data-placeholder");
 });
 
 test("model node だけに entity がある図でも note picker・往復・drag 作成を利用できる", async ({
@@ -4305,6 +4306,7 @@ test("model node だけに entity がある図でも note picker・往復・drag
   const note = projection.locator(":scope > [data-ark-harness-note]");
   await expect(note).toHaveCount(1);
   await expect(note).toHaveAttribute("contenteditable", "true");
+  await expect(note).toHaveAttribute("data-placeholder", "メモを入力");
   await expect(note).toHaveText("");
   const noteAfterSwitch = (await readCurrentModel(page)).nodes.find(
     node => node.id === added.id
@@ -4376,7 +4378,7 @@ test("model node だけに entity がある図でも note picker・往復・drag
   expect(createdNote).toMatchObject({
     kind: "note",
     noteText: "",
-    label: "新しいノード",
+    label: "",
   });
   if (!createdNote) throw new Error("note node がありません");
 
@@ -4388,9 +4390,15 @@ test("model node だけに entity がある図でも note picker・往復・drag
   );
   await expect(noteProjection).toHaveClass(/(^|\s)entity(\s|$)/);
   await expect(noteProjection).toHaveAttribute("data-kind", "note");
-  await expect(
-    noteProjection.locator(":scope > [data-ark-harness-note]")
-  ).toHaveCount(1);
+  const createdNoteBody = noteProjection.locator(
+    ":scope > [data-ark-harness-note]"
+  );
+  await expect(createdNoteBody).toHaveCount(1);
+  await expect(createdNoteBody).toHaveAttribute(
+    "data-placeholder",
+    "メモを入力"
+  );
+  await expect(createdNoteBody).toHaveText("");
   await expect(
     noteProjection.locator(":scope > h2, :scope > span, :scope > ul")
   ).toHaveCount(0);
@@ -4398,6 +4406,30 @@ test("model node だけに entity がある図でも note picker・往復・drag
   await expect(
     noteToolbar.getByRole("button", { name: "行を追加" })
   ).toBeDisabled();
+  const createdNotePicker = noteToolbar.locator(
+    "select.ark-harness-kind-select"
+  );
+  await createdNotePicker.selectOption("entity");
+  await expect(noteProjection).toHaveAttribute("data-kind", "entity");
+  await expect(createdNoteBody).toHaveCount(0);
+  const createdEntityLabel = noteProjection.locator(
+    `:scope > h2[data-model-id="${createdNote.id}"]`
+  );
+  await expect(createdEntityLabel).toHaveCount(1);
+  await expect(createdEntityLabel).toHaveText("");
+  await expect(createdEntityLabel).toHaveAttribute(
+    "data-placeholder",
+    "名前を入力"
+  );
+  expect(
+    (await readCurrentModel(page)).nodes.find(
+      node => node.id === createdNote.id
+    )
+  ).toMatchObject({
+    kind: "entity",
+    label: "",
+    noteText: "",
+  });
 });
 
 test("flat 図の authored kindless node は note を選ぶまで従来投影を維持する", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -4112,6 +4112,57 @@ test("kind 候補は CSS を先に model node のみを後に重複なしで収�
   await expect(picker.locator("option", { hasText: "comment" })).toHaveCount(0);
 });
 
+test("authored 先頭 entity を kind なしから戻すと h2 と内容を復元する", async ({
+  page,
+}) => {
+  await page.setContent(modelKindCandidateHtml());
+
+  const graph = page.locator('[data-ark-container="graph"]');
+  const authoredNodes = graph.locator(":scope > section.entity");
+  await expect(authoredNodes).toHaveCount(2);
+  await expect(authoredNodes.first()).toHaveAttribute(
+    "data-model-id",
+    "model-kind-source"
+  );
+
+  const source = authoredNodes.first();
+  const toolbar = await selectNode(page, "model-kind-source");
+  const picker = toolbar.locator("select.ark-harness-kind-select");
+  const fields = [{ id: "model-kind-source-id", label: "id" }];
+
+  await picker.selectOption("");
+  await expect(source).not.toHaveAttribute("data-kind", /.*/);
+  await expect(
+    source.locator(':scope > span[data-model-id="model-kind-source"]')
+  ).toHaveText("Source");
+  await expect(
+    source.locator(':scope > h2[data-model-id="model-kind-source"]')
+  ).toHaveCount(0);
+
+  await picker.selectOption("entity");
+  await expect(source).toHaveAttribute("data-kind", "entity");
+  await expect(
+    source.locator(':scope > span[data-model-id="model-kind-source"]')
+  ).toHaveCount(0);
+  await expect(
+    source.locator(':scope > h2[data-model-id="model-kind-source"]')
+  ).toHaveText("Source");
+  expect(
+    (await readCurrentModel(page)).nodes.find(
+      node => node.id === "model-kind-source"
+    )
+  ).toMatchObject({
+    kind: "entity",
+    label: "Source",
+    fields,
+  });
+  await expect(
+    source.locator(
+      ':scope > ul > li[data-model-id="model-kind-source-id"] .ark-harness-text'
+    )
+  ).toHaveText("id");
+});
+
 test("model node だけに kind がある図でも picker・drag 作成・kind なしを利用できる", async ({
   page,
 }) => {

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1323,7 +1323,7 @@ test("selection toolbar node action: +行と削除を既存 field・参照整合
   ).toEqual(["external"]);
 });
 
-test("selection toolbar edge action: 向き反転を2回行うと from/to だけが元に戻る", async ({
+test("selection toolbar edge action: 向き反転で from/to と cardinality を入替え2回で元に戻る", async ({
   page,
 }) => {
   await openEdgeSemanticsDiagram(page);
@@ -1337,7 +1337,11 @@ test("selection toolbar edge action: 向き反転を2回行うと from/to だけ
   expect(original).toMatchObject({
     from: "order",
     to: "user",
-    ext: { direction: "forward" },
+    ext: {
+      from_card: "one",
+      to_card: "zero-or-many",
+      direction: "forward",
+    },
   });
 
   await reverse.click();
@@ -1348,23 +1352,32 @@ test("selection toolbar edge action: 向き反転を2回行うと from/to だけ
   ).toMatchObject({
     from: "user",
     to: "order",
-    ext: { direction: "forward" },
+    ext: {
+      from_card: "zero-or-many",
+      to_card: "one",
+      direction: "forward",
+    },
   });
+  await expect(
+    toolbar.locator('select[data-ark-edge-control="from-card"]')
+  ).toHaveValue("zero-or-many");
+  await expect(
+    toolbar.locator('select[data-ark-edge-control="to-card"]')
+  ).toHaveValue("one");
+  await expect(
+    toolbar.locator('select[data-ark-edge-control="direction"]')
+  ).toHaveValue("forward");
   await expect(toolbar).toHaveAttribute(
     "data-ark-selection-id",
     "e_order_owner"
   );
 
   await reverse.click();
-  expect(
-    (await readCurrentModel(page)).edges.find(
-      edge => edge.id === "e_order_owner"
-    )
-  ).toMatchObject({
-    from: "order",
-    to: "user",
-    ext: { direction: "forward" },
-  });
+  const restored = (await readCurrentModel(page)).edges.find(
+    edge => edge.id === "e_order_owner"
+  );
+  expect(restored).toEqual(original);
+  expect(restored?.ext).toMatchObject({ direction: "forward" });
   await expect(selectedEdgeAnchor(page, "e_order_owner")).toHaveCount(1);
 });
 

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1457,11 +1457,16 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   await page.setContent(crudDiagramHtml(connectDragModel));
 
   const firstGraph = page.locator('[data-ark-container="graph"]').first();
-  const sourceBefore = structuredClone(
-    connectDragModel.nodes.find(node => node.id === "crud-b")
+  const source = firstGraph.locator(
+    '.ark-harness-graph-node[data-model-id="crud-b"]'
+  );
+  const existingPeer = firstGraph.locator(
+    '.ark-harness-graph-node[data-model-id="crud-a"]'
   );
   const initial = await readCurrentModel(page);
   const graphBox = await requiredBoundingBox(firstGraph);
+  const sourceBoxBefore = await requiredBoundingBox(source);
+  const existingPeerBoxBefore = await requiredBoundingBox(existingPeer);
   const drop = {
     x: graphBox.x + graphBox.width - 20,
     y: graphBox.y + graphBox.height - 20,
@@ -1483,15 +1488,16 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   expect(Number.isInteger((added?.ext as { y?: number })?.y)).toBe(true);
   expect(current.nodes).toHaveLength(initial.nodes.length + 1);
   expect(current.edges).toHaveLength(initial.edges.length + 1);
-  expect(current.nodes.find(node => node.id === "crud-b")).toEqual(
-    sourceBefore
+  for (const id of ["crud-a", "crud-b", "crud-d"]) {
+    const ext = current.nodes.find(node => node.id === id)?.ext as
+      | { x?: unknown; y?: unknown }
+      | undefined;
+    expect(Number.isFinite(ext?.x), `${id}.ext.x`).toBe(true);
+    expect(Number.isFinite(ext?.y), `${id}.ext.y`).toBe(true);
+  }
+  expect(current.nodes.find(node => node.id === "crud-other")?.ext).toBe(
+    undefined
   );
-  expect(
-    current.nodes.filter(node => {
-      const ext = node.ext as { x?: unknown; y?: unknown } | undefined;
-      return Number.isFinite(ext?.x) && Number.isFinite(ext?.y);
-    })
-  ).toEqual([added]);
   if (!added) throw new Error("追加 node がありません");
   const addedEdge = current.edges.find(
     edge => !connectDragModel.edges.some(old => old.id === edge.id)
@@ -1530,6 +1536,16 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   await expect(projection.locator(".ark-harness-node-delete")).toHaveCount(0);
 
   const newBox = await requiredBoundingBox(projection);
+  const sourceBoxAfter = await requiredBoundingBox(source);
+  const existingPeerBoxAfter = await requiredBoundingBox(existingPeer);
+  expect(Math.abs(sourceBoxAfter.x - sourceBoxBefore.x)).toBeLessThanOrEqual(4);
+  expect(Math.abs(sourceBoxAfter.y - sourceBoxBefore.y)).toBeLessThanOrEqual(4);
+  expect(
+    Math.abs(existingPeerBoxAfter.x - existingPeerBoxBefore.x)
+  ).toBeLessThanOrEqual(4);
+  expect(
+    Math.abs(existingPeerBoxAfter.y - existingPeerBoxBefore.y)
+  ).toBeLessThanOrEqual(4);
   expect((added.ext as { x: number }).x).toBe(
     Math.max(0, Math.round(drop.x - graphBox.x - newBox.width / 2))
   );

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1181,6 +1181,9 @@ test("selection toolbar: node・contenteditable・edge・解除を単一 root �
     0
   );
   await expect(
+    toolbar.getByRole("button", { name: "owned by の向きを反転" })
+  ).toHaveCount(1);
+  await expect(
     toolbar.getByRole("button", { name: "owned by を削除" })
   ).toHaveCount(1);
 
@@ -1320,6 +1323,51 @@ test("selection toolbar node action: +行と削除を既存 field・参照整合
   ).toEqual(["external"]);
 });
 
+test("selection toolbar edge action: 向き反転を2回行うと from/to だけが元に戻る", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  const toolbar = await selectEdge(page, "e_order_owner");
+  const reverse = toolbar.getByRole("button", {
+    name: "owned by の向きを反転",
+  });
+  const original = (await readCurrentModel(page)).edges.find(
+    edge => edge.id === "e_order_owner"
+  );
+  expect(original).toMatchObject({
+    from: "order",
+    to: "user",
+    ext: { direction: "forward" },
+  });
+
+  await reverse.click();
+  expect(
+    (await readCurrentModel(page)).edges.find(
+      edge => edge.id === "e_order_owner"
+    )
+  ).toMatchObject({
+    from: "user",
+    to: "order",
+    ext: { direction: "forward" },
+  });
+  await expect(toolbar).toHaveAttribute(
+    "data-ark-selection-id",
+    "e_order_owner"
+  );
+
+  await reverse.click();
+  expect(
+    (await readCurrentModel(page)).edges.find(
+      edge => edge.id === "e_order_owner"
+    )
+  ).toMatchObject({
+    from: "order",
+    to: "user",
+    ext: { direction: "forward" },
+  });
+  await expect(selectedEdgeAnchor(page, "e_order_owner")).toHaveCount(1);
+});
+
 test("selection toolbar edge action: rerender 後も選択を復元して対象 edge だけ削除する", async ({
   page,
 }) => {
@@ -1448,7 +1496,7 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   const addedEdge = current.edges.find(
     edge => !connectDragModel.edges.some(old => old.id === edge.id)
   );
-  expect(addedEdge).toMatchObject({ from: "crud-b", to: added.id });
+  expect(addedEdge).toMatchObject({ from: added.id, to: "crud-b" });
   expect(addedEdge?.id).toMatch(/^edge-/);
 
   const projection = firstGraph
@@ -1524,10 +1572,10 @@ test("node CRUD: 空白への接続 drag は anchor の方向に応じて新 nod
   const directionalModel = structuredClone(crudModel);
   directionalModel.edges = [];
   const scenarios = [
-    { anchor: "top", newNodeEnd: "from" },
-    { anchor: "bottom", newNodeEnd: "to" },
-    { anchor: "left", newNodeEnd: "from" },
-    { anchor: "right", newNodeEnd: "to" },
+    { anchor: "top", newNodeEnd: "to" },
+    { anchor: "bottom", newNodeEnd: "from" },
+    { anchor: "left", newNodeEnd: "to" },
+    { anchor: "right", newNodeEnd: "from" },
   ] as const;
 
   for (const scenario of scenarios) {
@@ -2148,7 +2196,7 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   expect(submission.html).not.toContain("--ark-harness-graph-x");
   expect(describeModelDiff(crudModel, submission.model)).toEqual([
     "新しいノード を追加",
-    "B から 新しいノード への関連を追加",
+    "新しいノード から B への関連を追加",
   ]);
 });
 

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1518,6 +1518,45 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   expect(errors).toEqual([]);
 });
 
+test("node CRUD: 空白への接続 drag は anchor の方向に応じて新 node を edge の始点・終点にする", async ({
+  page,
+}) => {
+  const directionalModel = structuredClone(crudModel);
+  directionalModel.edges = [];
+  const scenarios = [
+    { anchor: "top", newNodeEnd: "from" },
+    { anchor: "bottom", newNodeEnd: "to" },
+    { anchor: "left", newNodeEnd: "from" },
+    { anchor: "right", newNodeEnd: "to" },
+  ] as const;
+
+  for (const scenario of scenarios) {
+    await page.setContent(crudDiagramHtml(directionalModel));
+    const graph = page.locator('[data-ark-container="graph"]').first();
+    const graphBox = await requiredBoundingBox(graph);
+    await dragNodeAnchorToPoint(page, graph, "crud-b", scenario.anchor, {
+      x: graphBox.x + graphBox.width - 20,
+      y: graphBox.y + graphBox.height - 20,
+    });
+
+    const current = await readCurrentModel(page);
+    const addedNode = current.nodes.find(
+      node => !directionalModel.nodes.some(old => old.id === node.id)
+    );
+    expect(addedNode, scenario.anchor).toBeDefined();
+    if (!addedNode)
+      throw new Error(`${scenario.anchor}: 追加 node がありません`);
+    const addedEdge = current.edges.find(
+      edge => !directionalModel.edges.some(old => old.id === edge.id)
+    );
+    expect(addedEdge, scenario.anchor).toMatchObject(
+      scenario.newNodeEnd === "from"
+        ? { from: addedNode.id, to: "crud-b" }
+        : { from: "crud-b", to: addedNode.id }
+    );
+  }
+});
+
 test("node CRUD: note を選ぶと独立本文を投影し drag 作成にも引き継ぐ", async ({
   page,
 }) => {

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -107,7 +107,9 @@ describe("injectHarness", () => {
     expect(out).toContain("function renderEdgeToolbar(");
     expect(out).toContain("function collectKindCandidates(");
     expect(out).toContain("function updateNodeKind(");
-    expect(out).toContain("value && kindCandidates.indexOf(value) === -1");
+    expect(out).toContain(
+      'value === "note" ||\n        kindCandidates.indexOf(value) !== -1'
+    );
     expect(out).toContain("function updateEdgeExt(");
     expect(out).toContain("CARDINALITY_VALUES.indexOf(value)");
     expect(out).toContain("DIRECTION_VALUES.indexOf(direction)");
@@ -355,15 +357,16 @@ describe("injectHarness", () => {
     expect(out).toContain("function syncKindSelect(");
     expect(out).toContain("function updateNodeKind(");
     expect(out).toContain("getNode(state.model, id)");
-    expect(out).toContain("value && kindCandidates.indexOf(value) === -1");
-    expect(out).toContain("node.kind = value");
-    expect(out).toContain("else delete node.kind");
-    expect(out).toContain("function findNodeLabelEl(");
     expect(out).toContain(
-      "var labelEl = matched && id ? findNodeLabelEl(template, id) : null"
+      'value === "note" ||\n        kindCandidates.indexOf(value) !== -1'
     );
+    expect(out).toContain("node.kind = value");
+    expect(out).toContain('var note = createKindOption("note")');
+    expect(out).toContain('note.textContent = "note"');
+    expect(out).toContain("function findNodeLabelEl(");
+    expect(out).toContain("var labelEl = (matched || labelMatched) && id");
     expect(out).toContain(
-      'var tpl = projectionTemplate(graph, node.kind || "", id)'
+      "var tpl = projectionTemplateForKind(graph, root, value, id)"
     );
     expect(out).toContain('var targetTag = tpl.labelTag || "span"');
     expect(out).toContain(
@@ -372,14 +375,12 @@ describe("injectHarness", () => {
     expect(out).toContain("var next = document.createElement(targetTag)");
     expect(out).toContain("cur.parentNode.replaceChild(next, cur)");
     expect(out).toContain("wireEditableLeaf(next, null)");
-    expect(out).toContain('var none = createKindOption("")');
-    expect(out).toContain('lastKind === ""');
+    expect(out).toContain('lastKind === "note"');
     expect(out).toContain("lastKind = kind;");
     expect(out).toContain("syncNodeKinds();");
     expect(out).toContain("scheduleGraphRender(graph);");
     expect(out).toContain('el.setAttribute("data-kind", node.kind)');
     expect(out).not.toContain("aggregate");
-    expect(out).not.toContain("entity");
     expect(out).not.toContain('value === "event"');
     expect(out).not.toContain('kindCandidates = ["');
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
@@ -398,9 +399,9 @@ describe("injectHarness", () => {
     expect(
       out.match(/if \(excludeId && id === excludeId\) return;/g)
     ).toHaveLength(2);
-    expect(out).toContain("if (kind && excludeId) matched = true");
+    expect(out).toContain("if (kind && excludeId) labelMatched = true");
     expect(out).toContain(
-      'var tpl = projectionTemplate(graph, node.kind || "", id)'
+      "var template = remembered || projectionTemplate(graph, kind, id)"
     );
     expect(out).toContain(
       'var template = projectionTemplate(graph, node.kind || "")'
@@ -425,9 +426,7 @@ describe("injectHarness", () => {
     expect(out).toContain("isInsideHarnessUi(candidate)");
     expect(out).toContain('candidate.hasAttribute("data-ark-container")');
     expect(out).toContain('candidate.hasAttribute("data-ark-group")');
-    expect(out).toContain(
-      "var labelEl = matched && id ? findNodeLabelEl(template, id) : null"
-    );
+    expect(out).toContain("var labelEl = (matched || labelMatched) && id");
     expect(out).toContain("/^(H1|H2|H3|H4|H5|H6|SPAN|DIV|P|STRONG|HEADER)$/");
     expect(out).toContain("labelTag: labelTag");
     expect(out).toContain(
@@ -437,7 +436,7 @@ describe("injectHarness", () => {
     expect(out).toContain(
       "if (template.labelClassName) label.className = template.labelClassName"
     );
-    expect(out).toContain("var listEl = null;\n    if (id) {");
+    expect(out).toContain("var listEl = null;\n    if (matched && id) {");
     expect(out).toContain('template.querySelectorAll("ul, ol")');
     expect(out).toContain("findOwnerNodeId(state.model, candidate) === id");
     expect(out).toContain(
@@ -450,7 +449,37 @@ describe("injectHarness", () => {
     expect(out).toContain(
       "if (template.listClassName) list.className = template.listClassName"
     );
-    expect(out).toContain("return { root: root, label: label, list: list }");
+    expect(out).toContain(
+      "return { root: root, label: label, list: list, note: note }"
+    );
+  });
+
+  it("note を独立本文として生成・編集・再投影する契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><section data-model-id="node"></section></div>'
+      )
+    );
+
+    expect(out).toContain(
+      ".ark-harness-note { white-space: pre-wrap; min-height: 1.5em;"
+    );
+    expect(out).toContain("function createNoteProjection(node)");
+    expect(out).toContain('note.setAttribute("data-ark-harness-note", "")');
+    expect(out).toContain('note.setAttribute("contenteditable", "true")');
+    expect(out).toContain(
+      'note.textContent = typeof node.noteText === "string" ? node.noteText : ""'
+    );
+    expect(out).toContain("function wireNote(el, node)");
+    expect(out).toContain('node.noteText = text.replace(/\\r\\n?/g, "\\n")');
+    expect(out).toContain("function projectNoteContent(root, node)");
+    expect(out).toContain(
+      "function projectStructuredContent(root, node, template)"
+    );
+    expect(out).toContain("listBindingsByNode.delete(node.id)");
+    expect(out).toContain("createStructuredProjection(template, node)");
+    expect(out).toContain("registerProjectedList(node, projection.list)");
+    expect(out).toContain('if (kind === "note") node.noteText = ""');
   });
 
   it("node / edge CRUD と参照整合性の契約を注入する", () => {
@@ -531,7 +560,9 @@ describe("injectHarness", () => {
       'document.createElementNS("http://www.w3.org/2000/svg"'
     );
     expect(out).toContain('root.setAttribute("data-model-id", node.id)');
-    expect(out).toContain("label.textContent = node.label");
+    expect(out).toContain(
+      'label.textContent = typeof node.label === "string" ? node.label : ""'
+    );
     expect(out).toContain("(node.fields || []).forEach");
     expect(out).toContain("(model.edges || []).forEach");
     expect(out).toContain("(model.groups || []).forEach");

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -363,7 +363,7 @@ describe("injectHarness", () => {
       "var labelEl = matched && id ? findNodeLabelEl(template, id) : null"
     );
     expect(out).toContain(
-      'var tpl = projectionTemplate(graph, node.kind || "")'
+      'var tpl = projectionTemplate(graph, node.kind || "", id)'
     );
     expect(out).toContain('var targetTag = tpl.labelTag || "span"');
     expect(out).toContain(
@@ -383,6 +383,28 @@ describe("injectHarness", () => {
     expect(out).not.toContain('value === "event"');
     expect(out).not.toContain('kindCandidates = ["');
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
+  });
+
+  it("node kind 再投影だけ自 node を template 候補から除外する契約を注入する", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><section data-model-id="first"></section><section data-model-id="peer"></section></div>'
+      )
+    );
+
+    expect(out).toContain(
+      "function projectionTemplate(graph, kind, excludeId)"
+    );
+    expect(
+      out.match(/if \(excludeId && id === excludeId\) return;/g)
+    ).toHaveLength(2);
+    expect(out).toContain("if (kind && excludeId) matched = true");
+    expect(out).toContain(
+      'var tpl = projectionTemplate(graph, node.kind || "", id)'
+    );
+    expect(out).toContain(
+      'var template = projectionTemplate(graph, node.kind || "")'
+    );
   });
 
   it("node projection は matched label と id 所有 list の構造を複製する契約を注入する", () => {

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -484,7 +484,9 @@ describe("injectHarness", () => {
       'note.textContent = typeof node.noteText === "string" ? node.noteText : ""'
     );
     expect(out).toContain("function wireNote(el, node)");
-    expect(out).toContain('node.noteText = text.replace(/\\r\\n?/g, "\\n")');
+    expect(out).toContain("var ownerId = node.id");
+    expect(out).toContain("var current = getNode(state.model, ownerId)");
+    expect(out).toContain('current.noteText = text.replace(/\\r\\n?/g, "\\n")');
     expect(out).toContain("function projectNoteContent(root, node)");
     expect(out).toContain(
       "function projectStructuredContent(root, node, template)"

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -464,8 +464,13 @@ describe("injectHarness", () => {
     expect(out).toContain(
       ".ark-harness-note { white-space: pre-wrap; min-height: 1.5em;"
     );
+    expect(out).toContain(".ark-harness-editable:empty::before");
+    expect(out).toContain(".ark-harness-note:empty::before");
     expect(out).toContain("function createNoteProjection(node)");
     expect(out).toContain('note.setAttribute("data-ark-harness-note", "")');
+    expect(out).toContain(
+      'note.setAttribute("data-placeholder", "\\u30E1\\u30E2\\u3092\\u5165\\u529B")'
+    );
     expect(out).toContain('note.setAttribute("contenteditable", "true")');
     expect(out).toContain(
       'note.textContent = typeof node.noteText === "string" ? node.noteText : ""'
@@ -480,6 +485,11 @@ describe("injectHarness", () => {
     expect(out).toContain("createStructuredProjection(template, node)");
     expect(out).toContain("registerProjectedList(node, projection.list)");
     expect(out).toContain('if (kind === "note") node.noteText = ""');
+    expect(out).toContain(
+      'label.setAttribute("data-placeholder", "\\u540D\\u524D\\u3092\\u5165\\u529B")'
+    );
+    expect(out).toContain('label: kind === "note" ? "" : "新しいノード"');
+    expect(out).toContain('clone.querySelectorAll("[data-placeholder]")');
   });
 
   it("node / edge CRUD と参照整合性の契約を注入する", () => {

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -105,6 +105,10 @@ describe("injectHarness", () => {
 
     expect(out).toContain("function renderNodeToolbar(");
     expect(out).toContain("function renderEdgeToolbar(");
+    expect(out).toContain("ark-harness-edge-reverse");
+    expect(out).toContain("var current = getEdge(state.model, edge.id);");
+    expect(out).toContain("current.from = current.to;");
+    expect(out).toContain("current.to = previousFrom;");
     expect(out).toContain("function collectKindCandidates(");
     expect(out).toContain("function updateNodeKind(");
     expect(out).toContain(
@@ -516,6 +520,9 @@ describe("injectHarness", () => {
     expect(out).toContain("group.nodes = group.nodes.filter");
     expect(out).toContain('mode: "create"');
     expect(out).toContain('mode: "rewire"');
+    expect(out).toContain(
+      'var newNodeIsSource = anchorPosition === "bottom" || anchorPosition === "right";'
+    );
     expect(out).toContain("var EDGE_DRAG_MIN_DISTANCE = 8");
     expect(out).toContain("drag.didDrag");
     expect(out).toContain("drag.leftSource");

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -358,6 +358,20 @@ describe("injectHarness", () => {
     expect(out).toContain("value && kindCandidates.indexOf(value) === -1");
     expect(out).toContain("node.kind = value");
     expect(out).toContain("else delete node.kind");
+    expect(out).toContain("function findNodeLabelEl(");
+    expect(out).toContain(
+      "var labelEl = matched && id ? findNodeLabelEl(template, id) : null"
+    );
+    expect(out).toContain(
+      'var tpl = projectionTemplate(graph, node.kind || "")'
+    );
+    expect(out).toContain('var targetTag = tpl.labelTag || "span"');
+    expect(out).toContain(
+      "if (cur && cur.tagName.toLowerCase() !== targetTag)"
+    );
+    expect(out).toContain("var next = document.createElement(targetTag)");
+    expect(out).toContain("cur.parentNode.replaceChild(next, cur)");
+    expect(out).toContain("wireEditableLeaf(next, null)");
     expect(out).toContain('var none = createKindOption("")');
     expect(out).toContain('lastKind === ""');
     expect(out).toContain("lastKind = kind;");
@@ -383,13 +397,15 @@ describe("injectHarness", () => {
     );
     expect(out).toContain("var matched = false");
     expect(out).toContain("matched = true");
-    expect(out).toContain("var labelEl = null;\n    if (matched && id) {");
-    expect(out.match(/if \(matched && id\)/g)).toHaveLength(1);
-    expect(out).toContain('template.querySelectorAll("[data-model-id]")');
+    expect(out).toContain("function findNodeLabelEl(rootEl, id)");
+    expect(out).toContain('rootEl.querySelectorAll("[data-model-id]")');
     expect(out).toContain('candidate.getAttribute("data-model-id") !== id');
     expect(out).toContain("isInsideHarnessUi(candidate)");
     expect(out).toContain('candidate.hasAttribute("data-ark-container")');
     expect(out).toContain('candidate.hasAttribute("data-ark-group")');
+    expect(out).toContain(
+      "var labelEl = matched && id ? findNodeLabelEl(template, id) : null"
+    );
     expect(out).toContain("/^(H1|H2|H3|H4|H5|H6|SPAN|DIV|P|STRONG|HEADER)$/");
     expect(out).toContain("labelTag: labelTag");
     expect(out).toContain(

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -371,7 +371,7 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
-  it("node projection に authored label と空 list の構造を複製する契約を注入する", () => {
+  it("node projection は matched label と id 所有 list の構造を複製する契約を注入する", () => {
     const out = injectHarness(
       page(
         '<div data-ark-container="graph"><section class="entity" data-model-id="node"><h2 class="title" data-model-id="node">Node</h2><ul class="fields"><li data-model-id="field">Field</li></ul></section></div>'
@@ -383,7 +383,8 @@ describe("injectHarness", () => {
     );
     expect(out).toContain("var matched = false");
     expect(out).toContain("matched = true");
-    expect(out.match(/if \(matched && id\)/g)).toHaveLength(2);
+    expect(out).toContain("var labelEl = null;\n    if (matched && id) {");
+    expect(out.match(/if \(matched && id\)/g)).toHaveLength(1);
     expect(out).toContain('template.querySelectorAll("[data-model-id]")');
     expect(out).toContain('candidate.getAttribute("data-model-id") !== id');
     expect(out).toContain("isInsideHarnessUi(candidate)");
@@ -398,6 +399,7 @@ describe("injectHarness", () => {
     expect(out).toContain(
       "if (template.labelClassName) label.className = template.labelClassName"
     );
+    expect(out).toContain("var listEl = null;\n    if (id) {");
     expect(out).toContain('template.querySelectorAll("ul, ol")');
     expect(out).toContain("findOwnerNodeId(state.model, candidate) === id");
     expect(out).toContain(

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -107,8 +107,12 @@ describe("injectHarness", () => {
     expect(out).toContain("function renderEdgeToolbar(");
     expect(out).toContain("ark-harness-edge-reverse");
     expect(out).toContain("var current = getEdge(state.model, edge.id);");
-    expect(out).toContain("current.from = current.to;");
-    expect(out).toContain("current.to = previousFrom;");
+    expect(out).toContain("var dir = edgeDirection(current);");
+    expect(out).toContain(
+      'current.ext.direction = dir === "forward" ? "reverse" : "forward";'
+    );
+    expect(out).not.toContain("current.from = current.to;");
+    expect(out).not.toContain("previousFromCard");
     expect(out).toContain("function collectKindCandidates(");
     expect(out).toContain("function updateNodeKind(");
     expect(out).toContain(
@@ -521,8 +525,9 @@ describe("injectHarness", () => {
     expect(out).toContain('mode: "create"');
     expect(out).toContain('mode: "rewire"');
     expect(out).toContain(
-      'var newNodeIsSource = anchorPosition === "bottom" || anchorPosition === "right";'
+      "from: blankSource.id,\n              to: newNode.id"
     );
+    expect(out).not.toContain("newNodeIsSource");
     expect(out).toContain("var EDGE_DRAG_MIN_DISTANCE = 8");
     expect(out).toContain("drag.didDrag");
     expect(out).toContain("drag.leftSource");

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2328,7 +2328,7 @@ const RAW_HARNESS_JS = `(function () {
       ? labelEl.tagName.toLowerCase()
       : null;
     var listEl = null;
-    if (matched && id) {
+    if (id) {
       template.querySelectorAll("ul, ol").forEach(function (candidate) {
         if (!listEl && !isInsideHarnessUi(candidate) &&
             findOwnerNodeId(state.model, candidate) === id) {

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -112,9 +112,11 @@ const HARNESS_STYLE = `<style data-ark-harness-ui="1">
 .ark-harness-model-error { color: #f87171; font-size: 11.5px; white-space: pre-wrap; }
 .ark-harness-model-actions { display: flex; gap: .5rem; justify-content: flex-end; }
 .ark-harness-editable { outline: 1px dashed transparent; border-radius: 3px; }
+.ark-harness-editable:empty::before { content: attr(data-placeholder); color: rgba(148,163,184,.7); pointer-events: none; }
 .ark-harness-editable:hover { outline-color: rgba(56,189,248,.35); }
 .ark-harness-editable:focus { outline: 1px solid #38bdf8; outline-offset: 1px; background: rgba(56,189,248,.1); }
 .ark-harness-note { white-space: pre-wrap; min-height: 1.5em; padding: .4rem .6rem; outline: none; }
+.ark-harness-note:empty::before { content: attr(data-placeholder); color: rgba(148,163,184,.7); pointer-events: none; }
 li.ark-harness-row { display: flex; align-items: center; gap: .35rem; }
 li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-dragging { opacity: .4; }
@@ -2361,6 +2363,7 @@ const RAW_HARNESS_JS = `(function () {
     var note = document.createElement("div");
     note.className = "ark-harness-note";
     note.setAttribute("data-ark-harness-note", "");
+    note.setAttribute("data-placeholder", "\\u30E1\\u30E2\\u3092\\u5165\\u529B");
     note.setAttribute("contenteditable", "true");
     note.textContent = typeof node.noteText === "string" ? node.noteText : "";
     return note;
@@ -2371,6 +2374,7 @@ const RAW_HARNESS_JS = `(function () {
       ? document.createElement(template.labelTag)
       : document.createElement("span");
     label.setAttribute("data-model-id", node.id);
+    label.setAttribute("data-placeholder", "\\u540D\\u524D\\u3092\\u5165\\u529B");
     if (template.labelClassName) label.className = template.labelClassName;
     label.textContent = typeof node.label === "string" ? node.label : "";
     var list = null;
@@ -2485,7 +2489,7 @@ const RAW_HARNESS_JS = `(function () {
       updateStatus(!!submitPort, "一意な ID を生成できませんでした");
       return null;
     }
-    var node = { id: id, label: "新しいノード", ext: { x: 0, y: 0 } };
+    var node = { id: id, label: kind === "note" ? "" : "新しいノード", ext: { x: 0, y: 0 } };
     if (kind) node.kind = kind;
     if (kind === "note") node.noteText = "";
     var projection = createNodeProjection(graph, node);
@@ -3078,6 +3082,9 @@ const RAW_HARNESS_JS = `(function () {
     });
     clone.querySelectorAll("[contenteditable]").forEach(function (el) {
       el.removeAttribute("contenteditable");
+    });
+    clone.querySelectorAll("[data-placeholder]").forEach(function (el) {
+      el.removeAttribute("data-placeholder");
     });
     clone.querySelectorAll(".ark-harness-node-tabindex-added").forEach(function (el) {
       el.removeAttribute("tabindex");

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -696,6 +696,17 @@ const RAW_HARNESS_JS = `(function () {
     graph.container.classList.add("ark-harness-graph-layout");
   }
 
+  function freezeGraphPositions(graph) {
+    graphModelNodes(graph).forEach(function (entry) {
+      if (graphPosition(entry.node)) return;
+      var pos = graph.positionsById.get(entry.id);
+      if (!pos) return;
+      if (!isRecordObject(entry.node.ext)) entry.node.ext = {};
+      entry.node.ext.x = pos.x;
+      entry.node.ext.y = pos.y;
+    });
+  }
+
   function layoutGraph(graph) {
     var config = readLayoutConfig(state.model);
     var direction = config.direction;
@@ -1442,6 +1453,7 @@ const RAW_HARNESS_JS = `(function () {
           if (newEdgeId) {
             var anchorPosition = drag.handle.getAttribute("data-ark-anchor-position");
             var newNodeIsSource = anchorPosition === "bottom" || anchorPosition === "right";
+            freezeGraphPositions(drag.graph);
             state.model.edges.push({
               id: newEdgeId,
               from: newNodeIsSource ? newNode.id : blankSource.id,

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -114,6 +114,7 @@ const HARNESS_STYLE = `<style data-ark-harness-ui="1">
 .ark-harness-editable { outline: 1px dashed transparent; border-radius: 3px; }
 .ark-harness-editable:hover { outline-color: rgba(56,189,248,.35); }
 .ark-harness-editable:focus { outline: 1px solid #38bdf8; outline-offset: 1px; background: rgba(56,189,248,.1); }
+.ark-harness-note { white-space: pre-wrap; min-height: 1.5em; padding: .4rem .6rem; outline: none; }
 li.ark-harness-row { display: flex; align-items: center; gap: .35rem; }
 li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-dragging { opacity: .4; }
@@ -1425,8 +1426,8 @@ const RAW_HARNESS_JS = `(function () {
           x: event.clientX - graphRect.left,
           y: event.clientY - graphRect.top
         };
-        var kind = lastKind === ""
-          ? ""
+        var kind = lastKind === "note"
+          ? "note"
           : kindCandidates.indexOf(lastKind) !== -1
             ? lastKind
             : kindCandidates[0] || "";
@@ -1918,13 +1919,15 @@ const RAW_HARNESS_JS = `(function () {
 
   function syncKindSelect(select, node) {
     var current = typeof node.kind === "string" ? node.kind : "";
-    if (current && kindCandidates.indexOf(current) === -1) {
+    if (current && current !== "note" &&
+        kindCandidates.indexOf(current) === -1) {
       var currentOption = createKindOption(current);
       currentOption.textContent = current;
       currentOption.disabled = true;
       select.insertBefore(currentOption, select.children[1] || null);
     }
     select.value = current;
+    if (!current) select.selectedIndex = -1;
     var name = (typeof node.label === "string" && node.label) || node.id;
     var label = name + " \\u306E kind\\uFF08\\u73FE\\u5728 " +
       (current || "\\u306A\\u3057") + "\\uFF09";
@@ -1950,20 +1953,13 @@ const RAW_HARNESS_JS = `(function () {
     var select = document.createElement("select");
     select.className = "ark-harness-kind-select";
     markUi(select);
-    if (kindCandidates.length === 0) {
-      var none = createKindOption("");
-      none.textContent = "kind \\u306A\\u3057";
-      select.appendChild(none);
-      select.disabled = true;
-    } else {
-      var none = createKindOption("");
-      none.textContent = "kind \\u306A\\u3057";
-      select.appendChild(none);
-      kindCandidates.forEach(function (value) {
-        select.appendChild(createKindOption(value));
-      });
-      syncKindSelect(select, node);
-    }
+    var note = createKindOption("note");
+    note.textContent = "note";
+    select.appendChild(note);
+    kindCandidates.forEach(function (value) {
+      if (value !== "note") select.appendChild(createKindOption(value));
+    });
+    syncKindSelect(select, node);
     select.addEventListener("change", function (event) {
       event.stopPropagation();
       if (selection.kind === "node" && selection.id === node.id &&
@@ -2305,38 +2301,20 @@ const RAW_HARNESS_JS = `(function () {
     return labelEl;
   }
 
-  function projectionTemplate(graph, kind, excludeId) {
-    var template = null;
-    var matched = false;
-    graph.nodesById.forEach(function (root, id) {
-      if (excludeId && id === excludeId) return;
-      if (template) return;
-      var node = getNode(state.model, id);
-      if (kind && node && node.kind === kind) {
-        template = root;
-        matched = true;
-      }
-    });
-    if (!template) {
-      graph.nodesById.forEach(function (root, id) {
-        if (excludeId && id === excludeId) return;
-        if (!template) {
-          template = root;
-          if (kind && excludeId) matched = true;
-        }
-      });
-    }
+  function projectionTemplateForRoot(template, matched, labelMatched) {
     var tag = template && /^(ARTICLE|SECTION|DIV)$/.test(template.tagName)
       ? template.tagName.toLowerCase()
       : "article";
     var id = template && template.getAttribute("data-model-id");
-    var labelEl = matched && id ? findNodeLabelEl(template, id) : null;
+    var labelEl = (matched || labelMatched) && id
+      ? findNodeLabelEl(template, id)
+      : null;
     var labelTag = labelEl &&
       /^(H1|H2|H3|H4|H5|H6|SPAN|DIV|P|STRONG|HEADER)$/.test(labelEl.tagName)
       ? labelEl.tagName.toLowerCase()
       : null;
     var listEl = null;
-    if (id) {
+    if (matched && id) {
       template.querySelectorAll("ul, ol").forEach(function (candidate) {
         if (!listEl && !isInsideHarnessUi(candidate) &&
             findOwnerNodeId(state.model, candidate) === id) {
@@ -2354,6 +2332,61 @@ const RAW_HARNESS_JS = `(function () {
     };
   }
 
+  function projectionTemplate(graph, kind, excludeId) {
+    var template = null;
+    var matched = false;
+    var labelMatched = false;
+    graph.nodesById.forEach(function (root, id) {
+      if (excludeId && id === excludeId) return;
+      if (template) return;
+      var node = getNode(state.model, id);
+      if (kind && node && node.kind === kind) {
+        template = root;
+        matched = true;
+      }
+    });
+    if (!template) {
+      graph.nodesById.forEach(function (root, id) {
+        if (excludeId && id === excludeId) return;
+        if (!template) {
+          template = root;
+          if (kind && excludeId) labelMatched = true;
+        }
+      });
+    }
+    return projectionTemplateForRoot(template, matched, labelMatched);
+  }
+
+  function createNoteProjection(node) {
+    var note = document.createElement("div");
+    note.className = "ark-harness-note";
+    note.setAttribute("data-ark-harness-note", "");
+    note.setAttribute("contenteditable", "true");
+    note.textContent = typeof node.noteText === "string" ? node.noteText : "";
+    return note;
+  }
+
+  function createStructuredProjection(template, node) {
+    var label = template.labelTag
+      ? document.createElement(template.labelTag)
+      : document.createElement("span");
+    label.setAttribute("data-model-id", node.id);
+    if (template.labelClassName) label.className = template.labelClassName;
+    label.textContent = typeof node.label === "string" ? node.label : "";
+    var list = null;
+    if (template.listTag) {
+      list = document.createElement(template.listTag);
+      if (template.listClassName) list.className = template.listClassName;
+      (node.fields || []).forEach(function (field) {
+        var li = document.createElement("li");
+        li.setAttribute("data-model-id", field.id);
+        li.textContent = field.label;
+        list.appendChild(li);
+      });
+    }
+    return { label: label, list: list };
+  }
+
   function createNodeProjection(graph, node) {
     var template = projectionTemplate(graph, node.kind || "");
     var root = template.tag === "section"
@@ -2361,23 +2394,27 @@ const RAW_HARNESS_JS = `(function () {
       : template.tag === "div"
         ? document.createElement("div")
         : document.createElement("article");
-    var label = template.labelTag
-      ? document.createElement(template.labelTag)
-      : document.createElement("span");
     root.setAttribute("data-model-id", node.id);
-    label.setAttribute("data-model-id", node.id);
     if (node.kind) root.setAttribute("data-kind", node.kind);
     if (template.className) root.className = template.className;
-    if (template.labelClassName) label.className = template.labelClassName;
-    label.textContent = node.label;
-    root.appendChild(label);
+    var label = null;
     var list = null;
-    if (template.listTag) {
-      list = document.createElement(template.listTag);
-      if (template.listClassName) list.className = template.listClassName;
-      root.appendChild(list);
+    var note = null;
+    if (node.kind === "note") {
+      note = createNoteProjection(node);
+      root.appendChild(note);
+    } else {
+      if (node.kind === "entity") {
+        if (!template.labelTag) template.labelTag = "h2";
+        if (!template.listTag) template.listTag = "ul";
+      }
+      var structured = createStructuredProjection(template, node);
+      label = structured.label;
+      list = structured.list;
+      root.appendChild(label);
+      if (list) root.appendChild(list);
     }
-    return { root: root, label: label, list: list };
+    return { root: root, label: label, list: list, note: note };
   }
 
   function nodePlacementBlockers(graph, excluded) {
@@ -2441,7 +2478,8 @@ const RAW_HARNESS_JS = `(function () {
       updateStatus(!!submitPort, "配置先 graph を解決できませんでした");
       return null;
     }
-    if (kind && kindCandidates.indexOf(kind) === -1) return null;
+    if (kind !== "note" && kind &&
+        kindCandidates.indexOf(kind) === -1) return null;
     var id = generateUniqueModelId("node");
     if (!id) {
       updateStatus(!!submitPort, "一意な ID を生成できませんでした");
@@ -2449,6 +2487,7 @@ const RAW_HARNESS_JS = `(function () {
     }
     var node = { id: id, label: "新しいノード", ext: { x: 0, y: 0 } };
     if (kind) node.kind = kind;
+    if (kind === "note") node.noteText = "";
     var projection = createNodeProjection(graph, node);
     graph.container.appendChild(projection.root);
     projection.root.classList.add("ark-harness-graph-node");
@@ -2468,12 +2507,19 @@ const RAW_HARNESS_JS = `(function () {
       if (!registerGraphNode(graph, projection.root, node)) {
         throw new Error("node registration failed");
       }
-      wireEditableLeaf(projection.label, null);
+      if (projection.label) wireEditableLeaf(projection.label, null);
+      if (projection.note) wireNote(projection.note, node);
       if (projection.list) {
         var owned = listBindingsByNode.get(node.id) || [];
         owned.push({ listEl: projection.list, ownerNodeId: node.id });
         listBindingsByNode.set(node.id, owned);
         wireList(projection.list, node.id);
+        projection.list.querySelectorAll(":scope > li").forEach(function (li) {
+          wireEditableLeaf(li, {
+            listEl: projection.list,
+            ownerNodeId: node.id
+          });
+        });
       }
       lastKind = kind;
       graphs.forEach(function (entry) { scheduleGraphRender(entry); });
@@ -2680,27 +2726,103 @@ const RAW_HARNESS_JS = `(function () {
     return option;
   }
 
+  function rememberProjectionTemplate(root, kind) {
+    if (!kind || kind === "note") return;
+    if (!root.__arkHarnessProjectionTemplates) {
+      root.__arkHarnessProjectionTemplates = new Map();
+    }
+    root.__arkHarnessProjectionTemplates.set(
+      kind,
+      projectionTemplateForRoot(root, true, true)
+    );
+  }
+
+  function projectionTemplateForKind(graph, root, kind, id) {
+    var remembered = root.__arkHarnessProjectionTemplates &&
+      root.__arkHarnessProjectionTemplates.get(kind);
+    var template = remembered || projectionTemplate(graph, kind, id);
+    if (kind === "entity") {
+      if (!template.labelTag) template.labelTag = "h2";
+      if (!template.listTag) template.listTag = "ul";
+    }
+    return template;
+  }
+
+  function clearNodeProjection(root) {
+    Array.from(root.childNodes).forEach(function (child) {
+      if (child.nodeType === 1 && isInsideHarnessUi(child)) return;
+      root.removeChild(child);
+    });
+  }
+
+  function registerProjectedList(node, list) {
+    var binding = { listEl: list, ownerNodeId: node.id };
+    listBindingsByNode.set(node.id, [binding]);
+    wireList(list, node.id);
+    list.querySelectorAll(":scope > li").forEach(function (li) {
+      wireEditableLeaf(li, {
+        listEl: list,
+        ownerNodeId: node.id
+      });
+    });
+  }
+
+  function projectNoteContent(root, node) {
+    listBindingsByNode.delete(node.id);
+    clearNodeProjection(root);
+    var note = createNoteProjection(node);
+    root.insertBefore(note, root.firstChild);
+    wireNote(note, node);
+  }
+
+  function projectStructuredContent(root, node, template) {
+    listBindingsByNode.delete(node.id);
+    clearNodeProjection(root);
+    var projection = createStructuredProjection(template, node);
+    root.insertBefore(projection.label, root.firstChild);
+    wireEditableLeaf(projection.label, null);
+    if (projection.list) {
+      root.insertBefore(projection.list, projection.label.nextSibling);
+      registerProjectedList(node, projection.list);
+    }
+  }
+
   function updateNodeKind(graph, root, value) {
     var id = root.getAttribute("data-model-id");
-    if (!id || value && kindCandidates.indexOf(value) === -1) return;
+    if (!id || !(value === "note" ||
+        kindCandidates.indexOf(value) !== -1)) return;
     var node = getNode(state.model, id);
     if (!node) return;
-    if (value) node.kind = value;
-    else delete node.kind;
+    var previousKind = typeof node.kind === "string" ? node.kind : "";
+    if (previousKind === value) {
+      lastKind = value;
+      return;
+    }
+    rememberProjectionTemplate(root, previousKind);
+    node.kind = value;
     lastKind = value;
-    var tpl = projectionTemplate(graph, node.kind || "", id);
-    var targetTag = tpl.labelTag || "span";
-    var targetClass = tpl.labelClassName || "";
-    var cur = findNodeLabelEl(root, id);
-    if (cur && cur.tagName.toLowerCase() !== targetTag) {
-      var next = document.createElement(targetTag);
-      if (targetClass) next.className = targetClass;
-      next.setAttribute("data-model-id", id);
-      next.textContent = typeof node.label === "string"
-        ? node.label
-        : (cur.textContent || "");
-      cur.parentNode.replaceChild(next, cur);
-      wireEditableLeaf(next, null);
+    if (value === "note") {
+      if (typeof node.noteText !== "string") node.noteText = "";
+      projectNoteContent(root, node);
+    } else {
+      var tpl = projectionTemplateForKind(graph, root, value, id);
+      if (tpl.listTag || previousKind === "note") {
+        projectStructuredContent(root, node, tpl);
+      } else {
+        var targetTag = tpl.labelTag || "span";
+        var targetClass = tpl.labelClassName || "";
+        var cur = findNodeLabelEl(root, id);
+        if (cur && cur.tagName.toLowerCase() !== targetTag) {
+          var next = document.createElement(targetTag);
+          if (targetClass) next.className = targetClass;
+          next.setAttribute("data-model-id", id);
+          next.textContent = typeof node.label === "string"
+            ? node.label
+            : (cur.textContent || "");
+          cur.parentNode.replaceChild(next, cur);
+          wireEditableLeaf(next, null);
+        }
+      }
     }
     syncNodeKinds();
     renderContextToolbar();
@@ -2791,6 +2913,17 @@ const RAW_HARNESS_JS = `(function () {
     if (rowInfo) {
       attachRowControls(el, rowInfo.listEl, rowInfo.ownerNodeId);
     }
+  }
+
+  function wireNote(el, node) {
+    if (el.__arkHarnessNoteWired) return;
+    el.__arkHarnessNoteWired = true;
+    el.addEventListener("input", function () {
+      var text = typeof el.innerText === "string"
+        ? el.innerText
+        : (el.textContent || "");
+      node.noteText = text.replace(/\\r\\n?/g, "\\n");
+    });
   }
 
   function syncFieldOrder(listEl, ownerNodeId) {
@@ -2898,6 +3031,15 @@ const RAW_HARNESS_JS = `(function () {
         }
       }
       wireEditableLeaf(el, rowInfo);
+    });
+  }
+
+  function initNoteProjections() {
+    graphs.forEach(function (graph) {
+      graph.nodesById.forEach(function (root, id) {
+        var node = getNode(state.model, id);
+        if (node && node.kind === "note") projectNoteContent(root, node);
+      });
     });
   }
 
@@ -3107,6 +3249,7 @@ const RAW_HARNESS_JS = `(function () {
       initEditing();
       buildContextToolbar();
       initGraphs();
+      initNoteProjections();
     } catch (e) {
       console.error("[ark-harness] 初期化に失敗しました", e);
     }

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2288,6 +2288,23 @@ const RAW_HARNESS_JS = `(function () {
     return kept.join(" ");
   }
 
+  function findNodeLabelEl(rootEl, id) {
+    var labelEl = null;
+    rootEl.querySelectorAll("[data-model-id]").forEach(function (candidate) {
+      if (labelEl || candidate === rootEl ||
+          candidate.getAttribute("data-model-id") !== id ||
+          isInsideHarnessUi(candidate) ||
+          candidate.hasAttribute("data-ark-container") ||
+          candidate.hasAttribute("data-ark-group")) return;
+      var nested = candidate.querySelectorAll("[data-model-id]");
+      for (var i = 0; i < nested.length; i++) {
+        if (nested[i].getAttribute("data-model-id") === id) return;
+      }
+      labelEl = candidate;
+    });
+    return labelEl;
+  }
+
   function projectionTemplate(graph, kind) {
     var template = null;
     var matched = false;
@@ -2308,21 +2325,7 @@ const RAW_HARNESS_JS = `(function () {
       ? template.tagName.toLowerCase()
       : "article";
     var id = template && template.getAttribute("data-model-id");
-    var labelEl = null;
-    if (matched && id) {
-      template.querySelectorAll("[data-model-id]").forEach(function (candidate) {
-        if (labelEl || candidate === template ||
-            candidate.getAttribute("data-model-id") !== id ||
-            isInsideHarnessUi(candidate) ||
-            candidate.hasAttribute("data-ark-container") ||
-            candidate.hasAttribute("data-ark-group")) return;
-        var nested = candidate.querySelectorAll("[data-model-id]");
-        for (var i = 0; i < nested.length; i++) {
-          if (nested[i].getAttribute("data-model-id") === id) return;
-        }
-        labelEl = candidate;
-      });
-    }
+    var labelEl = matched && id ? findNodeLabelEl(template, id) : null;
     var labelTag = labelEl &&
       /^(H1|H2|H3|H4|H5|H6|SPAN|DIV|P|STRONG|HEADER)$/.test(labelEl.tagName)
       ? labelEl.tagName.toLowerCase()
@@ -2680,6 +2683,20 @@ const RAW_HARNESS_JS = `(function () {
     if (value) node.kind = value;
     else delete node.kind;
     lastKind = value;
+    var tpl = projectionTemplate(graph, node.kind || "");
+    var targetTag = tpl.labelTag || "span";
+    var targetClass = tpl.labelClassName || "";
+    var cur = findNodeLabelEl(root, id);
+    if (cur && cur.tagName.toLowerCase() !== targetTag) {
+      var next = document.createElement(targetTag);
+      if (targetClass) next.className = targetClass;
+      next.setAttribute("data-model-id", id);
+      next.textContent = typeof node.label === "string"
+        ? node.label
+        : (cur.textContent || "");
+      cur.parentNode.replaceChild(next, cur);
+      wireEditableLeaf(next, null);
+    }
     syncNodeKinds();
     renderContextToolbar();
     scheduleGraphRender(graph);

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -1441,7 +1441,7 @@ const RAW_HARNESS_JS = `(function () {
           var newEdgeId = generateUniqueModelId("edge");
           if (newEdgeId) {
             var anchorPosition = drag.handle.getAttribute("data-ark-anchor-position");
-            var newNodeIsSource = anchorPosition === "top" || anchorPosition === "left";
+            var newNodeIsSource = anchorPosition === "bottom" || anchorPosition === "right";
             state.model.edges.push({
               id: newEdgeId,
               from: newNodeIsSource ? newNode.id : blankSource.id,
@@ -2009,6 +2009,22 @@ const RAW_HARNESS_JS = `(function () {
       contextToolbar.appendChild(select);
     });
     var name = (typeof edge.label === "string" && edge.label) || edge.id;
+    var reverse = createButton(
+      "\\u5411\\u304D\\u53CD\\u8EE2",
+      "ark-harness-edge-reverse",
+      name + " \\u306E\\u5411\\u304D\\u3092\\u53CD\\u8EE2"
+    );
+    reverse.addEventListener("click", function () {
+      if (selection.kind !== "edge" || selection.id !== edge.id) return;
+      var current = getEdge(state.model, edge.id);
+      if (!current || current.from === current.to) return;
+      var previousFrom = current.from;
+      current.from = current.to;
+      current.to = previousFrom;
+      graphs.forEach(function (entry) { scheduleGraphRender(entry); });
+      renderContextToolbar();
+    });
+    contextToolbar.appendChild(reverse);
     var del = createButton(
       "\\u524A\\u9664",
       "ark-harness-edge-delete",

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2033,6 +2033,14 @@ const RAW_HARNESS_JS = `(function () {
       var previousFrom = current.from;
       current.from = current.to;
       current.to = previousFrom;
+      if (isRecordObject(current.ext)) {
+        var previousFromCard = current.ext.from_card;
+        var previousToCard = current.ext.to_card;
+        if (previousToCard === undefined) delete current.ext.from_card;
+        else current.ext.from_card = previousToCard;
+        if (previousFromCard === undefined) delete current.ext.to_card;
+        else current.ext.to_card = previousFromCard;
+      }
       graphs.forEach(function (entry) { scheduleGraphRender(entry); });
       renderContextToolbar();
     });

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2024,6 +2024,8 @@ const RAW_HARNESS_JS = `(function () {
       "ark-harness-edge-reverse",
       name + " \\u306E\\u5411\\u304D\\u3092\\u53CD\\u8EE2"
     );
+    var reversible = edgeDirection(edge);
+    reverse.disabled = reversible !== "forward" && reversible !== "reverse";
     reverse.addEventListener("click", function () {
       if (selection.kind !== "edge" || selection.id !== edge.id) return;
       var current = getEdge(state.model, edge.id);
@@ -2949,13 +2951,16 @@ const RAW_HARNESS_JS = `(function () {
   }
 
   function wireNote(el, node) {
+    var ownerId = node.id;
     if (el.__arkHarnessNoteWired) return;
     el.__arkHarnessNoteWired = true;
     el.addEventListener("input", function () {
       var text = typeof el.innerText === "string"
         ? el.innerText
         : (el.textContent || "");
-      node.noteText = text.replace(/\\r\\n?/g, "\\n");
+      var current = getNode(state.model, ownerId);
+      if (!current) return;
+      current.noteText = text.replace(/\\r\\n?/g, "\\n");
     });
   }
 
@@ -3192,6 +3197,7 @@ const RAW_HARNESS_JS = `(function () {
         syncNodeKinds();
         syncLayoutDirectionButton();
         reconcileSelection();
+        initNoteProjections();
         graphs.forEach(function (graph) { scheduleGraphRender(graph); });
         error.style.display = "none";
         panel.style.display = "none";

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2305,10 +2305,11 @@ const RAW_HARNESS_JS = `(function () {
     return labelEl;
   }
 
-  function projectionTemplate(graph, kind) {
+  function projectionTemplate(graph, kind, excludeId) {
     var template = null;
     var matched = false;
     graph.nodesById.forEach(function (root, id) {
+      if (excludeId && id === excludeId) return;
       if (template) return;
       var node = getNode(state.model, id);
       if (kind && node && node.kind === kind) {
@@ -2317,8 +2318,12 @@ const RAW_HARNESS_JS = `(function () {
       }
     });
     if (!template) {
-      graph.nodesById.forEach(function (root) {
-        if (!template) template = root;
+      graph.nodesById.forEach(function (root, id) {
+        if (excludeId && id === excludeId) return;
+        if (!template) {
+          template = root;
+          if (kind && excludeId) matched = true;
+        }
       });
     }
     var tag = template && /^(ARTICLE|SECTION|DIV)$/.test(template.tagName)
@@ -2683,7 +2688,7 @@ const RAW_HARNESS_JS = `(function () {
     if (value) node.kind = value;
     else delete node.kind;
     lastKind = value;
-    var tpl = projectionTemplate(graph, node.kind || "");
+    var tpl = projectionTemplate(graph, node.kind || "", id);
     var targetTag = tpl.labelTag || "span";
     var targetClass = tpl.labelClassName || "";
     var cur = findNodeLabelEl(root, id);

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -1440,10 +1440,12 @@ const RAW_HARNESS_JS = `(function () {
         } else {
           var newEdgeId = generateUniqueModelId("edge");
           if (newEdgeId) {
+            var anchorPosition = drag.handle.getAttribute("data-ark-anchor-position");
+            var newNodeIsSource = anchorPosition === "top" || anchorPosition === "left";
             state.model.edges.push({
               id: newEdgeId,
-              from: blankSource.id,
-              to: newNode.id
+              from: newNodeIsSource ? newNode.id : blankSource.id,
+              to: newNodeIsSource ? blankSource.id : newNode.id
             });
           } else {
             removeNode(newNode.id);

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -1451,13 +1451,11 @@ const RAW_HARNESS_JS = `(function () {
         } else {
           var newEdgeId = generateUniqueModelId("edge");
           if (newEdgeId) {
-            var anchorPosition = drag.handle.getAttribute("data-ark-anchor-position");
-            var newNodeIsSource = anchorPosition === "bottom" || anchorPosition === "right";
             freezeGraphPositions(drag.graph);
             state.model.edges.push({
               id: newEdgeId,
-              from: newNodeIsSource ? newNode.id : blankSource.id,
-              to: newNodeIsSource ? blankSource.id : newNode.id
+              from: blankSource.id,
+              to: newNode.id
             });
           } else {
             removeNode(newNode.id);
@@ -2029,18 +2027,11 @@ const RAW_HARNESS_JS = `(function () {
     reverse.addEventListener("click", function () {
       if (selection.kind !== "edge" || selection.id !== edge.id) return;
       var current = getEdge(state.model, edge.id);
-      if (!current || current.from === current.to) return;
-      var previousFrom = current.from;
-      current.from = current.to;
-      current.to = previousFrom;
-      if (isRecordObject(current.ext)) {
-        var previousFromCard = current.ext.from_card;
-        var previousToCard = current.ext.to_card;
-        if (previousToCard === undefined) delete current.ext.from_card;
-        else current.ext.from_card = previousToCard;
-        if (previousFromCard === undefined) delete current.ext.to_card;
-        else current.ext.to_card = previousFromCard;
-      }
+      if (!current) return;
+      var dir = edgeDirection(current);
+      if (dir !== "forward" && dir !== "reverse") return;
+      if (!isRecordObject(current.ext)) current.ext = {};
+      current.ext.direction = dir === "forward" ? "reverse" : "forward";
       graphs.forEach(function (entry) { scheduleGraphRender(entry); });
       renderContextToolbar();
     });

--- a/packages/server/src/lib/diagram-model.test.ts
+++ b/packages/server/src/lib/diagram-model.test.ts
@@ -52,6 +52,33 @@ describe("parseDiagramModel", () => {
     }
   });
 
+  it("noteText を label・fields と独立して保持する", () => {
+    const result = parseDiagramModel(
+      JSON.stringify({
+        version: 1,
+        nodes: [
+          {
+            id: "memo",
+            label: "Memo",
+            kind: "note",
+            noteText: "1行目\n2行目",
+            fields: [{ id: "memo-id", label: "id" }],
+          },
+        ],
+      })
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.nodes[0]).toMatchObject({
+        label: "Memo",
+        kind: "note",
+        noteText: "1行目\n2行目",
+        fields: [{ id: "memo-id", label: "id" }],
+      });
+    }
+  });
+
   it("図全体の layout 設定と未知の情報を top-level ext に保持する", () => {
     const ext = {
       layout: {

--- a/packages/server/src/lib/diagram-model.ts
+++ b/packages/server/src/lib/diagram-model.ts
@@ -17,6 +17,8 @@ export interface DiagramNode {
   label: string;
   /** entity / step / state など。サーバーは解釈せず、投影側と skill の取り決め */
   kind?: string;
+  /** kind=note の自由記述本文。label / fields とは独立して保持する */
+  noteText?: string;
   fields?: DiagramField[];
   ext?: Record<string, unknown>;
 }
@@ -113,6 +115,7 @@ export function parseDiagramModel(json: string): ParseResult {
       id: n.id,
       label: n.label,
       kind: typeof n.kind === "string" ? n.kind : undefined,
+      noteText: typeof n.noteText === "string" ? n.noteText : undefined,
       fields: fields.length > 0 ? fields : undefined,
       ext: asExt(n.ext),
     });


### PR DESCRIPTION
## 概要

#268 (接続ドラッグで新ノード生成) のフォローアップ。実機フィードバックに基づき、note ノードの独立化と接続ドラッグ/向き編集の挙動を安定化する。

## 変更点

### note を独立した組み込み kind に
- kind picker の「kindなし」を「note」に置き換え。note は名前なし・自由記述の複数行メモ（`node.noteText`）
- entity の `fields` と note の `noteText` を独立保持し、kind 切替で相互にデータが消えない（切替時は kind に応じて DOM を再投影）
- kind 再投影の自己参照バグ修正（切替対象自身をテンプレート採取から除外）
- note 作成時は名前空 + placeholder（名前「名前を入力」/ 本文「メモを入力」）。placeholder は保存 HTML から除去

### 接続ドラッグの安定化
- アンカーから空白へのドラッグで作る新規 edge は**常に「元ノード → 新ノード」**（矢印が作成したノードに向く）
- 生成時に既存ノードの現在位置を `ext.x/y` に固定し、**既存ノードが再レイアウトで動かない**（新ノードだけがドロップ位置に現れる）

### エッジ「向き反転」ボタン
- エッジ選択ツールバーに「向き反転」を追加。`ext.direction` を forward ⇔ reverse でトグルし、direction ドロップダウンと完全連動（from/to・カーディナリティ・ノード位置は不変、2回押すと元に戻る）

### その他
- origin/main を取り込み（@anthropic-ai/claude-code 2.1.221）

## 検証

- Playwright E2E: 68 件 PASS / 全 unit: 685 件 PASS / `pnpm check` / `pnpm build`
- 注入後ハーネスサイズ: 126,411 bytes（< 128 KiB 上限）
- production の diagram-diff.ts / describeModelDiff は不変（noteText は describeModelDiff 未知プロパティ = 非還流）
- ライブプレビューでの実機検証: note 切替/独立保持 12 項目、全アンカーの edge 向き + 矢印描画、向き反転のドロップダウン連動・冪等、既存ノード不動（Δ=0）を headless ブラウザで確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ノードに「メモ」種別を追加し、本文を入力・保存できるようになりました。
  - メモの本文、ラベル、フィールド、配置情報を保持したまま編集・再表示できます。
  - エッジの向きを選択中のツールバーから反転できるようになりました。
  - ノード作成時の種別候補や初期値を改善し、既存の種別も維持します。

- **改善**
  - ノードやエッジの追加・変換時に、既存の配置や関連情報が保持されやすくなりました。
  - メモ選択時の操作項目を整理し、不要な編集操作を無効化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->