### PR TITLE
図解: 内蔵図種に flow / state / context-map を追加

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -18,6 +18,13 @@ Ark が配信時に生成し、生成物はファイルへ焼き付かない（�
 | --- | --- | --- |
 | `er` | ER 図・集約設計・エンティティ表 | `entity`（既定）/ `root` / `vo` / `external` / `invariant` / `principle` / `note` |
 | `event-storming` | イベントストーミング | `command` / `event` / `aggregate` / `policy` / `actor` / `read-model` / `external-system` / `note` |
+| `flow` | 業務フロー・シナリオ・処理の分岐 | `step`（既定）/ `command` / `decision` / `policy` / `event` / `outcome` / `error` / `actor` / `note` |
+| `state` | 状態遷移 | `state`（既定）/ `initial` / `terminal-ok` / `terminal-cancel` / `note` |
+| `context-map` | コンテキストマップ（戦略設計） | `supporting`（既定）/ `core` / `generic` / `developed` / `external` / `note` |
+
+語彙にない kind を書くとその図種の既定スタイルになる。`flow` の出口は成功を
+`outcome`、失敗を `error` に分けると、色に頼らず読めるようになる。区間の枠
+（単一Tx境界、スイムレーン、境界づけられたコンテキスト）は group で表す。
 
 ```html
 <!doctype html>

--- a/e2e/diagram-builtin.spec.ts
+++ b/e2e/diagram-builtin.spec.ts
@@ -41,6 +41,24 @@ const erModel: DiagramModel = {
   groups: [{ id: "ordering", label: "Ordering", nodes: ["customer", "order"] }],
 };
 
+const stateModel: DiagramModel = {
+  version: 1,
+  type: "state",
+  title: "注文ステータス",
+  nodes: [
+    { id: "i", label: "開始", kind: "initial" },
+    { id: "c", label: "注文確定", kind: "state" },
+    { id: "d", label: "配達完了", kind: "terminal-ok" },
+    { id: "x", label: "キャンセル", kind: "terminal-cancel" },
+  ],
+  edges: [
+    { id: "e1", from: "i", to: "c", label: "confirm" },
+    { id: "e2", from: "c", to: "d", label: "deliver" },
+    { id: "e3", from: "c", to: "x", label: "cancel" },
+  ],
+  groups: [],
+};
+
 const stormingModel: DiagramModel = {
   version: 1,
   type: "event-storming",
@@ -195,6 +213,28 @@ test("event-storming: kind 名を可視の見出しとして出し note 本文�
   await expect(
     page.locator('article[data-model-id="memo"] [data-ark-harness-note]')
   ).toContainText("未決: 在庫の引当");
+});
+
+test("state: 開始と2つの終端を色以外でも区別して描画する", async ({ page }) => {
+  // CSS 変数の値を比べるだけでは実表示を保証できない（codex 指摘）。
+  // 疑似要素に解決されたグリフを実際に読む
+  await openBuiltin(page, stateModel);
+
+  const glyph = (id: string) =>
+    page
+      .locator(`article[data-model-id="${id}"]`)
+      .evaluate(el => getComputedStyle(el, "::before").content);
+
+  // state 図は kind 見出しを出さずグリフ自体が意味を担うので、対応まで固定する
+  expect(await glyph("i")).toBe('"●"');
+  expect(await glyph("c")).toBe('"○"');
+  expect(await glyph("d")).toBe('"✔"');
+  expect(await glyph("x")).toBe('"✖"');
+  // 取消は線種でも区別する
+  await expect(page.locator('article[data-model-id="x"]')).toHaveCSS(
+    "border-top-style",
+    "dashed"
+  );
 });
 
 test("kind を変えると可視の kind 見出しも追従する", async ({ page }) => {

--- a/packages/server/src/lib/diagram-builtin.test.ts
+++ b/packages/server/src/lib/diagram-builtin.test.ts
@@ -132,6 +132,75 @@ describe("injectBuiltinProjection", () => {
     expect(out).toMatch(/\.ark-builtin-node::before\{content:var\(--kg/);
   });
 
+  it.each([
+    [
+      "flow",
+      [
+        "step",
+        "command",
+        "decision",
+        "policy",
+        "event",
+        "outcome",
+        "error",
+        "actor",
+        "note",
+      ],
+    ],
+    ["state", ["initial", "state", "terminal-ok", "terminal-cancel", "note"]],
+    [
+      "context-map",
+      ["core", "supporting", "generic", "developed", "external", "note"],
+    ],
+  ] as const)("%s は語彙の全 kind を node root だけに当てる", (type, kinds) => {
+    const out = injectBuiltinProjection(
+      page(modelScript),
+      model({
+        type,
+        nodes: kinds.map((kind, index) => ({
+          id: `n${index}`,
+          label: `ノード${index}`,
+          kind,
+        })),
+        edges: [],
+        groups: [],
+      })
+    );
+    const style = out.slice(out.indexOf("<style"), out.indexOf("</style>"));
+
+    expect(out).toContain(`data-ark-builtin="${type}"`);
+    for (const kind of kinds) {
+      expect(style).toContain(`.ark-builtin-node[data-kind="${kind}"]`);
+      expect(out).toContain(`data-kind="${kind}"`);
+    }
+    // 素の [data-kind] は label span にも当たるので使わない
+    const kindRules = style.match(/\[data-kind=/g) ?? [];
+    const scoped = style.match(/\.ark-builtin-node\[data-kind=/g) ?? [];
+    expect(scoped).toHaveLength(kindRules.length);
+  });
+
+  it("state の2つの終端を色以外でも区別する", () => {
+    // 色覚・モノクロ表示でも「正常終了」と「取消」を読み分けられること
+    const out = injectBuiltinProjection(
+      page(modelScript),
+      model({ type: "state", nodes: [], edges: [], groups: [] })
+    );
+    const rule = (kind: string) =>
+      out.match(
+        new RegExp(`\\.ark-builtin-node\\[data-kind="${kind}"\\]\\{[^}]*\\}`)
+      )?.[0] ?? "";
+
+    const glyph = (kind: string) => rule(kind).match(/--kg:"([^"]*)"/)?.[1];
+
+    // 入れ替わりも検出できるよう、kind とグリフの対応まで固定する
+    expect(glyph("initial")).toBe("\\25CF"); // ●
+    expect(glyph("state")).toBe("\\25CB"); // ○
+    expect(glyph("terminal-ok")).toBe("\\2714"); // ✔
+    expect(glyph("terminal-cancel")).toBe("\\2716"); // ✖
+    // 取消は線種でも区別する
+    expect(rule("terminal-cancel")).toContain("border-style:dashed");
+  });
+
   it("引用符なしの graph 属性を持つ図にも触らない", () => {
     // HTML は data-ark-container=graph も許す。見落とすと graph が二重になる
     const authored = page(

--- a/packages/server/src/lib/diagram-builtin.test.ts
+++ b/packages/server/src/lib/diagram-builtin.test.ts
@@ -167,11 +167,18 @@ describe("injectBuiltinProjection", () => {
       })
     );
     const style = out.slice(out.indexOf("<style"), out.indexOf("</style>"));
+    // style 内の同じ文字列で通ってしまわないよう、判定は graph の中だけで行う
+    const graphStart = out.indexOf('<div data-ark-container="graph"');
+    expect(graphStart).toBeGreaterThanOrEqual(0);
+    const graphHtml = out.slice(graphStart);
 
     expect(out).toContain(`data-ark-builtin="${type}"`);
     for (const kind of kinds) {
       expect(style).toContain(`.ark-builtin-node[data-kind="${kind}"]`);
-      expect(out).toContain(`data-kind="${kind}"`);
+      // data-kind は node root（article）に直接付く
+      expect(graphHtml).toMatch(
+        new RegExp(`<article\\b[^>]*data-kind="${kind}"`)
+      );
     }
     // 素の [data-kind] は label span にも当たるので使わない
     const kindRules = style.match(/\[data-kind=/g) ?? [];

--- a/packages/server/src/lib/diagram-builtin.ts
+++ b/packages/server/src/lib/diagram-builtin.ts
@@ -94,9 +94,60 @@ const STORMING_CSS = `${BASE_CSS}
 [data-ark-builtin="event-storming"] .ark-builtin-node[data-kind="note"]{--kn:"note";--k:#94a3b8;--kb:#1b2130;width:17rem;border-style:dashed;border-left-style:solid}
 `;
 
+/**
+ * 業務フロー・シナリオ。分岐と出口の性格（成功 / エラー）が読めることが要件で、
+ * group は「単一Tx境界」「同期応答」のような区間の枠として使う。
+ */
+const FLOW_CSS = `${BASE_CSS}
+[data-ark-builtin="flow"] .ark-builtin-node::before{content:var(--kg,"\\25A3") "\\00A0" var(--kn,"")}
+[data-ark-builtin="flow"] .ark-builtin-node{--kn:"step";--k:#38bdf8;--kb:#12283a;--kg:"\\25A3"}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="step"]{--kn:"step";--k:#38bdf8;--kb:#12283a;--kg:"\\25A3"}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="command"]{--kn:"command";--k:#60a5fa;--kb:#172a46;--kg:"\\25B6"}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="decision"]{--kn:"decision";--k:#c084fc;--kb:#302044;--kg:"\\25C7"}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="policy"]{--kn:"policy";--k:#c084fc;--kb:#241a33;--kg:"\\25C7"}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="event"]{--kn:"event";--k:#f59e0b;--kb:#2c1f0d;--kg:"\\26A1"}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="outcome"]{--kn:"outcome";--k:#4ade80;--kb:#153522;--kg:"\\2714"}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="error"]{--kn:"error";--k:#f87171;--kb:#3a1a1a;--kg:"\\2716"}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="actor"]{--kn:"actor";--k:#f472b6;--kb:#3b1e35;--kg:"\\25CE";width:9rem}
+[data-ark-builtin="flow"] .ark-builtin-node[data-kind="note"]{--kn:"note";--k:#94a3b8;--kb:#1b2130;width:19rem;border-style:dashed;border-left-style:solid}
+`;
+
+/**
+ * 状態遷移。開始と終了の区別が読めることが要件で、終了は「正常」と「取消」を
+ * 別 kind にする。遷移は edge の label と direction で表す。
+ */
+const STATE_CSS = `${BASE_CSS}
+[data-ark-builtin="state"] .ark-builtin-node{--k:#60a5fa;--kb:#172a46;--kg:"\\25CB";
+width:11.5rem;border-radius:1.1rem;text-align:center}
+[data-ark-builtin="state"] .ark-builtin-node[data-kind="initial"]{--k:#94a3b8;--kb:#242a36;--kg:"\\25CF"}
+[data-ark-builtin="state"] .ark-builtin-node[data-kind="state"]{--k:#60a5fa;--kb:#172a46;--kg:"\\25CB"}
+[data-ark-builtin="state"] .ark-builtin-node[data-kind="terminal-ok"]{--k:#4ade80;--kb:#153522;--kg:"\\2714";border-width:2px}
+[data-ark-builtin="state"] .ark-builtin-node[data-kind="terminal-cancel"]{--k:#f87171;--kb:#3a1a1a;--kg:"\\2716";border-width:2px;border-style:dashed}
+[data-ark-builtin="state"] .ark-builtin-node[data-kind="note"]{--k:#94a3b8;--kb:#1b2130;width:18rem;
+border-radius:6px;text-align:left;border-style:dashed;border-left-style:solid}
+`;
+
+/**
+ * コンテキストマップ（戦略設計）。中核と補助と外部の区別が読めることが要件で、
+ * 上流下流や関係の種類は edge の label と `edge.ext` に置く。
+ */
+const CONTEXT_MAP_CSS = `${BASE_CSS}
+[data-ark-builtin="context-map"] .ark-builtin-node::before{content:var(--kg,"\\25A3") "\\00A0" var(--kn,"")}
+[data-ark-builtin="context-map"] .ark-builtin-node{--kn:"supporting";--k:#60a5fa;--kb:#172a46;--kg:"\\25A3";width:15rem}
+[data-ark-builtin="context-map"] .ark-builtin-node[data-kind="core"]{--kn:"core domain";--k:#facc15;--kb:#332b0e;--kg:"\\2605";border-width:2px;border-left-width:5px}
+[data-ark-builtin="context-map"] .ark-builtin-node[data-kind="supporting"]{--kn:"supporting";--k:#60a5fa;--kb:#172a46;--kg:"\\25A3"}
+[data-ark-builtin="context-map"] .ark-builtin-node[data-kind="generic"]{--kn:"generic";--k:#4ade80;--kb:#153522;--kg:"\\25A3"}
+[data-ark-builtin="context-map"] .ark-builtin-node[data-kind="developed"]{--kn:"this phase";--k:#c084fc;--kb:#2a2044;--kg:"\\25B6"}
+[data-ark-builtin="context-map"] .ark-builtin-node[data-kind="external"]{--kn:"external";--k:#a3a3a3;--kb:#26262b;--kg:"\\2601";border-style:dashed;border-left-style:solid}
+[data-ark-builtin="context-map"] .ark-builtin-node[data-kind="note"]{--kn:"note";--k:#94a3b8;--kb:#1b2130;width:19rem;border-style:dashed;border-left-style:solid}
+`;
+
 export const BUILTIN_DIAGRAM_TYPES: Readonly<Record<string, BuiltinType>> = {
   er: { css: ER_CSS },
   "event-storming": { css: STORMING_CSS },
+  flow: { css: FLOW_CSS },
+  state: { css: STATE_CSS },
+  "context-map": { css: CONTEXT_MAP_CSS },
 };
 
 function escapeHtml(value: string): string {


### PR DESCRIPTION
## 問題

#293 で内蔵図種（`er` / `event-storming`）を入れたので、既存ボードを新形式へ移そうとしたところ、**7枚のうち移せるのは2枚だけ**だった。残り5枚の kind 語彙はこうなっていた:

| ボード | kind 語彙 | 既存の図種で表せるか |
| --- | --- | --- |
| 集約設計 | entity / root / vo / external / invariant / principle | `er` ✓ |
| ドメインイベント | actor / aggregate / command / event / policy / read-model | `event-storming` ✓ |
| シナリオ×2 | step / decision / error / outcome / command / policy | ✗ |
| 状態遷移 | initial / state / terminal-ok / terminal-cancel | ✗ |
| コンテキストマップ | core / supporting / developed / external | ✗ |

## 変更点

図種の追加は CSS ブロックと registry 1行で済む形にしてあるので、実際に使う3種類を足す。

- **`flow`**: `step`（既定）/ `command` / `decision` / `policy` / `event` / `outcome` / `error` / `actor` / `note`。出口を `outcome` と `error` に分け、色に頼らず成否が読めるようにする。区間の枠（単一Tx境界・同期応答）は group で表す
- **`state`**: `state`（既定）/ `initial` / `terminal-ok` / `terminal-cancel` / `note`。角丸のピル型で、終端は ✔ と ✖ の別グリフ + 取消は破線
- **`context-map`**: `supporting`（既定）/ `core` / `generic` / `developed` / `external` / `note`

kind 別スタイルは全図種で node root に限定する（label span にも `data-kind` が同期されるため。#293 で踏んだのと同じ穴）。この不変条件を**全図種に対して**検査するテストを追加した。

## 検証

- unit: server 全 564 件 PASS（図種ごとに語彙の全 kind を検査する parametrized テストを追加）
- E2E: 内蔵図種 9 件 PASS。`state` の4グリフは**疑似要素に解決された実表示**を読んで対応まで固定している（CSS 変数の比較では入れ替わりを検出できないため）
- 実機の描画をスクリーンショットで確認済み
- `tsc -b` / biome PASS・codex P5 ゲート PASS（4周）

## codex レビューで直したもの

1. `terminal-ok` と `terminal-cancel` が同じグリフで**差が色だけ**だった（自分で立てた「色だけに頼らない」規約の違反）→ ✔ / ✖ + 破線で区別
2. グリフのテストが「互いに異なる」しか見ておらず入れ替わりを検出できない → kind とグリフの対応を明示的に固定
3. 語彙外 kind のフォールバックが、ドキュメントに書いた既定 kind（`flow` は `step`、`context-map` は `supporting`）と一致していない → ルート規則を既定 kind に揃えた


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 組み込み図として「業務フロー」「状態遷移」「コンテキストマップ」を追加しました。
  - 業務フローでは成功・失敗の出口や区間境界を表現できます。
  - 状態遷移図では開始、通常、成功終了、キャンセル終了を表現できます。
  - キャンセル終了は破線で表示され、各図の要素が視覚的に区別されます。

- **テスト**
  - 追加された図種と表示ルールを自動テストで検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->