### PR TITLE
図解の還流メッセージ: note・空labelノードの表示名を noteText/kind から解決

### DIFF
--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -86,6 +86,63 @@ describe("describeModelDiff", () => {
     ]);
   });
 
+  it("空 label の note 追加では noteText の抜粋を表示名にする", () => {
+    const note = {
+      id: "note-1",
+      label: "",
+      kind: "note",
+      noteText: "合ってる",
+    };
+
+    expect(describeModelDiff(model([]), model([note]))).toEqual([
+      "メモ「合ってる」を追加",
+    ]);
+  });
+
+  it("空 label の note どうしの関連では両端の noteText の抜粋を表示名にする", () => {
+    const question = {
+      id: "note-question",
+      label: "",
+      kind: "note",
+      noteText: "この理解でよい？",
+    };
+    const answer = {
+      id: "note-answer",
+      label: "",
+      kind: "note",
+      noteText: "合ってる",
+    };
+    const before = model([question, answer]);
+    const after = model(
+      [question, answer],
+      [{ id: "e1", from: question.id, to: answer.id }]
+    );
+
+    expect(describeModelDiff(before, after)).toEqual([
+      "メモ「この理解でよい？」から メモ「合ってる」への関連を追加",
+    ]);
+  });
+
+  it("空 label かつ noteText なしのノードは kind と id を表示名にする", () => {
+    const node = { id: "node-x", label: "", kind: "entity" };
+
+    expect(describeModelDiff(model([]), model([node]))).toEqual([
+      "entity ノード (node-x) を追加",
+    ]);
+  });
+
+  it("noteText だけの変更は意味差分に含めない", () => {
+    const before = {
+      id: "note-1",
+      label: "",
+      kind: "note",
+      noteText: "変更前",
+    };
+    const after = { ...before, noteText: "変更後" };
+
+    expect(describeModelDiff(model([before]), model([after]))).toEqual([]);
+  });
+
   it("関連の追加を述べる", () => {
     const user = { id: "user", label: "User" };
     const before = model([order, user]);
@@ -530,6 +587,40 @@ describe("describeModelDiff（label の無害化 / プロンプト注入対策�
     const inserted = line.replace("Order に ", "").replace(" を追加", "");
     expect(inserted).toHaveLength(80);
     expect(inserted).toBe(`${"x".repeat(79)}…`);
+  });
+
+  it("長い noteText は先頭20文字と省略記号を表示名にする", () => {
+    const noteText = "あ".repeat(30);
+    const note = { id: "note-1", label: "", kind: "note", noteText };
+
+    expect(describeModelDiff(model([]), model([note]))).toEqual([
+      `メモ「${"あ".repeat(20)}…」を追加`,
+    ]);
+  });
+
+  it("noteText の改行・制御文字を除去して前後を trim する", () => {
+    const note = {
+      id: "note-1",
+      label: "",
+      kind: "note",
+      noteText: "  一行目\n\u0000二行目\u0007  ",
+    };
+
+    expect(describeModelDiff(model([]), model([note]))).toEqual([
+      "メモ「一行目二行目」を追加",
+    ]);
+  });
+
+  it("node 表示名に使う kind と id の改行・制御文字も除去する", () => {
+    const node = {
+      id: "node\n-x\u0000",
+      label: "",
+      kind: "enti\u0007ty\n",
+    };
+
+    expect(describeModelDiff(model([]), model([node]))).toEqual([
+      "entity ノード (node-x) を追加",
+    ]);
   });
 
   it("通常の label は変わらない", () => {

--- a/packages/server/src/lib/diagram-diff.ts
+++ b/packages/server/src/lib/diagram-diff.ts
@@ -9,11 +9,11 @@
  * モデルしか受け取らないため、生成コードや他人が書いた図が任意の散文を
  * 会話へ流し込めない。
  *
- * ただし node / field / edge の label 自体は外部入力である（ユーザーの
- * インライン編集、または他人が PR で持ち込む .diagram.html 内のモデル
- * JSON）。label をテンプレートへ素通しすると、この前提が崩れて label
- * 経由で任意の指示文を注入できてしまう。そのため文へ挿入する直前に
- * sanitizeLabel() を通す。
+ * ただし node / field / edge の label と、node の noteText / kind / id は
+ * 外部入力である（ユーザーのインライン編集、または他人が PR で持ち込む
+ * .diagram.html 内のモデル JSON）。これらをテンプレートへ素通しすると、
+ * この前提が崩れて任意の指示文を注入できてしまう。そのため文へ挿入する
+ * 直前に sanitizeLabel() を通す（node は nodeDisplayName() 内で行う）。
  */
 
 import type {
@@ -26,6 +26,7 @@ import type {
 const LABEL_MAX_LENGTH = 80;
 const LABEL_ELLIPSIS = "…";
 const LABEL_FALLBACK = "(無題)";
+const NOTE_EXCERPT_LENGTH = 20;
 
 /** C0制御文字（コードポイント 0-31）と DEL（127）かどうかを判定する */
 function isControlCodePoint(codePoint: number): boolean {
@@ -52,16 +53,62 @@ function isControlCodePoint(codePoint: number): boolean {
  * これは表示用の変換であり、モデルに保存される label 自体（呼び出し元が
  * 保持するオブジェクト）は変更しない。
  */
-function sanitizeLabel(label: string): string {
+function sanitizeLabel(
+  label: string,
+  fallback: string = LABEL_FALLBACK
+): string {
   const stripped = Array.from(label)
     .filter(ch => !isControlCodePoint(ch.codePointAt(0) ?? 0))
     .join("")
     .trim();
-  if (stripped.length === 0) return LABEL_FALLBACK;
+  if (stripped.length === 0) return fallback;
   if (stripped.length <= LABEL_MAX_LENGTH) return stripped;
   return (
     stripped.slice(0, LABEL_MAX_LENGTH - LABEL_ELLIPSIS.length) + LABEL_ELLIPSIS
   );
+}
+
+/** node の label、メモ本文、種別と id の順で生成文向けの表示名を解決する */
+function nodeDisplayName(node: DiagramNode): string {
+  const label = sanitizeLabel(node.label ?? "");
+  if (label !== LABEL_FALLBACK) return label;
+
+  if (typeof node.noteText === "string") {
+    const noteText = sanitizeLabel(node.noteText, "");
+    if (noteText.length > 0) {
+      const characters = Array.from(noteText);
+      const excerpt =
+        characters.length > NOTE_EXCERPT_LENGTH
+          ? `${characters.slice(0, NOTE_EXCERPT_LENGTH).join("")}${LABEL_ELLIPSIS}`
+          : noteText;
+      return `メモ「${excerpt}」`;
+    }
+  }
+
+  const id = sanitizeLabel(node.id);
+  return node.kind
+    ? `${sanitizeLabel(node.kind)} ノード (${id})`
+    : `ノード (${id})`;
+}
+
+/** noteText 由来の表示名だけは、日本語の鉤括弧に助詞を直結する */
+function isNoteExcerptDisplayName(
+  node: DiagramNode,
+  displayName: string
+): boolean {
+  return (
+    sanitizeLabel(node.label ?? "") === LABEL_FALLBACK &&
+    displayName.startsWith("メモ「") &&
+    displayName.endsWith("」")
+  );
+}
+
+function withParticle(
+  displayName: string,
+  particle: string,
+  compact: boolean
+): string {
+  return `${displayName}${compact ? "" : " "}${particle}`;
 }
 
 function byId<T extends { id: string }>(items: T[]): Map<string, T> {
@@ -71,6 +118,7 @@ function byId<T extends { id: string }>(items: T[]): Map<string, T> {
 /** フィールド列の差分を述べる（追加・削除・改名・並べ替え） */
 function diffFields(
   nodeLabel: string,
+  compactNodeLabel: boolean,
   before: DiagramField[],
   after: DiagramField[]
 ): string[] {
@@ -80,15 +128,20 @@ function diffFields(
 
   for (const f of after) {
     const prev = b.get(f.id);
-    if (!prev) out.push(`${nodeLabel} に ${sanitizeLabel(f.label)} を追加`);
+    if (!prev)
+      out.push(
+        `${withParticle(nodeLabel, "に", compactNodeLabel)} ${sanitizeLabel(f.label)} を追加`
+      );
     else if (prev.label !== f.label)
       out.push(
-        `${nodeLabel} の ${sanitizeLabel(prev.label)} を ${sanitizeLabel(f.label)} に変更`
+        `${withParticle(nodeLabel, "の", compactNodeLabel)} ${sanitizeLabel(prev.label)} を ${sanitizeLabel(f.label)} に変更`
       );
   }
   for (const f of before) {
     if (!a.has(f.id))
-      out.push(`${nodeLabel} から ${sanitizeLabel(f.label)} を削除`);
+      out.push(
+        `${withParticle(nodeLabel, "から", compactNodeLabel)} ${sanitizeLabel(f.label)} を削除`
+      );
   }
 
   // 追加・削除を除いた並びが変わっていれば並べ替えとして述べる
@@ -96,7 +149,9 @@ function diffFields(
   const keptAfter = after.filter(f => b.has(f.id)).map(f => f.id);
   if (keptBefore.length > 1 && keptBefore.join(" ") !== keptAfter.join(" ")) {
     const order = after.map(f => sanitizeLabel(f.label)).join(", ");
-    out.push(`${nodeLabel} のフィールド順を ${order} に変更`);
+    out.push(
+      `${withParticle(nodeLabel, "の", compactNodeLabel)}フィールド順を ${order} に変更`
+    );
   }
   return out;
 }
@@ -108,27 +163,41 @@ function diffNodes(before: DiagramNode[], after: DiagramNode[]): string[] {
 
   for (const n of after) {
     const prev = b.get(n.id);
-    const label = sanitizeLabel(n.label);
+    const label = nodeDisplayName(n);
+    const compactLabel = isNoteExcerptDisplayName(n, label);
     if (!prev) {
-      out.push(`${label} を追加`);
+      out.push(`${withParticle(label, "を", compactLabel)}追加`);
       continue;
     }
-    if (prev.label !== n.label)
-      out.push(`${sanitizeLabel(prev.label)} を ${label} に改名`);
-    out.push(...diffFields(label, prev.fields ?? [], n.fields ?? []));
+    if (prev.label !== n.label) {
+      const prevLabel = nodeDisplayName(prev);
+      out.push(
+        `${withParticle(prevLabel, "を", isNoteExcerptDisplayName(prev, prevLabel))} ${withParticle(label, "に", compactLabel)}改名`
+      );
+    }
+    out.push(
+      ...diffFields(label, compactLabel, prev.fields ?? [], n.fields ?? [])
+    );
   }
   for (const n of before) {
     // 削除の主語は before 側の label（after には存在しない）
-    if (!a.has(n.id)) out.push(`${sanitizeLabel(n.label)} を削除`);
+    if (!a.has(n.id)) {
+      const label = nodeDisplayName(n);
+      out.push(
+        `${withParticle(label, "を", isNoteExcerptDisplayName(n, label))}削除`
+      );
+    }
   }
   return out;
 }
 
 function edgeText(edge: DiagramEdge, nodes: Map<string, DiagramNode>): string {
-  const from = sanitizeLabel(nodes.get(edge.from)?.label ?? edge.from);
-  const to = sanitizeLabel(nodes.get(edge.to)?.label ?? edge.to);
+  const fromNode = nodes.get(edge.from);
+  const toNode = nodes.get(edge.to);
+  const from = fromNode ? nodeDisplayName(fromNode) : sanitizeLabel(edge.from);
+  const to = toNode ? nodeDisplayName(toNode) : sanitizeLabel(edge.to);
   const label = edge.label ? `「${sanitizeLabel(edge.label)}」` : "";
-  return `${from} から ${to} への関連${label}`;
+  return `${withParticle(from, "から", fromNode ? isNoteExcerptDisplayName(fromNode, from) : false)} ${withParticle(to, "への", toNode ? isNoteExcerptDisplayName(toNode, to) : false)}関連${label}`;
 }
 
 function diffEdges(before: DiagramModel, after: DiagramModel): string[] {


### PR DESCRIPTION
Closes #280

**Stacked PR**: base は #282 (`feature/diagram/autosave`)。#282 マージ後に base が main へ切り替わってからマージする。

## 問題（実機で確認）

label を持たない note ノードの追加・関連を送信すると還流が「(無題) を追加」「(無題) から (無題) への関連を追加」となり、Claude が内容を読めない。

## 変更点

`describeModelDiff` の**表示名解決のみ**を `nodeDisplayName` に一元化:

1. label（従来どおり・sanitize 済み）
2. note は noteText の先頭 20 字抜粋 → 『メモ「合ってる」を追加』
3. kind + id フォールバック → 『entity ノード (node-x) を追加』

edge の端点表示にも同じ解決を適用。noteText / kind / id はすべて既存 sanitizeLabel を通す（注入対策の設計コメントも更新）。

## 不変条件

- **noteText の変更自体は diff として検出しない**（非還流維持・テストで実証）
- 還流対象の判定ロジック（追加・削除・改名・field 差分）は不変
- ハーネス非接触（サイズ影響なし）

## 実際の改善（今日の実送信シナリオを新実装で再現）

Before: `(無題) を追加 / (無題) から (無題) への関連を追加`
After: `メモ「合ってる」を追加 / メモ「合ってる」から メモ「①注文確定時点の金額の意味（最重要）不定…」への関連を追加`

## 検証

対象 45 / 全 692 テスト PASS・`pnpm check`・`pnpm build` PASS