### PR TITLE
図解編集 Phase C: クロム掃除（非編集時は完全無地キャンバス）

### DIFF
--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -2319,6 +2319,25 @@ test("ark-debug hash で下部 debug UI を動的に切り替える", async ({ p
   await expect(directionButton).toBeHidden();
 });
 
+test("ark-debug の部分文字列を含む hash では下部 debug UI を表示しない", async ({
+  page,
+}) => {
+  await page.setContent(diagramHtml());
+  const toolbar = page.locator(".ark-harness-toolbar");
+  const editButton = page.getByRole("button", {
+    name: "モデル JSON を直接編集する",
+    includeHidden: true,
+  });
+  const directionButton = page.locator(".ark-harness-layout-direction");
+
+  await page.evaluate(() => {
+    location.hash = "ark-debugging";
+  });
+  await expect(toolbar).toBeHidden();
+  await expect(editButton).toBeHidden();
+  await expect(directionButton).toBeHidden();
+});
+
 test("ノードのラベル編集時だけ送信 UI を表示する", async ({ page }) => {
   await page.setContent(diagramHtml());
   const toolbar = page.locator(".ark-harness-toolbar");

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -741,8 +741,32 @@ async function connectSubmissionPort(page: Page) {
     window.postMessage({ type: "ark:test-connect" }, "*", [channel.port2]);
   });
   await expect(
-    page.getByRole("button", { name: "変更を親フレームへ送信する" })
+    page.getByRole("button", {
+      name: "変更を親フレームへ送信する",
+      includeHidden: true,
+    })
   ).toBeEnabled();
+}
+
+async function enableDiagramDebug(page: Page) {
+  await page.evaluate(() => {
+    location.hash = "ark-debug";
+  });
+  await expect(
+    page.getByRole("button", { name: "モデル JSON を直接編集する" })
+  ).toBeVisible();
+}
+
+async function openModelPanel(page: Page, programmatic = false) {
+  await enableDiagramDebug(page);
+  const button = page.getByRole("button", {
+    name: "モデル JSON を直接編集する",
+  });
+  if (programmatic) {
+    await button.evaluate(element => (element as HTMLButtonElement).click());
+  } else {
+    await button.click();
+  }
 }
 
 const crudModel: DiagramModel = {
@@ -808,9 +832,7 @@ function crudDiagramHtml(
 }
 
 async function readCurrentModel(page: Page): Promise<DiagramModel> {
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   const value = await page.locator(".ark-harness-textarea").inputValue();
   await page.getByRole("button", { name: "閉じる", exact: true }).click();
   return JSON.parse(value) as DiagramModel;
@@ -1442,9 +1464,7 @@ test("selection toolbar stale・submission: model 直接削除で解除し選択
     ...group,
     nodes: group.nodes.filter(id => id !== "order"),
   }));
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   await page.locator(".ark-harness-textarea").fill(JSON.stringify(nextModel));
   await page.getByRole("button", { name: "反映", exact: true }).click();
   await expect(toolbar).toBeHidden();
@@ -2242,6 +2262,84 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   ]);
 });
 
