### PR TITLE
図解の還流: ノート本文(noteText)と種別(kind)の変更を意味差分として述べる

### DIFF
--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -6465,3 +6465,65 @@ test("不正座標は座標未指定として自動配置し graph 外参照だ�
   expectNoOverlaps(await graphNodeBoxes(page));
   expect(errors).toEqual([]);
 });
+
+test("既存 note の本文編集と field 改名を同じ送信で意味差分に両方述べる", async ({
+  page,
+}) => {
+  // ノートと entity を両方編集して送信したとき、entity の差分だけが還流し
+  // ノート本文の変更が黙って消えるバグの回帰テスト。1回目の送信 model を
+  // サーバーの baseline（最終通知 model）に見立て、UI 編集 → submit →
+  // describeModelDiff まで実経路で確認する
+  const errors = await openDiagram(page);
+  await connectSubmissionPort(page);
+
+  const toolbar = await selectNode(page, "user");
+  await toolbar.locator("select.ark-harness-kind-select").selectOption("note");
+  const note = page.locator(
+    '.ark-harness-graph-node[data-model-id="user"] > .ark-harness-note'
+  );
+  await note.fill("元の本文");
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const baseline = (await page.evaluate(() => {
+    const browserWindow = window as typeof window & {
+      arkHarnessSubmission?: unknown;
+    };
+    const submission = browserWindow.arkHarnessSubmission;
+    delete browserWindow.arkHarnessSubmission;
+    return submission;
+  })) as { type: string; model: DiagramModel };
+  expect(baseline.type).toBe("ark:diagram-submit");
+
+  const status = page.locator('li[data-model-id="order_status"]');
+  await status.locator(".ark-harness-text").fill("state");
+  await note.fill("書き換えた本文");
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  const second = (await page.evaluate(
+    () =>
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+  )) as { type: string; model: DiagramModel };
+  expect(second.type).toBe("ark:diagram-submit");
+
+  const sent = describeModelDiff(baseline.model, second.model);
+  expect(sent).toEqual([
+    "Order の status を state に変更",
+    "User の本文を「書き換えた本文」に変更",
+  ]);
+  expect(errors).toEqual([]);
+});

--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -131,7 +131,10 @@ describe("describeModelDiff", () => {
     ]);
   });
 
