### PR TITLE
図解: 決まった図種は type だけで描く（内蔵 er / event-storming レンダラ）

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -9,7 +9,48 @@ description: 図解を求められたときに .diagram.html を生成する規�
 `<名前>.diagram.html` を組み合わせ、1 ファイルで書く。書き込む直前に
 parent directory が存在しない場合だけ作成し、書いた後に `board_open` でペインを開かせる。
 
-## ファイルの構造
+## まず図種を確かめる（内蔵レンダラ）
+
+書式が決まっている図は `type` を書くだけでよい。投影（HTML）も CSS も書かない。
+Ark が配信時に生成し、生成物はファイルへ焼き付かない（モデルだけが残る）。
+
+| `type` | 使う場面 | 使える kind |
+| --- | --- | --- |
+| `er` | ER 図・集約設計・エンティティ表 | `entity`（既定）/ `root` / `vo` / `external` / `invariant` / `principle` / `note` |
+| `event-storming` | イベントストーミング | `command` / `event` / `aggregate` / `policy` / `actor` / `read-model` / `external-system` / `note` |
+
+```html
+<!doctype html>
+<html lang="ja">
+<head><meta charset="utf-8"><title>注文まわり</title></head>
+<body>
+<script type="application/json" id="ark-diagram-model">
+{
+  "version": 1,
+  "type": "er",
+  "title": "注文まわり",
+  "nodes": [
+    { "id": "order", "label": "Order", "kind": "entity",
+      "fields": [ { "id": "order_id", "label": "id PK" } ] }
+  ],
+  "edges": [],
+  "groups": []
+}
+</script>
+</body>
+</html>
+```
+
+これで足りる図に手書きの投影を足さないこと。同じ意味を二度書くことになり、
+モデルと投影が食い違う余地を作ってしまう。多重度（`edge.ext` の
+`from_card` / `to_card` / `direction` / `type`）、group 境界、自動レイアウトは
+内蔵レンダラでもそのまま効く。
+
+自前の graph container（`data-ark-container="graph"`）を書いた図には内蔵レンダラは
+一切触らない。決まった図種でない図（ロードマップ、説明図、スイムレーンの厳密な
+座標指定など）は、以下の手書き投影で作る。
+
+## ファイルの構造（手書き投影・`type` が無いとき）
 
 モデル（意味）と投影（見た目）を 1 ファイルに入れる。
 

--- a/e2e/diagram-builtin.spec.ts
+++ b/e2e/diagram-builtin.spec.ts
@@ -1,0 +1,237 @@
+import { expect, type Page, test } from "@playwright/test";
+import { injectBuiltinProjection } from "../packages/server/src/lib/diagram-builtin";
+import { injectHarness } from "../packages/server/src/lib/diagram-harness";
+import type { DiagramModel } from "../packages/server/src/lib/diagram-model";
+
+/**
+ * 内蔵図種（model の type だけで投影を生成する経路）の実機確認。
+ * 生成物が書くのはモデル JSON だけで、DOM も CSS もサーバーが作る。
+ */
+
+const erModel: DiagramModel = {
+  version: 1,
+  type: "er",
+  title: "注文まわり",
+  nodes: [
+    {
+      id: "customer",
+      label: "Customer",
+      kind: "entity",
+      fields: [{ id: "c_id", label: "id PK" }],
+    },
+    {
+      id: "order",
+      label: "Order",
+      kind: "root",
+      fields: [
+        { id: "o_id", label: "id PK" },
+        { id: "o_customer", label: "customer_id FK" },
+      ],
+    },
+  ],
+  edges: [
+    {
+      id: "e_places",
+      from: "customer",
+      to: "order",
+      label: "places",
+      ext: { from_card: "one", to_card: "zero-or-many", type: "identifying" },
+    },
+  ],
+  groups: [{ id: "ordering", label: "Ordering", nodes: ["customer", "order"] }],
+};
+
+const stormingModel: DiagramModel = {
+  version: 1,
+  type: "event-storming",
+  title: "購買イベント",
+  nodes: [
+    { id: "buyer", label: "Buyer", kind: "actor" },
+    { id: "place", label: "Place order", kind: "command" },
+    { id: "placed", label: "Order placed", kind: "event" },
+    { id: "memo", label: "メモ", kind: "note", noteText: "未決: 在庫の引当" },
+  ],
+  edges: [
+    { id: "e1", from: "buyer", to: "place", label: "requests" },
+    { id: "e2", from: "place", to: "placed", label: "emits" },
+  ],
+  groups: [{ id: "lane", label: "Ordering", nodes: ["place", "placed"] }],
+};
+
+/** 生成物が書く想定の「モデルだけ」のファイルを配信時の形へ通す */
+function modelOnlyPage(model: DiagramModel): string {
+  const raw =
+    `<!doctype html><html lang="ja"><head><meta charset="utf-8">` +
+    `<title>${model.title ?? ""}</title></head><body>` +
+    `<script type="application/json" id="ark-diagram-model">` +
+    `${JSON.stringify(model)}</script></body></html>`;
+  return injectHarness(injectBuiltinProjection(raw, model));
+}
+
+async function openBuiltin(page: Page, model: DiagramModel) {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  await page.setContent(modelOnlyPage(model));
+  await expect(page.locator(".ark-harness-graph-node").first()).toBeVisible();
+}
+
+async function connectSubmissionPort(page: Page) {
+  await page.evaluate(() => {
+    const browserWindow = window as typeof window & {
+      arkHarnessSubmission?: unknown;
+    };
+    const channel = new MessageChannel();
+    channel.port1.onmessage = event => {
+      if (event.data?.type === "ark:diagram-autosave") {
+        channel.port1.postMessage({
+          type: "ark:diagram-autosave-result",
+          ok: true,
+        });
+      } else {
+        browserWindow.arkHarnessSubmission = event.data;
+      }
+    };
+    window.postMessage({ type: "ark:test-connect" }, "*", [channel.port2]);
+  });
+  await expect(
+    page.getByRole("button", {
+      name: "変更を親フレームへ送信する",
+      includeHidden: true,
+    })
+  ).toBeEnabled();
+}
+
+async function submitAndRead(page: Page) {
+  await page
+    .getByRole("button", { name: "変更を親フレームへ送信する" })
+    .click();
+  await page.waitForFunction(() =>
+    Boolean(
+      (window as typeof window & { arkHarnessSubmission?: unknown })
+        .arkHarnessSubmission
+    )
+  );
+  return page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          arkHarnessSubmission?: { model: DiagramModel; html: string };
+        }
+      ).arkHarnessSubmission
+  );
+}
+
+test("er: モデルだけのファイルから entity・field・group・多重度を描画する", async ({
+  page,
+}) => {
+  await openBuiltin(page, erModel);
+
+  // node と field
+  await expect(
+    page.locator('article[data-model-id="customer"][data-kind="entity"]')
+  ).toBeVisible();
+  await expect(
+    page.locator('article[data-model-id="order"][data-kind="root"]')
+  ).toBeVisible();
+  await expect(page.locator('li[data-model-id="o_customer"]')).toContainText(
+    "customer_id FK"
+  );
+  // group 境界はハーネスの geometry が解決したときだけ表示される
+  await expect(
+    page.locator('.ark-builtin-group[data-model-id="ordering"]')
+  ).toHaveClass(/ark-harness-graph-group/);
+  // edge と crow's foot（多重度）が描かれる
+  await expect(
+    page.locator('.ark-harness-edge-main[data-ark-edge-id="e_places"]')
+  ).toHaveAttribute("data-ark-edge-type", "identifying");
+  const markers = await page.locator('[data-ark-edge-id="e_places"]').count();
+  expect(markers).toBeGreaterThan(1);
+});
+
+test("kind 別スタイルが label span へ漏れない", async ({ page }) => {
+  // ハーネスが label span へ data-kind を同期するため、kind セレクタの
+  // 書き方を誤ると破線 kind のラベルに二重枠が出る
+  await openBuiltin(page, erModel);
+
+  const labelBorder = await page
+    .locator('span[data-model-id="order"]')
+    .evaluate(el => getComputedStyle(el).borderTopStyle);
+  expect(labelBorder).toBe("none");
+});
+
+test("er: 自動レイアウトが node を重ねずに配置する", async ({ page }) => {
+  await openBuiltin(page, erModel);
+
+  const first = await page
+    .locator('article[data-model-id="customer"]')
+    .boundingBox();
+  const second = await page
+    .locator('article[data-model-id="order"]')
+    .boundingBox();
+  expect(first).not.toBeNull();
+  expect(second).not.toBeNull();
+  if (!first || !second) return;
+  const overlaps =
+    first.x < second.x + second.width &&
+    second.x < first.x + first.width &&
+    first.y < second.y + second.height &&
+    second.y < first.y + first.height;
+  expect(overlaps).toBe(false);
+});
+
+test("event-storming: kind 名を可視テキストで併置し note 本文を描画する", async ({
+  page,
+}) => {
+  await openBuiltin(page, stormingModel);
+
+  await expect(
+    page.locator('article[data-model-id="placed"] .ark-builtin-kind-name')
+  ).toHaveText("event");
+  await expect(
+    page.locator('article[data-model-id="buyer"] .ark-builtin-kind-name')
+  ).toHaveText("actor");
+  await expect(
+    page.locator('article[data-model-id="memo"] [data-ark-harness-note]')
+  ).toContainText("未決: 在庫の引当");
+});
+
+test("送信 HTML は生成投影を含まずモデルだけが残る", async ({ page }) => {
+  await openBuiltin(page, erModel);
+  await connectSubmissionPort(page);
+
+  // ラベルを編集してから送る（編集が効くことも同時に確認する）
+  await page.locator('span[data-model-id="order"]').fill("受注");
+  const submission = await submitAndRead(page);
+
+  expect(submission?.model.nodes.find(n => n.id === "order")?.label).toBe(
+    "受注"
+  );
+  expect(submission?.model.type).toBe("er");
+  // 生成した DOM・CSS はファイルへ焼き付かない
+  expect(submission?.html).not.toContain('data-ark-container="graph"');
+  expect(submission?.html).not.toContain("ark-builtin-node");
+  expect(submission?.html).not.toContain("ark-builtin-title");
+  expect(submission?.html).not.toContain("--ark-harness-group-x");
+  // モデルブロックは残る
+  expect(submission?.html).toContain("ark-diagram-model");
+});
+
+test("生成投影の図でも node を drag して座標をモデルへ保存できる", async ({
+  page,
+}) => {
+  await openBuiltin(page, erModel);
+  await connectSubmissionPort(page);
+
+  const node = page.locator('article[data-model-id="customer"]');
+  const before = await node.boundingBox();
+  expect(before).not.toBeNull();
+  if (!before) return;
+  await page.mouse.move(before.x + 20, before.y + 10);
+  await page.mouse.down();
+  await page.mouse.move(before.x + 200, before.y + 160, { steps: 12 });
+  await page.mouse.up();
+
+  const submission = await submitAndRead(page);
+  const moved = submission?.model.nodes.find(n => n.id === "customer");
+  expect(Number.isFinite(moved?.ext?.x as number)).toBe(true);
+  expect(Number.isFinite(moved?.ext?.y as number)).toBe(true);
+});