+test("下部ツールバーは既定で方向トグルだけを表示する", async ({ page }) => {
+  await page.setContent(diagramHtml());
+
+  await expect(page.locator(".ark-harness-layout-direction")).toBeVisible();
+  await expect(
+    page.getByRole("button", {
+      name: "モデル JSON を直接編集する",
+      includeHidden: true,
+    })
+  ).toBeHidden();
+  await expect(
+    page.getByRole("button", {
+      name: "変更を親フレームへ送信する",
+      includeHidden: true,
+    })
+  ).toBeHidden();
+  await expect(page.locator(".ark-harness-status")).toBeHidden();
+});
+
+test("ark-debug hash でモデル直接編集ボタンを動的に切り替える", async ({
+  page,
+}) => {
+  await page.setContent(diagramHtml());
+  const editButton = page.getByRole("button", {
+    name: "モデル JSON を直接編集する",
+    includeHidden: true,
+  });
+
+  await expect(editButton).toBeHidden();
+  await page.evaluate(() => {
+    location.hash = "ark-debug";
+  });
+  await expect(editButton).toBeVisible();
+  await page.evaluate(() => {
+    location.hash = "";
+  });
+  await expect(editButton).toBeHidden();
+});
+
+test("ノードのラベル編集時だけ送信 UI を表示する", async ({ page }) => {
+  await page.setContent(diagramHtml());
+
+  await page
+    .locator('[data-ark-container="graph"] h2[data-model-id="order"]')
+    .fill("Edited Order");
+  await expect(
+    page.getByRole("button", { name: "変更を親フレームへ送信する" })
+  ).toBeVisible();
+  await expect(page.locator(".ark-harness-status")).toBeVisible();
+  await expect(page.locator(".ark-harness-status")).toHaveText(
+    "親フレーム未接続"
+  );
+});
+
+test("送信成功後に送信 UI を再び隠す", async ({ page }) => {
+  await page.setContent(diagramHtml());
+  await connectSubmissionPort(page);
+  const sendButton = page.getByRole("button", {
+    name: "変更を親フレームへ送信する",
+  });
+  const status = page.locator(".ark-harness-status");
+
+  await page
+    .locator('[data-ark-container="graph"] h2[data-model-id="order"]')
+    .fill("Edited Order");
+  await expect(sendButton).toBeVisible();
+  await expect(status).toBeVisible();
+  await sendButton.click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  await expect(sendButton).toBeHidden();
+  await expect(status).toBeHidden();
+});
+
 test("レイアウト方向を LR から TB へ切り替えて再配置・保存する", async ({
   page,
 }) => {
@@ -2262,6 +2360,7 @@ test("レイアウト方向を LR から TB へ切り替えて再配置・保存
   });
   const editModelButton = page.getByRole("button", {
     name: "モデル JSON を直接編集する",
+    includeHidden: true,
   });
   await expect(directionButton).toHaveText("方向: LR");
   await expect(directionButton).toHaveAttribute(
@@ -2405,9 +2504,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
         name: "方向: LR（現在 LR。TB に切り替える）",
       })
       .click();
-    await page
-      .getByRole("button", { name: "モデル JSON を直接編集する" })
-      .click();
+    await openModelPanel(page);
     const currentModel = JSON.parse(
       await page.locator(".ark-harness-textarea").inputValue()
     ) as DiagramModel;
@@ -2434,9 +2531,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
       direction: "LR",
     },
   };
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   await page.locator(".ark-harness-textarea").fill(JSON.stringify(tbModel));
   await page.getByRole("button", { name: "反映", exact: true }).click();
   await expect(
@@ -2463,10 +2558,11 @@ test("レイアウト方向 UI は graph がない文書には表示しない", 
 
   await expect(
     page.getByRole("button", { name: "モデル JSON を直接編集する" })
-  ).toBeVisible();
+  ).toBeHidden();
   await expect(
     page.getByRole("button", { name: "変更を親フレームへ送信する" })
-  ).toBeVisible();
+  ).toBeHidden();
+  await expect(page.locator(".ark-harness-status")).toBeHidden();
   await expect(page.locator(".ark-harness-layout-direction")).toHaveCount(0);
 });
 
