### PR TITLE
図解編集: ノード本体ドラッグで移動（⠿ハンドル撤去）

### DIFF
--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -964,6 +964,19 @@ async function requiredBoundingBox(locator: Locator) {
   return box;
 }
 
+async function dragNodeBody(
+  page: Page,
+  node: Locator,
+  delta: { x: number; y: number }
+) {
+  const box = await requiredBoundingBox(node);
+  const start = { x: box.x + 8, y: box.y + 8 };
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(start.x + delta.x, start.y + delta.y, { steps: 5 });
+  await page.mouse.up();
+}
+
 async function dragNodeAnchorToPoint(
   page: Page,
   graph: Locator,
@@ -1851,7 +1864,7 @@ test("node CRUD: anchor から空白へ drag して pin node と edge を原子�
   await expect(
     contextToolbar(page).getByRole("button", { name: "行を追加" })
   ).toBeEnabled();
-  await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(1);
+  await expect(projection.locator(".ark-harness-graph-handle")).toHaveCount(0);
   await expect(
     firstGraph.locator(
       `.ark-harness-node-connectors[data-ark-node-id="${added.id}"] .ark-harness-node-anchor`
@@ -3034,9 +3047,7 @@ test("自動配置 LR は分岐・循環・self-edge・孤立 node を決定的�
   await expect(graph.locator(":scope > .ark-harness-graph-node")).toHaveCount(
     autoLayoutNodes.length
   );
-  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(
-    autoLayoutNodes.length
-  );
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(0);
   await expect(
     graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
   ).toHaveCount(autoLayoutEdges.length);
@@ -3121,7 +3132,7 @@ test("手動座標と座標未指定 node を混在させ、manual 同士の重�
   for (const autoId of ["auto_missing", "auto_partial", "auto_invalid"]) {
     await expect(
       graph.locator(`[data-model-id="${autoId}"] .ark-harness-graph-handle`)
-    ).toHaveCount(1);
+    ).toHaveCount(0);
     expect(boxesOverlap(byId[autoId], byId.manual_a)).toBe(false);
     expect(boxesOverlap(byId[autoId], byId.manual_b)).toBe(false);
   }
@@ -3166,23 +3177,11 @@ test("表示時は座標を非永続化し、ドラッグした node だけ手�
 
   const autoNode = page.locator('[data-model-id="auto_missing"]').first();
   const before = await requiredBoundingBox(autoNode);
-  const handle = await requiredBoundingBox(
-    autoNode.locator(".ark-harness-graph-handle")
-  );
   await page.evaluate(() => {
     delete (window as typeof window & { arkHarnessSubmission?: unknown })
       .arkHarnessSubmission;
   });
-  await page.mouse.move(
-    handle.x + handle.width / 2,
-    handle.y + handle.height / 2
-  );
-  await page.mouse.down();
-  await page.mouse.move(
-    handle.x + handle.width / 2 + 60,
-    handle.y + handle.height / 2 + 40
-  );
-  await page.mouse.up();
+  await dragNodeBody(page, autoNode, { x: 60, y: 40 });
   await submit.click();
   await page.waitForFunction(() =>
     Boolean(
@@ -3529,23 +3528,11 @@ test("group-aware auto layout は座標を還流せず drag した member だけ
   const graph = page.locator('[data-ark-container="graph"]');
   const member = graph.locator('[data-model-id="cart_item"]').first();
   const memberBefore = await requiredBoundingBox(member);
-  const handle = await requiredBoundingBox(
-    member.locator(".ark-harness-graph-handle")
-  );
   await page.evaluate(() => {
     delete (window as typeof window & { arkHarnessSubmission?: unknown })
       .arkHarnessSubmission;
   });
-  await page.mouse.move(
-    handle.x + handle.width / 2,
-    handle.y + handle.height / 2
-  );
-  await page.mouse.down();
-  await page.mouse.move(
-    handle.x + handle.width / 2 + 48,
-    handle.y + handle.height / 2 + 36
-  );
-  await page.mouse.up();
+  await dragNodeBody(page, member, { x: 48, y: 36 });
   await expect
     .poll(async () => (await requiredBoundingBox(member)).x)
     .toBeCloseTo(memberBefore.x + 48, 0);
@@ -4162,12 +4149,7 @@ test("edge 端点 handle を最前面の専用 layer に配置する", async ({ 
       .locator('.ark-harness-graph-node[data-model-id="order"]')
       .evaluate(element => getComputedStyle(element).zIndex)
   ).toBe("2");
-  expect(
-    await graph
-      .locator(".ark-harness-graph-handle")
-      .first()
-      .evaluate(element => getComputedStyle(element).zIndex)
-  ).toBe("3");
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(0);
 });
 
 test("edge 終点を張り替えて記号と clean HTML を同期する", async ({ page }) => {
@@ -4570,7 +4552,7 @@ test("group は複数 node を囲むラベル付き境界として投影する",
   await expect(
     graph.locator('.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
   ).toHaveCount(1);
-  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(0);
   await expect(
     order.locator('li[data-model-id="order_id"] .ark-harness-text')
   ).toHaveAttribute("contenteditable", "true");
@@ -4589,20 +4571,7 @@ test("node ドラッグで group 境界と edge だけが追従する", async ({
   const beforeOrder = await requiredBoundingBox(order);
   const beforeUser = await requiredBoundingBox(user);
   const beforeEdge = await readEdge(page);
-  const handleBox = await requiredBoundingBox(
-    order.locator(".ark-harness-graph-handle")
-  );
-
-  await page.mouse.move(
-    handleBox.x + handleBox.width / 2,
-    handleBox.y + handleBox.height / 2
-  );
-  await page.mouse.down();
-  await page.mouse.move(
-    handleBox.x + handleBox.width / 2 + 80,
-    handleBox.y + handleBox.height / 2 + 60
-  );
-  await page.mouse.up();
+  await dragNodeBody(page, order, { x: 80, y: 60 });
 
   await expect
     .poll(async () => (await order.boundingBox())?.x)
@@ -5177,7 +5146,7 @@ test("flat 図の authored kindless node は note を選ぶまで従来投影を
 
   const graph = page.locator('[data-ark-container="graph"]');
   await expect(graph.locator(".ark-harness-kind-picker")).toHaveCount(0);
-  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(4);
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(0);
   await expect(
     graph.locator('[data-model-id="valid_a"].ark-harness-editable')
   ).toHaveAttribute("contenteditable", "true");
@@ -5590,7 +5559,7 @@ test("sample は複数 kind を色とアイコンで区別する", async ({ page
   await expect(
     graph.locator('.ark-harness-edge-main[data-ark-edge-id="e_order_user"]')
   ).toHaveCount(1);
-  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(2);
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(0);
   await expect(
     graph.locator('li[data-model-id="order_id"] .ark-harness-text')
   ).toHaveAttribute("contenteditable", "true");
@@ -6240,20 +6209,9 @@ test("kind 変更と node・edge・field・list 編集を同じ送信 model に�
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
       })
   );
-  const handle = order.locator(".ark-harness-graph-handle");
   const beforeBox = await requiredBoundingBox(order);
   const beforeEdge = await readEdge(page);
-  const handleBox = await requiredBoundingBox(handle);
-  await page.mouse.move(
-    handleBox.x + handleBox.width / 2,
-    handleBox.y + handleBox.height / 2
-  );
-  await page.mouse.down();
-  await page.mouse.move(
-    handleBox.x + handleBox.width / 2 + 80,
-    handleBox.y + handleBox.height / 2 + 60
-  );
-  await page.mouse.up();
+  await dragNodeBody(page, order, { x: 80, y: 60 });
 
   await expect
     .poll(async () => (await order.boundingBox())?.x)
@@ -6404,19 +6362,7 @@ test("モデル直接編集後の kind 再同期と node ドラッグを送信 m
   expect(afterStyle.icon).not.toBe("");
   expect(afterStyle.icon).not.toBe(beforeStyle.icon);
 
-  const handleBox = await requiredBoundingBox(
-    order.locator(".ark-harness-graph-handle")
-  );
-  await page.mouse.move(
-    handleBox.x + handleBox.width / 2,
-    handleBox.y + handleBox.height / 2
-  );
-  await page.mouse.down();
-  await page.mouse.move(
-    handleBox.x + handleBox.width / 2 + 80,
-    handleBox.y + handleBox.height / 2 + 60
-  );
-  await page.mouse.up();
+  await dragNodeBody(page, order, { x: 80, y: 60 });
 
   await page
     .getByRole("button", { name: "変更を親フレームへ送信する" })
@@ -6477,13 +6423,13 @@ test("不正座標は座標未指定として自動配置し graph 外参照だ�
   await expect(
     graph.locator(".ark-harness-edge-main[data-ark-edge-id]")
   ).toHaveCount(2);
-  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(4);
+  await expect(graph.locator(".ark-harness-graph-handle")).toHaveCount(0);
   await expect(
     graph.locator('[data-model-id="string_x"] .ark-harness-graph-handle')
-  ).toHaveCount(1);
+  ).toHaveCount(0);
   await expect(
     graph.locator('[data-model-id="null_y"] .ark-harness-graph-handle')
-  ).toHaveCount(1);
+  ).toHaveCount(0);
   expectNoOverlaps(await graphNodeBoxes(page));
   expect(errors).toEqual([]);
 });

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1292,6 +1292,94 @@ test("selection toolbar: node・contenteditable・edge・解除を単一 root �
   await expect(selectedNodeAnchor(page, "order")).toHaveCount(0);
 });
 
+test("node 本体を4px超ドラッグすると座標を更新する", async ({ page }) => {
+  await openDiagram(page);
+  const order = page.locator('.ark-harness-graph-node[data-model-id="order"]');
+  const heading = order.locator("h2");
+  const [before, headingBox] = await Promise.all([
+    requiredBoundingBox(order),
+    requiredBoundingBox(heading),
+  ]);
+  const start = {
+    x: headingBox.x + headingBox.width - 10,
+    y: headingBox.y + headingBox.height / 2,
+  };
+
+  await page.mouse.move(start.x, start.y);
+  await page.mouse.down();
+  await page.mouse.move(start.x + 70, start.y + 45, { steps: 5 });
+  await page.mouse.up();
+
+  await expect
+    .poll(async () => (await order.boundingBox())?.x)
+    .toBeCloseTo(before.x + 70, 0);
+  const after = await requiredBoundingBox(order);
+  expect(after.y).toBeCloseTo(before.y + 45, 0);
+  const current = await readCurrentModel(page);
+  expect(current.nodes.find(node => node.id === "order")?.ext).toMatchObject({
+    x: 110,
+    y: 95,
+  });
+});
+
+test("node 本体の4px以下操作はラベルと行の編集フォーカスを維持する", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  const order = page.locator('.ark-harness-graph-node[data-model-id="order"]');
+  const before = await requiredBoundingBox(order);
+  for (const editable of [
+    order.locator("h2"),
+    order.locator('li[data-model-id="order_id"] .ark-harness-text'),
+  ]) {
+    const box = await requiredBoundingBox(editable);
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(
+      box.x + box.width / 2 + 2,
+      box.y + box.height / 2 + 1
+    );
+    await page.mouse.up();
+    await expect(editable).toBeFocused();
+  }
+  const after = await requiredBoundingBox(order);
+  expect(after.x).toBeCloseTo(before.x, 0);
+  expect(after.y).toBeCloseTo(before.y, 0);
+});
+
+test("フォーカス済み editable 内のドラッグでは node を移動しない", async ({
+  page,
+}) => {
+  await openDiagram(page);
+  const order = page.locator('.ark-harness-graph-node[data-model-id="order"]');
+  const editable = order.locator(
+    'li[data-model-id="order_id"] .ark-harness-text'
+  );
+  await editable.focus();
+  await expect(editable).toBeFocused();
+  const [before, editableBox] = await Promise.all([
+    requiredBoundingBox(order),
+    requiredBoundingBox(editable),
+  ]);
+
+  await page.mouse.move(
+    editableBox.x + 2,
+    editableBox.y + editableBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    editableBox.x + editableBox.width - 2,
+    editableBox.y + editableBox.height / 2,
+    { steps: 5 }
+  );
+  await page.mouse.up();
+
+  const after = await requiredBoundingBox(order);
+  expect(after.x).toBeCloseTo(before.x, 0);
+  expect(after.y).toBeCloseTo(before.y, 0);
+  await expect(editable).toBeFocused();
+});
+
 test("selection toolbar hover-gap: node と edge から gap 経由で移動しても 250ms 後まで維持する", async ({
   page,
 }) => {

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -1335,28 +1335,50 @@ test("node 本体を4px超ドラッグすると座標を更新する", async ({ 
   });
 });
 
-test("node 本体の4px以下操作はラベルと行の編集フォーカスを維持する", async ({
+test("node 本体の4px境界で編集フォーカスとドラッグ開始を分ける", async ({
   page,
 }) => {
   await openDiagram(page);
   const order = page.locator('.ark-harness-graph-node[data-model-id="order"]');
   const before = await requiredBoundingBox(order);
-  for (const editable of [
-    order.locator("h2"),
-    order.locator('li[data-model-id="order_id"] .ark-harness-text'),
-  ]) {
+  const boundaryCases = [
+    { editable: order.locator("h2"), dx: 3, dy: 0 },
+    {
+      editable: order.locator('li[data-model-id="order_id"] .ark-harness-text'),
+      dx: 0,
+      dy: 4,
+    },
+  ];
+  for (const { editable, dx, dy } of boundaryCases) {
     const box = await requiredBoundingBox(editable);
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
     await page.mouse.down();
     await page.mouse.move(
-      box.x + box.width / 2 + 2,
-      box.y + box.height / 2 + 1
+      box.x + box.width / 2 + dx,
+      box.y + box.height / 2 + dy
     );
     await page.mouse.up();
     await expect(editable).toBeFocused();
+    const unchanged = await requiredBoundingBox(order);
+    expect(unchanged.x).toBeCloseTo(before.x, 0);
+    expect(unchanged.y).toBeCloseTo(before.y, 0);
   }
+
+  const heading = order.locator("h2");
+  const headingBox = await requiredBoundingBox(heading);
+  await page.mouse.move(
+    headingBox.x + headingBox.width / 2,
+    headingBox.y + headingBox.height / 2
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    headingBox.x + headingBox.width / 2 + 5,
+    headingBox.y + headingBox.height / 2
+  );
+  await page.mouse.up();
+
   const after = await requiredBoundingBox(order);
-  expect(after.x).toBeCloseTo(before.x, 0);
+  expect(after.x).toBeCloseTo(before.x + 5, 0);
   expect(after.y).toBeCloseTo(before.y, 0);
 });
 
@@ -1370,23 +1392,33 @@ test("フォーカス済み editable 内のドラッグでは node を移動し�
   );
   await editable.focus();
   await expect(editable).toBeFocused();
-  const [before, editableBox] = await Promise.all([
+  const [before, textBox] = await Promise.all([
     requiredBoundingBox(order),
-    requiredBoundingBox(editable),
+    editable.evaluate(element => {
+      const text = element.firstChild;
+      if (!(text instanceof Text))
+        throw new Error("editable text node not found");
+      const range = document.createRange();
+      range.selectNodeContents(text);
+      const rect = range.getBoundingClientRect();
+      return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+    }),
   ]);
 
-  await page.mouse.move(
-    editableBox.x + 2,
-    editableBox.y + editableBox.height / 2
-  );
+  await page.mouse.move(textBox.x, textBox.y + textBox.height / 2);
   await page.mouse.down();
   await page.mouse.move(
-    editableBox.x + editableBox.width - 2,
-    editableBox.y + editableBox.height / 2,
+    textBox.x + textBox.width,
+    textBox.y + textBox.height / 2,
     { steps: 5 }
   );
   await page.mouse.up();
 
+  const selectedText = await page.evaluate(
+    () => document.getSelection()?.toString() ?? ""
+  );
+  expect(selectedText).not.toBe("");
+  expect(selectedText).toContain("id");
   const after = await requiredBoundingBox(order);
   expect(after.x).toBeCloseTo(before.x, 0);
   expect(after.y).toBeCloseTo(before.y, 0);

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -46,7 +46,7 @@ describe("injectHarness", () => {
 
     expect(out).toContain('[data-ark-container="graph"]');
     expect(out).toContain("ark-harness-edge-layer");
-    expect(out).toContain("ark-harness-graph-handle");
+    expect(out).not.toContain("ark-harness-graph-handle");
     expect(out).toContain("ark-harness-edge-handle-layer");
     expect(out).toContain("ark-harness-edge-handle");
     expect(out).toContain("function syncEdgeHandles(");

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -1688,6 +1688,46 @@ const RAW_HARNESS_JS = `(function () {
     }
   }
 
+  function startGraphDrag(graph, el, handle, event, start) {
+    if (graphDrag || edgeDrag) return false;
+    var id = el.getAttribute("data-model-id");
+    if (!id) return false;
+    var currentNode = getNode(state.model, id);
+    var position = graphPosition(currentNode) || graph.positionsById.get(id);
+    if (!position) return false;
+    event.preventDefault();
+    handle.setPointerCapture(event.pointerId);
+    el.classList.add("ark-harness-graph-dragging");
+    graphDrag = {
+      pointerId: event.pointerId,
+      handle: handle,
+      graph: graph,
+      el: el,
+      node: currentNode,
+      start: {
+        clientX: start ? start.x : event.clientX,
+        clientY: start ? start.y : event.clientY,
+        x: position.x,
+        y: position.y
+      }
+    };
+    return true;
+  }
+
+  function updateGraphDrag(event) {
+    if (!graphDrag || event.pointerId !== graphDrag.pointerId) return;
+    var drag = graphDrag;
+    var x = Math.max(0, Math.round(drag.start.x + event.clientX - drag.start.clientX));
+    var y = Math.max(0, Math.round(drag.start.y + event.clientY - drag.start.clientY));
+    if (!isRecordObject(drag.node.ext)) drag.node.ext = {};
+    drag.node.ext.x = x;
+    drag.node.ext.y = y;
+    drag.graph.positionsById.set(drag.node.id, { x: x, y: y });
+    drag.el.style.setProperty("--ark-harness-graph-x", x + "px");
+    drag.el.style.setProperty("--ark-harness-graph-y", y + "px");
+    scheduleGraphRender(drag.graph);
+  }
+
   function attachGraphHandle(graph, el, node) {
     var handle = createButton(
       "\\u283F",
@@ -1695,45 +1735,59 @@ const RAW_HARNESS_JS = `(function () {
       (node.label || node.id) + " をドラッグして移動"
     );
     handle.addEventListener("pointerdown", function (event) {
-      if (graphDrag || edgeDrag) return;
-      var id = el.getAttribute("data-model-id");
-      if (!id) return;
-      var currentNode = getNode(state.model, id);
-      var position = graphPosition(currentNode) || graph.positionsById.get(id);
-      if (!position) return;
-      event.preventDefault();
-      handle.setPointerCapture(event.pointerId);
-      el.classList.add("ark-harness-graph-dragging");
-      graphDrag = {
-        pointerId: event.pointerId,
-        handle: handle,
-        graph: graph,
-        el: el,
-        node: currentNode,
-        start: {
-          clientX: event.clientX,
-          clientY: event.clientY,
-          x: position.x,
-          y: position.y
-        }
-      };
+      startGraphDrag(graph, el, handle, event);
     });
-    handle.addEventListener("pointermove", function (event) {
-      if (!graphDrag || event.pointerId !== graphDrag.pointerId) return;
-      var drag = graphDrag;
-      var x = Math.max(0, Math.round(drag.start.x + event.clientX - drag.start.clientX));
-      var y = Math.max(0, Math.round(drag.start.y + event.clientY - drag.start.clientY));
-      if (!isRecordObject(drag.node.ext)) drag.node.ext = {};
-      drag.node.ext.x = x;
-      drag.node.ext.y = y;
-      drag.graph.positionsById.set(drag.node.id, { x: x, y: y });
-      drag.el.style.setProperty("--ark-harness-graph-x", x + "px");
-      drag.el.style.setProperty("--ark-harness-graph-y", y + "px");
-      scheduleGraphRender(drag.graph);
-    });
+    handle.addEventListener("pointermove", updateGraphDrag);
     handle.addEventListener("pointerup", finishGraphDrag);
     handle.addEventListener("pointercancel", finishGraphDrag);
     el.appendChild(handle);
+
+    var pending = null;
+    var suppressClick = false;
+    el.addEventListener("pointerdown", function (event) {
+      if (!event.isTrusted || event.button !== 0 || graphDrag || edgeDrag ||
+          !event.target.closest) return;
+      var editable = event.target.closest('[contenteditable="true"],input,textarea');
+      if (event.target.closest('button,select,option,.ark-harness-node-anchor,.ark-harness-node-connectors,[draggable="true"]') ||
+          editable === document.activeElement) return;
+      pending = {
+        pointerId: event.pointerId,
+        x: event.clientX,
+        y: event.clientY,
+        editable: editable
+      };
+      el.setPointerCapture(event.pointerId);
+    });
+    el.addEventListener("pointermove", function (event) {
+      if (!pending || event.pointerId !== pending.pointerId) {
+        updateGraphDrag(event);
+        return;
+      }
+      var dx = event.clientX - pending.x;
+      var dy = event.clientY - pending.y;
+      if (dx * dx + dy * dy <= 16) return;
+      var start = pending;
+      pending = null;
+      if (start.editable) start.editable.blur();
+      if (startGraphDrag(graph, el, el, event, start)) {
+        suppressClick = true;
+        updateGraphDrag(event);
+      }
+    });
+    var finish = function (event) {
+      if (pending && event.pointerId === pending.pointerId) pending = null;
+      finishGraphDrag(event);
+      if (el.hasPointerCapture(event.pointerId)) el.releasePointerCapture(event.pointerId);
+      if (suppressClick) window.setTimeout(function () { suppressClick = false; });
+    };
+    el.addEventListener("pointerup", finish);
+    el.addEventListener("pointercancel", finish);
+    el.addEventListener("click", function (event) {
+      if (!suppressClick) return;
+      suppressClick = false;
+      event.preventDefault();
+      event.stopPropagation();
+    }, true);
   }
 
   function syncNodeConnectors(graph) {
@@ -3461,22 +3515,53 @@ function requireIndex(value: string, marker: string): number {
   return index;
 }
 
+const AUTO_LAYOUT_START = "  function assignLayerRanks(";
+const AUTO_LAYOUT_END = "function applyGroupLayout(";
+const autoLayoutStart = requireIndex(
+  GROUP_COMPACTED_HARNESS_JS,
+  AUTO_LAYOUT_START
+);
+const autoLayoutEnd = requireIndex(GROUP_COMPACTED_HARNESS_JS, AUTO_LAYOUT_END);
+const AUTO_LAYOUT_COMPACTED_HARNESS_JS =
+  GROUP_COMPACTED_HARNESS_JS.slice(0, autoLayoutStart) +
+  compactTrustedJavaScript(
+    GROUP_COMPACTED_HARNESS_JS.slice(autoLayoutStart, autoLayoutEnd)
+  ) +
+  GROUP_COMPACTED_HARNESS_JS.slice(autoLayoutEnd);
+
+const GRAPH_DRAG_START = "  function finishGraphDrag(";
+const GRAPH_DRAG_END = "  function syncNodeConnectors(";
+const graphDragStart = requireIndex(
+  AUTO_LAYOUT_COMPACTED_HARNESS_JS,
+  GRAPH_DRAG_START
+);
+const graphDragEnd = requireIndex(
+  AUTO_LAYOUT_COMPACTED_HARNESS_JS,
+  GRAPH_DRAG_END
+);
+const GRAPH_DRAG_COMPACTED_HARNESS_JS =
+  AUTO_LAYOUT_COMPACTED_HARNESS_JS.slice(0, graphDragStart) +
+  compactTrustedJavaScript(
+    AUTO_LAYOUT_COMPACTED_HARNESS_JS.slice(graphDragStart, graphDragEnd)
+  ) +
+  AUTO_LAYOUT_COMPACTED_HARNESS_JS.slice(graphDragEnd);
+
 const STATUS_STATE_START = "  function updateStatus(";
 const STATUS_STATE_END = "  function attachRowControls(";
 const statusStateStart = requireIndex(
-  GROUP_COMPACTED_HARNESS_JS,
+  GRAPH_DRAG_COMPACTED_HARNESS_JS,
   STATUS_STATE_START
 );
 const statusStateEnd = requireIndex(
-  GROUP_COMPACTED_HARNESS_JS,
+  GRAPH_DRAG_COMPACTED_HARNESS_JS,
   STATUS_STATE_END
 );
 const STATUS_COMPACTED_HARNESS_JS =
-  GROUP_COMPACTED_HARNESS_JS.slice(0, statusStateStart) +
+  GRAPH_DRAG_COMPACTED_HARNESS_JS.slice(0, statusStateStart) +
   compactTrustedJavaScript(
-    GROUP_COMPACTED_HARNESS_JS.slice(statusStateStart, statusStateEnd)
+    GRAPH_DRAG_COMPACTED_HARNESS_JS.slice(statusStateStart, statusStateEnd)
   ) +
-  GROUP_COMPACTED_HARNESS_JS.slice(statusStateEnd);
+  GRAPH_DRAG_COMPACTED_HARNESS_JS.slice(statusStateEnd);
 const SUBMIT_START = "  function handleSubmit(";
 const SUBMIT_END = "  function buildModelPanel(";
 const submitStart = requireIndex(STATUS_COMPACTED_HARNESS_JS, SUBMIT_START);

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -222,11 +222,6 @@ li.ark-harness-row .ark-harness-text { flex: 1 1 auto; min-width: 0; }
   position: absolute; box-sizing: border-box; border: 2px solid #0ea5b7;
   border-radius: 8px; background: transparent; pointer-events: none;
 }
-.ark-harness-graph-handle {
-  position: absolute; top: .25rem; right: .25rem; z-index: 3;
-  border: 1px solid rgba(100,116,139,.45); border-radius: 4px; background: rgba(255,255,255,.9);
-  color: #64748b; cursor: grab; line-height: 1; padding: .25rem; touch-action: none;
-}
 .ark-harness-graph-node.ark-harness-node-selected {
   outline: 2px solid #0ea5b7; outline-offset: 3px;
 }
@@ -1728,20 +1723,7 @@ const RAW_HARNESS_JS = `(function () {
     scheduleGraphRender(drag.graph);
   }
 
-  function attachGraphHandle(graph, el, node) {
-    var handle = createButton(
-      "\\u283F",
-      "ark-harness-graph-handle",
-      (node.label || node.id) + " をドラッグして移動"
-    );
-    handle.addEventListener("pointerdown", function (event) {
-      startGraphDrag(graph, el, handle, event);
-    });
-    handle.addEventListener("pointermove", updateGraphDrag);
-    handle.addEventListener("pointerup", finishGraphDrag);
-    handle.addEventListener("pointercancel", finishGraphDrag);
-    el.appendChild(handle);
-
+  function attachNodeDrag(graph, el) {
     var pending = null;
     var suppressClick = false;
     el.addEventListener("pointerdown", function (event) {
@@ -1934,18 +1916,11 @@ const RAW_HARNESS_JS = `(function () {
         scheduleNodeAffordanceClose(controller);
       });
     });
-    var affordances = [
-      root.querySelector(".ark-harness-graph-handle"),
-      connectors
-    ];
-    affordances.forEach(function (affordance) {
-      if (!affordance) return;
-      affordance.addEventListener("pointerenter", function () {
-        openNodeAffordance(controller);
-      });
-      affordance.addEventListener("pointerleave", function () {
-        scheduleNodeAffordanceClose(controller);
-      });
+    connectors.addEventListener("pointerenter", function () {
+      openNodeAffordance(controller);
+    });
+    connectors.addEventListener("pointerleave", function () {
+      scheduleNodeAffordanceClose(controller);
     });
     graph.nodeAffordancesById.set(id, controller);
   }
@@ -2318,7 +2293,7 @@ const RAW_HARNESS_JS = `(function () {
     graph.nodesById.set(node.id, root);
     root.classList.add("ark-harness-graph-node");
     attachNodeSelection(root, node.id);
-    attachGraphHandle(graph, root, node);
+    attachNodeDrag(graph, root);
     attachNodeConnectors(graph, root);
     attachNodeAffordanceHover(graph, root, node.id);
     if (graph.resizeObserver) graph.resizeObserver.observe(root);
@@ -2560,9 +2535,6 @@ const RAW_HARNESS_JS = `(function () {
     graph.nodesById.forEach(add);
     graph.svg.querySelectorAll("text[data-ark-edge-id]").forEach(add);
     graph.edgeHandlesByKey.forEach(add);
-    graph.nodesById.forEach(function (nodeRoot) {
-      nodeRoot.querySelectorAll(".ark-harness-graph-handle").forEach(add);
-    });
     return blockers;
   }
 


### PR DESCRIPTION
Closes #285

## 概要

ノード移動が⠿ハンドル限定だった問題（実機フィードバック「ドラッグしたら移動できるように」→「ハンドルは不要」）。本体を掴んで動かせるようにし、ハンドルは撤去した。

## 変更点

### 本体ドラッグ（4px 閾値・編集と共存）
- ノード root の pointerdown から移動距離 4px 超で既存のノード移動 drag を開始（開始時に対象 editable を blur・直後の click を抑止）。4px 未満で離せば従来どおりクリック→編集フォーカス
- **編集中（フォーカス済み）の editable 内ドラッグはノードを動かさない** = 文字選択が生きる（変更前後で同一挙動を実測比較済み）
- 除外: button / select / エッジ作成アンカー / draggable（行並べ替え）/ 合成イベント（isTrusted ガード・既存のプログラム操作とテストを保護）
- 実装は既存 drag ロジックを startGraphDrag / updateGraphDrag に共通化して流用

### ⠿ハンドル撤去（純減）
- ノード移動ハンドルの生成・リスナ・CSS を削除（行並べ替えの⠿は別物・不変）
- ハンドル依存だった E2E は実マウス入力の本体ドラッグへ書き換え

## サイズ

注入後 **128,627 bytes**（#284 比 **-1,058 純減**・guard まで残 2,445）。auto-layout / graph drag 領域の追加 compaction とハンドル撤去による。

## 検証

- Playwright E2E 85（本体ドラッグ新規3件含む）/ unit 704 / `pnpm check` / `pnpm build` PASS
- 実機（実マウス）: 本体 drag Δ完全一致・閾値未満クリックで編集フォーカス・編集中 drag はノード不動・文字選択は変更前後の dist 比較で同一・⠿消滅・行⠿残存
- 回帰: note 12/12・Phase D 10/10・autosave 6/6（それぞれライブ検証）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ノード本体を直接ドラッグして移動できるようになりました。
  - ドラッグ中もノードの接続点が表示されます。
  - 編集可能な領域やハーネス操作への意図しない影響を防止します。

- **バグ修正**
  - 微小なポインター移動やクリック時に、誤ってノードが移動する問題を改善しました。
  - ノード配置時の衝突判定を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->