### PR TITLE
図解ボード: ズーム（ボタン + トラックパッドピンチ）/ パン

### DIFF
--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -770,6 +770,61 @@ async function enableDiagramDebug(page: Page) {
   ).toBeVisible();
 }
 
+test("ctrl+wheel は pinch として親 port へ転送し通常 wheel は転送しない", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  await connectSubmissionPort(page);
+
+  const ctrlPrevented = await page.evaluate(() => {
+    const event = new WheelEvent("wheel", {
+      ctrlKey: true,
+      deltaY: -80,
+      cancelable: true,
+    });
+    window.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(ctrlPrevented).toBe(true);
+  await page.waitForFunction(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { type?: string };
+        }
+      ).arkHarnessSubmission?.type === "ark:diagram-pinch"
+  );
+  expect(
+    await page.evaluate(
+      () =>
+        (window as typeof window & { arkHarnessSubmission?: unknown })
+          .arkHarnessSubmission
+    )
+  ).toEqual({ type: "ark:diagram-pinch", deltaY: -80 });
+
+  const plainPrevented = await page.evaluate(() => {
+    delete (window as typeof window & { arkHarnessSubmission?: unknown })
+      .arkHarnessSubmission;
+    const event = new WheelEvent("wheel", {
+      deltaY: 80,
+      cancelable: true,
+    });
+    window.dispatchEvent(event);
+    return event.defaultPrevented;
+  });
+  expect(plainPrevented).toBe(false);
+  await page.evaluate(
+    () => new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+  );
+  expect(
+    await page.evaluate(
+      () =>
+        (window as typeof window & { arkHarnessSubmission?: unknown })
+          .arkHarnessSubmission
+    )
+  ).toBeUndefined();
+});
+
 async function openModelPanel(page: Page, programmatic = false) {
   await enableDiagramDebug(page);
   const button = page.getByRole("button", {

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -2385,10 +2385,15 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   expect(submission.html).not.toContain("ark-harness-node-anchor");
   expect(submission.html).not.toContain("ark-harness-edge-hit");
   expect(submission.html).not.toContain("--ark-harness-graph-x");
-  expect(describeModelDiff(crudModel, submission.model)).toEqual([
-    "(無題) を追加",
-    "B から (無題) への関連を追加",
+  const diff = describeModelDiff(crudModel, submission.model);
+  expect(diff).toEqual([
+    expect.stringMatching(/^event ノード \(node-[0-9a-f-]+\) を追加$/),
+    expect.stringMatching(
+      /^B から event ノード \(node-[0-9a-f-]+\) への関連を追加$/
+    ),
   ]);
+  expect(diff[0]).toContain(`(${added.id})`);
+  expect(diff[1]).toContain(`(${added.id})`);
 });
 
 test("下部ツールバーは既定で非表示になり余白を残さない", async ({ page }) => {

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -3413,6 +3413,7 @@ const RAW_HARNESS_JS = `(function () {
 
   init();
 
+  window.addEventListener("wheel",function(e){if(!e.ctrlKey||!submitPort)return;e.preventDefault();submitPort.postMessage({type:"ark:diagram-pinch",deltaY:e.deltaY})},{passive:false});
   window.addEventListener("message", function onMessage(event) {
     // event.origin は検証しない: sandbox iframe は不透明オリジンで
     // event.origin === "null" になる（実測済み）。port を持っていること
@@ -3486,22 +3487,32 @@ const SUBMIT_COMPACTED_HARNESS_JS =
     STATUS_COMPACTED_HARNESS_JS.slice(submitStart, submitEnd)
   ) +
   STATUS_COMPACTED_HARNESS_JS.slice(submitEnd);
+const INIT_START = "  function init() {";
+const INIT_END = "  init();";
+const initStart = requireIndex(SUBMIT_COMPACTED_HARNESS_JS, INIT_START);
+const initEnd = requireIndex(SUBMIT_COMPACTED_HARNESS_JS, INIT_END);
+const INIT_COMPACTED_HARNESS_JS =
+  SUBMIT_COMPACTED_HARNESS_JS.slice(0, initStart) +
+  compactTrustedJavaScript(
+    SUBMIT_COMPACTED_HARNESS_JS.slice(initStart, initEnd)
+  ) +
+  SUBMIT_COMPACTED_HARNESS_JS.slice(initEnd);
 const PORT_HANDLER_START = "    if (submitPort) return;";
 const PORT_HANDLER_END = "  });\n})();";
 const portHandlerStart = requireIndex(
-  SUBMIT_COMPACTED_HARNESS_JS,
+  INIT_COMPACTED_HARNESS_JS,
   PORT_HANDLER_START
 );
 const portHandlerEnd = requireIndex(
-  SUBMIT_COMPACTED_HARNESS_JS,
+  INIT_COMPACTED_HARNESS_JS,
   PORT_HANDLER_END
 );
 const HARNESS_JS =
-  SUBMIT_COMPACTED_HARNESS_JS.slice(0, portHandlerStart) +
+  INIT_COMPACTED_HARNESS_JS.slice(0, portHandlerStart) +
   compactTrustedJavaScript(
-    SUBMIT_COMPACTED_HARNESS_JS.slice(portHandlerStart, portHandlerEnd)
+    INIT_COMPACTED_HARNESS_JS.slice(portHandlerStart, portHandlerEnd)
   ) +
-  SUBMIT_COMPACTED_HARNESS_JS.slice(portHandlerEnd);
+  INIT_COMPACTED_HARNESS_JS.slice(portHandlerEnd);
 
 export const DIAGRAM_HARNESS_SCRIPT = `${HARNESS_STYLE}
 <script id="${DIAGRAM_HARNESS_MARKER}" data-ark-harness-ui="1">

--- a/packages/web/src/components/DiagramPane.test.ts
+++ b/packages/web/src/components/DiagramPane.test.ts
@@ -2,11 +2,13 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import {
+  applyDiagramPinchZoom,
   DIAGRAM_ZOOM_MAX,
   DIAGRAM_ZOOM_MIN,
   DiagramViewport,
   emitDiagramAutosave,
   getDiagramZoomPercent,
+  handleDiagramPinchMessage,
   resetDiagramZoom,
   stepDiagramZoom,
 } from "./DiagramPane";
@@ -62,6 +64,47 @@ describe("emitDiagramAutosave", () => {
 });
 
 describe("DiagramPane zoom", () => {
+  it("pinch メッセージで連続ズームし 200% / 25% で clamp する", () => {
+    let zoom = 1;
+    const setZoom = (update: (current: number) => number) => {
+      zoom = update(zoom);
+    };
+
+    expect(
+      handleDiagramPinchMessage(
+        { type: "ark:diagram-pinch", deltaY: -40 },
+        setZoom
+      )
+    ).toBe(true);
+    expect(zoom).toBeCloseTo(Math.exp(0.1));
+
+    handleDiagramPinchMessage(
+      { type: "ark:diagram-pinch", deltaY: 80 },
+      setZoom
+    );
+    expect(zoom).toBeCloseTo(Math.exp(-0.1));
+    expect(applyDiagramPinchZoom(1, -10_000)).toBe(DIAGRAM_ZOOM_MAX);
+    expect(applyDiagramPinchZoom(1, 10_000)).toBe(DIAGRAM_ZOOM_MIN);
+  });
+
+  it("不正な pinch メッセージは zoom を変更しない", () => {
+    const setZoom = vi.fn();
+
+    expect(
+      handleDiagramPinchMessage(
+        { type: "ark:diagram-pinch", deltaY: "-40" },
+        setZoom
+      )
+    ).toBe(false);
+    expect(
+      handleDiagramPinchMessage(
+        { type: "ark:diagram-pinch", deltaY: Number.NaN },
+        setZoom
+      )
+    ).toBe(false);
+    expect(setZoom).not.toHaveBeenCalled();
+  });
+
   it("＋/−で percent 表示と iframe の width/transform が変わる", () => {
     const zoomedIn = stepDiagramZoom(1, "in");
     expect(getDiagramZoomPercent(zoomedIn)).toBe(125);

--- a/packages/web/src/components/DiagramPane.test.ts
+++ b/packages/web/src/components/DiagramPane.test.ts
@@ -1,5 +1,36 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
-import { emitDiagramAutosave } from "./DiagramPane";
+import {
+  DIAGRAM_ZOOM_MAX,
+  DIAGRAM_ZOOM_MIN,
+  DiagramViewport,
+  emitDiagramAutosave,
+  getDiagramZoomPercent,
+  resetDiagramZoom,
+  stepDiagramZoom,
+} from "./DiagramPane";
+
+const REL_PATH = ".claude/diagrams/sample.diagram.html";
+const HTML = "<!doctype html><html><body>diagram</body></html>";
+
+function renderViewport(zoom: number, relPath = REL_PATH): string {
+  return renderToStaticMarkup(
+    createElement(DiagramViewport, {
+      relPath,
+      html: HTML,
+      zoom,
+      onZoomOut: vi.fn(),
+      onZoomReset: vi.fn(),
+      onZoomIn: vi.fn(),
+      onIframeLoad: vi.fn(),
+    })
+  );
+}
+
+function getRenderedSrcDoc(markup: string): string | undefined {
+  return markup.match(/srcDoc="([^"]*)"/)?.[1];
+}
 
 describe("emitDiagramAutosave", () => {
   it("ACK timeout を保存失敗として reply する", () => {
@@ -27,5 +58,68 @@ describe("emitDiagramAutosave", () => {
       ok: false,
       error: "保存がタイムアウトしました",
     });
+  });
+});
+
+describe("DiagramPane zoom", () => {
+  it("＋/−で percent 表示と iframe の width/transform が変わる", () => {
+    const zoomedIn = stepDiagramZoom(1, "in");
+    expect(getDiagramZoomPercent(zoomedIn)).toBe(125);
+    expect(renderViewport(zoomedIn)).toContain(
+      "width:calc(100% / 1.25);height:calc(100% / 1.25);transform:scale(1.25);transform-origin:0 0"
+    );
+
+    const zoomedOut = stepDiagramZoom(1, "out");
+    expect(getDiagramZoomPercent(zoomedOut)).toBe(80);
+    expect(renderViewport(zoomedOut)).toContain(
+      "width:calc(100% / 0.8);height:calc(100% / 0.8);transform:scale(0.8);transform-origin:0 0"
+    );
+  });
+
+  it("200% / 25% で clamp し、対応するボタンを disabled にする", () => {
+    let upper = 1;
+    let lower = 1;
+    for (let i = 0; i < 10; i += 1) {
+      upper = stepDiagramZoom(upper, "in");
+      lower = stepDiagramZoom(lower, "out");
+    }
+
+    expect(upper).toBe(DIAGRAM_ZOOM_MAX);
+    expect(lower).toBe(DIAGRAM_ZOOM_MIN);
+    expect(stepDiagramZoom(upper, "in")).toBe(DIAGRAM_ZOOM_MAX);
+    expect(stepDiagramZoom(lower, "out")).toBe(DIAGRAM_ZOOM_MIN);
+    expect(renderViewport(upper)).toContain('title="ズームイン" disabled=""');
+    expect(renderViewport(lower)).toContain('title="ズームアウト" disabled=""');
+  });
+
+  it("percent リセットで 100% に戻り、iframe の transform が外れる", () => {
+    const zoom = resetDiagramZoom();
+    const markup = renderViewport(zoom);
+
+    expect(getDiagramZoomPercent(zoom)).toBe(100);
+    expect(markup).toContain(">100%</button>");
+    expect(markup).not.toContain("transform:");
+    expect(markup).not.toContain("<iframe style=");
+  });
+
+  it("relPath 変更時は 100% にリセットした表示になる", () => {
+    const before = renderViewport(stepDiagramZoom(1, "in"), REL_PATH);
+    const after = renderViewport(
+      resetDiagramZoom(),
+      ".claude/diagrams/other.diagram.html"
+    );
+
+    expect(before).toContain(">125%</button>");
+    expect(after).toContain(">100%</button>");
+    expect(after).not.toContain("transform:");
+  });
+
+  it("zoom 変更では iframe の srcDoc が変わらない", () => {
+    const before = renderViewport(1);
+    const after = renderViewport(stepDiagramZoom(1, "in"));
+
+    expect(getRenderedSrcDoc(before)).toBeDefined();
+    expect(getRenderedSrcDoc(after)).toBe(getRenderedSrcDoc(before));
+    expect(after).toContain('sandbox="allow-scripts"');
   });
 });

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -12,6 +12,7 @@ import type {
   DiagramListItem,
   ServerToClientEvents,
 } from "@ark/shared";
+import type { CSSProperties } from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
 import {
@@ -63,6 +64,96 @@ interface DiagramAutosaveRequest {
 interface DiagramAutosaveResponse {
   ok: boolean;
   error?: string;
+}
+
+export const DIAGRAM_ZOOM_MIN = 0.25;
+export const DIAGRAM_ZOOM_MAX = 2;
+export const DIAGRAM_ZOOM_STEP = 1.25;
+export const DIAGRAM_ZOOM_DEFAULT = 1;
+
+export function stepDiagramZoom(zoom: number, direction: "in" | "out"): number {
+  const next =
+    direction === "in" ? zoom * DIAGRAM_ZOOM_STEP : zoom / DIAGRAM_ZOOM_STEP;
+  return Math.min(DIAGRAM_ZOOM_MAX, Math.max(DIAGRAM_ZOOM_MIN, next));
+}
+
+export function getDiagramZoomPercent(zoom: number): number {
+  return Math.round(zoom * 100);
+}
+
+export function getDiagramZoomStyle(zoom: number): CSSProperties | undefined {
+  if (zoom === DIAGRAM_ZOOM_DEFAULT) return undefined;
+  return {
+    width: `calc(100% / ${zoom})`,
+    height: `calc(100% / ${zoom})`,
+    transform: `scale(${zoom})`,
+    transformOrigin: "0 0",
+  };
+}
+
+export function resetDiagramZoom(): number {
+  return DIAGRAM_ZOOM_DEFAULT;
+}
+
+interface DiagramViewportProps {
+  relPath: string;
+  html: string;
+  zoom: number;
+  onZoomOut: () => void;
+  onZoomReset: () => void;
+  onZoomIn: () => void;
+  onIframeLoad: (event: React.SyntheticEvent<HTMLIFrameElement>) => void;
+}
+
+export function DiagramViewport({
+  relPath,
+  html,
+  zoom,
+  onZoomOut,
+  onZoomReset,
+  onZoomIn,
+  onIframeLoad,
+}: DiagramViewportProps) {
+  return (
+    <div className="relative min-h-0 flex-1 overflow-hidden">
+      <div className="absolute top-2 right-2 z-10 flex items-center rounded-md border border-border bg-background/90 p-0.5 shadow-sm">
+        <button
+          type="button"
+          title="ズームアウト"
+          disabled={zoom <= DIAGRAM_ZOOM_MIN}
+          className="inline-flex size-7 items-center justify-center rounded text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={onZoomOut}
+        >
+          −
+        </button>
+        <button
+          type="button"
+          title="ズームをリセット"
+          className="h-7 min-w-12 rounded px-1 text-xs tabular-nums text-foreground transition-colors hover:bg-accent"
+          onClick={onZoomReset}
+        >
+          {getDiagramZoomPercent(zoom)}%
+        </button>
+        <button
+          type="button"
+          title="ズームイン"
+          disabled={zoom >= DIAGRAM_ZOOM_MAX}
+          className="inline-flex size-7 items-center justify-center rounded text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-40"
+          onClick={onZoomIn}
+        >
+          ＋
+        </button>
+      </div>
+      <iframe
+        title={relPath}
+        srcDoc={html}
+        sandbox="allow-scripts"
+        className="block h-full w-full border-0 bg-white"
+        style={getDiagramZoomStyle(zoom)}
+        onLoad={onIframeLoad}
+      />
+    </div>
+  );
 }
 
 export function emitDiagramAutosave(
@@ -130,6 +221,7 @@ export function DiagramPane({
   const [listRefreshKey, setListRefreshKey] = useState(0);
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteMessage, setDeleteMessage] = useState<string | null>(null);
+  const [zoom, setZoom] = useState(DIAGRAM_ZOOM_DEFAULT);
   const activeListRequestRef = useRef<object | null>(null);
   const deleteInFlightRef = useRef(false);
   // 進行中の fetch を追跡し、古いタブの結果が新しいタブを上書きしないようにする
@@ -188,6 +280,7 @@ export function DiagramPane({
   useEffect(() => {
     setHtml(null);
     setError(null);
+    setZoom(resetDiagramZoom());
     portGrantedForRef.current = null;
     if (!relPath) {
       abortControllerRef.current?.abort();
@@ -499,12 +592,18 @@ export function DiagramPane({
                 </button>
               </div>
             )}
-            <iframe
-              title={relPath}
-              srcDoc={html}
-              sandbox="allow-scripts"
-              className="min-h-0 w-full flex-1 border-0 bg-white"
-              onLoad={handleIframeLoad}
+            <DiagramViewport
+              relPath={relPath}
+              html={html}
+              zoom={zoom}
+              onZoomOut={() =>
+                setZoom(current => stepDiagramZoom(current, "out"))
+              }
+              onZoomReset={() => setZoom(resetDiagramZoom())}
+              onZoomIn={() =>
+                setZoom(current => stepDiagramZoom(current, "in"))
+              }
+              onIframeLoad={handleIframeLoad}
             />
           </div>
         )}

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -53,6 +53,11 @@ interface DiagramAutosaveMessage {
   html: string;
 }
 
+interface DiagramPinchMessage {
+  type: "ark:diagram-pinch";
+  deltaY: number;
+}
+
 interface DiagramAutosaveRequest {
   sessionId: string;
   worktreePath: string;
@@ -74,6 +79,11 @@ export const DIAGRAM_ZOOM_DEFAULT = 1;
 export function stepDiagramZoom(zoom: number, direction: "in" | "out"): number {
   const next =
     direction === "in" ? zoom * DIAGRAM_ZOOM_STEP : zoom / DIAGRAM_ZOOM_STEP;
+  return Math.min(DIAGRAM_ZOOM_MAX, Math.max(DIAGRAM_ZOOM_MIN, next));
+}
+
+export function applyDiagramPinchZoom(zoom: number, deltaY: number): number {
+  const next = zoom * Math.exp(-deltaY / 400);
   return Math.min(DIAGRAM_ZOOM_MAX, Math.max(DIAGRAM_ZOOM_MIN, next));
 }
 
@@ -186,6 +196,25 @@ function isDiagramAutosaveMessage(
     data !== null &&
     (data as { type?: unknown }).type === "ark:diagram-autosave"
   );
+}
+
+function isDiagramPinchMessage(data: unknown): data is DiagramPinchMessage {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    (data as { type?: unknown }).type === "ark:diagram-pinch" &&
+    typeof (data as { deltaY?: unknown }).deltaY === "number" &&
+    Number.isFinite((data as { deltaY: number }).deltaY)
+  );
+}
+
+export function handleDiagramPinchMessage(
+  data: unknown,
+  setZoom: (update: (zoom: number) => number) => void
+): boolean {
+  if (!isDiagramPinchMessage(data)) return false;
+  setZoom(zoom => applyDiagramPinchZoom(zoom, data.deltaY));
+  return true;
 }
 
 /**
@@ -500,6 +529,7 @@ export function DiagramPane({
       const channel = new MessageChannel();
       portRef.current = channel.port1;
       channel.port1.onmessage = (event: MessageEvent) => {
+        if (handleDiagramPinchMessage(event.data, setZoom)) return;
         if (isDiagramSubmitMessage(event.data)) {
           handleSubmit(event.data.model, event.data.html);
           return;


### PR DESCRIPTION
Closes #281

## 概要

大きい図（3260px 級のイベントマップ等）をボードで俯瞰・拡大できるようにする。実機フィードバック起因。

## 設計: pane 側 CSS transform・ハーネスほぼ無改修

注入後ハーネスの残量が数百 bytes しかないため、ズームは **DiagramPane 側の iframe transform トリック**で実装:
`width/height: calc(100%/z)` + `transform: scale(z)`。iframe 内部の座標系は不変なので、**drag・アンカー接続・ツールバーはハーネス無改修で正しく動く**（ブラウザがイベント座標を写像。scale(0.5) 下で「画面30pxのドラッグ→論理60pxがmodelに入る」ことを実測で証明済み）。パンは従来どおり iframe 内スクロール。

## 変更点

- **ズームv1**: ペイン右上のフローティングコントロール ［−］［%表示=クリックでリセット］［＋］。25%〜200%・×1.25 ステップ・図切替でリセット・100% 時は従来と同一スタイル（transform なし）・zoom 変更で iframe は再ロードされない
- **ピンチ**: トラックパッドのピンチ（= ctrlKey 付き wheel）はポインタが iframe 上にあるためハーネスが捕捉し、既存 submitPort で `ark:diagram-pinch {deltaY}` を親へ転送（追加1行・{passive:false}）。pane が `exp(-deltaY/400)` で連続ズーム。**ctrl なし wheel は転送せずスクロール（パン）のまま**
- **E2E 期待値の #283 追従修正**: main 既存の還流文言テスト（「(無題) を追加」期待）が #283 の表示名変更に未追従で失敗していたのを修正（CI は browser E2E を実行しないためすり抜けていた）

## 制限（v2 候補・#281 に記録）

- ズーム基準は左上（カーソル/ピンチ位置中心化は iframe 内スクロール補正が必要）
- fit-to-view はハーネスからのコンテンツサイズ報告が必要

## サイズ

注入後 **130,685 bytes**（+45・残 387 bytes）。ピンチ捕捉はミニ化済み1行 + 既存 init 区間の追加 compaction で相殺。

## 検証

- Playwright E2E 82 / unit 704 / `pnpm check` / `pnpm build` PASS
- 実機（scale(0.5) の sandbox srcDoc iframe・実ペイン同構成）: hover ハンドル出現・**drag 座標写像の完全一致**・クリック選択ツールバー出現
- 実機（port エミュレーション）: Ctrl+wheel で pinch が port に届く / ctrl なし wheel は転送されない
- autosave 回帰 6/6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 図のズーム操作に対応しました（固定倍率、ピンチ操作、ズーム率表示、リセット）。
  * 図を切り替えるとズーム倍率が自動的に初期化されます。
  * Ctrlキー＋ホイールによるズーム操作に対応しました。
  * ズーム倍率には上下限を設定し、通常のホイール操作は従来どおり扱います。

* **テスト**
  * ズーム操作、入力検証、表示更新、図の切り替え時のリセットを追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->