--- a/e2e/diagram-builtin.spec.ts
+++ b/e2e/diagram-builtin.spec.ts
@@ -178,20 +178,45 @@ test("er: 自動レイアウトが node を重ねずに配置する", async ({ p
   expect(overlaps).toBe(false);
 });
 
-test("event-storming: kind 名を可視テキストで併置し note 本文を描画する", async ({
+/** node root の ::before に出る kind 見出し（icon + kind 名） */
+async function kindHeading(page: Page, id: string): Promise<string> {
+  return page
+    .locator(`article[data-model-id="${id}"]`)
+    .evaluate(el => getComputedStyle(el, "::before").content);
+}
+
+test("event-storming: kind 名を可視の見出しとして出し note 本文を描画する", async ({
   page,
 }) => {
   await openBuiltin(page, stormingModel);
 
-  await expect(
-    page.locator('article[data-model-id="placed"] .ark-builtin-kind-name')
-  ).toHaveText("event");
-  await expect(
-    page.locator('article[data-model-id="buyer"] .ark-builtin-kind-name')
-  ).toHaveText("actor");
+  expect(await kindHeading(page, "placed")).toContain("event");
+  expect(await kindHeading(page, "buyer")).toContain("actor");
   await expect(
     page.locator('article[data-model-id="memo"] [data-ark-harness-note]')
   ).toContainText("未決: 在庫の引当");
+});
+
+test("kind を変えると可視の kind 見出しも追従する", async ({ page }) => {
+  // kind 名を DOM の静的テキストで持つと、ハーネスは root の data-kind しか
+  // 更新しないため表示が古いまま残る（CodeRabbit #293 の指摘・実機で再現）
+  await openBuiltin(page, stormingModel);
+
+  const node = page.locator('article[data-model-id="placed"]');
+  expect(await kindHeading(page, "placed")).toContain("event");
+
+  await node.dispatchEvent("pointerdown", { button: 0 });
+  await node.dispatchEvent("click", { button: 0 });
+  const toolbar = page.locator("[data-ark-selection-id]").first();
+  await expect(toolbar).toHaveAttribute("data-ark-selection-id", "placed");
+  await toolbar
+    .locator("select.ark-harness-kind-select")
+    .selectOption("command");
+
+  await expect(node).toHaveAttribute("data-kind", "command");
+  const after = await kindHeading(page, "placed");
+  expect(after).toContain("command");
+  expect(after).not.toContain("event");
 });
 
 test("送信 HTML は生成投影を含まずモデルだけが残る", async ({ page }) => {
@@ -213,6 +238,36 @@ test("送信 HTML は生成投影を含まずモデルだけが残る", async ({
   expect(submission?.html).not.toContain("--ark-harness-group-x");
   // モデルブロックは残る
   expect(submission?.html).toContain("ark-diagram-model");
+});
+
+test("パレットで追加した node も内蔵の kind 見出しを持つ", async ({ page }) => {
+  // 見出しを node root の ::before で出すので、ハーネスが作った DOM でも
+  // class と data-kind さえ揃えば同じ装飾になる
+  await openBuiltin(page, stormingModel);
+
+  const source = page.locator('article[data-model-id="place"]');
+  await source.dispatchEvent("pointerdown", { button: 0 });
+  await source.dispatchEvent("click", { button: 0 });
+  const toolbar = page.locator("[data-ark-selection-id]").first();
+  await toolbar.locator("select.ark-harness-kind-select").selectOption("event");
+
+  const box = await source.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) return;
+  // 下辺の anchor から空白へ drag して node を追加する
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height);
+  await page.mouse.down();
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height + 260, {
+    steps: 12,
+  });
+  await page.mouse.up();
+
+  const added = page.locator('article[data-kind="event"]').last();
+  await expect(added).toHaveClass(/ark-builtin-node/);
+  const heading = await added.evaluate(
+    el => getComputedStyle(el, "::before").content
+  );
+  expect(heading).toContain("event");
 });
 
 test("生成投影の図でも node を drag して座標をモデルへ保存できる", async ({

--- a/e2e/diagram-harness.spec.ts
+++ b/e2e/diagram-harness.spec.ts
@@ -2575,13 +2575,15 @@ test("構造変更: clean submission は semantic node を残し CRUD UI と見�
   expect(submission.html).not.toContain("--ark-harness-graph-x");
   const diff = describeModelDiff(crudModel, submission.model);
   expect(diff).toEqual([
+    // kind select は選択中の node にも適用される（B が entity → event）
+    "B の種別を entity から event に変更",
     expect.stringMatching(/^event ノード \(node-[0-9a-f-]+\) を追加$/),
     expect.stringMatching(
       /^B から event ノード \(node-[0-9a-f-]+\) への関連を追加$/
     ),
   ]);
-  expect(diff[0]).toContain(`(${added.id})`);
   expect(diff[1]).toContain(`(${added.id})`);
+  expect(diff[2]).toContain(`(${added.id})`);
 });
 
 test("下部ツールバーは既定で非表示になり余白を残さない", async ({ page }) => {
@@ -4901,7 +4903,11 @@ test("authored entity と note を往復して label・fields・noteText を独�
       ).arkHarnessSubmission
   );
   if (!submission) throw new Error("submission がありません");
-  expect(describeModelDiff(beforeModel, submission.model)).toEqual([]);
+  // kind と noteText の変更は意味差分として述べる（#289）
+  expect(describeModelDiff(beforeModel, submission.model)).toEqual([
+    "Source の種別を entity から note に変更",
+    "Source の本文を「設計メモ2行目」に変更",
+  ]);
   expect(
     submission.model.nodes.find(node => node.id === "model-kind-source")
   ).toMatchObject({
@@ -5492,7 +5498,9 @@ test("kind toolbar で CSS 候補を選び投影・geometry・保存へ同期す
       node.id === "order" ? { ...node, kind: "event" } : node
     ),
   });
-  expect(describeModelDiff(beforeModel, submission.model)).toEqual([]);
+  expect(describeModelDiff(beforeModel, submission.model)).toEqual([
+    "Order の種別を aggregate から event に変更",
+  ]);
   expect(submission.html).toContain('data-kind="event"');
   expect(submission.html).toContain('id="ark-diagram-model"');
   expect(submission.html).toContain('data-ark-container="graph"');
@@ -6338,6 +6346,7 @@ test("kind 変更と node・edge・field・list 編集を同じ送信 model に�
   });
   const submittedModel = (submission as { model: DiagramModel }).model;
   expect(describeModelDiff(model, submittedModel)).toEqual([
+    "Order の種別を aggregate から event に変更",
     "Order の status を state に変更",
     "Order のフィールド順を state, id に変更",
     "Order から User への関連「belongs to」を Order から Order への関連「belongs to」 に変更",

--- a/packages/server/src/lib/diagram-builtin.test.ts
+++ b/packages/server/src/lib/diagram-builtin.test.ts
@@ -111,8 +111,9 @@ describe("injectBuiltinProjection", () => {
     expect(out).toContain("未決の論点");
   });
 
-  it("event-storming は kind 名を可視テキストとして併置する", () => {
-    // 色だけで kind を伝えない（作図規約のアクセシビリティ要件）
+  it("event-storming の kind 見出しは DOM ではなく CSS 由来にする", () => {
+    // 静的テキストで書くと、ハーネスで kind を変えた後も古い名前が残る
+    // （root の data-kind しか更新されないため。実機で再現済み）
     const out = injectBuiltinProjection(
       page(modelScript),
       model({
@@ -124,7 +125,37 @@ describe("injectBuiltinProjection", () => {
     );
 
     expect(out).toContain('data-ark-builtin="event-storming"');
-    expect(out).toMatch(/ark-builtin-kind-name[^>]*>event</);
+    // kind 名は DOM に焼き込まない
+    expect(out).not.toContain("ark-builtin-kind-name");
+    // 色だけに頼らないための可視名は CSS 変数 + ::before で出す
+    expect(out).toContain('--kn:"event"');
+    expect(out).toMatch(/\.ark-builtin-node::before\{content:var\(--kg/);
+  });
+
+  it("引用符なしの graph 属性を持つ図にも触らない", () => {
+    // HTML は data-ark-container=graph も許す。見落とすと graph が二重になる
+    const authored = page(
+      `${modelScript}<div data-ark-container=graph><div data-model-id="order">Order</div></div>`
+    );
+
+    expect(injectBuiltinProjection(authored, model())).toBe(authored);
+  });
+
+  it("script 本文や comment の中の文字列を graph と誤認しない", () => {
+    // 誤認すると投影を生成せず白紙になる
+    const decoy =
+      '<script type="application/json" id="ark-diagram-model">' +
+      '{"note":"data-ark-container=\\"graph\\" と書いただけ"}</script>' +
+      '<!-- data-ark-container="graph" -->';
+
+    const out = injectBuiltinProjection(page(decoy), model());
+
+    // 生成された graph container はちょうど1つ
+    // （CSS の selector やコメント内の文字列とは区別する）
+    expect(
+      out.match(/data-ark-container="graph" data-ark-builtin="er"/g)
+    ).toHaveLength(1);
+    expect(out).toContain("ark-builtin-node");
   });
 
   it("未知の図種と図種なしには何もしない", () => {

--- a/packages/server/src/lib/diagram-builtin.test.ts
+++ b/packages/server/src/lib/diagram-builtin.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { injectBuiltinProjection } from "./diagram-builtin.js";
+import type { DiagramModel } from "./diagram-model.js";
+
+const page = (body: string) =>
+  `<!doctype html><html><head></head><body>${body}</body></html>`;
+
+const modelScript =
+  '<script type="application/json" id="ark-diagram-model">{}</script>';
+
+function model(overrides: Partial<DiagramModel> = {}): DiagramModel {
+  return {
+    version: 1,
+    type: "er",
+    title: "注文まわり",
+    nodes: [
+      {
+        id: "order",
+        label: "Order",
+        kind: "entity",
+        fields: [
+          { id: "o_id", label: "id PK" },
+          { id: "o_status", label: "status" },
+        ],
+      },
+      { id: "customer", label: "Customer", kind: "entity" },
+    ],
+    edges: [
+      {
+        id: "e1",
+        from: "customer",
+        to: "order",
+        label: "places",
+        ext: { from_card: "one", to_card: "zero-or-many" },
+      },
+    ],
+    groups: [{ id: "g1", label: "Ordering", nodes: ["order", "customer"] }],
+    ...overrides,
+  };
+}
+
+describe("injectBuiltinProjection", () => {
+  it("既知の図種で投影が無ければ node・field・group を生成する", () => {
+    const out = injectBuiltinProjection(page(modelScript), model());
+
+    // graph container と図種の印
+    expect(out).toContain('data-ark-container="graph"');
+    expect(out).toContain('data-ark-builtin="er"');
+    // node root と label が同じ id を持つ（ハーネスの投影契約）
+    expect(out).toContain('data-model-id="order"');
+    expect(out).toContain("Order");
+    // field は li として id 付きで出る
+    expect(out).toContain('data-model-id="o_id"');
+    expect(out).toContain("id PK");
+    expect(out).toContain('data-model-id="o_status"');
+    // group は data-ark-group + group-label
+    expect(out).toContain("data-ark-group");
+    expect(out).toContain('data-model-id="g1"');
+    expect(out).toContain("Ordering");
+    // kind は投影 root の data-kind に載る
+    expect(out).toContain('data-kind="entity"');
+  });
+
+  it("生成物は送信 HTML から取り除かれる印を持つ", () => {
+    // 図ファイルをモデルだけに保つのが目的。印が無いと最初の保存で
+    // 生成された投影がファイルに焼き付き、二重管理に戻ってしまう
+    const out = injectBuiltinProjection(page(modelScript), model());
+
+    expect(out).toContain('data-ark-harness-generated="1"');
+    expect(out).toMatch(/<style[^>]*data-ark-harness-ui="1"/);
+  });
+
+  it("label・field・kind を HTML エスケープする", () => {
+    const out = injectBuiltinProjection(
+      page(modelScript),
+      model({
+        nodes: [
+          {
+            id: 'x"><img src=x onerror=alert(1)>',
+            label: '<script>alert("xss")</script>',
+            kind: 'entity"><b>',
+            fields: [{ id: "f1", label: "<b>bold</b>" }],
+          },
+        ],
+        edges: [],
+        groups: [],
+      })
+    );
+
+    expect(out).not.toContain("<script>alert(");
+    expect(out).not.toContain("<img src=x");
+    expect(out).not.toContain("<b>bold</b>");
+    expect(out).toContain("&lt;script&gt;");
+    expect(out).toContain("&lt;b&gt;bold&lt;/b&gt;");
+  });
+
+  it("kind=note は本文を note 投影として生成する", () => {
+    const out = injectBuiltinProjection(
+      page(modelScript),
+      model({
+        type: "event-storming",
+        nodes: [
+          { id: "n1", label: "メモ", kind: "note", noteText: "未決の論点" },
+        ],
+        edges: [],
+        groups: [],
+      })
+    );
+
+    expect(out).toContain("data-ark-harness-note");
+    expect(out).toContain("未決の論点");
+  });
+
+  it("event-storming は kind 名を可視テキストとして併置する", () => {
+    // 色だけで kind を伝えない（作図規約のアクセシビリティ要件）
+    const out = injectBuiltinProjection(
+      page(modelScript),
+      model({
+        type: "event-storming",
+        nodes: [{ id: "e1", label: "Order placed", kind: "event" }],
+        edges: [],
+        groups: [],
+      })
+    );
+
+    expect(out).toContain('data-ark-builtin="event-storming"');
+    expect(out).toMatch(/ark-builtin-kind-name[^>]*>event</);
+  });
+
+  it("未知の図種と図種なしには何もしない", () => {
+    const html = page(modelScript);
+
+    expect(injectBuiltinProjection(html, model({ type: "mindmap" }))).toBe(
+      html
+    );
+    expect(injectBuiltinProjection(html, model({ type: undefined }))).toBe(
+      html
+    );
+  });
+
+  it("生成物が自前の graph container を持つ図には何もしない", () => {
+    // 手書き投影の図は従来どおり作者のものを尊重する
+    const authored = page(
+      `${modelScript}<div data-ark-container="graph"><div data-model-id="order">Order</div></div>`
+    );
+
+    expect(injectBuiltinProjection(authored, model())).toBe(authored);
+  });
+
+  it("二重適用しても投影は増えない", () => {
+    const once = injectBuiltinProjection(page(modelScript), model());
+    const twice = injectBuiltinProjection(once, model());
+
+    expect(twice).toBe(once);
+    expect(once.match(/data-ark-container="graph"/g)).toHaveLength(1);
+  });
+
+  it("body が無い文書でも末尾に生成する", () => {
+    const out = injectBuiltinProjection(modelScript, model());
+
+    expect(out).toContain('data-ark-container="graph"');
+    expect(out.indexOf(modelScript)).toBeLessThan(
+      out.indexOf('data-ark-container="graph"')
+    );
+  });
+
+  it("kind 別スタイルを node root だけに当てる", () => {
+    // ハーネスは label span にも data-kind を同期する。素の [data-kind] で
+    // 書くと label にも枠線や幅が乗り、二重枠として描画される（実機で確認）
+    const out = injectBuiltinProjection(page(modelScript), model());
+    const style = out.slice(out.indexOf("<style"), out.indexOf("</style>"));
+    const kindRules = style.match(/\[data-kind=/g) ?? [];
+    const scoped = style.match(/\.ark-builtin-node\[data-kind=/g) ?? [];
+
+    expect(kindRules.length).toBeGreaterThan(0);
+    expect(scoped).toHaveLength(kindRules.length);
+  });
+
+  it("外部リソースを参照しない", () => {
+    const out = injectBuiltinProjection(page(modelScript), model());
+
+    expect(out).not.toContain("https://");
+    expect(out).not.toContain("@font-face");
+    expect(out).not.toContain('rel="stylesheet"');
+  });
+});

--- a/packages/server/src/lib/diagram-builtin.ts
+++ b/packages/server/src/lib/diagram-builtin.ts
@@ -35,8 +35,6 @@ export const GENERATED_ATTR = "data-ark-harness-generated";
 interface BuiltinType {
   /** 図種専用の CSS（外部リソースを参照しない） */
   css: string;
-  /** kind 名を可視テキストとして併置するか（色だけに頼らないため） */
-  showKindName: boolean;
 }
 
 const BASE_CSS = `
@@ -47,9 +45,8 @@ font-family:"Hiragino Sans","Noto Sans JP",system-ui,sans-serif;font-size:14px}
 .ark-builtin-node{box-sizing:border-box;width:13.5rem;padding:.45rem .6rem;
 border:1px solid var(--k,#565f89);border-left:5px solid var(--k,#565f89);
 border-radius:6px;background:var(--kb,#1e202b)}
-.ark-builtin-kind{display:inline-block;width:1.15em}
-.ark-builtin-kind::before{content:var(--kg,"\\25A3")}
-.ark-builtin-kind-name{font-size:.58rem;color:var(--k,#94a3b8);letter-spacing:.05em}
+.ark-builtin-node::before{display:block;font-size:.58rem;letter-spacing:.05em;
+color:var(--k,#94a3b8);content:var(--kg,"\\25A3")}
 .ark-builtin-label{display:block;font-size:.84rem;font-weight:650;line-height:1.35;margin-top:.05rem}
 .ark-builtin-fields{list-style:none;margin:.32rem 0 0;padding:.28rem 0 0;
 border-top:1px solid rgba(148,163,184,.28)}
@@ -85,20 +82,21 @@ const ER_CSS = `${BASE_CSS}
  * policy=紫 / actor=桃 / read-model=緑 を既定にし、必ず kind 名を併置する。
  */
 const STORMING_CSS = `${BASE_CSS}
+[data-ark-builtin="event-storming"] .ark-builtin-node::before{content:var(--kg,"\\25A3") "\\00A0" var(--kn,"")}
 [data-ark-builtin="event-storming"] .ark-builtin-node{--k:#94a3b8;--kb:#202b3c;--kg:"\\25A3"}
-[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="event"]{--k:#f59e0b;--kb:#3b2810;--kg:"\\26A1"}
-[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="command"]{--k:#60a5fa;--kb:#172a46;--kg:"\\25B6"}
-[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="aggregate"]{--k:#facc15;--kb:#3a3111;--kg:"\\25C6"}
-[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="policy"]{--k:#c084fc;--kb:#302044;--kg:"\\25C7"}
-[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="actor"]{--k:#f472b6;--kb:#3b1e35;--kg:"\\25CE";width:9rem}
-[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="read-model"]{--k:#4ade80;--kb:#153522;--kg:"\\25A4"}
-[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="external-system"]{--k:#94a3b8;--kb:#202b3c;--kg:"\\2601"}
-[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="note"]{--k:#94a3b8;--kb:#1b2130;width:17rem;border-style:dashed;border-left-style:solid}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="event"]{--kn:"event";--k:#f59e0b;--kb:#3b2810;--kg:"\\26A1"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="command"]{--kn:"command";--k:#60a5fa;--kb:#172a46;--kg:"\\25B6"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="aggregate"]{--kn:"aggregate";--k:#facc15;--kb:#3a3111;--kg:"\\25C6"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="policy"]{--kn:"policy";--k:#c084fc;--kb:#302044;--kg:"\\25C7"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="actor"]{--kn:"actor";--k:#f472b6;--kb:#3b1e35;--kg:"\\25CE";width:9rem}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="read-model"]{--kn:"read-model";--k:#4ade80;--kb:#153522;--kg:"\\25A4"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="external-system"]{--kn:"external-system";--k:#94a3b8;--kb:#202b3c;--kg:"\\2601"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="note"]{--kn:"note";--k:#94a3b8;--kb:#1b2130;width:17rem;border-style:dashed;border-left-style:solid}
 `;
 
 export const BUILTIN_DIAGRAM_TYPES: Readonly<Record<string, BuiltinType>> = {
-  er: { css: ER_CSS, showKindName: false },
-  "event-storming": { css: STORMING_CSS, showKindName: true },
+  er: { css: ER_CSS },
+  "event-storming": { css: STORMING_CSS },
 };
 
 function escapeHtml(value: string): string {
@@ -110,7 +108,16 @@ function escapeHtml(value: string): string {
     .replace(/'/g, "&#39;");
 }
 
-function renderNode(node: DiagramNode, type: BuiltinType): string {
+/**
+ * node 1 個の投影。
+ *
+ * kind の見出し（icon と kind 名）は DOM に書かず、node root の `::before` を
+ * CSS 変数で出す。ハーネスは kind 変更時に root の `data-kind` を更新するだけで
+ * 中身の装飾までは面倒を見ないため、静的テキストで書くと kind を変えた後も
+ * 古い名前が残る（実機で再現済み）。CSS 由来にすれば表示は `data-kind` の
+ * 純粋な関数になり、パレットで追加した node も同じ見出しを得る。
+ */
+function renderNode(node: DiagramNode): string {
   const id = escapeHtml(node.id);
   const kindAttr = node.kind ? ` data-kind="${escapeHtml(node.kind)}"` : "";
   const parts: string[] = [];
@@ -121,12 +128,6 @@ function renderNode(node: DiagramNode, type: BuiltinType): string {
       `<div class="ark-builtin-note" data-ark-harness-note>${escapeHtml(node.noteText ?? "")}</div>`
     );
   } else {
-    parts.push('<span class="ark-builtin-kind" aria-hidden="true"></span>');
-    if (type.showKindName && node.kind) {
-      parts.push(
-        `<span class="ark-builtin-kind-name">${escapeHtml(node.kind)}</span>`
-      );
-    }
     parts.push(
       `<span class="ark-builtin-label" data-model-id="${id}">${escapeHtml(node.label)}</span>`
     );
@@ -154,9 +155,21 @@ function renderGroup(id: string, label: string): string {
   );
 }
 
-/** 生成物が自前の graph を持っているか（持っていれば作者のものを尊重する） */
+/**
+ * 生成物が自前の graph を持っているか（持っていれば作者のものを尊重する）。
+ *
+ * HTML は引用符なしの属性値も許すため `data-ark-container=graph` も拾う。
+ * 逆に script 本文（モデル JSON の label 等）や HTML コメントの中の同じ文字列は
+ * 属性ではないので、判定前に取り除く。誤検出すると投影を生成せず白紙になり、
+ * 見落とすと graph が二重になる。
+ */
 function hasAuthoredGraph(html: string): boolean {
-  return /data-ark-container\s*=\s*["']graph["']/i.test(html);
+  const markup = html
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
+  return /data-ark-container\s*=\s*(?:"graph"|'graph'|graph(?=[\s/>]|$))/i.test(
+    markup
+  );
 }
 
 /**
@@ -181,7 +194,7 @@ export function injectBuiltinProjection(
   const groups = model.groups
     .map(group => renderGroup(group.id, group.label))
     .join("");
-  const nodes = model.nodes.map(node => renderNode(node, type)).join("");
+  const nodes = model.nodes.map(node => renderNode(node)).join("");
   const projection =
     `<style data-ark-harness-ui="1">${type.css}</style>` +
     title +

--- a/packages/server/src/lib/diagram-builtin.ts
+++ b/packages/server/src/lib/diagram-builtin.ts
@@ -1,0 +1,196 @@
+/**
+ * 既知の図種の投影（DOM + CSS）を配信時に生成する。
+ *
+ * ## なぜサーバー側で生成するか
+ *
+ * ER 図やイベントストーミングのように書式が決まっている図では、モデルから
+ * 見た目への写像は一意に決まる。それでも生成物に HTML を書かせると、
+ * (1) モデルと投影という食い違いうる真実が二つできる、
+ * (2) 同じ概念の CSS が図ごとに少しずつ違う、
+ * (3) 生成コストの半分が転記作業になる、
+ * という三つの問題が出る。図種が既知なら投影は導出できるので、ここで生成する。
+ *
+ * ハーネス（diagram-harness.ts）側に足さないのは注入サイズの都合。ハーネスは
+ * 全図に配られるため上限（128KiB）が近く、図種ごとの CSS を積むと全図が
+ * その分を払うことになる。ここで生成すれば、費用を払うのはその図種の図だけ。
+ *
+ * ## 生成物をファイルに焼き付けない
+ *
+ * 生成した DOM には `data-ark-harness-generated` を、CSS には
+ * `data-ark-harness-ui` を付ける。どちらもハーネスの `buildSubmissionHtml` が
+ * 送信 HTML から取り除くため、図ファイルはモデルだけの状態を保つ。
+ * これが崩れると最初の保存で投影が焼き付き、二重管理へ逆戻りする。
+ *
+ * ## 手書き投影との関係
+ *
+ * 生成物が自前の graph container を持つ図には一切触らない。決まった図種でない
+ * 図（ロードマップ、説明図）を自由に書ける現状の強みを残すための逃げ道。
+ */
+
+import type { DiagramModel, DiagramNode } from "./diagram-model.js";
+
+/** ハーネスが送信 HTML から取り除く印（生成 DOM 用） */
+export const GENERATED_ATTR = "data-ark-harness-generated";
+
+interface BuiltinType {
+  /** 図種専用の CSS（外部リソースを参照しない） */
+  css: string;
+  /** kind 名を可視テキストとして併置するか（色だけに頼らないため） */
+  showKindName: boolean;
+}
+
+const BASE_CSS = `
+body{margin:0;padding:1.25rem;background:#0f1117;color:#e2e8f0;
+font-family:"Hiragino Sans","Noto Sans JP",system-ui,sans-serif;font-size:14px}
+.ark-builtin-title{margin:0 0 .9rem;font-size:1.05rem;font-weight:700}
+[data-ark-builtin]{position:relative;min-height:60vh}
+.ark-builtin-node{box-sizing:border-box;width:13.5rem;padding:.45rem .6rem;
+border:1px solid var(--k,#565f89);border-left:5px solid var(--k,#565f89);
+border-radius:6px;background:var(--kb,#1e202b)}
+.ark-builtin-kind{display:inline-block;width:1.15em}
+.ark-builtin-kind::before{content:var(--kg,"\\25A3")}
+.ark-builtin-kind-name{font-size:.58rem;color:var(--k,#94a3b8);letter-spacing:.05em}
+.ark-builtin-label{display:block;font-size:.84rem;font-weight:650;line-height:1.35;margin-top:.05rem}
+.ark-builtin-fields{list-style:none;margin:.32rem 0 0;padding:.28rem 0 0;
+border-top:1px solid rgba(148,163,184,.28)}
+.ark-builtin-fields li{padding:.14rem 0;font-size:.7rem;line-height:1.4;color:#aeb7d6}
+.ark-builtin-note{white-space:pre-wrap;font-size:.72rem;line-height:1.45;color:#cbd5e1}
+.ark-builtin-group{display:none;box-sizing:border-box;position:absolute;
+left:calc(var(--ark-harness-group-x) - 1.3rem);
+top:calc(var(--ark-harness-group-y) - 2.3rem);
+width:calc(var(--ark-harness-group-width) + 2.6rem);
+height:calc(var(--ark-harness-group-height) + 3.4rem);
+border:1px solid #475569;border-radius:.8rem;background:rgba(125,207,255,.05)}
+.ark-builtin-group.ark-harness-graph-group{display:block}
+.ark-builtin-group .group-label{position:absolute;top:.5rem;left:.8rem;
+font-size:.72rem;font-weight:700;color:#7dd3fc}
+`;
+
+/**
+ * ER / 集約図。entity と field 一覧が主役で、多重度は edge.ext からハーネスが
+ * 描く。DDD の戦術設計で使う root / vo / invariant も同じ形なのでここに含める。
+ */
+const ER_CSS = `${BASE_CSS}
+[data-ark-builtin="er"] .ark-builtin-node{--k:#60a5fa;--kb:#172a46;--kg:"\\25B7"}
+[data-ark-builtin="er"] .ark-builtin-node[data-kind="root"]{--k:#facc15;--kb:#332b0e;--kg:"\\25C6";border-width:2px;border-left-width:5px}
+[data-ark-builtin="er"] .ark-builtin-node[data-kind="vo"]{--k:#4ade80;--kb:#153522;--kg:"\\25C7"}
+[data-ark-builtin="er"] .ark-builtin-node[data-kind="external"]{--k:#a3a3a3;--kb:#26262b;--kg:"\\25A4";border-style:dashed;border-left-style:solid}
+[data-ark-builtin="er"] .ark-builtin-node[data-kind="invariant"]{--k:#f87171;--kb:#3a1c1c;--kg:"\\26A0";border-style:dashed;border-left-style:solid}
+[data-ark-builtin="er"] .ark-builtin-node[data-kind="principle"]{--k:#c084fc;--kb:#2a2044;--kg:"\\00A7";width:15rem}
+[data-ark-builtin="er"] .ark-builtin-node[data-kind="note"]{--k:#94a3b8;--kb:#1b2130;width:17rem;border-style:dashed;border-left-style:solid}
+`;
+
+/**
+ * イベントストーミング。kind ごとの色は event=橙 / command=青 / aggregate=黄 /
+ * policy=紫 / actor=桃 / read-model=緑 を既定にし、必ず kind 名を併置する。
+ */
+const STORMING_CSS = `${BASE_CSS}
+[data-ark-builtin="event-storming"] .ark-builtin-node{--k:#94a3b8;--kb:#202b3c;--kg:"\\25A3"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="event"]{--k:#f59e0b;--kb:#3b2810;--kg:"\\26A1"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="command"]{--k:#60a5fa;--kb:#172a46;--kg:"\\25B6"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="aggregate"]{--k:#facc15;--kb:#3a3111;--kg:"\\25C6"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="policy"]{--k:#c084fc;--kb:#302044;--kg:"\\25C7"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="actor"]{--k:#f472b6;--kb:#3b1e35;--kg:"\\25CE";width:9rem}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="read-model"]{--k:#4ade80;--kb:#153522;--kg:"\\25A4"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="external-system"]{--k:#94a3b8;--kb:#202b3c;--kg:"\\2601"}
+[data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="note"]{--k:#94a3b8;--kb:#1b2130;width:17rem;border-style:dashed;border-left-style:solid}
+`;
+
+export const BUILTIN_DIAGRAM_TYPES: Readonly<Record<string, BuiltinType>> = {
+  er: { css: ER_CSS, showKindName: false },
+  "event-storming": { css: STORMING_CSS, showKindName: true },
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderNode(node: DiagramNode, type: BuiltinType): string {
+  const id = escapeHtml(node.id);
+  const kindAttr = node.kind ? ` data-kind="${escapeHtml(node.kind)}"` : "";
+  const parts: string[] = [];
+
+  if (node.kind === "note") {
+    // note は label ではなく noteText が本文。ハーネスの note 投影契約に合わせる
+    parts.push(
+      `<div class="ark-builtin-note" data-ark-harness-note>${escapeHtml(node.noteText ?? "")}</div>`
+    );
+  } else {
+    parts.push('<span class="ark-builtin-kind" aria-hidden="true"></span>');
+    if (type.showKindName && node.kind) {
+      parts.push(
+        `<span class="ark-builtin-kind-name">${escapeHtml(node.kind)}</span>`
+      );
+    }
+    parts.push(
+      `<span class="ark-builtin-label" data-model-id="${id}">${escapeHtml(node.label)}</span>`
+    );
+    const fields = node.fields ?? [];
+    if (fields.length > 0) {
+      const items = fields
+        .map(
+          field =>
+            `<li data-model-id="${escapeHtml(field.id)}">${escapeHtml(field.label)}</li>`
+        )
+        .join("");
+      parts.push(`<ul class="ark-builtin-fields">${items}</ul>`);
+    }
+  }
+
+  return `<article class="ark-builtin-node" data-model-id="${id}"${kindAttr}>${parts.join("")}</article>`;
+}
+
+function renderGroup(id: string, label: string): string {
+  const safeId = escapeHtml(id);
+  return (
+    `<section class="ark-builtin-group" data-ark-group data-model-id="${safeId}">` +
+    `<span class="group-label" data-model-id="${safeId}">${escapeHtml(label)}</span>` +
+    "</section>"
+  );
+}
+
+/** 生成物が自前の graph を持っているか（持っていれば作者のものを尊重する） */
+function hasAuthoredGraph(html: string): boolean {
+  return /data-ark-container\s*=\s*["']graph["']/i.test(html);
+}
+
+/**
+ * 既知の図種なら投影 DOM と CSS を html へ差し込む。
+ * 未知・未指定の図種、または自前の graph を持つ図はそのまま返す。
+ */
+export function injectBuiltinProjection(
+  html: string,
+  model: DiagramModel
+): string {
+  const typeName = model.type;
+  if (typeof typeName !== "string") return html;
+  if (!Object.hasOwn(BUILTIN_DIAGRAM_TYPES, typeName)) return html;
+  const type = BUILTIN_DIAGRAM_TYPES[typeName];
+  if (!type) return html;
+  if (hasAuthoredGraph(html)) return html;
+
+  const safeType = escapeHtml(typeName);
+  const title = model.title
+    ? `<h1 class="ark-builtin-title" ${GENERATED_ATTR}="1">${escapeHtml(model.title)}</h1>`
+    : "";
+  const groups = model.groups
+    .map(group => renderGroup(group.id, group.label))
+    .join("");
+  const nodes = model.nodes.map(node => renderNode(node, type)).join("");
+  const projection =
+    `<style data-ark-harness-ui="1">${type.css}</style>` +
+    title +
+    `<div data-ark-container="graph" data-ark-builtin="${safeType}" ${GENERATED_ATTR}="1">` +
+    groups +
+    nodes +
+    "</div>";
+
+  const closing = html.toLowerCase().lastIndexOf("</body>");
+  if (closing === -1) return html + projection;
+  return html.slice(0, closing) + projection + html.slice(closing);
+}

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -588,6 +588,22 @@ describe("injectHarness", () => {
     expect(out).toContain('element.hasAttribute("data-ark-container")');
   });
 
+  it("サーバー生成の投影を送信 HTML から取り除く", () => {
+    // 内蔵図種（diagram-builtin.ts）の投影は配信のたびに作り直す。
+    // 送信 HTML に残すと最初の保存でファイルへ焼き付き、モデルと投影の
+    // 二重管理に逆戻りする
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+
+    expect(out).toContain('querySelectorAll("[data-ark-harness-generated]")');
+    expect(
+      out.indexOf('querySelectorAll("[data-ark-harness-generated]")')
+    ).toBeGreaterThan(out.indexOf("function buildSubmissionHtml("));
+  });
+
   it("CRUD DOM を安全な API だけで生成し全 model id を予約する", () => {
     const out = injectHarness(
       page(

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -3207,6 +3207,9 @@ const RAW_HARNESS_JS = `(function () {
     clone.querySelectorAll("[data-ark-harness-ui]").forEach(function (el) {
       if (el.parentNode) el.parentNode.removeChild(el);
     });
+    clone.querySelectorAll("[data-ark-harness-generated]").forEach(function (el) {
+      if (el.parentNode) el.parentNode.removeChild(el);
+    });
     if (clone.body) {
       clone.body.style.removeProperty("--ark-harness-toolbar-height");
       if (clone.body.style.length === 0) clone.body.removeAttribute("style");

--- a/packages/server/src/lib/diagram-model.test.ts
+++ b/packages/server/src/lib/diagram-model.test.ts
@@ -164,6 +164,39 @@ describe("parseDiagramModel", () => {
     }
   });
 
+  it("図種 type を文字列のまま保持し、保存の往復で失わない", () => {
+    // type は内蔵レンダラの選択に使う。parse が落とすと最初の保存で図種が
+    // 消え、次の配信から投影が生成されなくなる
+    const json = JSON.stringify({
+      version: 1,
+      type: "er",
+      nodes: [{ id: "order", label: "Order", kind: "entity" }],
+    });
+
+    const result = parseDiagramModel(json);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.model.type).toBe("er");
+      const round = parseDiagramModel(JSON.stringify(result.model));
+      expect(round.ok).toBe(true);
+      if (round.ok) expect(round.model.type).toBe("er");
+    }
+  });
+
+  it("type が文字列でなければ落とす", () => {
+    const json = JSON.stringify({
+      version: 1,
+      type: { name: "er" },
+      nodes: [{ id: "order", label: "Order" }],
+    });
+
+    const result = parseDiagramModel(json);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.model.type).toBeUndefined();
+  });
+
   it("group の label / nodes / ext を保持する", () => {
     const json = JSON.stringify({
       version: 1,

--- a/packages/server/src/lib/diagram-model.ts
+++ b/packages/server/src/lib/diagram-model.ts
@@ -40,6 +40,12 @@ export interface DiagramGroup {
 
 export interface DiagramModel {
   version: 1;
+  /**
+   * 図種（er / event-storming など）。サーバーは値を解釈せず保持するだけで、
+   * 既知の図種なら配信時に投影 DOM と CSS を生成する（diagram-builtin.ts）。
+   * 未知の値・未指定なら従来どおり生成物が書いた投影をそのまま使う。
+   */
+  type?: string;
   title?: string;
   nodes: DiagramNode[];
   edges: DiagramEdge[];
@@ -187,6 +193,7 @@ export function parseDiagramModel(json: string): ParseResult {
     ok: true,
     model: {
       version: 1,
+      type: typeof raw.type === "string" ? raw.type : undefined,
       title: typeof raw.title === "string" ? raw.title : undefined,
       nodes,
       edges,

--- a/packages/server/src/lib/diagram-reader.ts
+++ b/packages/server/src/lib/diagram-reader.ts
@@ -11,6 +11,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import { injectBuiltinProjection } from "./diagram-builtin.js";
 import { extractModel, injectCsp } from "./diagram-file.js";
 import { injectHarness } from "./diagram-harness.js";
 import type { DiagramModel } from "./diagram-model.js";
@@ -110,10 +111,14 @@ export async function readDiagram(
   if (!read.ok) return read;
   const model = extractModel(read.raw);
   if (!model.ok) return { ok: false, status: 422, error: model.error };
+  // 内蔵図種の投影生成 → CSP → ハーネスの順。投影はハーネスが読む DOM 契約を
+  // 満たす必要があるため、ハーネス注入より前に置く
   return {
     ok: true,
     absPath: read.absPath,
-    html: injectHarness(injectCsp(read.raw)),
+    html: injectHarness(
+      injectCsp(injectBuiltinProjection(read.raw, model.model))
+    ),
     model: model.model,
   };
 }


### PR DESCRIPTION
## 問題

ER 図やイベントストーミングのように**書式が決まっている図**でも、生成物にモデル JSON と投影 HTML/CSS の両方を書かせていた。決まった図種ならモデルから見た目への写像は一意に決まるので、この HTML は「既に決まっているものを毎回手で転記する作業」でしかない。実害は3つ:

1. **モデルと投影という食い違いうる真実が二つできる** — #289（noteText / kind の還流バグ）はまさにこの構造が原因だった
2. **一貫性が壊れる** — 同じ概念を描く CSS が図ごとに少しずつ違う
3. **生成コストの半分が転記** — 既存ボード7枚を実測すると、モデル 39% / 投影 43% / CSS 16%

## 変更点

- `DiagramModel` に `type` を追加（サーバーは値を解釈せず保持する。`kind` と同じ方針）。**保存の往復で失わないことが要件** — parse が落とすと最初の保存で図種が消え、以後投影が生成されなくなる
- `diagram-builtin.ts` を新設し、既知の図種（`er` / `event-storming`）の投影 DOM と CSS を配信時に生成する。フックは `readDiagram` の一箇所
- 生成 DOM に `data-ark-harness-generated`、CSS に `data-ark-harness-ui` を付け、ハーネスの `buildSubmissionHtml` で取り除く。**図ファイルはモデルだけの状態を保つ**（ここが崩れると最初の保存で投影が焼き付き、二重管理へ逆戻りする）
- 作図スキルに図種と使える kind を明文化

### なぜハーネスではなくサーバー側か

ハーネスの注入は全図に配られる。実測したところ **128,498 / 131,072 バイト（余裕 2.5KB）** で上限が目前で、図種ごとの CSS を積むと全図がその分を払うことになる。サーバー側で生成すれば、費用を払うのはその図種の図だけ。今回ハーネスに足したのは送信時の除去1行（+147 バイト）のみ。

### 逃げ道は残す

生成物が自前の `data-ark-container="graph"` を書いた図には一切触らない。決まった図種でない図（ロードマップ、説明図、厳密な座標指定のスイムレーン）を自由に書ける現状の強みは維持される。既存ボードは `type` を持たないのでそのまま動く。

## 効果（実測）

同じ内容のボードを内蔵図種で書き直した場合の生成コスト:

| ボード | 現行 | 内蔵 | 削減 |
| --- | --- | --- | --- |
| 集約設計 | 6,673 tok | 3,080 tok | 54% |
| イベントストーミング | 5,329 tok | 2,619 tok | 51% |
| イベントカタログ | 6,124 tok | 2,618 tok | 57% |

## 検証

- unit: server 全 570 件 PASS（`diagram-builtin` 11 件・`diagram-model` の type 往復 2 件・ハーネスの除去契約 1 件を追加）
- E2E: `e2e/diagram-builtin.spec.ts` を新設（6 件）。**モデルだけのファイルから描画されること**、多重度・group・自動レイアウトが効くこと、**送信 HTML が生成投影を含まないこと**、ラベル編集と node ドラッグがモデルへ反映されることを実経路で確認
- 実機の描画をスクリーンショットで確認し、**kind 別スタイルが label span へ漏れて二重枠になるバグを発見・修正**した（ハーネスは label にも `data-kind` を同期するため、素の `[data-kind=]` セレクタでは当たりすぎる）。回帰テストを unit と E2E の両方に追加
- `tsc -b` / biome PASS・codex P5 ゲート PASS

## ついでの修正

#289 で意味差分の契約を変えた際に更新し損ねていた **e2e の期待値 4 件**を直した。kind 変更が差分に出るようになったための陳腐化で、実装は正しい（テスト自身が kind select を操作している）。

**CI がこれを検出できなかった点は別途相談したい**: `ci.yml` は `pnpm install` / `pnpm check` / `pnpm build` のみで、unit テストも E2E も回していない。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ER図とEvent Stormingに対応する内蔵レンダラーを追加しました。
  * モデルJSONからノード、フィールド、グループ、エッジ、注記などを自動生成し、レイアウトも適用します。
  * 図の編集内容やドラッグ位置をモデルへ保存できるようになりました。
* **改善**
  * 生成された表示用要素を送信データから自動的に除外し、編集結果を正確に反映します。
  * 対応する図種や利用条件をドキュメントに追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->