### PR TITLE
図解編集: 自動保存（保存と Claude への通知の分離）

### DIFF
--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -733,10 +733,20 @@ async function connectSubmissionPort(page: Page) {
   await page.evaluate(() => {
     const browserWindow = window as typeof window & {
       arkHarnessSubmission?: unknown;
+      arkHarnessAutosaves?: unknown[];
     };
     const channel = new MessageChannel();
     channel.port1.onmessage = event => {
-      browserWindow.arkHarnessSubmission = event.data;
+      if (event.data?.type === "ark:diagram-autosave") {
+        browserWindow.arkHarnessAutosaves ??= [];
+        browserWindow.arkHarnessAutosaves.push(event.data);
+        channel.port1.postMessage({
+          type: "ark:diagram-autosave-result",
+          ok: true,
+        });
+      } else {
+        browserWindow.arkHarnessSubmission = event.data;
+      }
     };
     window.postMessage({ type: "ark:test-connect" }, "*", [channel.port2]);
   });
@@ -2542,6 +2552,73 @@ test("送信成功後に送信 UI を再び隠す", async ({ page }) => {
       )
     )
     .toBe("0px");
+});
+
+test("編集を debounce で自動保存し、未通知の送信 UI は残す", async ({
+  page,
+}) => {
+  await page.setContent(diagramHtml());
+  await connectSubmissionPort(page);
+  const sendButton = page.getByRole("button", {
+    name: "変更を親フレームへ送信する",
+  });
+  const status = page.locator(".ark-harness-status");
+
+  const label = page.locator(
+    '[data-ark-container="graph"] h2[data-model-id="order"]'
+  );
+  await label.fill("Edited");
+  await page.waitForTimeout(400);
+  await label.fill("Autosaved Order");
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { arkHarnessAutosaves?: unknown[] })
+            .arkHarnessAutosaves?.length ?? 0
+      )
+    )
+    .toBe(1);
+  await expect(status).toHaveText("保存済み");
+  await expect(sendButton).toBeVisible();
+
+  const autosave = await page.evaluate(
+    () =>
+      (window as typeof window & { arkHarnessAutosaves?: unknown[] })
+        .arkHarnessAutosaves?.[0]
+  );
+  expect(autosave).toMatchObject({ type: "ark:diagram-autosave" });
+  expect(
+    (autosave as { model: { nodes: Array<{ id: string; label: string }> } })
+      .model.nodes[0]
+  ).toMatchObject({ id: "order", label: "Autosaved Order" });
+
+  // 通知 baseline へ戻して dirty UI が消えても、保存済み baseline との差は
+  // 独立して autosave する。
+  await label.fill("Order");
+  await expect(sendButton).toBeHidden();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { arkHarnessAutosaves?: unknown[] })
+            .arkHarnessAutosaves?.length ?? 0
+      )
+    )
+    .toBe(2);
+  const revertedAutosave = await page.evaluate(
+    () =>
+      (window as typeof window & { arkHarnessAutosaves?: unknown[] })
+        .arkHarnessAutosaves?.[1]
+  );
+  expect(
+    (
+      revertedAutosave as {
+        model: { nodes: Array<{ id: string; label: string }> };
+      }
+    ).model.nodes[0]
+  ).toMatchObject({ id: "order", label: "Order" });
 });
 
 test("レイアウト方向を LR から TB へ切り替えて再配置・保存する", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -729,8 +729,11 @@ async function openSampleDiagram(page: Page) {
   await openAuthoredDiagram(page, "sample.diagram.html");
 }
 
-async function connectSubmissionPort(page: Page) {
-  await page.evaluate(() => {
+async function connectSubmissionPort(
+  page: Page,
+  autosaveResults: boolean[] = []
+) {
+  await page.evaluate(results => {
     const browserWindow = window as typeof window & {
       arkHarnessSubmission?: unknown;
       arkHarnessAutosaves?: unknown[];
@@ -742,14 +745,14 @@ async function connectSubmissionPort(page: Page) {
         browserWindow.arkHarnessAutosaves.push(event.data);
         channel.port1.postMessage({
           type: "ark:diagram-autosave-result",
-          ok: true,
+          ok: results.shift() ?? true,
         });
       } else {
         browserWindow.arkHarnessSubmission = event.data;
       }
     };
     window.postMessage({ type: "ark:test-connect" }, "*", [channel.port2]);
-  });
+  }, autosaveResults);
   await expect(
     page.getByRole("button", {
       name: "変更を親フレームへ送信する",
@@ -2568,7 +2571,7 @@ test("編集を debounce で自動保存し、未通知の送信 UI は残す", 
     '[data-ark-container="graph"] h2[data-model-id="order"]'
   );
   await label.fill("Edited");
-  await page.waitForTimeout(400);
+  await page.waitForTimeout(150);
   await label.fill("Autosaved Order");
 
   await expect
@@ -2619,6 +2622,27 @@ test("編集を debounce で自動保存し、未通知の送信 UI は残す", 
       }
     ).model.nodes[0]
   ).toMatchObject({ id: "order", label: "Order" });
+});
+
+test("自動保存に失敗した変更を次の tick で再試行する", async ({ page }) => {
+  await page.setContent(diagramHtml());
+  await connectSubmissionPort(page, [false, true]);
+  const status = page.locator(".ark-harness-status");
+
+  await page
+    .locator('[data-ark-container="graph"] h2[data-model-id="order"]')
+    .fill("Retry Order");
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          (window as typeof window & { arkHarnessAutosaves?: unknown[] })
+            .arkHarnessAutosaves?.length ?? 0
+      )
+    )
+    .toBe(2);
+  await expect(status).toHaveText("保存済み");
 });
 
 test("レイアウト方向を LR から TB へ切り替えて再配置・保存する", async ({

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -44,6 +44,7 @@ import {
   BoardMcpServer,
   BoardSessionRegistry,
 } from "./lib/board-mcp-server.js";
+import { rememberFifoEntry } from "./lib/bounded-fifo-map.js";
 import {
   buildTunnelEntries,
   collectBridgeSessions,
@@ -186,9 +187,6 @@ export interface ServerHandle {
 const TUNNEL_STATE_FILE = path.join(os.tmpdir(), "ark-tunnel-state.json");
 
 const MANAGED_WORKTREE_CACHE_TTL_MS = 30_000;
-
-/** 図ごとの、最後に Claude へ通知できたモデル。autosave では更新しない。 */
-const lastNotifiedModels = new Map<string, DiagramModel>();
 
 function diagramModelKey(worktreePath: string, relPath: string): string {
   return `${worktreePath}\0${relPath}`;
@@ -476,6 +474,14 @@ export async function startServer(
    */
   const managedWorktreeCache = new Map<string, { at: number }>();
   const MANAGED_WORKTREE_CACHE_MAX = 256;
+
+  /** 図ごとの、最後に Claude へ通知できたモデル。autosave では更新しない。 */
+  const lastNotifiedModels = new Map<string, DiagramModel>();
+  const LAST_NOTIFIED_MODELS_MAX = 256;
+
+  function rememberNotifiedModel(key: string, model: DiagramModel): void {
+    rememberFifoEntry(lastNotifiedModels, key, model, LAST_NOTIFIED_MODELS_MAX);
+  }
 
   /**
    * 期限切れエントリを掃除し、なおサイズ上限を超えていれば最古（Map の挿入順
@@ -1108,7 +1114,7 @@ export async function startServer(
     // 既存値は未通知の autosave 差分を含み得るため上書きしない。
     const modelKey = diagramModelKey(resolved, relPath);
     if (!lastNotifiedModels.has(modelKey)) {
-      lastNotifiedModels.set(modelKey, result.model);
+      rememberNotifiedModel(modelKey, result.model);
     }
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     // 本文に meta CSP を注入済み。クライアントは srcDoc で描画するため
@@ -2326,7 +2332,7 @@ export async function startServer(
         // baseline を進めず、明示 submit まで未通知差分を蓄積する。
         const modelKey = diagramModelKey(resolved, d.relPath);
         if (!lastNotifiedModels.has(modelKey)) {
-          lastNotifiedModels.set(modelKey, saved.previousModel);
+          rememberNotifiedModel(modelKey, saved.previousModel);
         }
         reply({ ok: true });
       } catch (error) {
@@ -2402,7 +2408,7 @@ export async function startServer(
         }
 
         // 通知が成功した（または意味差分が無かった）時だけ baseline を進める。
-        lastNotifiedModels.set(modelKey, saved.savedModel);
+        rememberNotifiedModel(modelKey, saved.savedModel);
         reply({ ok: true, sent });
       } catch (error) {
         reply({ ok: false, error: getErrorMessage(error) });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -66,11 +66,11 @@ import {
   isDiagramTracked,
 } from "./lib/diagram-delete.js";
 import { describeModelDiff } from "./lib/diagram-diff.js";
-import { ensureDoctype, replaceModelBlock } from "./lib/diagram-file.js";
 import { handleDiagramListRequest, listDiagrams } from "./lib/diagram-list.js";
-import { parseDiagramModel } from "./lib/diagram-model.js";
+import type { DiagramModel } from "./lib/diagram-model.js";
 import { resolveDiagramPath } from "./lib/diagram-path.js";
-import { readDiagram, readDiagramModel } from "./lib/diagram-reader.js";
+import { readDiagram } from "./lib/diagram-reader.js";
+import { saveDiagramEdit } from "./lib/diagram-save.js";
 import { diagramWatcher } from "./lib/diagram-watcher.js";
 import { getErrorMessage } from "./lib/errors.js";
 import { readFileFromWorktree } from "./lib/file-manager.js";
@@ -186,6 +186,13 @@ export interface ServerHandle {
 const TUNNEL_STATE_FILE = path.join(os.tmpdir(), "ark-tunnel-state.json");
 
 const MANAGED_WORKTREE_CACHE_TTL_MS = 30_000;
+
+/** 図ごとの、最後に Claude へ通知できたモデル。autosave では更新しない。 */
+const lastNotifiedModels = new Map<string, DiagramModel>();
+
+function diagramModelKey(worktreePath: string, relPath: string): string {
+  return `${worktreePath}\0${relPath}`;
+}
 
 /** トンネル状態をファイルに保存する */
 function saveTunnelState(port: number): void {
@@ -1096,6 +1103,12 @@ export async function startServer(
     if (!result.ok) {
       res.status(result.status).json({ error: result.error });
       return;
+    }
+    // 初回配信時のモデルは Claude が生成済みの状態として通知 baseline にする。
+    // 既存値は未通知の autosave 差分を含み得るため上書きしない。
+    const modelKey = diagramModelKey(resolved, relPath);
+    if (!lastNotifiedModels.has(modelKey)) {
+      lastNotifiedModels.set(modelKey, result.model);
     }
     res.setHeader("Content-Type", "text/html; charset=utf-8");
     // 本文に meta CSP を注入済み。クライアントは srcDoc で描画するため
@@ -2133,6 +2146,18 @@ export async function startServer(
 
     // ===== 図解キャンバス（board_open による表示 + 更新監視） =====
     const diagramUnsubs = new Map<string, () => void>();
+    // autosave の自己書き込みで、この socket の iframe だけを再読込しない。
+    // O_TRUNC と本文書き込みが別々に見える環境もあるため短い期間で抑制する。
+    const suppressedDiagramUpdates = new Map<string, NodeJS.Timeout>();
+
+    const suppressNextDiagramUpdate = (absPath: string) => {
+      const previous = suppressedDiagramUpdates.get(absPath);
+      if (previous) clearTimeout(previous);
+      const timeout = setTimeout(() => {
+        suppressedDiagramUpdates.delete(absPath);
+      }, 2_500);
+      suppressedDiagramUpdates.set(absPath, timeout);
+    };
 
     socket.on("diagram:list", (data: unknown, callback: unknown) => {
       if (typeof callback !== "function") return;
@@ -2173,6 +2198,13 @@ export async function startServer(
           if (session) io.emit("session:updated", session);
         },
         onDeleted: data => {
+          const session = sessionOrchestrator.getSession(data.sessionId);
+          const resolved = session
+            ? resolveManagedWorktreePath(session.worktreePath)
+            : null;
+          if (resolved) {
+            lastNotifiedModels.delete(diagramModelKey(resolved, data.relPath));
+          }
           io.emit("diagram:deleted", data);
         },
       })
@@ -2213,6 +2245,7 @@ export async function startServer(
       if (!pathResolved.ok) return; // パス自体が不正 (403 相当) なら購読しない
 
       const off = diagramWatcher.subscribe(pathResolved.absPath, () => {
+        if (suppressedDiagramUpdates.has(pathResolved.absPath)) return;
         // クライアントへは購読要求で送られてきた worktreePath（生パス）を
         // そのままエコーバックする。サーバー内部の購読キー・ファイル解決は
         // realpath（resolved）で行うが、クライアント（DiagramPane）は
@@ -2246,28 +2279,13 @@ export async function startServer(
       diagramUnsubs.delete(key);
     });
 
-    /**
-     * 図の編集結果を保存し、意味差分を会話へ還流する。
-     *
-     * html のサイズ上限（無制限だとメモリを一気に確保してしまう）。
-     * 2MB は .diagram.html が意味モデル + 軽量な HTML 投影であるという
-     * 前提（画像等の埋め込みは想定しない）に基づく余裕を持った上限。
-     */
-    const DIAGRAM_SUBMIT_MAX_HTML_BYTES = 2 * 1024 * 1024;
-
-    socket.on("diagram:submit", async (data: unknown, callback: unknown) => {
-      // ack callback は外部入力なので関数であることを検証してから呼ぶ
-      // （slash:list と同じ方針）
+    /** 図の編集結果をファイルへ保存する。会話への通知と baseline 更新はしない。 */
+    socket.on("diagram:autosave", async (data: unknown, callback: unknown) => {
       if (typeof callback !== "function") return;
       const reply = callback as (response: {
         ok: boolean;
-        sent?: string[];
         error?: string;
       }) => void;
-
-      // payload は外部入力。分割代入前に型を検証しないと、引数なし emit や
-      // null/不正形状の payload でハンドラ内 throw → プロセスごと落ちる
-      // （socket.io の同期ハンドラ内例外は uncaughtException になる）。
       const d = data as {
         sessionId?: unknown;
         worktreePath?: unknown;
@@ -2286,97 +2304,90 @@ export async function startServer(
         reply({ ok: false, error: "不正なリクエストです" });
         return;
       }
-      const { sessionId, worktreePath, relPath, model, html } = d;
 
       try {
-        const resolved = resolveManagedWorktreePath(worktreePath);
+        const resolved = resolveManagedWorktreePath(d.worktreePath);
         if (!resolved) {
           reply({ ok: false, error: "worktree を解決できません" });
           return;
         }
+        const saved = await saveDiagramEdit(
+          resolved,
+          d.relPath,
+          d.model,
+          d.html,
+          suppressNextDiagramUpdate
+        );
+        if (!saved.ok) {
+          reply(saved);
+          return;
+        }
+        // 未登録時だけ保存前モデルを初期 baseline にする。以後の autosave は
+        // baseline を進めず、明示 submit まで未通知差分を蓄積する。
+        const modelKey = diagramModelKey(resolved, d.relPath);
+        if (!lastNotifiedModels.has(modelKey)) {
+          lastNotifiedModels.set(modelKey, saved.previousModel);
+        }
+        reply({ ok: true });
+      } catch (error) {
+        reply({ ok: false, error: getErrorMessage(error) });
+      }
+    });
 
-        // 現在のファイルを読み、差分の基準となる旧モデルを得る
-        // （TOCTOU 対策込みの検証も兼ねる）。ここは配信ではないので
-        // CSP/ハーネス注入をしない軽量版を使う（毎 submit の無駄を省く）。
-        const current = await readDiagramModel(resolved, relPath);
-        if (!current.ok) {
-          reply({ ok: false, error: current.error });
-          return;
-        }
+    /** 図を保存し、最後に通知したモデルからの意味差分を会話へ還流する。 */
+    socket.on("diagram:submit", async (data: unknown, callback: unknown) => {
+      if (typeof callback !== "function") return;
+      const reply = callback as (response: {
+        ok: boolean;
+        sent?: string[];
+        error?: string;
+      }) => void;
+      const d = data as {
+        sessionId?: unknown;
+        worktreePath?: unknown;
+        relPath?: unknown;
+        model?: unknown;
+        html?: unknown;
+      } | null;
+      if (
+        !d ||
+        typeof d !== "object" ||
+        typeof d.sessionId !== "string" ||
+        typeof d.worktreePath !== "string" ||
+        typeof d.relPath !== "string" ||
+        typeof d.html !== "string"
+      ) {
+        reply({ ok: false, error: "不正なリクエストです" });
+        return;
+      }
 
-        // 受け取ったモデルを検証する。不正なら保存しない。
-        // model は unknown（構造化された JS 値。iframe からの
-        // postMessage は structured clone のため文字列ではない）なので、
-        // parseDiagramModel（JSON 文字列を受け取る）へ渡す前に文字列化する。
-        // undefined/関数等は JSON.stringify が undefined を返すため、
-        // その場合はモデル未指定として弾く。
-        const modelJson = JSON.stringify(model);
-        if (modelJson === undefined) {
-          reply({ ok: false, error: "モデルが指定されていません" });
+      try {
+        const resolved = resolveManagedWorktreePath(d.worktreePath);
+        if (!resolved) {
+          reply({ ok: false, error: "worktree を解決できません" });
           return;
         }
-        const parsed = parseDiagramModel(modelJson);
-        if (!parsed.ok) {
-          reply({ ok: false, error: parsed.error });
+        const saved = await saveDiagramEdit(
+          resolved,
+          d.relPath,
+          d.model,
+          d.html
+        );
+        if (!saved.ok) {
+          reply(saved);
           return;
-        }
-
-        if (Buffer.byteLength(html, "utf-8") > DIAGRAM_SUBMIT_MAX_HTML_BYTES) {
-          reply({ ok: false, error: "図のサイズが大きすぎます（上限 2MB）" });
-          return;
-        }
-
-        // html 内のモデルブロック（クライアントが送ってくる html 内のブロック
-        // は編集前の古い JSON のまま）を最新モデルで差し替える。DOM 側は
-        // 変更しない。
-        const replaced = replaceModelBlock(html, parsed.model);
-        if (!replaced.ok) {
-          reply({ ok: false, error: replaced.error });
-          return;
-        }
-
-        const pathResolved = resolveDiagramPath(resolved, relPath);
-        if (!pathResolved.ok) {
-          reply({ ok: false, error: pathResolved.error });
-          return;
-        }
-        // ハーネスが送る html は document.documentElement.outerHTML 由来で
-        // doctype を含まない。補わないと送信のたびにファイルから落ちる。
-        //
-        // TOCTOU/symlink 対策: 読み込み側(readRawVerified)は inode/dev + realpath で
-        // worktree 外脱出を弾くが、書き込みは resolveDiagramPath(文字列解決のみ)の後
-        // fs.writeFile が symlink を辿るため、読み書きの間に外向き symlink へ
-        // 差し替えられると worktree 外へ書けてしまう。/api/session の配信(L1163)と
-        // 同じく O_NOFOLLOW で最終要素が symlink なら open を失敗させて防ぐ。
-        let writeHandle: fs.promises.FileHandle;
-        try {
-          writeHandle = await fs.promises.open(
-            pathResolved.absPath,
-            fs.constants.O_WRONLY |
-              fs.constants.O_TRUNC |
-              fs.constants.O_NOFOLLOW
-          );
-        } catch {
-          // ELOOP(最終要素が symlink に差し替わった) / ENOENT(読み込み後に削除) 等
-          reply({ ok: false, error: "図ファイルの実体を検証できません" });
-          return;
-        }
-        try {
-          await writeHandle.writeFile(ensureDoctype(replaced.html), "utf-8");
-        } finally {
-          await writeHandle.close();
         }
 
-        // 意味差分を組み立てて会話へ還流する。文面は describeModelDiff の
-        // 出力だけで組む（html の中身などクライアント由来の文字列は
-        // 混ぜない = 注入対策）。変更が無ければ送信しない。
-        const sent = describeModelDiff(current.model, parsed.model);
+        const modelKey = diagramModelKey(resolved, d.relPath);
+        const baseline =
+          lastNotifiedModels.get(modelKey) ?? saved.previousModel;
+        const sent = describeModelDiff(baseline, saved.savedModel);
         if (sent.length > 0) {
-          const message = `図を編集しました（${relPath}）:\n${sent
+          const message = `図を編集しました（${d.relPath}）:\n${sent
             .map(line => `- ${line}`)
             .join("\n")}`;
           try {
-            sessionOrchestrator.sendMessage(sessionId, message);
+            sessionOrchestrator.sendMessage(d.sessionId, message);
           } catch (error) {
             console.error(
               "[Diagram] sendMessage failed:",
@@ -2390,6 +2401,8 @@ export async function startServer(
           }
         }
 
+        // 通知が成功した（または意味差分が無かった）時だけ baseline を進める。
+        lastNotifiedModels.set(modelKey, saved.savedModel);
         reply({ ok: true, sent });
       } catch (error) {
         reply({ ok: false, error: getErrorMessage(error) });
@@ -3936,6 +3949,10 @@ export async function startServer(
         }
       }
       diagramUnsubs.clear();
+      for (const timeout of suppressedDiagramUpdates.values()) {
+        clearTimeout(timeout);
+      }
+      suppressedDiagramUpdates.clear();
 
       forwardHandlers.forEach((handler, event) => {
         sessionOrchestrator.off(event, handler);

--- a/packages/server/src/lib/bounded-fifo-map.test.ts
+++ b/packages/server/src/lib/bounded-fifo-map.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { rememberFifoEntry } from "./bounded-fifo-map.js";
+
+describe("rememberFifoEntry", () => {
+  it("257件目で最古の要素を削除し、256件以内に保つ", () => {
+    const entries = new Map<string, number>();
+
+    for (let index = 0; index < 257; index += 1) {
+      rememberFifoEntry(entries, `model-${index}`, index, 256);
+    }
+
+    expect(entries).toHaveLength(256);
+    expect(entries.has("model-0")).toBe(false);
+    expect(entries.get("model-1")).toBe(1);
+    expect(entries.get("model-256")).toBe(256);
+  });
+});

--- a/packages/server/src/lib/bounded-fifo-map.ts
+++ b/packages/server/src/lib/bounded-fifo-map.ts
@@ -1,0 +1,14 @@
+/** Map の挿入順を FIFO として使い、指定件数以内に保って値を記憶する。 */
+export function rememberFifoEntry<K, V>(
+  entries: Map<K, V>,
+  key: K,
+  value: V,
+  maximumSize: number
+): void {
+  entries.delete(key);
+  if (entries.size >= maximumSize) {
+    const oldestKey = entries.keys().next().value;
+    if (oldestKey !== undefined) entries.delete(oldestKey);
+  }
+  entries.set(key, value);
+}

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -58,9 +58,7 @@ describe("injectHarness", () => {
     expect(out).toContain("var baselineModelJson;");
     expect(out).toContain("function syncDirtyState(");
     expect(out).toContain("function isDebugMode(");
-    expect(out).toContain(
-      "return /(^|[#,])ark-debug($|[,])/.test(location.hash);"
-    );
+    expect(out).toContain("ark-debug($|[,])/.test(location.hash)");
     expect(out).not.toContain('location.hash.indexOf("ark-debug") !== -1');
     expect(out).toContain(
       'window.addEventListener("hashchange", syncDebugChrome)'

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -37,7 +37,7 @@ export const DIAGRAM_HARNESS_MARKER = "ark-diagram-harness";
 
 /**
  * 注入サイズを抑えるため、既知の trusted source から文字列外の空白だけを除く。
- * 対象にする kernel / adapter 区間には comment と正規表現 literal を置かない。
+ * 対象区間には comment と、空白を含む正規表現 literal を置かない。
  */
 function compactTrustedJavaScript(source: string): string {
   let result = "";
@@ -324,6 +324,7 @@ const RAW_HARNESS_JS = `(function () {
   var layoutDirectionBtn = null;
   var toolbarEl = null;
   var baselineModelJson;
+  var savedJson, savingJson, autosaveTimer, submitPending;
 
   function isRecordObject(v) {
     return v !== null && typeof v === "object" && !Array.isArray(v);
@@ -2941,10 +2942,24 @@ const RAW_HARNESS_JS = `(function () {
   }
 
   function syncDirtyState() {
-    var dirty = JSON.stringify(state.model) !== baselineModelJson;
+    var modelJson = JSON.stringify(state.model);
+    var dirty = modelJson !== baselineModelJson;
     if (sendBtn) sendBtn.style.display = dirty ? "" : "none";
     if (statusEl) statusEl.style.display = dirty ? "" : "none";
     syncToolbarVisibility(dirty);
+    clearTimeout(autosaveTimer);
+    if (modelJson !== savedJson && !savingJson && submitPort) {
+      autosaveTimer = setTimeout(function () {
+        try {
+          savingJson = JSON.stringify(state.model);
+          updateStatus(true, "保存中…");
+          submitPort.postMessage({ type: "ark:diagram-autosave", model: state.model, html: buildSubmissionHtml() });
+        } catch {
+          savingJson = null;
+          updateStatus(true, "保存失敗");
+        }
+      }, 800);
+    }
   }
 
   function syncToolbarVisibility(dirty) {
@@ -3225,10 +3240,16 @@ const RAW_HARNESS_JS = `(function () {
       updateStatus(false, "親フレーム未接続のため送信できません");
       return;
     }
+    if (savingJson) {
+      submitPending = true;
+      return;
+    }
     try {
+      clearTimeout(autosaveTimer);
       var html = buildSubmissionHtml();
       submitPort.postMessage({ type: "ark:diagram-submit", model: state.model, html: html });
       baselineModelJson = JSON.stringify(state.model);
+      savedJson = baselineModelJson;
       updateStatus(true, "送信しました");
       syncDirtyState();
     } catch (e) {
@@ -3376,6 +3397,7 @@ const RAW_HARNESS_JS = `(function () {
       if (!model) return;
       state.model = model;
       baselineModelJson = JSON.stringify(state.model);
+      savedJson = baselineModelJson;
       reservedModelIds = collectModelIds(model);
       syncNodeKinds();
       kindCandidates = collectKindCandidates();
@@ -3398,7 +3420,20 @@ const RAW_HARNESS_JS = `(function () {
     if (submitPort) return;
     if (event.ports && event.ports.length > 0) {
       submitPort = event.ports[0];
+      submitPort.onmessage = function (e) {
+        if (e.data && e.data.type === "ark:diagram-autosave-result") {
+          if (e.data.ok) savedJson = savingJson;
+          savingJson = null;
+          updateStatus(true, e.data.ok ? "保存済み" : "保存失敗");
+          if (!e.data.ok) statusEl.classList.remove("ark-harness-status-ok");
+          if (submitPending) {
+            submitPending = false;
+            handleSubmit();
+          } else if (e.data.ok) syncDirtyState();
+        }
+      };
       updateStatus(true);
+      syncDirtyState();
     }
   });
 })();`;
@@ -3410,12 +3445,47 @@ const groupAdapterEnd = RAW_HARNESS_JS.indexOf(
   GROUP_ADAPTER_END,
   groupAdapterStart
 );
-const HARNESS_JS =
+const GROUP_COMPACTED_HARNESS_JS =
   RAW_HARNESS_JS.slice(0, groupAdapterStart) +
   compactTrustedJavaScript(
     RAW_HARNESS_JS.slice(groupAdapterStart, groupAdapterEnd)
   ) +
   RAW_HARNESS_JS.slice(groupAdapterEnd);
+const STATUS_STATE_START = "  function updateStatus(";
+const STATUS_STATE_END = "  function attachRowControls(";
+const statusStateStart = GROUP_COMPACTED_HARNESS_JS.indexOf(STATUS_STATE_START);
+const statusStateEnd = GROUP_COMPACTED_HARNESS_JS.indexOf(
+  STATUS_STATE_END,
+  statusStateStart
+);
+const STATUS_COMPACTED_HARNESS_JS =
+  GROUP_COMPACTED_HARNESS_JS.slice(0, statusStateStart) +
+  compactTrustedJavaScript(
+    GROUP_COMPACTED_HARNESS_JS.slice(statusStateStart, statusStateEnd)
+  ) +
+  GROUP_COMPACTED_HARNESS_JS.slice(statusStateEnd);
+const SUBMIT_START = "  function handleSubmit(";
+const SUBMIT_END = "  function buildModelPanel(";
+const submitStart = STATUS_COMPACTED_HARNESS_JS.indexOf(SUBMIT_START);
+const submitEnd = STATUS_COMPACTED_HARNESS_JS.indexOf(SUBMIT_END, submitStart);
+const SUBMIT_COMPACTED_HARNESS_JS =
+  STATUS_COMPACTED_HARNESS_JS.slice(0, submitStart) +
+  compactTrustedJavaScript(
+    STATUS_COMPACTED_HARNESS_JS.slice(submitStart, submitEnd)
+  ) +
+  STATUS_COMPACTED_HARNESS_JS.slice(submitEnd);
+const PORT_HANDLER_START = "    if (submitPort) return;";
+const PORT_HANDLER_END = "  });\n})();";
+const portHandlerStart =
+  SUBMIT_COMPACTED_HARNESS_JS.lastIndexOf(PORT_HANDLER_START);
+const portHandlerEnd =
+  SUBMIT_COMPACTED_HARNESS_JS.lastIndexOf(PORT_HANDLER_END);
+const HARNESS_JS =
+  SUBMIT_COMPACTED_HARNESS_JS.slice(0, portHandlerStart) +
+  compactTrustedJavaScript(
+    SUBMIT_COMPACTED_HARNESS_JS.slice(portHandlerStart, portHandlerEnd)
+  ) +
+  SUBMIT_COMPACTED_HARNESS_JS.slice(portHandlerEnd);
 
 export const DIAGRAM_HARNESS_SCRIPT = `${HARNESS_STYLE}
 <script id="${DIAGRAM_HARNESS_MARKER}" data-ark-harness-ui="1">

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -3424,12 +3424,12 @@ const RAW_HARNESS_JS = `(function () {
         if (e.data && e.data.type === "ark:diagram-autosave-result") {
           if (e.data.ok) savedJson = savingJson;
           savingJson = null;
-          updateStatus(true, e.data.ok ? "保存済み" : "保存失敗");
-          if (!e.data.ok) statusEl.classList.remove("ark-harness-status-ok");
+          if (e.data.ok) updateStatus(true, "保存済み");
+          else updateStatus(false, "保存失敗");
           if (submitPending) {
             submitPending = false;
             handleSubmit();
-          } else if (e.data.ok) syncDirtyState();
+          } else syncDirtyState();
         }
       };
       updateStatus(true);
@@ -3451,12 +3451,24 @@ const GROUP_COMPACTED_HARNESS_JS =
     RAW_HARNESS_JS.slice(groupAdapterStart, groupAdapterEnd)
   ) +
   RAW_HARNESS_JS.slice(groupAdapterEnd);
+
+function requireIndex(value: string, marker: string): number {
+  const index = value.indexOf(marker);
+  if (index === -1) {
+    throw new Error(`ハーネス圧縮マーカーが見つかりません: ${marker}`);
+  }
+  return index;
+}
+
 const STATUS_STATE_START = "  function updateStatus(";
 const STATUS_STATE_END = "  function attachRowControls(";
-const statusStateStart = GROUP_COMPACTED_HARNESS_JS.indexOf(STATUS_STATE_START);
-const statusStateEnd = GROUP_COMPACTED_HARNESS_JS.indexOf(
-  STATUS_STATE_END,
-  statusStateStart
+const statusStateStart = requireIndex(
+  GROUP_COMPACTED_HARNESS_JS,
+  STATUS_STATE_START
+);
+const statusStateEnd = requireIndex(
+  GROUP_COMPACTED_HARNESS_JS,
+  STATUS_STATE_END
 );
 const STATUS_COMPACTED_HARNESS_JS =
   GROUP_COMPACTED_HARNESS_JS.slice(0, statusStateStart) +
@@ -3466,8 +3478,8 @@ const STATUS_COMPACTED_HARNESS_JS =
   GROUP_COMPACTED_HARNESS_JS.slice(statusStateEnd);
 const SUBMIT_START = "  function handleSubmit(";
 const SUBMIT_END = "  function buildModelPanel(";
-const submitStart = STATUS_COMPACTED_HARNESS_JS.indexOf(SUBMIT_START);
-const submitEnd = STATUS_COMPACTED_HARNESS_JS.indexOf(SUBMIT_END, submitStart);
+const submitStart = requireIndex(STATUS_COMPACTED_HARNESS_JS, SUBMIT_START);
+const submitEnd = requireIndex(STATUS_COMPACTED_HARNESS_JS, SUBMIT_END);
 const SUBMIT_COMPACTED_HARNESS_JS =
   STATUS_COMPACTED_HARNESS_JS.slice(0, submitStart) +
   compactTrustedJavaScript(
@@ -3476,10 +3488,14 @@ const SUBMIT_COMPACTED_HARNESS_JS =
   STATUS_COMPACTED_HARNESS_JS.slice(submitEnd);
 const PORT_HANDLER_START = "    if (submitPort) return;";
 const PORT_HANDLER_END = "  });\n})();";
-const portHandlerStart =
-  SUBMIT_COMPACTED_HARNESS_JS.lastIndexOf(PORT_HANDLER_START);
-const portHandlerEnd =
-  SUBMIT_COMPACTED_HARNESS_JS.lastIndexOf(PORT_HANDLER_END);
+const portHandlerStart = requireIndex(
+  SUBMIT_COMPACTED_HARNESS_JS,
+  PORT_HANDLER_START
+);
+const portHandlerEnd = requireIndex(
+  SUBMIT_COMPACTED_HARNESS_JS,
+  PORT_HANDLER_END
+);
 const HARNESS_JS =
   SUBMIT_COMPACTED_HARNESS_JS.slice(0, portHandlerStart) +
   compactTrustedJavaScript(

--- a/packages/server/src/lib/diagram-save.test.ts
+++ b/packages/server/src/lib/diagram-save.test.ts
@@ -1,0 +1,86 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { extractModel } from "./diagram-file.js";
+import type { DiagramModel } from "./diagram-model.js";
+import { DIAGRAM_DIR } from "./diagram-path.js";
+import { saveDiagramEdit } from "./diagram-save.js";
+
+const initialModel: DiagramModel = {
+  version: 1,
+  nodes: [{ id: "order", label: "Order" }],
+  edges: [],
+  groups: [],
+};
+
+const html = (model: DiagramModel, label = model.nodes[0]?.label ?? "") =>
+  `<html><body><script type="application/json" id="ark-diagram-model">${JSON.stringify(model)}</script><h1>${label}</h1></body></html>`;
+
+let worktree: string;
+let absPath: string;
+
+beforeEach(() => {
+  worktree = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ark-diagram-save-"))
+  );
+  const directory = path.join(worktree, DIAGRAM_DIR);
+  fs.mkdirSync(directory, { recursive: true });
+  absPath = path.join(directory, "sample.diagram.html");
+  fs.writeFileSync(absPath, `<!doctype html>\n${html(initialModel, "Order")}`);
+});
+
+afterEach(() => {
+  fs.rmSync(worktree, { recursive: true, force: true });
+});
+
+describe("saveDiagramEdit", () => {
+  it("検証済みモデルへブロックを差し替え、保存前モデルも返す", async () => {
+    const edited: DiagramModel = {
+      ...initialModel,
+      nodes: [{ id: "order", label: "Edited Order" }],
+    };
+    const beforeWrite: string[] = [];
+
+    const result = await saveDiagramEdit(
+      worktree,
+      "sample.diagram.html",
+      edited,
+      html(initialModel, "Edited Order"),
+      path => beforeWrite.push(path)
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      previousModel: initialModel,
+      savedModel: edited,
+    });
+    expect(beforeWrite).toEqual([absPath]);
+    const savedHtml = fs.readFileSync(absPath, "utf8");
+    expect(savedHtml).toMatch(/^<!doctype html>/i);
+    expect(extractModel(savedHtml)).toEqual({ ok: true, model: edited });
+    expect(savedHtml).toContain("<h1>Edited Order</h1>");
+  });
+
+  it("不正モデルは保存せず、beforeWrite も呼ばない", async () => {
+    const original = fs.readFileSync(absPath, "utf8");
+    let beforeWriteCalled = false;
+
+    const result = await saveDiagramEdit(
+      worktree,
+      "sample.diagram.html",
+      { version: 2 },
+      html(initialModel),
+      () => {
+        beforeWriteCalled = true;
+      }
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: "version は 1 である必要があります",
+    });
+    expect(beforeWriteCalled).toBe(false);
+    expect(fs.readFileSync(absPath, "utf8")).toBe(original);
+  });
+});

--- a/packages/server/src/lib/diagram-save.test.ts
+++ b/packages/server/src/lib/diagram-save.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { extractModel } from "./diagram-file.js";
 import type { DiagramModel } from "./diagram-model.js";
 import { DIAGRAM_DIR } from "./diagram-path.js";
@@ -31,6 +31,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   fs.rmSync(worktree, { recursive: true, force: true });
 });
 
@@ -82,5 +83,35 @@ describe("saveDiagramEdit", () => {
     });
     expect(beforeWriteCalled).toBe(false);
     expect(fs.readFileSync(absPath, "utf8")).toBe(original);
+  });
+
+  it("write が失敗しても元ファイルを空にしない", async () => {
+    const original = fs.readFileSync(absPath, "utf8");
+    const open = fs.promises.open.bind(fs.promises);
+    const close = vi.fn();
+
+    await expect(
+      saveDiagramEdit(
+        worktree,
+        "sample.diagram.html",
+        initialModel,
+        html(initialModel, "Updated"),
+        () => {
+          vi.spyOn(fs.promises, "open").mockImplementation(async (...args) => {
+            const handle = await open(...args);
+            close.mockImplementation(() => handle.close());
+            return {
+              write: vi.fn().mockRejectedValue(new Error("write failed")),
+              truncate: vi.fn(),
+              close,
+            } as unknown as fs.promises.FileHandle;
+          });
+        }
+      )
+    ).rejects.toThrow("write failed");
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(fs.readFileSync(absPath, "utf8")).toBe(original);
+    expect(fs.statSync(absPath).size).toBe(Buffer.byteLength(original));
   });
 });

--- a/packages/server/src/lib/diagram-save.ts
+++ b/packages/server/src/lib/diagram-save.ts
@@ -1,0 +1,77 @@
+/**
+ * DiagramPane から受け取った編集結果を検証して保存する共通処理。
+ * autosave と明示 submit の保存境界を同一に保つ。
+ */
+
+import fs from "node:fs";
+import { ensureDoctype, replaceModelBlock } from "./diagram-file.js";
+import { type DiagramModel, parseDiagramModel } from "./diagram-model.js";
+import { resolveDiagramPath } from "./diagram-path.js";
+import { readDiagramModel } from "./diagram-reader.js";
+
+export const DIAGRAM_SAVE_MAX_HTML_BYTES = 2 * 1024 * 1024;
+
+export type SaveDiagramEditResult =
+  | {
+      ok: true;
+      absPath: string;
+      previousModel: DiagramModel;
+      savedModel: DiagramModel;
+    }
+  | { ok: false; error: string };
+
+export async function saveDiagramEdit(
+  worktreeReal: string,
+  relPath: string,
+  model: unknown,
+  html: string,
+  beforeWrite?: (absPath: string) => void
+): Promise<SaveDiagramEditResult> {
+  // 保存前の read は既存ファイルの検証と、明示 submit の fallback baseline の
+  // 取得を兼ねる。配信用の CSP / ハーネス注入は行わない。
+  const current = await readDiagramModel(worktreeReal, relPath);
+  if (!current.ok) return { ok: false, error: current.error };
+
+  const modelJson = JSON.stringify(model);
+  if (modelJson === undefined) {
+    return { ok: false, error: "モデルが指定されていません" };
+  }
+  const parsed = parseDiagramModel(modelJson);
+  if (!parsed.ok) return parsed;
+
+  if (Buffer.byteLength(html, "utf-8") > DIAGRAM_SAVE_MAX_HTML_BYTES) {
+    return { ok: false, error: "図のサイズが大きすぎます（上限 2MB）" };
+  }
+
+  // クライアント HTML 内のモデルブロックは編集前のままなので、検証済みの
+  // 最新モデルへ差し替える。DOM 投影には触れない。
+  const replaced = replaceModelBlock(html, parsed.model);
+  if (!replaced.ok) return replaced;
+
+  const pathResolved = resolveDiagramPath(worktreeReal, relPath);
+  if (!pathResolved.ok) return pathResolved;
+
+  // read と write の間に最終要素を外向き symlink へ差し替えられても辿らない。
+  beforeWrite?.(pathResolved.absPath);
+  let writeHandle: fs.promises.FileHandle;
+  try {
+    writeHandle = await fs.promises.open(
+      pathResolved.absPath,
+      fs.constants.O_WRONLY | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW
+    );
+  } catch {
+    return { ok: false, error: "図ファイルの実体を検証できません" };
+  }
+  try {
+    await writeHandle.writeFile(ensureDoctype(replaced.html), "utf-8");
+  } finally {
+    await writeHandle.close();
+  }
+
+  return {
+    ok: true,
+    absPath: pathResolved.absPath,
+    previousModel: current.model,
+    savedModel: parsed.model,
+  };
+}

--- a/packages/server/src/lib/diagram-save.ts
+++ b/packages/server/src/lib/diagram-save.ts
@@ -57,13 +57,15 @@ export async function saveDiagramEdit(
   try {
     writeHandle = await fs.promises.open(
       pathResolved.absPath,
-      fs.constants.O_WRONLY | fs.constants.O_TRUNC | fs.constants.O_NOFOLLOW
+      fs.constants.O_WRONLY | fs.constants.O_NOFOLLOW
     );
   } catch {
     return { ok: false, error: "図ファイルの実体を検証できません" };
   }
   try {
-    await writeHandle.writeFile(ensureDoctype(replaced.html), "utf-8");
+    const body = Buffer.from(ensureDoctype(replaced.html), "utf-8");
+    await writeHandle.write(body, 0, body.byteLength, 0);
+    await writeHandle.truncate(body.byteLength);
   } finally {
     await writeHandle.close();
   }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -693,6 +693,18 @@ export interface ClientToServerEvents {
     relPath: string;
   }) => void;
 
+  /** 図の編集結果を保存する。会話への還流は行わない。 */
+  "diagram:autosave": (
+    data: {
+      sessionId: string;
+      worktreePath: string;
+      relPath: string;
+      model: unknown;
+      html: string;
+    },
+    callback: (response: { ok: boolean; error?: string }) => void
+  ) => void;
+
   /**
    * 図の編集結果を保存し、意味差分を会話へ還流する。
    * model は構造化モデル、html は投影（ハーネスと meta CSP を除いたもの）。

--- a/packages/web/src/components/DiagramPane.test.ts
+++ b/packages/web/src/components/DiagramPane.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import { emitDiagramAutosave } from "./DiagramPane";
+
+describe("emitDiagramAutosave", () => {
+  it("ACK timeout を保存失敗として reply する", () => {
+    const reply = vi.fn();
+    const emit = vi.fn(
+      (_event: string, _request: unknown, callback: (error: Error) => void) =>
+        callback(new Error("operation has timed out"))
+    );
+    const timeout = vi.fn(() => ({ emit }));
+
+    emitDiagramAutosave(
+      { timeout } as never,
+      {
+        sessionId: "session-1",
+        worktreePath: "/worktree",
+        relPath: ".claude/diagrams/sample.diagram.html",
+        model: {},
+        html: "<html></html>",
+      },
+      reply
+    );
+
+    expect(timeout).toHaveBeenCalledWith(10_000);
+    expect(reply).toHaveBeenCalledWith({
+      ok: false,
+      error: "保存がタイムアウトしました",
+    });
+  });
+});

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -46,11 +46,27 @@ interface DiagramSubmitMessage {
   html: string;
 }
 
+interface DiagramAutosaveMessage {
+  type: "ark:diagram-autosave";
+  model: unknown;
+  html: string;
+}
+
 function isDiagramSubmitMessage(data: unknown): data is DiagramSubmitMessage {
   return (
     typeof data === "object" &&
     data !== null &&
     (data as { type?: unknown }).type === "ark:diagram-submit"
+  );
+}
+
+function isDiagramAutosaveMessage(
+  data: unknown
+): data is DiagramAutosaveMessage {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    (data as { type?: unknown }).type === "ark:diagram-autosave"
   );
 }
 
@@ -291,6 +307,38 @@ export function DiagramPane({
     [socket, isConnected, sessionId, worktreePath, relPath]
   );
 
+  // 自動保存はファイルだけを更新し、会話への還流は行わない。ACK は port で
+  // ハーネスへ返し、「保存中… / 保存済み」の表示を確定させる。
+  const handleAutosave = useCallback(
+    (
+      model: unknown,
+      submittedHtml: string,
+      reply: (response: { ok: boolean; error?: string }) => void
+    ) => {
+      if (!relPath) {
+        reply({ ok: false, error: "図が選択されていません" });
+        return;
+      }
+      if (!socket || !isConnected) {
+        const error = "サーバーに未接続のため保存できません";
+        setSubmitError(error);
+        reply({ ok: false, error });
+        return;
+      }
+      socket.emit(
+        "diagram:autosave",
+        { sessionId, worktreePath, relPath, model, html: submittedHtml },
+        response => {
+          setSubmitError(
+            response.ok ? null : (response.error ?? "自動保存に失敗しました")
+          );
+          reply(response);
+        }
+      );
+    },
+    [socket, isConnected, sessionId, worktreePath, relPath]
+  );
+
   // iframe のロード（初回表示 / worktreePath・relPath 変更 / diagram:updated
   // による再読込のいずれも "load" イベントを起こす）のたびに MessageChannel を
   // 新規に張り直し、port2 をハーネスへ渡す。ハーネス側も document 再生成のたびに
@@ -325,8 +373,18 @@ export function DiagramPane({
       const channel = new MessageChannel();
       portRef.current = channel.port1;
       channel.port1.onmessage = (event: MessageEvent) => {
-        if (!isDiagramSubmitMessage(event.data)) return;
-        handleSubmit(event.data.model, event.data.html);
+        if (isDiagramSubmitMessage(event.data)) {
+          handleSubmit(event.data.model, event.data.html);
+          return;
+        }
+        if (isDiagramAutosaveMessage(event.data)) {
+          handleAutosave(event.data.model, event.data.html, response => {
+            channel.port1.postMessage({
+              type: "ark:diagram-autosave-result",
+              ...response,
+            });
+          });
+        }
       };
 
       // targetOrigin に "*" を使う理由:
@@ -342,7 +400,7 @@ export function DiagramPane({
         channel.port2,
       ]);
     },
-    [handleSubmit, html]
+    [handleAutosave, handleSubmit, html]
   );
 
   return (

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -52,6 +52,33 @@ interface DiagramAutosaveMessage {
   html: string;
 }
 
+interface DiagramAutosaveRequest {
+  sessionId: string;
+  worktreePath: string;
+  relPath: string;
+  model: unknown;
+  html: string;
+}
+
+interface DiagramAutosaveResponse {
+  ok: boolean;
+  error?: string;
+}
+
+export function emitDiagramAutosave(
+  socket: TypedSocket,
+  request: DiagramAutosaveRequest,
+  reply: (response: DiagramAutosaveResponse) => void
+): void {
+  socket.timeout(10_000).emit("diagram:autosave", request, (err, response) => {
+    if (err) {
+      reply({ ok: false, error: "保存がタイムアウトしました" });
+      return;
+    }
+    reply(response);
+  });
+}
+
 function isDiagramSubmitMessage(data: unknown): data is DiagramSubmitMessage {
   return (
     typeof data === "object" &&
@@ -96,6 +123,7 @@ export function DiagramPane({
   const [html, setHtml] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [diagrams, setDiagrams] = useState<DiagramListItem[]>([]);
   const [listLoading, setListLoading] = useState(false);
   const [listError, setListError] = useState<string | null>(null);
@@ -292,17 +320,23 @@ export function DiagramPane({
         setSubmitError("サーバーに未接続のため送信できません");
         return;
       }
-      socket.emit(
-        "diagram:submit",
-        { sessionId, worktreePath, relPath, model, html: submittedHtml },
-        response => {
-          if (!response.ok) {
-            setSubmitError(response.error ?? "送信に失敗しました");
-            return;
+      socket
+        .timeout(10_000)
+        .emit(
+          "diagram:submit",
+          { sessionId, worktreePath, relPath, model, html: submittedHtml },
+          (err, response) => {
+            if (err) {
+              setSubmitError("送信がタイムアウトしました");
+              return;
+            }
+            if (!response.ok) {
+              setSubmitError(response.error ?? "送信に失敗しました");
+              return;
+            }
+            setSubmitError(null);
           }
-          setSubmitError(null);
-        }
-      );
+        );
     },
     [socket, isConnected, sessionId, worktreePath, relPath]
   );
@@ -321,15 +355,15 @@ export function DiagramPane({
       }
       if (!socket || !isConnected) {
         const error = "サーバーに未接続のため保存できません";
-        setSubmitError(error);
+        setSaveError(error);
         reply({ ok: false, error });
         return;
       }
-      socket.emit(
-        "diagram:autosave",
+      emitDiagramAutosave(
+        socket,
         { sessionId, worktreePath, relPath, model, html: submittedHtml },
         response => {
-          setSubmitError(
+          setSaveError(
             response.ok ? null : (response.error ?? "自動保存に失敗しました")
           );
           reply(response);
@@ -441,6 +475,18 @@ export function DiagramPane({
           </div>
         ) : (
           <div className="flex h-full flex-col">
+            {saveError && (
+              <div className="flex shrink-0 items-start justify-between gap-2 border-b border-destructive/20 bg-destructive/10 px-3 py-1.5 text-xs text-destructive">
+                <span className="flex-1">{saveError}</span>
+                <button
+                  type="button"
+                  className="shrink-0 text-xs underline"
+                  onClick={() => setSaveError(null)}
+                >
+                  閉じる
+                </button>
+              </div>
+            )}
             {submitError && (
               <div className="flex shrink-0 items-start justify-between gap-2 border-b border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
                 <span className="flex-1">{submitError}</span>


### PR DESCRIPTION
Closes #279

## 概要

ボード編集が「変更を送る」まで揮発する問題（実機フィードバック「編集して永続化がない」）への対処。**保存（ファイル）と通知（会話への還流）を分離**する。

## 変更点

### サーバー
- `diagram:autosave` イベントを追加。検証・サニタイズ・symlink 対策（O_NOFOLLOW）を `diagram-save.ts` に共通化し、明示 submit と同一の保存境界を通す
- **還流 baseline の分離**: 図ごとに「最後に Claude へ通知したモデル」を保持（配信時に seed）。autosave はファイルのみ更新し、明示 submit が baseline との差分をまとめて還流して baseline を進める（autosave 済み差分が還流から漏れない）
- **自己書き込みの抑制**: autosave によるファイル更新では発信元 socket への `diagram:updated` を抑制し、編集中の iframe が再読込されない（他の閲覧者へは通常どおり通知）
- 外部書き込み（Claude 直編集等）を検知したら baseline を破棄し、現在ファイル比較へフォールバック

### ペイン / 型
- port 経由の `ark:diagram-autosave` を Socket.IO `diagram:autosave` へ中継し、ACK を `ark:diagram-autosave-result` で返す

### ハーネス
- モデル変更を 800ms debounce で自動保存。「保存中… / 保存済み / 保存失敗」を表示
- **未通知 dirty の意味は不変**: 自動保存しても「変更を送る」は残り、押すと Claude へ差分が届く。autosave 実行中の明示送信は完了後に自動実行
- サイズ確保のため status / submit / port 領域を compaction 対象に追加

## サイズ（要注意）

注入後 **130,927 bytes** — guard 131,072 まで**残 145 bytes**。以後のハーネス変更は原資確保（さらなる compaction / 削減）とセットで行う必要がある（#281 にも記載）。

## 検証

- server unit 530 / 図解 E2E 80 / `pnpm check` / `pnpm build` PASS。diagram-diff.ts は不変
- ライブ実機（実際のイベントストーミング図 + ペイン相当の port/socket 中継を再現）:
  - ノード drag → 800ms 後に autosave 1回発火 → **送信ボタンなしでファイル保存** → 「保存済み」表示 → 「変更を送る」は残存 → **リロードで編集が残る**（6/6）
  - 実運用でも確認: ボード編集 → autosave（還流なし）→ 明示送信で構造差分がまとめて会話へ到着
  - 回帰: Phase C クロム 13/13・Phase D 10/10・note 12/12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 図の編集内容を自動保存できるようになりました。
  * 保存中・保存済みの状態を画面で確認できます。
  * 自動保存中の送信操作は適切に保留されます。
  * 自動保存では通知を発生させず、明示的な送信時のみ変更内容が通知されます。

* **改善**
  * 保存失敗時にエラー結果を受け取れるようになりました。
  * 自動保存後も、送信画面の未送信状態が維持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->