-  it("noteText だけの変更は意味差分に含めない", () => {
+  // noteText の変更はかつて意図的に非還流だった（#276 のスコープ都合を #283 が
+  // 不変条件として踏襲）。しかし「ノートを編集して送ったのに何も伝わらない/
+  // entity の蓄積差分だけが送られる」という実害が出たため、還流対象に変更した。
+  it("ノート本文の変更を述べる", () => {
     const before = {
       id: "note-1",
       label: "",
@@ -140,7 +143,61 @@ describe("describeModelDiff", () => {
     };
     const after = { ...before, noteText: "変更後" };
 
-    expect(describeModelDiff(model([before]), model([after]))).toEqual([]);
+    expect(describeModelDiff(model([before]), model([after]))).toEqual([
+      "メモ「変更前」の本文を「変更後」に変更",
+    ]);
+  });
+
+  it("ノート本文の変更は抜粋 20 文字に切り詰める", () => {
+    const before = { id: "note-1", label: "", kind: "note", noteText: "元" };
+    const after = { ...before, noteText: "あ".repeat(25) };
+
+    expect(describeModelDiff(model([before]), model([after]))).toEqual([
+      `メモ「元」の本文を「${"あ".repeat(20)}…」に変更`,
+    ]);
+  });
+
+  it("ノート本文を空にしたら本文の削除と述べる", () => {
+    const before = { id: "note-1", label: "", kind: "note", noteText: "消す" };
+    const after = { ...before, noteText: "" };
+
+    expect(describeModelDiff(model([before]), model([after]))).toEqual([
+      "メモ「消す」の本文を削除",
+    ]);
+  });
+
+  it("kind の変更を述べる", () => {
+    const before = { id: "order", label: "Order", kind: "entity" };
+    const after = { ...before, kind: "note" };
+
+    expect(describeModelDiff(model([before]), model([after]))).toEqual([
+      "Order の種別を entity から note に変更",
+    ]);
+  });
+
+  it("entity の変更とノート本文の変更を両方述べる", () => {
+    const note = {
+      id: "note-1",
+      label: "",
+      kind: "note",
+      noteText: "元の本文",
+    };
+    const before = model([order, note]);
+    const after = model([
+      {
+        ...order,
+        fields: [
+          ...(order.fields ?? []),
+          { id: "f_cancelled", label: "cancelled_at" },
+        ],
+      },
+      { ...note, noteText: "書き換えた本文" },
+    ]);
+
+    expect(describeModelDiff(before, after)).toEqual([
+      "Order に cancelled_at を追加",
+      "メモ「元の本文」の本文を「書き換えた本文」に変更",
+    ]);
   });
 
   it("関連の追加を述べる", () => {
@@ -425,7 +482,10 @@ describe("describeModelDiff（境界ケース）", () => {
     expect(describeModelDiff(before, after)).toEqual([]);
   });
 
-  it("kind / ext の変更はサーバーが解釈しない要素なので無視される", () => {
+  // kind はかつて ext と同列の「サーバーが解釈しない要素」として非還流だったが、
+  // entity/aggregate/note というドメイン語彙そのものであり、ボードの kind picker
+  // から変更できるため還流対象に変更した。ext（色・座標等）は引き続き無視する
+  it("ext の変更は無視し kind の変更は種別変更として述べる", () => {
     const before = {
       id: "order",
       label: "Order",
@@ -439,20 +499,9 @@ describe("describeModelDiff（境界ケース）", () => {
       ext: { color: "blue" },
     };
 
-    expect(describeModelDiff(model([before]), model([after]))).toEqual([]);
-  });
-
-  it("kind 単独の変更は会話用意味差分に含めない", () => {
-    const before = {
-      ...order,
-      kind: "entity",
-    };
-    const after = {
-      ...order,
-      kind: "aggregate",
-    };
-
-    expect(describeModelDiff(model([before]), model([after]))).toEqual([]);
+    expect(describeModelDiff(model([before]), model([after]))).toEqual([
+      "Order の種別を entity から aggregate に変更",
+    ]);
   });
 
   it("node.ext の座標変更は意味差分に含めない", () => {
@@ -561,7 +610,7 @@ describe("describeModelDiff（label の無害化 / プロンプト注入対策�
   });
 
   it("制御文字を落とす", () => {
-    const label = "id status"; // NUL, BEL などの制御文字
+    const label = "id\u0000\u0007status"; // NUL, BEL などの制御文字
     const after = model([
       {
         ...order,
@@ -638,7 +687,7 @@ describe("describeModelDiff（label の無害化 / プロンプト注入対策�
   });
 
   it("無害化後に空になる label は代替文字列になる", () => {
-    const label = "\n\t   "; // 改行・タブ・制御文字・空白のみ
+    const label = "\n\t\u0000  "; // 改行・タブ・制御文字・空白のみ
     const after = model([
       {
         ...order,
@@ -719,7 +768,7 @@ describe("describeModelDiff（node / edge CRUD）", () => {
     ]);
   });
 
-  it("CRUD と既存 field / endpoint 編集が共存し見た目変更を返さない", () => {
+  it("CRUD と既存 field / endpoint / 種別編集が共存し座標・ext 変更を返さない", () => {
     const after: DiagramModel = {
       version: 1,
       nodes: [
@@ -739,6 +788,7 @@ describe("describeModelDiff（node / edge CRUD）", () => {
       ext: { layout: { direction: "TB" } },
     };
     expect(describeModelDiff(base, after)).toEqual([
+      "A の種別を (未指定) から aggregate に変更",
       "A の name を display name に変更",
       "C を追加",
       "B を削除",

--- a/packages/server/src/lib/diagram-diff.test.ts
+++ b/packages/server/src/lib/diagram-diff.test.ts
@@ -166,6 +166,15 @@ describe("describeModelDiff", () => {
     ]);
   });
 
+  it("空白だけになるノート本文の変更は述べない", () => {
+    // contenteditable の空行操作で "" → "\n" になるケース。意味は空のままなので
+    // 「本文を削除」と誤報告しない
+    const before = { id: "note-1", label: "", kind: "note", noteText: "" };
+    const after = { ...before, noteText: "\n" };
+
+    expect(describeModelDiff(model([before]), model([after]))).toEqual([]);
+  });
+
   it("kind の変更を述べる", () => {
     const before = { id: "order", label: "Order", kind: "entity" };
     const after = { ...before, kind: "note" };
@@ -611,6 +620,22 @@ describe("describeModelDiff（label の無害化 / プロンプト注入対策�
 
   it("制御文字を落とす", () => {
     const label = "id\u0000\u0007status"; // NUL, BEL などの制御文字
+    const after = model([
+      {
+        ...order,
+        fields: [...(order.fields ?? []), { id: "f_note", label }],
+      },
+    ]);
+
+    expect(describeModelDiff(model([order]), after)).toEqual([
+      "Order に idstatus を追加",
+    ]);
+  });
+
+  it("U+2028 / U+2029 の行区切りも落とす", () => {
+    // C0 制御文字ではないが改行として描画されうるため、1行封じ込めの
+    // 注入対策として同様に除去する
+    const label = "id\u2028\u2029status";
     const after = model([
       {
         ...order,

--- a/packages/server/src/lib/diagram-diff.ts
+++ b/packages/server/src/lib/diagram-diff.ts
@@ -68,21 +68,24 @@ function sanitizeLabel(
   );
 }
 
+/** メモ本文を生成文向けの抜粋（sanitize + 先頭20文字）にする。空なら null */
+function noteExcerpt(noteText: string): string | null {
+  const sanitized = sanitizeLabel(noteText, "");
+  if (sanitized.length === 0) return null;
+  const characters = Array.from(sanitized);
+  return characters.length > NOTE_EXCERPT_LENGTH
+    ? `${characters.slice(0, NOTE_EXCERPT_LENGTH).join("")}${LABEL_ELLIPSIS}`
+    : sanitized;
+}
+
 /** node の label、メモ本文、種別と id の順で生成文向けの表示名を解決する */
 function nodeDisplayName(node: DiagramNode): string {
   const label = sanitizeLabel(node.label ?? "");
   if (label !== LABEL_FALLBACK) return label;
 
   if (typeof node.noteText === "string") {
-    const noteText = sanitizeLabel(node.noteText, "");
-    if (noteText.length > 0) {
-      const characters = Array.from(noteText);
-      const excerpt =
-        characters.length > NOTE_EXCERPT_LENGTH
-          ? `${characters.slice(0, NOTE_EXCERPT_LENGTH).join("")}${LABEL_ELLIPSIS}`
-          : noteText;
-      return `メモ「${excerpt}」`;
-    }
+    const excerpt = noteExcerpt(node.noteText);
+    if (excerpt !== null) return `メモ「${excerpt}」`;
   }
 
   const id = sanitizeLabel(node.id);
@@ -173,6 +176,27 @@ function diffNodes(before: DiagramNode[], after: DiagramNode[]): string[] {
       const prevLabel = nodeDisplayName(prev);
       out.push(
         `${withParticle(prevLabel, "を", isNoteExcerptDisplayName(prev, prevLabel))} ${withParticle(label, "に", compactLabel)}改名`
+      );
+    }
+    // 変更前後の両方が意味を持つ差分（種別・メモ本文）の主語は before 側の
+    // 表示名にする。note の表示名は noteText 由来のため、after 側を主語に
+    // すると「新本文の本文を新本文に変更」と同語反復になる
+    const prevSubject = nodeDisplayName(prev);
+    const compactPrevSubject = isNoteExcerptDisplayName(prev, prevSubject);
+    if ((prev.kind ?? "") !== (n.kind ?? "")) {
+      const prevKind = sanitizeLabel(prev.kind ?? "", "(未指定)");
+      const nextKind = sanitizeLabel(n.kind ?? "", "(未指定)");
+      out.push(
+        `${withParticle(prevSubject, "の", compactPrevSubject)}種別を ${prevKind} から ${nextKind} に変更`
+      );
+    }
+    if ((prev.noteText ?? "") !== (n.noteText ?? "")) {
+      const excerpt =
+        typeof n.noteText === "string" ? noteExcerpt(n.noteText) : null;
+      out.push(
+        excerpt === null
+          ? `${withParticle(prevSubject, "の", compactPrevSubject)}本文を削除`
+          : `${withParticle(prevSubject, "の", compactPrevSubject)}本文を「${excerpt}」に変更`
       );
     }
     out.push(

--- a/packages/server/src/lib/diagram-diff.ts
+++ b/packages/server/src/lib/diagram-diff.ts
@@ -28,9 +28,20 @@ const LABEL_ELLIPSIS = "…";
 const LABEL_FALLBACK = "(無題)";
 const NOTE_EXCERPT_LENGTH = 20;
 
-/** C0制御文字（コードポイント 0-31）と DEL（127）かどうかを判定する */
+/**
+ * 生成文から除去すべきコードポイントかを判定する。
+ * C0 制御文字（0-31）・DEL（127）・C1 制御文字（128-159、改行扱いされうる
+ * NEL U+0085 を含む）に加え、C0 ではないが改行として描画されうる
+ * U+2028 LINE SEPARATOR / U+2029 PARAGRAPH SEPARATOR も対象にする
+ * （1行封じ込めの注入対策を迂回させないため）
+ */
 function isControlCodePoint(codePoint: number): boolean {
-  return codePoint <= 31 || codePoint === 127;
+  return (
+    codePoint <= 31 ||
+    (codePoint >= 127 && codePoint <= 159) ||
+    codePoint === 0x2028 ||
+    codePoint === 0x2029
+  );
 }
 
 /**
@@ -66,6 +77,18 @@ function sanitizeLabel(
   return (
     stripped.slice(0, LABEL_MAX_LENGTH - LABEL_ELLIPSIS.length) + LABEL_ELLIPSIS
   );
+}
+
+/**
+ * メモ本文の意味比較用キー。制御文字を落とし前後空白を除く（長さは切らない）。
+ * "" → "\n" のような空白だけの編集を「本文を削除」と誤報告しないための比較軸
+ */
+function noteBodyKey(noteText: string | undefined): string {
+  if (typeof noteText !== "string") return "";
+  return Array.from(noteText)
+    .filter(ch => !isControlCodePoint(ch.codePointAt(0) ?? 0))
+    .join("")
+    .trim();
 }
 
 /** メモ本文を生成文向けの抜粋（sanitize + 先頭20文字）にする。空なら null */
@@ -190,7 +213,7 @@ function diffNodes(before: DiagramNode[], after: DiagramNode[]): string[] {
         `${withParticle(prevSubject, "の", compactPrevSubject)}種別を ${prevKind} から ${nextKind} に変更`
       );
     }
-    if ((prev.noteText ?? "") !== (n.noteText ?? "")) {
+    if (noteBodyKey(prev.noteText) !== noteBodyKey(n.noteText)) {
       const excerpt =
         typeof n.noteText === "string" ? noteExcerpt(n.noteText) : null;
       out.push(


### PR DESCRIPTION
## 問題（実機で確認）

図解ボードでノートと entity を両方編集して「変更を送る」を押すと、**entity の差分だけが還流し、ノート本文の変更が黙って消える**。ノートだけを編集した場合は何も送られず、しかも通知 baseline だけが進むため、その変更は以後の送信でも二度と通知されない。

## 原因

`describeModelDiff` がノードの差分として「追加/削除・label 改名・fields」しか比較しておらず、`noteText` と `kind` の変更を検出していなかった。

この非還流は #276 のスコープ都合（noteText は describeModelDiff の未知プロパティ）を #280 / #283 が「不変条件」として踏襲したもので、プロダクト上の理由は無い。autosave（#282）が明示 submit まで未通知差分を蓄積する設計と組み合わさり、「ノートを送ったのに entity が送られる」という体験になっていた。

## 変更点

- `diffNodes` に noteText 比較を追加: 『メモ「元抜粋」の本文を「新抜粋」に変更』（空にした場合は『本文を削除』。既存の sanitize + 20 文字抜粋を再利用）
- `kind` 比較を追加: 『Order の種別を entity から aggregate に変更』（ext・座標は引き続き非還流）
- 旧仕様を明文化していたテスト 3 件（noteText 非還流・kind 非還流）を新仕様に更新

### codex レビュー指摘対応（P2 ×2）

- `"" → "\n"` のような空白だけの編集を「本文を削除」と誤報告 → 制御文字除去 + trim の比較キー（`noteBodyKey`）で意味比較
- U+2028 / U+2029 が `sanitizeLabel` を素通りし、1 行封じ込めの注入対策を迂回できた → C1 制御文字（NEL 含む）とあわせて除去対象に追加（label 全般に効く既存の穴の修正）

### その他

- テストファイル内の生 NUL / BEL バイトを `\u0000` 表記に置換（挙動不変。grep / file がバイナリ扱いする問題の解消）

## 検証

- unit: diagram-diff 50 件（+7 新規）/ server 全 544 件 PASS・`tsc -b`・biome PASS
- E2E: 実ハーネス UI（kind 切替 → note 本文入力 → field 改名 →「変更を送る」）→ submit model → `describeModelDiff` の実経路の回帰テストを追加。**修正前コードに差し替えると entity の行だけになりノート行が欠落することを確認**（RED 証明）。harness E2E 全 82 件 PASS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ダイアグラムの差分表示で、ノート本文の変更・削除を検出できるようになりました。
  * ノード種別の変更も差分結果に表示されるようになりました。
  * 空白のみの本文変更は差分として扱わず、長い本文は読みやすく要約表示します。
  * 差分表示に含まれる制御文字や特殊な改行文字を適切に処理します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->