@@ -2585,8 +2681,9 @@ test("表示時は座標を非永続化し、ドラッグした node だけ手�
   await connectSubmissionPort(page);
   const submit = page.getByRole("button", {
     name: "変更を親フレームへ送信する",
+    includeHidden: true,
   });
-  await submit.click();
+  await submit.evaluate(element => (element as HTMLButtonElement).click());
   await page.waitForFunction(() =>
     Boolean(
       (window as typeof window & { arkHarnessSubmission?: unknown })
@@ -2707,9 +2804,7 @@ test("自動配置は text resize とモデル JSON 再適用で再計算する"
       parsed.ext.layout.direction = "TB";
       return parsed;
     });
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   await page.locator(".ark-harness-textarea").fill(JSON.stringify(editedModel));
   await page.getByRole("button", { name: "反映", exact: true }).click();
   await expect
@@ -2827,9 +2922,7 @@ for (const direction of ["LR", "TB"] as const) {
     const before = Object.fromEntries(
       nodeBoxes.map(box => [box.id, { x: box.x, y: box.y }])
     );
-    await page
-      .getByRole("button", { name: "モデル JSON を直接編集する" })
-      .click();
+    await openModelPanel(page);
     await page
       .locator(".ark-harness-textarea")
       .fill(JSON.stringify(initialModel));
@@ -2915,8 +3008,9 @@ test("group-aware auto layout は座標を還流せず drag した member だけ
   await connectSubmissionPort(page);
   const submit = page.getByRole("button", {
     name: "変更を親フレームへ送信する",
+    includeHidden: true,
   });
-  await submit.click();
+  await submit.evaluate(element => (element as HTMLButtonElement).click());
   await page.waitForFunction(() =>
     Boolean(
       (window as typeof window & { arkHarnessSubmission?: unknown })
@@ -3050,9 +3144,7 @@ test("group-aware auto layout は重複 membership などを deterministic legac
   }
 
   const current = await readCurrentModel(page);
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   await page.locator(".ark-harness-textarea").fill(JSON.stringify(current));
   await page.getByRole("button", { name: "反映", exact: true }).click();
   await expect
@@ -3150,6 +3242,7 @@ test("cardinality・方向・type を edge SVG に安全に投影する", async 
   await expect(edge).not.toHaveAttribute("marker-start", /.+/);
   await expect(edge).toHaveAttribute("marker-end", /url\(.+\)/);
 
+  await enableDiagramDebug(page);
   const editButton = page.getByRole("button", {
     name: "モデル JSON を直接編集する",
   });
@@ -3417,9 +3510,7 @@ test("unknown edge ext は allowlist placeholder と forward fallback で安全�
   ).toBe(false);
   expect(requests.filter(url => url.startsWith("http"))).toEqual([]);
 
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   const beforeNormalization = JSON.parse(
     await page.locator(".ark-harness-textarea").inputValue()
   ) as { edges: Array<{ ext: Record<string, unknown> }> };
@@ -3475,9 +3566,7 @@ test("モデル直接編集後の edge toolbar を current model と同期して
       },
     },
   ];
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .evaluate(element => (element as HTMLButtonElement).click());
+  await openModelPanel(page);
   await page.locator(".ark-harness-textarea").fill(JSON.stringify(nextModel));
   await page
     .getByRole("button", { name: "反映", exact: true })
@@ -3503,6 +3592,7 @@ test("モデル直接編集後の edge toolbar を current model と同期して
 
 test("カーディナリティ 5 語彙を self-loop にも投影する", async ({ page }) => {
   const errors = await openEdgeSemanticsDiagram(page);
+  await enableDiagramDebug(page);
   const editButton = page.getByRole("button", {
     name: "モデル JSON を直接編集する",
   });
@@ -3799,9 +3889,7 @@ test("edge 始点の張り替えと self-edge を同じ handle 機構で扱う",
       'line.ark-harness-edge-main[data-ark-edge-id="e_order_owner"]'
     )
   ).toHaveCount(1);
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   const rewiredFromModel = JSON.parse(
     await page.locator(".ark-harness-textarea").inputValue()
   ) as typeof edgeSemanticsModel;
@@ -3832,8 +3920,11 @@ test("edge 始点の張り替えと self-edge を同じ handle 機構で扱う",
   ).toHaveCount(2);
 
   await page
-    .getByRole("button", { name: "変更を親フレームへ送信する" })
-    .click();
+    .getByRole("button", {
+      name: "変更を親フレームへ送信する",
+      includeHidden: true,
+    })
+    .evaluate(element => (element as HTMLButtonElement).click());
   await page.waitForFunction(() =>
     Boolean(
       (window as typeof window & { arkHarnessSubmission?: unknown })
@@ -3878,9 +3969,7 @@ test("端点 drag 中の model 直接削除でも stale edge を更新しない"
     ...edgeSemanticsModel,
     edges: edgeSemanticsModel.edges.filter(edge => edge.id !== "e_order_owner"),
   };
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .evaluate(element => (element as HTMLButtonElement).click());
+  await openModelPanel(page, true);
   await page
     .locator(".ark-harness-textarea")
     .fill(JSON.stringify(withoutDraggedEdge));
@@ -3950,8 +4039,11 @@ test("edge 端点 drag の Escape と pointercancel は model を変更しない
   await page.mouse.up();
 
   await page
-    .getByRole("button", { name: "変更を親フレームへ送信する" })
-    .click();
+    .getByRole("button", {
+      name: "変更を親フレームへ送信する",
+      includeHidden: true,
+    })
+    .evaluate(element => (element as HTMLButtonElement).click());
   await page.waitForFunction(() =>
     Boolean(
       (window as typeof window & { arkHarnessSubmission?: unknown })
@@ -4099,9 +4191,7 @@ test("invalid / cross-graph group 境界を安全に除外する", async ({ page
         : group
     ),
   };
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   await page
     .locator(".ark-harness-textarea")
     .fill(JSON.stringify(invalidatedModel));
@@ -4381,9 +4471,7 @@ test("モデル直接編集後の note 入力を現行モデルへ反映して�
   const note = source.locator(":scope > [data-ark-harness-note]");
   await note.fill("適用前のメモ");
 
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   await page.getByRole("button", { name: "反映", exact: true }).click();
 
   const currentNote = source.locator(":scope > [data-ark-harness-note]");
@@ -4720,6 +4808,7 @@ test("モデル直接編集後に kind toolbar と方向表示を再同期する
   );
   const toolbar = await selectNode(page, "order");
   const picker = toolbar.locator("select.ark-harness-kind-select");
+  await enableDiagramDebug(page);
   const editButton = page.getByRole("button", {
     name: "モデル JSON を直接編集する",
   });
@@ -5820,9 +5909,7 @@ test("モデル直接編集後の kind 再同期と node ドラッグを送信 m
       icon: icon ? getComputedStyle(icon, "::before").content : "none",
     };
   });
-  await page
-    .getByRole("button", { name: "モデル JSON を直接編集する" })
-    .click();
+  await openModelPanel(page);
   await page.locator(".ark-harness-textarea").fill(JSON.stringify(editedModel));
   await page.getByRole("button", { name: "反映", exact: true }).click();
 

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -2262,10 +2262,12 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   ]);
 });
 
-test("下部ツールバーは既定で方向トグルだけを表示する", async ({ page }) => {
+test("下部ツールバーは既定で非表示になり余白を残さない", async ({ page }) => {
   await page.setContent(diagramHtml());
 
-  await expect(page.locator(".ark-harness-layout-direction")).toBeVisible();
+  const toolbar = page.locator(".ark-harness-toolbar");
+  await expect(toolbar).toBeHidden();
+  await expect(page.locator(".ark-harness-layout-direction")).toBeHidden();
   await expect(
     page.getByRole("button", {
       name: "モデル JSON を直接編集する",
@@ -2279,38 +2281,64 @@ test("下部ツールバーは既定で方向トグルだけを表示する", as
     })
   ).toBeHidden();
   await expect(page.locator(".ark-harness-status")).toBeHidden();
+  await expect
+    .poll(() =>
+      page.evaluate(() => ({
+        height: document.body.style.getPropertyValue(
+          "--ark-harness-toolbar-height"
+        ),
+        paddingBottom: getComputedStyle(document.body).paddingBottom,
+      }))
+    )
+    .toEqual({ height: "0px", paddingBottom: "0px" });
 });
 
-test("ark-debug hash でモデル直接編集ボタンを動的に切り替える", async ({
-  page,
-}) => {
+test("ark-debug hash で下部 debug UI を動的に切り替える", async ({ page }) => {
   await page.setContent(diagramHtml());
+  const toolbar = page.locator(".ark-harness-toolbar");
   const editButton = page.getByRole("button", {
     name: "モデル JSON を直接編集する",
     includeHidden: true,
   });
+  const directionButton = page.locator(".ark-harness-layout-direction");
 
+  await expect(toolbar).toBeHidden();
   await expect(editButton).toBeHidden();
+  await expect(directionButton).toBeHidden();
   await page.evaluate(() => {
     location.hash = "ark-debug";
   });
+  await expect(toolbar).toBeVisible();
   await expect(editButton).toBeVisible();
+  await expect(directionButton).toBeVisible();
   await page.evaluate(() => {
     location.hash = "";
   });
+  await expect(toolbar).toBeHidden();
   await expect(editButton).toBeHidden();
+  await expect(directionButton).toBeHidden();
 });
 
 test("ノードのラベル編集時だけ送信 UI を表示する", async ({ page }) => {
   await page.setContent(diagramHtml());
+  const toolbar = page.locator(".ark-harness-toolbar");
 
+  await expect(toolbar).toBeHidden();
   await page
     .locator('[data-ark-container="graph"] h2[data-model-id="order"]')
     .fill("Edited Order");
+  await expect(toolbar).toBeVisible();
   await expect(
     page.getByRole("button", { name: "変更を親フレームへ送信する" })
   ).toBeVisible();
   await expect(page.locator(".ark-harness-status")).toBeVisible();
+  await expect(page.locator(".ark-harness-layout-direction")).toBeHidden();
+  await expect(
+    page.getByRole("button", {
+      name: "モデル JSON を直接編集する",
+      includeHidden: true,
+    })
+  ).toBeHidden();
   await expect(page.locator(".ark-harness-status")).toHaveText(
     "親フレーム未接続"
   );
@@ -2323,12 +2351,14 @@ test("送信成功後に送信 UI を再び隠す", async ({ page }) => {
     name: "変更を親フレームへ送信する",
   });
   const status = page.locator(".ark-harness-status");
+  const toolbar = page.locator(".ark-harness-toolbar");
 
   await page
     .locator('[data-ark-container="graph"] h2[data-model-id="order"]')
     .fill("Edited Order");
   await expect(sendButton).toBeVisible();
   await expect(status).toBeVisible();
+  await expect(toolbar).toBeVisible();
   await sendButton.click();
   await page.waitForFunction(() =>
     Boolean(
@@ -2338,6 +2368,14 @@ test("送信成功後に送信 UI を再び隠す", async ({ page }) => {
   );
   await expect(sendButton).toBeHidden();
   await expect(status).toBeHidden();
+  await expect(toolbar).toBeHidden();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        document.body.style.getPropertyValue("--ark-harness-toolbar-height")
+      )
+    )
+    .toBe("0px");
 });
 
 test("レイアウト方向を LR から TB へ切り替えて再配置・保存する", async ({
@@ -2353,6 +2391,7 @@ test("レイアウト方向を LR から TB へ切り替えて再配置・保存
   const initialModel = autoLayoutModel(layout);
   await page.setContent(autoLayoutHtml(layout));
   await connectSubmissionPort(page);
+  await enableDiagramDebug(page);
 
   const toolbar = page.locator(".ark-harness-toolbar");
   const directionButton = page.getByRole("button", {
@@ -2464,6 +2503,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
 }) => {
   await page.setContent(diagramHtml());
   await connectSubmissionPort(page);
+  await enableDiagramDebug(page);
   const directionButton = page.getByRole("button", {
     name: "方向: LR（現在 LR。TB に切り替える）",
   });
@@ -2499,6 +2539,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
     ],
   ] as const) {
     await page.setContent(diagramHtml({ ...model, ext: invalidExt }));
+    await enableDiagramDebug(page);
     await page
       .getByRole("button", {
         name: "方向: LR（現在 LR。TB に切り替える）",
@@ -2520,6 +2561,7 @@ test("レイアウト方向は ext 欠損を補い、モデル直接編集後も
   await page.setContent(
     autoLayoutHtml(tbModel.ext?.layout as Record<string, unknown>)
   );
+  await enableDiagramDebug(page);
   const tbButton = page.getByRole("button", {
     name: "方向: TB（現在 TB。LR に切り替える）",
   });
@@ -3361,6 +3403,7 @@ test("edge cardinality・edge direction control を即時投影し非還流で�
   const initialModel = structuredClone(edgeSemanticsModel);
   const errors = await openEdgeSemanticsDiagram(page, initialModel);
   await connectSubmissionPort(page);
+  await enableDiagramDebug(page);
   const graph = page.locator('[data-ark-container="graph"]');
   const controls = await selectEdge(page, "e_order_owner");
   const main = graph.locator(
@@ -5731,6 +5774,7 @@ test("kind 変更と node・edge・field・list 編集を同じ送信 model に�
 }) => {
   await openDiagram(page);
   await connectSubmissionPort(page);
+  await enableDiagramDebug(page);
 
   const order = page.locator('section[data-model-id="order"]');
   const nodeToolbar = await selectNode(page, "order");

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -57,7 +57,11 @@ describe("injectHarness", () => {
     expect(out).toContain("function toggleLayoutDirection(");
     expect(out).toContain("var baselineModelJson;");
     expect(out).toContain("function syncDirtyState(");
-    expect(out).toContain('location.hash.indexOf("ark-debug") !== -1');
+    expect(out).toContain("function isDebugMode(");
+    expect(out).toContain(
+      "return /(^|[#,])ark-debug($|[,])/.test(location.hash);"
+    );
+    expect(out).not.toContain('location.hash.indexOf("ark-debug") !== -1');
     expect(out).toContain(
       'window.addEventListener("hashchange", syncDebugChrome)'
     );

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -55,6 +55,15 @@ describe("injectHarness", () => {
     expect(out).toContain("ark-harness-layout-direction");
     expect(out).toContain("function syncLayoutDirectionButton(");
     expect(out).toContain("function toggleLayoutDirection(");
+    expect(out).toContain("var baselineModelJson;");
+    expect(out).toContain("function syncDirtyState(");
+    expect(out).toContain('location.hash.indexOf("ark-debug") !== -1');
+    expect(out).toContain(
+      'window.addEventListener("hashchange", syncDebugChrome)'
+    );
+    expect(out).toContain(
+      'createButton("変更を送る", "ark-harness-btn ark-harness-btn-secondary"'
+    );
     expect(out).toContain('var label = visibleLabel + "（現在 "');
     expect(out).toContain(
       "if (!isRecordObject(state.model.ext)) state.model.ext = {};"

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -318,6 +318,7 @@ const RAW_HARNESS_JS = `(function () {
   var statusEl = null;
   var sendBtn = null;
   var layoutDirectionBtn = null;
+  var toolbarEl = null;
   var baselineModelJson;
 
   function isRecordObject(v) {
@@ -2899,6 +2900,14 @@ const RAW_HARNESS_JS = `(function () {
     var dirty = JSON.stringify(state.model) !== baselineModelJson;
     if (sendBtn) sendBtn.style.display = dirty ? "" : "none";
     if (statusEl) statusEl.style.display = dirty ? "" : "none";
+    syncToolbarVisibility(dirty);
+  }
+
+  function syncToolbarVisibility(dirty) {
+    if (!toolbarEl) return;
+    if (dirty === undefined) dirty = JSON.stringify(state.model) !== baselineModelJson;
+    var debug = location.hash.indexOf("ark-debug") !== -1;
+    toolbarEl.style.display = dirty || debug ? "" : "none";
   }
 
   function attachRowControls(li, listEl, ownerNodeId) {
@@ -3234,9 +3243,7 @@ const RAW_HARNESS_JS = `(function () {
   function syncToolbarHeight(bar) {
     var update = function () {
       var height = Math.ceil(bar.getBoundingClientRect().height);
-      if (height > 0) {
-        document.body.style.setProperty("--ark-harness-toolbar-height", height + "px");
-      }
+      document.body.style.setProperty("--ark-harness-toolbar-height", height + "px");
     };
     update();
     window.requestAnimationFrame(update);
@@ -3250,6 +3257,7 @@ const RAW_HARNESS_JS = `(function () {
     var bar = document.createElement("div");
     bar.className = "ark-harness-toolbar";
     markUi(bar);
+    toolbarEl = bar;
 
     if (document.querySelector('[data-ark-container="graph"]')) {
       layoutDirectionBtn = createButton("", "ark-harness-btn ark-harness-btn-secondary ark-harness-layout-direction");
@@ -3293,7 +3301,10 @@ const RAW_HARNESS_JS = `(function () {
     });
 
     function syncDebugChrome() {
-      editModelBtn.style.display = location.hash.indexOf("ark-debug") !== -1 ? "" : "none";
+      var debug = location.hash.indexOf("ark-debug") !== -1;
+      editModelBtn.style.display = debug ? "" : "none";
+      if (layoutDirectionBtn) layoutDirectionBtn.style.display = debug ? "" : "none";
+      syncToolbarVisibility();
     }
     syncDebugChrome();
     window.addEventListener("hashchange", syncDebugChrome);

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2896,6 +2896,10 @@ const RAW_HARNESS_JS = `(function () {
     }
   }
 
+  function isDebugMode() {
+    return /(^|[#,])ark-debug($|[,])/.test(location.hash);
+  }
+
   function syncDirtyState() {
     var dirty = JSON.stringify(state.model) !== baselineModelJson;
     if (sendBtn) sendBtn.style.display = dirty ? "" : "none";
@@ -2906,7 +2910,7 @@ const RAW_HARNESS_JS = `(function () {
   function syncToolbarVisibility(dirty) {
     if (!toolbarEl) return;
     if (dirty === undefined) dirty = JSON.stringify(state.model) !== baselineModelJson;
-    var debug = location.hash.indexOf("ark-debug") !== -1;
+    var debug = isDebugMode();
     toolbarEl.style.display = dirty || debug ? "" : "none";
   }
 
@@ -3301,7 +3305,7 @@ const RAW_HARNESS_JS = `(function () {
     });
 
     function syncDebugChrome() {
-      var debug = location.hash.indexOf("ark-debug") !== -1;
+      var debug = isDebugMode();
       editModelBtn.style.display = debug ? "" : "none";
       if (layoutDirectionBtn) layoutDirectionBtn.style.display = debug ? "" : "none";
       syncToolbarVisibility();

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -318,6 +318,7 @@ const RAW_HARNESS_JS = `(function () {
   var statusEl = null;
   var sendBtn = null;
   var layoutDirectionBtn = null;
+  var baselineModelJson;
 
   function isRecordObject(v) {
     return v !== null && typeof v === "object" && !Array.isArray(v);
@@ -982,6 +983,7 @@ const RAW_HARNESS_JS = `(function () {
     if (!edge) return;
     if (!isRecordObject(edge.ext)) edge.ext = {};
     edge.ext[property] = value;
+    syncDirtyState();
     scheduleGraphRender(graph);
   }
 
@@ -1259,6 +1261,7 @@ const RAW_HARNESS_JS = `(function () {
   }
 
   function scheduleGraphRender(graph) {
+    syncDirtyState();
     if (graph.scheduled) return;
     graph.scheduled = true;
     window.requestAnimationFrame(function () { renderGraph(graph); });
@@ -2893,6 +2896,12 @@ const RAW_HARNESS_JS = `(function () {
     }
   }
 
+  function syncDirtyState() {
+    var dirty = JSON.stringify(state.model) !== baselineModelJson;
+    if (sendBtn) sendBtn.style.display = dirty ? "" : "none";
+    if (statusEl) statusEl.style.display = dirty ? "" : "none";
+  }
+
   function attachRowControls(li, listEl, ownerNodeId) {
     var handle = createButton("\\u283F", "ark-harness-handle", "ドラッグして並べ替え");
     handle.draggable = true;
@@ -2917,6 +2926,7 @@ const RAW_HARNESS_JS = `(function () {
         node.fields = node.fields.filter(function (f) { return f.id !== id; });
       }
       li.remove();
+      syncDirtyState();
     });
 
     li.appendChild(handle);
@@ -2943,6 +2953,7 @@ const RAW_HARNESS_JS = `(function () {
     editableTarget.addEventListener("input", function () {
       var entry = findEntry(state.model, id);
       if (entry) entry.set(editableTarget.textContent || "");
+      syncDirtyState();
     });
 
     if (rowInfo) {
@@ -2961,6 +2972,7 @@ const RAW_HARNESS_JS = `(function () {
       var current = getNode(state.model, ownerId);
       if (!current) return;
       current.noteText = text.replace(/\\r\\n?/g, "\\n");
+      syncDirtyState();
     });
   }
 
@@ -2986,6 +2998,7 @@ const RAW_HARNESS_JS = `(function () {
       if (reordered.indexOf(f) === -1) reordered.push(f);
     });
     node.fields = reordered;
+    syncDirtyState();
   }
 
   function addField(listEl, ownerNodeId) {
@@ -2999,6 +3012,7 @@ const RAW_HARNESS_JS = `(function () {
     var field = { id: id, label: "新しい項目" };
     if (!node.fields) node.fields = [];
     node.fields.push(field);
+    syncDirtyState();
 
     var li = document.createElement("li");
     li.setAttribute("data-model-id", id);
@@ -3149,7 +3163,9 @@ const RAW_HARNESS_JS = `(function () {
     try {
       var html = buildSubmissionHtml();
       submitPort.postMessage({ type: "ark:diagram-submit", model: state.model, html: html });
+      baselineModelJson = JSON.stringify(state.model);
       updateStatus(true, "送信しました");
+      syncDirtyState();
     } catch (e) {
       updateStatus(true, "送信に失敗しました: " + (e instanceof Error ? e.message : String(e)));
     }
@@ -3199,6 +3215,7 @@ const RAW_HARNESS_JS = `(function () {
         reconcileSelection();
         initNoteProjections();
         graphs.forEach(function (graph) { scheduleGraphRender(graph); });
+        syncDirtyState();
         error.style.display = "none";
         panel.style.display = "none";
       } catch (e) {
@@ -3252,7 +3269,7 @@ const RAW_HARNESS_JS = `(function () {
     statusEl.className = "ark-harness-status";
     markUi(statusEl);
 
-    sendBtn = createButton("変更を送る", "ark-harness-btn ark-harness-btn-primary", "変更を親フレームへ送信する");
+    sendBtn = createButton("変更を送る", "ark-harness-btn ark-harness-btn-secondary", "変更を親フレームへ送信する");
     sendBtn.disabled = true;
     sendBtn.addEventListener("click", handleSubmit);
 
@@ -3276,7 +3293,14 @@ const RAW_HARNESS_JS = `(function () {
       panel.style.display = opening ? "flex" : "none";
     });
 
+    function syncDebugChrome() {
+      editModelBtn.style.display = location.hash.indexOf("ark-debug") !== -1 ? "" : "none";
+    }
+    syncDebugChrome();
+    window.addEventListener("hashchange", syncDebugChrome);
+
     updateStatus(false);
+    syncDirtyState();
   }
 
   function init() {
@@ -3284,6 +3308,7 @@ const RAW_HARNESS_JS = `(function () {
       var model = loadModel();
       if (!model) return;
       state.model = model;
+      baselineModelJson = JSON.stringify(state.model);
       reservedModelIds = collectModelIds(model);
       syncNodeKinds();
       kindCandidates = collectKindCandidates();

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -1261,10 +1261,9 @@ const RAW_HARNESS_JS = `(function () {
   }
 
   function scheduleGraphRender(graph) {
-    syncDirtyState();
     if (graph.scheduled) return;
     graph.scheduled = true;
-    window.requestAnimationFrame(function () { renderGraph(graph); });
+    window.requestAnimationFrame(function () { renderGraph(graph); syncDirtyState(); });
   }
 
   function positionEdgeHandle(handle, endpoint) {


### PR DESCRIPTION
Closes #269

## 概要

設計 #266 の Phase C。非編集時のボードからクロムを全て取り払い、完全無地のキャンバスにする。

## 変更点

### C-1: 「モデルを直接編集」を debug 送り
- 既定で非表示。URL ハッシュに `ark-debug` を含むときのみ表示（`hashchange` で動的トグル）
- モーダル本体・適用ロジックは不変（廃止ではなく debug 用に温存）

### C-2: 「変更を送る」を変更検知時のみ控えめに表示
- `baselineModelJson` スナップショット比較による dirty 判定（init / 送信成功時に baseline 更新）
- dirty 時のみ送信ボタン + ステータスを表示。スタイルは primary → secondary に降格
- dirty 判定はレンダリングと同じ rAF に集約し、drag 中も 1 フレーム 1 回に抑制

### C-3: 下部ツールバーの完全非表示（spec からの拡張）
- レイアウト方向トグル（LR/TB）も **debug 送り**に変更（spec は「残す」だったが、日常編集で触らないためユーザー判断で撤去）
- 結果、非編集・非 debug 時は**バー自体を非表示**にし、`--ark-harness-toolbar-height` を 0px に同期して下部 padding も消す

## 意図的なトレードオフ

- ボードの iframe からは生 JSON 編集に到達できなくなる（ハッシュを付けられないため）。**図の URL を別タブで開いて `#ark-debug` を付ける運用**とする（ユーザー決定）
- edge ラベル・group・edge type 等の JSON でしか編集できない項目の直接操作化は Phase D (#270) 側で扱う
- クリーン状態での再送信は不可になる（送信失敗時は dirty が残るためリトライ可能）

## サイズ

注入後 **127,936 bytes**（ベース 126,670 比 **+1,270**）。spec の「純減」目標は未達 — dirty 検知・表示同期の追加が撤去分を上回った。guard 131,072 への余裕は 3,136 bytes で、Phase D の「微増」は吸収可能な見込み。

## 検証

- Playwright E2E: 74 件 PASS（表示出し分けの新規テスト含む）/ 全 unit: 685 件 PASS / `pnpm check` / `pnpm build`
- production の diagram-diff.ts / describeModelDiff は不変（非還流契約維持）
- ライブプレビューで実機検証: 既定完全無地（バー不可視・padding 0）→ `#ark-debug` で方向トグル + JSON 編集出現 → 編集で送信 UI のみ出現 → 送信フロー end-to-end（ファイル更新・構造変更のみ会話へ還流）の 13 項目 + note 回帰 12 項目

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モデル編集中のみ、変更内容を送信するツールバーとステータスを表示するようになりました。
  * 編集内容が保存済みの状態に戻ると、送信操作を自動的に非表示にします。
  * デバッグ用表示は通常非表示となり、編集時またはデバッグモード有効時のみ利用できます。

* **改善**
  * モデル編集、レイアウト変更、エッジやグループなどの操作で、変更状態が正確に反映されるようになりました。
  * 送信成功後は、送信済みの内容を新しい基準として状態を更新します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->