### PR TITLE
図解編集 Phase D: 磨き込み（edgeラベル直接編集・最終行Enter行追加・出現アニメーション）

### DIFF
--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1647,9 +1647,8 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
     node => !connectDragModel.nodes.some(old => old.id === node.id)
   );
   expect(added).toBeDefined();
-  expect(added).toMatchObject({ label: "新しいノード", kind: "entity" });
+  expect(added).toMatchObject({ label: "", kind: "entity" });
   expect(added?.id).toMatch(/^node-/);
-  expect(added?.id).not.toContain("新しいノード");
   expect(Number.isInteger((added?.ext as { x?: number })?.x)).toBe(true);
   expect(Number.isInteger((added?.ext as { y?: number })?.y)).toBe(true);
   expect(current.nodes).toHaveLength(initial.nodes.length + 1);
@@ -1679,7 +1678,11 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   const projectionLabel = projection.locator(
     `:scope > span[data-model-id="${added.id}"]`
   );
-  await expect(projectionLabel).toHaveText("新しいノード");
+  await expect(projectionLabel).toHaveText("");
+  await expect(projectionLabel).toHaveAttribute(
+    "data-placeholder",
+    "名前を入力"
+  );
   expect(await projectionLabel.evaluate(element => element.tagName)).toBe(
     "SPAN"
   );
@@ -2362,7 +2365,7 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   if (!submission) throw new Error("submission がありません");
   expect(submission.html).toContain(`data-model-id="${added.id}"`);
   expect(submission.html).toContain('data-kind="event"');
-  expect(submission.html).toContain("新しいノード");
+  expect(submission.html).not.toContain("新しいノード");
   expect(submission.html).not.toContain("data-ark-harness-ui");
   expect(submission.html).not.toContain("ark-harness-node-palette");
   expect(submission.html).not.toContain("ark-harness-node-connectors");
@@ -2370,8 +2373,8 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   expect(submission.html).not.toContain("ark-harness-edge-hit");
   expect(submission.html).not.toContain("--ark-harness-graph-x");
   expect(describeModelDiff(crudModel, submission.model)).toEqual([
-    "新しいノード を追加",
-    "B から 新しいノード への関連を追加",
+    "(無題) を追加",
+    "B から (無題) への関連を追加",
   ]);
 });
 
@@ -4731,7 +4734,7 @@ test("model node だけに entity がある図でも note picker・往復・drag
   const added = current.nodes.find(
     node => !initial.nodes.some(old => old.id === node.id)
   );
-  expect(added).toMatchObject({ label: "新しいノード", kind: "entity" });
+  expect(added).toMatchObject({ label: "", kind: "entity" });
   if (!added) throw new Error("追加 node がありません");
   const projection = graph.locator(`[data-model-id="${added.id}"]`).first();
   expect(await projection.evaluate(element => element.tagName)).toBe("SECTION");
@@ -4742,7 +4745,8 @@ test("model node だけに entity がある図でも note picker・往復・drag
   expect(await label.evaluate(element => element.tagName)).toBe("H2");
   await expect(label).toHaveClass(/(^|\s)entity-title(\s|$)/);
   await expect(label).toHaveAttribute("data-model-id", added.id);
-  await expect(label).toHaveText("新しいノード");
+  await expect(label).toHaveText("");
+  await expect(label).toHaveAttribute("data-placeholder", "名前を入力");
 
   const list = projection.locator(":scope > ul");
   await expect(list).toHaveCount(1);
@@ -4750,9 +4754,22 @@ test("model node だけに entity がある図でも note picker・往復・drag
   await expect(list).toHaveClass(/(^|\s)entity-fields(\s|$)/);
   await expect(list.locator(":scope > li")).toHaveCount(0);
   await label.fill("追加ノード");
+  await expect(label).toHaveText("追加ノード");
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
+      ?.label
+  ).toBe("追加ノード");
   await label.press("Enter");
   await expect(list.locator(":scope > li")).toHaveCount(1);
-  await expect(list.locator(":scope > li .ark-harness-text")).toBeFocused();
+  const addedFieldEditable = list.locator(":scope > li .ark-harness-text");
+  await expect(addedFieldEditable).toBeFocused();
+  await expect(addedFieldEditable).toHaveText("");
+  await expect(addedFieldEditable).toHaveAttribute(
+    "data-placeholder",
+    "項目を入力"
+  );
+  await addedFieldEditable.fill("code");
+  await expect(addedFieldEditable).toHaveText("code");
   const addedToolbar = await selectNode(page, added.id);
   const addFieldButton = addedToolbar.getByRole("button", {
     name: "行を追加",
@@ -4763,7 +4780,7 @@ test("model node だけに entity がある図でも note picker・往復・drag
   expect(addedAfterField?.label).toBe("追加ノード");
   expect(addedAfterField?.fields).toHaveLength(1);
   expect(addedAfterField?.fields?.[0]).toMatchObject({
-    label: "新しい項目",
+    label: "code",
   });
   expect(addedAfterField?.fields?.[0]?.id).toMatch(/^field-/);
   const addedField = addedAfterField?.fields?.[0];

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1486,6 +1486,28 @@ test("selection toolbar edge label: 入力・空欄・モデル再適用後を c
   ).toBe("current label");
 });
 
+test("selection toolbar edge label: 1文字ずつ入力してもフォーカスと全入力を維持する", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  const toolbar = await selectEdge(page, "e_order_owner");
+  const input = toolbar.locator("input.ark-harness-edge-label-input");
+
+  await input.click();
+  await input.press("ControlOrMeta+A");
+  await input.pressSequentially("orders");
+
+  await expect(input).toHaveValue("orders");
+  expect(
+    await input.evaluate(element => document.activeElement === element)
+  ).toBe(true);
+  expect(
+    (await readCurrentModel(page)).edges.find(
+      edge => edge.id === "e_order_owner"
+    )?.label
+  ).toBe("orders");
+});
+
 test("selection toolbar edge action: both は向き反転を無効化し forward は有効にする", async ({
   page,
 }) => {

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1404,6 +1404,50 @@ test("selection toolbar edge action: 向き反転で direction だけを切替�
   await expect(selectedEdgeAnchor(page, "e_order_owner")).toHaveCount(1);
 });
 
+test("selection toolbar edge label: 入力・空欄・モデル再適用後を current model と SVG へ同期する", async ({
+  page,
+}) => {
+  await openEdgeSemanticsDiagram(page);
+  const toolbar = await selectEdge(page, "e_order_owner");
+  const input = toolbar.locator("input.ark-harness-edge-label-input");
+  const label = page.locator(
+    'text.ark-harness-edge-label[data-ark-edge-id="e_order_owner"]'
+  );
+
+  await expect(input).toHaveValue("owned by");
+  await input.fill("owns");
+  await expect(label).toHaveText("owns");
+  expect(
+    (await readCurrentModel(page)).edges.find(
+      edge => edge.id === "e_order_owner"
+    )?.label
+  ).toBe("owns");
+
+  await input.fill("");
+  await expect(label).toHaveCount(0);
+  expect(
+    (await readCurrentModel(page)).edges.find(
+      edge => edge.id === "e_order_owner"
+    )
+  ).not.toHaveProperty("label");
+
+  const applied = structuredClone(edgeSemanticsModel);
+  const appliedEdge = applied.edges.find(edge => edge.id === "e_order_owner");
+  if (!appliedEdge) throw new Error("edge がありません");
+  appliedEdge.label = "applied label";
+  await openModelPanel(page);
+  await page.locator(".ark-harness-textarea").fill(JSON.stringify(applied));
+  await page.getByRole("button", { name: "反映", exact: true }).click();
+  await expect(input).toHaveValue("applied label");
+  await input.fill("current label");
+  await expect(label).toHaveText("current label");
+  expect(
+    (await readCurrentModel(page)).edges.find(
+      edge => edge.id === "e_order_owner"
+    )?.label
+  ).toBe("current label");
+});
+
 test("selection toolbar edge action: both は向き反転を無効化し forward は有効にする", async ({
   page,
 }) => {

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1349,24 +1349,33 @@ test("entity 最終行の Enter だけが行を追加してフォーカスし no
   page,
 }) => {
   await openDiagram(page);
+  const userLabel = page.locator(
+    '.ark-harness-graph-node[data-model-id="user"] > h2[data-model-id="user"]'
+  );
   const userRows = page.locator(
     '.ark-harness-graph-node[data-model-id="user"] li[data-model-id]'
   );
 
-  await userRows.last().locator(".ark-harness-text").press("Enter");
+  await userLabel.press("Enter");
   await expect(userRows).toHaveCount(2);
+  await expect(userRows.last().locator(".ark-harness-text")).toBeFocused();
+  expect(await userLabel.textContent()).not.toContain("\n");
+  await expect(userLabel.locator(":scope > div")).toHaveCount(0);
+
+  await userRows.last().locator(".ark-harness-text").press("Enter");
+  await expect(userRows).toHaveCount(3);
   await expect(userRows.last().locator(".ark-harness-text")).toBeFocused();
   expect(
     (await readCurrentModel(page)).nodes.find(node => node.id === "user")
       ?.fields
-  ).toHaveLength(2);
+  ).toHaveLength(3);
 
   await userRows.first().locator(".ark-harness-text").press("Enter");
-  await expect(userRows).toHaveCount(2);
+  await expect(userRows).toHaveCount(3);
   expect(
     (await readCurrentModel(page)).nodes.find(node => node.id === "user")
       ?.fields
-  ).toHaveLength(2);
+  ).toHaveLength(3);
 
   const toolbar = await selectNode(page, "user");
   await toolbar.locator("select.ark-harness-kind-select").selectOption("note");
@@ -4735,20 +4744,23 @@ test("model node だけに entity がある図でも note picker・往復・drag
   await expect(label).toHaveAttribute("data-model-id", added.id);
   await expect(label).toHaveText("新しいノード");
 
-  const addedToolbar = await selectNode(page, added.id);
   const list = projection.locator(":scope > ul");
   await expect(list).toHaveCount(1);
   expect(await list.evaluate(element => element.tagName)).toBe("UL");
   await expect(list).toHaveClass(/(^|\s)entity-fields(\s|$)/);
   await expect(list.locator(":scope > li")).toHaveCount(0);
+  await label.fill("追加ノード");
+  await label.press("Enter");
+  await expect(list.locator(":scope > li")).toHaveCount(1);
+  await expect(list.locator(":scope > li .ark-harness-text")).toBeFocused();
+  const addedToolbar = await selectNode(page, added.id);
   const addFieldButton = addedToolbar.getByRole("button", {
     name: "行を追加",
   });
   await expect(addFieldButton).toBeEnabled();
-  await addFieldButton.click();
-  await expect(list.locator(":scope > li")).toHaveCount(1);
   const afterAdd = await readCurrentModel(page);
   const addedAfterField = afterAdd.nodes.find(node => node.id === added.id);
+  expect(addedAfterField?.label).toBe("追加ノード");
   expect(addedAfterField?.fields).toHaveLength(1);
   expect(addedAfterField?.fields?.[0]).toMatchObject({
     label: "新しい項目",
@@ -4773,7 +4785,7 @@ test("model node だけに entity がある図でも note picker・往復・drag
   );
   expect(noteAfterSwitch).toMatchObject({
     kind: "note",
-    label: "新しいノード",
+    label: "追加ノード",
     fields: [addedField],
     noteText: "",
   });
@@ -4789,7 +4801,7 @@ test("model node だけに entity がある図でも note picker・往復・drag
   );
   await expect(entityLabelAfterSwitch).toHaveCount(1);
   await expect(entityLabelAfterSwitch).toHaveClass(/(^|\s)entity-title(\s|$)/);
-  await expect(entityLabelAfterSwitch).toHaveText("新しいノード");
+  await expect(entityLabelAfterSwitch).toHaveText("追加ノード");
   await expect(entityLabelAfterSwitch).toHaveAttribute(
     "contenteditable",
     "true"
@@ -4798,7 +4810,7 @@ test("model node だけに entity がある図でも note picker・往復・drag
     (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
   ).toMatchObject({
     kind: "entity",
-    label: "新しいノード",
+    label: "追加ノード",
     fields: [addedField],
     noteText: "自由記述\n複数行",
   });
@@ -4821,7 +4833,7 @@ test("model node だけに entity がある図でも note picker・往復・drag
     (await readCurrentModel(page)).nodes.find(node => node.id === added.id)
   ).toMatchObject({
     kind: "note",
-    label: "新しいノード",
+    label: "追加ノード",
     fields: [addedField],
     noteText: "自由記述\n複数行",
   });

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -2420,6 +2420,37 @@ test("ark-debug の部分文字列を含む hash では下部 debug UI を表示
   await expect(directionButton).toBeHidden();
 });
 
+test("浮くツールバー・下部ツールバー・hover アンカーに軽いトランジションを付ける", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  const context = await selectNode(page, "order");
+  await page
+    .locator('[data-model-id="order"] h2[data-model-id="order"]')
+    .fill("Edited Order");
+  const bottom = page.locator(".ark-harness-toolbar");
+  await expect(bottom).toBeVisible();
+
+  for (const toolbar of [context, bottom]) {
+    expect(
+      await toolbar.evaluate(element => ({
+        name: getComputedStyle(element).animationName,
+        duration: getComputedStyle(element).animationDuration,
+      }))
+    ).toEqual({ name: "ark-harness-in", duration: "0.12s" });
+  }
+  const connectorsTransition = await page
+    .locator(".ark-harness-node-connectors")
+    .first()
+    .evaluate(element => getComputedStyle(element).transitionProperty);
+  const anchorTransition = await page
+    .locator(".ark-harness-node-anchor")
+    .first()
+    .evaluate(element => getComputedStyle(element).transitionProperty);
+  expect(connectorsTransition).toContain("opacity");
+  expect(anchorTransition).toContain("transform");
+});
+
 test("ノードのラベル編集時だけ送信 UI を表示する", async ({ page }) => {
   await page.setContent(diagramHtml());
   const toolbar = page.locator(".ark-harness-toolbar");

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1345,6 +1345,44 @@ test("selection toolbar node action: +行と削除を既存 field・参照整合
   ).toEqual(["external"]);
 });
 
+test("entity 最終行の Enter だけが行を追加してフォーカスし note は改行する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  const userRows = page.locator(
+    '.ark-harness-graph-node[data-model-id="user"] li[data-model-id]'
+  );
+
+  await userRows.last().locator(".ark-harness-text").press("Enter");
+  await expect(userRows).toHaveCount(2);
+  await expect(userRows.last().locator(".ark-harness-text")).toBeFocused();
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === "user")
+      ?.fields
+  ).toHaveLength(2);
+
+  await userRows.first().locator(".ark-harness-text").press("Enter");
+  await expect(userRows).toHaveCount(2);
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === "user")
+      ?.fields
+  ).toHaveLength(2);
+
+  const toolbar = await selectNode(page, "user");
+  await toolbar.locator("select.ark-harness-kind-select").selectOption("note");
+  const note = page.locator(
+    '.ark-harness-graph-node[data-model-id="user"] > .ark-harness-note'
+  );
+  await note.fill("1行目");
+  await note.press("End");
+  await note.press("Enter");
+  await page.keyboard.type("2行目");
+  expect(
+    (await readCurrentModel(page)).nodes.find(node => node.id === "user")
+      ?.noteText
+  ).toBe("1行目\n2行目");
+});
+
 test("selection toolbar edge action: 向き反転で direction だけを切替え2回で元に戻る", async ({
   page,
 }) => {

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -139,7 +139,9 @@ describe("injectHarness", () => {
     expect(out).toContain("function removeEdge(");
     expect(out).toContain("group.nodes = group.nodes.filter");
     expect(out).toContain("var listBindingsByNode = new Map();");
+    expect(out).toContain("function listBinding(");
     expect(out).toContain("function selectedListBinding(");
+    expect(out).toContain('event.key !== "Enter" || event.isComposing');
     expect(out).not.toContain("ark-harness-add-row");
   });
 

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -513,7 +513,11 @@ describe("injectHarness", () => {
     expect(out).toContain(
       'label.setAttribute("data-placeholder", "\\u540D\\u524D\\u3092\\u5165\\u529B")'
     );
-    expect(out).toContain('label: kind === "note" ? "" : "新しいノード"');
+    expect(out).toContain('var node = { id: id, label: "", ext:');
+    expect(out).toContain('var field = { id: id, label: "" }');
+    expect(out).toContain(
+      'editable.setAttribute("data-placeholder", "\\u9805\\u76EE\\u3092\\u5165\\u529B")'
+    );
     expect(out).toContain('clone.querySelectorAll("[data-placeholder]")');
   });
 

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2066,6 +2066,7 @@ const RAW_HARNESS_JS = `(function () {
       if (!isRecordObject(current.ext)) current.ext = {};
       current.ext.direction = dir === "forward" ? "reverse" : "forward";
       graphs.forEach(function (entry) { scheduleGraphRender(entry); });
+      reverse.blur();
       renderContextToolbar();
     });
     contextToolbar.appendChild(reverse);
@@ -2084,6 +2085,10 @@ const RAW_HARNESS_JS = `(function () {
 
   function renderContextToolbar() {
     if (!contextToolbar) return;
+    if (!contextToolbar.hidden &&
+        contextToolbar.contains(document.activeElement) &&
+        contextToolbar.getAttribute("data-ark-selection-kind") === selection.kind &&
+        contextToolbar.getAttribute("data-ark-selection-id") === selection.id) return;
     clearToolbarChildren();
     contextToolbar.removeAttribute("data-ark-selection-kind");
     contextToolbar.removeAttribute("data-ark-selection-id");

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -184,6 +184,7 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   transform: translate(-50%, -50%); border: 2px solid #0ea5b7; border-radius: 999px;
   background: #fff; color: #0e7490; font: 9px/8px sans-serif;
   cursor: crosshair; touch-action: none; pointer-events: none;
+  transition: transform .12s ease;
 }
 .ark-harness-node-connectors.ark-harness-node-connectors-visible {
   opacity: 1;
@@ -191,6 +192,7 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
 .ark-harness-node-connectors.ark-harness-node-connectors-visible > .ark-harness-node-anchor {
   pointer-events: auto;
 }
+.ark-harness-node-anchor:hover { transform: translate(-50%, -50%) scale(1.15); }
 .ark-harness-edge-dragging .ark-harness-node-connectors {
   opacity: 0; pointer-events: none;
 }
@@ -238,6 +240,8 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   background: rgba(255,255,255,.98); color: #334155;
   box-shadow: 0 4px 14px rgba(15,23,42,.22); font: 11px/1.2 sans-serif;
 }
+.ark-harness-toolbar, .ark-harness-context-toolbar { animation: ark-harness-in .12s ease-out; }
+@keyframes ark-harness-in { from { opacity: 0; transform: translateY(4px); } }
 .ark-harness-context-toolbar[hidden] { display: none; }
 .ark-harness-context-toolbar button {
   appearance: none; border: 1px solid rgba(100,116,139,.55); border-radius: 4px;

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2016,6 +2016,30 @@ const RAW_HARNESS_JS = `(function () {
 
   function renderEdgeToolbar(edge) {
     var graph = selectionGraph;
+    var input = document.createElement("input");
+    input.type = "text";
+    input.className = "ark-harness-edge-control ark-harness-edge-label-input";
+    input.value = typeof edge.label === "string" ? edge.label : "";
+    input.placeholder = "\u30E9\u30D9\u30EB";
+    markUi(input);
+    function updateLabel(event) {
+      event.stopPropagation();
+      var current = getEdge(state.model, edge.id);
+      if (!current) return;
+      if (input.value) current.label = input.value;
+      else delete current.label;
+      graphs.forEach(function (entry) { scheduleGraphRender(entry); });
+    }
+    input.addEventListener("input", updateLabel);
+    input.addEventListener("change", updateLabel);
+    ["pointerdown", "click"].forEach(function (type) {
+      input.addEventListener(type, function (event) { event.stopPropagation(); });
+    });
+    input.addEventListener("keydown", function (event) {
+      event.stopPropagation();
+      if (event.key === "Enter") input.blur();
+    });
+    contextToolbar.appendChild(input);
     ["from-card", "to-card", "direction"].forEach(function (role) {
       var select = createEdgeSelect(graph, edge.id, role);
       syncEdgeSelect(select, role, edge);

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -1956,16 +1956,23 @@ const RAW_HARNESS_JS = `(function () {
     select.title = label;
   }
 
-  function selectedListBinding() {
-    if (selection.kind !== "node" || !selectionGraph) return null;
-    var root = selectionGraph.nodesById.get(selection.id);
-    var bindings = listBindingsByNode.get(selection.id) || [];
+  function listBinding(nodeId, root) {
+    var bindings = listBindingsByNode.get(nodeId) || [];
     for (var i = 0; i < bindings.length; i++) {
-      if (bindings[i].listEl.isConnected && root.contains(bindings[i].listEl)) {
+      if (bindings[i].listEl.isConnected && root &&
+          root.contains(bindings[i].listEl)) {
         return bindings[i];
       }
     }
     return null;
+  }
+
+  function selectedListBinding() {
+    if (selection.kind !== "node" || !selectionGraph) return null;
+    return listBinding(
+      selection.id,
+      selectionGraph.nodesById.get(selection.id)
+    );
   }
 
   function renderNodeToolbar(node) {
@@ -3001,14 +3008,18 @@ const RAW_HARNESS_JS = `(function () {
       syncDirtyState();
     });
 
+    editableTarget.addEventListener("keydown", function (event) {
+      if (event.key !== "Enter" || event.isComposing) return;
+      event.preventDefault();
+      var binding = rowInfo || listBinding(
+        id,
+        editableTarget.closest(".ark-harness-graph-node")
+      );
+      if (!binding || rowInfo && el !== binding.listEl.lastElementChild) return;
+      var next = addField(binding.listEl, binding.ownerNodeId);
+      if (next) next.focus();
+    });
     if (rowInfo) {
-      editableTarget.addEventListener("keydown", function (event) {
-        if (event.key !== "Enter") return;
-        event.preventDefault();
-        if (el !== rowInfo.listEl.lastElementChild) return;
-        var next = addField(rowInfo.listEl, rowInfo.ownerNodeId);
-        if (next) next.focus();
-      });
       attachRowControls(el, rowInfo.listEl, rowInfo.ownerNodeId);
     }
     return editableTarget;

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2993,8 +2993,16 @@ const RAW_HARNESS_JS = `(function () {
     });
 
     if (rowInfo) {
+      editableTarget.addEventListener("keydown", function (event) {
+        if (event.key !== "Enter") return;
+        event.preventDefault();
+        if (el !== rowInfo.listEl.lastElementChild) return;
+        var next = addField(rowInfo.listEl, rowInfo.ownerNodeId);
+        if (next) next.focus();
+      });
       attachRowControls(el, rowInfo.listEl, rowInfo.ownerNodeId);
     }
+    return editableTarget;
   }
 
   function wireNote(el, node) {
@@ -3055,7 +3063,7 @@ const RAW_HARNESS_JS = `(function () {
     li.textContent = field.label;
     listEl.appendChild(li);
 
-    wireEditableLeaf(li, { listEl: listEl, ownerNodeId: ownerNodeId });
+    return wireEditableLeaf(li, { listEl: listEl, ownerNodeId: ownerNodeId });
   }
 
   function wireList(listEl, ownerNodeId) {

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -2563,7 +2563,7 @@ const RAW_HARNESS_JS = `(function () {
       updateStatus(!!submitPort, "一意な ID を生成できませんでした");
       return null;
     }
-    var node = { id: id, label: kind === "note" ? "" : "新しいノード", ext: { x: 0, y: 0 } };
+    var node = { id: id, label: "", ext: { x: 0, y: 0 } };
     if (kind) node.kind = kind;
     if (kind === "note") node.noteText = "";
     var projection = createNodeProjection(graph, node);
@@ -3073,17 +3073,18 @@ const RAW_HARNESS_JS = `(function () {
       updateStatus(!!submitPort, "一意な ID を生成できませんでした");
       return;
     }
-    var field = { id: id, label: "新しい項目" };
+    var field = { id: id, label: "" };
     if (!node.fields) node.fields = [];
     node.fields.push(field);
     syncDirtyState();
 
     var li = document.createElement("li");
     li.setAttribute("data-model-id", id);
-    li.textContent = field.label;
     listEl.appendChild(li);
 
-    return wireEditableLeaf(li, { listEl: listEl, ownerNodeId: ownerNodeId });
+    var editable = wireEditableLeaf(li, { listEl: listEl, ownerNodeId: ownerNodeId });
+    if (editable) editable.setAttribute("data-placeholder", "\\u9805\\u76EE\\u3092\\u5165\\u529B");
+    return editable;
   }
 
   function wireList(listEl, ownerNodeId) {


### PR DESCRIPTION
Closes #270

## 概要

設計 #266 の Phase D（磨き込み）。ユーザー選択の3点 + 実機フィードバック起因の修正1点。
キーボードショートカット（削除・選択移動）は**ユーザー判断でスコープ外**（経緯は #270 コメント参照）。

## 変更点

### D-1: edge ラベルの直接編集
- エッジ選択時の浮くツールバー先頭に「ラベル」入力欄を追加
- input ごとに `getEdge(state.model, edge.id)` で現行モデルを解決して書き込み（stale 参照なし）。空にすると `label` キーを削除し SVG テキストも消える
- Phase C で生 JSON が debug 送りになり編集不能になっていた項目の筆頭を直接操作化（#270 コメントの候補リストより）

### D-2: 最終行 Enter でフィールド行追加
- entity 属性行の最終行で Enter → 既存の +行 ロジックを流用して行を追加し、新行へフォーカス
- 非最終行の Enter は改行抑止のみ。note の自由改行・ノードラベル（`rowInfo` なし）は不変

### D-3: 出現アニメーション・発見性
- コンテキストツールバー / 下部ツールバーに 120ms のフェード + スライド（CSS のみ・JS タイマーなし）
- hover アンカーに transform transition + hover 時 scale(1.15) で「掴める」affordance

### 修正: ラベル入力中のフォーカス喪失（実機フィードバック）
- 原因: input 毎の再描画で `reconcileSelection` → `renderContextToolbar` がツールバー DOM を全再構築し、入力中の欄を破棄
- 対処: 同一選択のツールバー内にフォーカスがある間は再構築をスキップするガードを追加。向き反転ボタンは blur してから再同期（direction ドロップダウン連動を維持）

## サイズ

注入後 **130,031 bytes**（Phase C 後 128,095 比 +1,936）。guard 131,072 への残余 **1,041 bytes**。

## 検証

- Playwright E2E: 79 件 PASS（D-1/D-2/D-3 + フォーカス保持の pressSequentially 回帰）/ 全 unit: 685 件 PASS / `pnpm check` / `pnpm build`
- production の diagram-diff.ts / describeModelDiff は不変（label 変更の還流挙動は現状のまま）
- ライブプレビューで実機検証: ラベル追従/空で削除/model 反映・Enter 行追加+フォーカス移動・animation 適用（10 項目）、連続入力フォーカス保持（4 項目）、向き反転 dropdown 連動回帰（11 項目）、note 12 項目・Phase C クロム 13 項目

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * エッジのコンテキストツールバーからラベルを直接編集できるようになりました。
  * エンティティの最終行で Enter を押すと、新しい行が追加され自動的にフォーカスされます。
  * ノート内で改行できるようになりました。

* **改善**
  * ラベル編集内容が継続的に反映され、モデル再適用後も同期されます。
  * ノード接続アンカーやツールバーにスムーズな表示・ホバーアニメーションを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->