### PR TITLE
AUQ カードに直前のターミナル画面を verbatim 添付する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,10 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 
 **情報源分離の原則 (チャット UI v3 の核心)**: 会話内容は 100% JSONL transcript
 から取得する。tmux capture-pane は busy/AWAITING の existence チェック
-(`session:previews` の bridgeStatus) のみに使い、**画面テキストから内容を
-パースすることは全面禁止** (過去 2 回の挑戦の断念原因)。
+(`session:previews` の bridgeStatus) と、AUQ カードの「直前の画面」の
+**verbatim 表示** (`auq-screen-context.ts`。無解釈のスクリーンショット的添付)
+のみに使い、**画面テキストから内容をパースすることは全面禁止**
+(過去 2 回の挑戦の断念原因)。
 
 1. **tmux**: Claude CLIプロセスをdetachedセッションで管理。サーバー再起動後もセッションが永続化される
 2. **JsonlTailManager**: worktree 毎の JSONL を fs.watch + 1 秒 polling で tail し、新規行を購読 socket に push。/clear のファイル切替は onReset → 空 snapshot で追従
@@ -49,6 +51,9 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 - **質問のリアルタイム検出**: セッション起動時に `--settings` で注入する
   PreToolUse hook (`auq-hook-bridge.ts`) が tool_input.questions を
   `/api/internal/auq-event` へ POST → `session:auq` でカード表示
+- **質問の文脈**: AUQ 表示中は直前の会話も JSONL に無いため、hook 受信時の
+  tmux 画面を capture し verbatim でカードに添付する (「直前の画面」表示。
+  解釈・パースはしない)
 - **回答**: カードから tmux キー送出 (単問 single = digit 一発 / multiSelect =
   digit トグル → Right → Review digit 1 / 自由入力 = digit → literal → Enter)
 - **カードを閉じる**: JSONL に解決イベントが出現したとき (`hasResolvedAuqSince`)

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -37,6 +37,10 @@ import {
   AUQ_TOKEN_HEADER,
   auqHookBridge,
 } from "./lib/auq-hook-bridge.js";
+import {
+  AUQ_SCREEN_CAPTURE_LINES,
+  buildAuqScreenContext,
+} from "./lib/auq-screen-context.js";
 import { authManager } from "./lib/auth.js";
 import { beaconManager } from "./lib/beacon-manager.js";
 import {
@@ -653,14 +657,22 @@ export async function startServer(
       res.status(204).end();
       return;
     }
+    // 直前の会話文脈は AUQ 解決まで JSONL に書かれないため、hook 受信の
+    // この瞬間 (質問ボックス描画前後) の tmux 画面を verbatim で添付する。
+    // 解釈はしない (auq-screen-context.ts の原則境界コメント参照)
+    const screen = buildAuqScreenContext(
+      tmuxManager.capturePane(session.id, AUQ_SCREEN_CAPTURE_LINES)
+    );
     const entry = auqHookBridge.setPending(
       session.id,
-      body.tool_input.questions
+      body.tool_input.questions,
+      screen
     );
     io.emit("session:auq", {
       sessionId: session.id,
       at: entry.at,
       questions: entry.questions,
+      screen: entry.screen,
     });
     console.log(`[AuqHook] session:auq 配信: ${session.id} (${body.cwd})`);
     res.status(204).end();
@@ -2468,6 +2480,7 @@ export async function startServer(
           sessionId,
           at: pendingAuq.at,
           questions: pendingAuq.questions,
+          screen: pendingAuq.screen,
         });
       }
     });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -668,7 +668,9 @@ export async function startServer(
       body.tool_input.questions,
       screen
     );
-    io.emit("session:auq", {
+    // screen は端末の生画面なので、コマンド出力・パス・token 等を含みうる。
+    // 全 socket への broadcast はやめ、当該セッションの購読者だけへ送る
+    io.to(sessionRoom(session.id)).emit("session:auq", {
       sessionId: session.id,
       at: entry.at,
       questions: entry.questions,
@@ -1697,6 +1699,12 @@ export async function startServer(
   // (Socket.IO room) にブロードキャストする。
   const BRIDGE_ROOM = "bridge:subscribers";
   const GRID_ROOM = "grid:subscribers";
+  /**
+   * セッション単位の配信先。JSONL を購読しているクライアント
+   * （= そのセッションの会話ビューを開いている画面）だけが入る。
+   * 端末画面のような機微を含む配信を全 socket へ broadcast しないため。
+   */
+  const sessionRoom = (sessionId: string) => `session:${sessionId}`;
 
   // 直近のブロードキャスト結果。新規 subscribe 時に即時応答として送る
   // (subscribe ハンドラ内で hostMetrics.sample() を再実行すると、内部の prev*
@@ -2466,6 +2474,9 @@ export async function startServer(
           lines: snapshot.map(l => l.raw),
         });
         jsonlUnsubscribers.set(sessionId, unsubscribe);
+        // このセッションの会話ビューを開いている socket として登録する
+        // （session:auq の配信先。broadcast による端末画面の漏洩を防ぐ）
+        socket.join(sessionRoom(sessionId));
       } catch (err) {
         console.error("[JsonlTail] Subscribe error:", getErrorMessage(err));
         return;
@@ -2492,6 +2503,7 @@ export async function startServer(
         unsub();
         jsonlUnsubscribers.delete(sessionId);
       }
+      socket.leave(sessionRoom(sessionId));
     });
 
     // ===== Slash command 候補列挙 =====

--- a/packages/server/src/lib/auq-hook-bridge.test.ts
+++ b/packages/server/src/lib/auq-hook-bridge.test.ts
@@ -1,0 +1,47 @@
+/**
+ * auq-hook-bridge のテスト
+ *
+ * PendingAuq が screen (hook 受信時の tmux 画面 verbatim スナップショット)
+ * を保持し、再接続時の再送 (getPending) でも返せることを検証する。
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./database.js", () => ({
+  db: {
+    getSetting: vi.fn(() => null),
+    setSetting: vi.fn(),
+  },
+}));
+
+vi.mock("./paths.js", () => ({
+  getDataDir: vi.fn(() => "/tmp/ark-test-data"),
+}));
+
+import { AuqHookBridge } from "./auq-hook-bridge.js";
+
+describe("AuqHookBridge - screen スナップショット", () => {
+  it("setPending で渡した screen を getPending が返す", () => {
+    const bridge = new AuqHookBridge();
+    const questions = [{ question: "どちらにしますか?" }];
+    bridge.setPending("s1", questions, "直前の行1\n直前の行2");
+
+    const pending = bridge.getPending("s1");
+    expect(pending).not.toBeNull();
+    expect(pending!.questions).toBe(questions);
+    expect(pending!.screen).toBe("直前の行1\n直前の行2");
+  });
+
+  it("screen が null (capture 失敗) でも保持できる", () => {
+    const bridge = new AuqHookBridge();
+    bridge.setPending("s1", [], null);
+    expect(bridge.getPending("s1")!.screen).toBeNull();
+  });
+
+  it("同一セッションの再 setPending で screen も上書きされる", () => {
+    const bridge = new AuqHookBridge();
+    bridge.setPending("s1", [], "古い画面");
+    bridge.setPending("s1", [], "新しい画面");
+    expect(bridge.getPending("s1")!.screen).toBe("新しい画面");
+  });
+});

--- a/packages/server/src/lib/auq-hook-bridge.test.ts
+++ b/packages/server/src/lib/auq-hook-bridge.test.ts
@@ -28,8 +28,8 @@ describe("AuqHookBridge - screen スナップショット", () => {
 
     const pending = bridge.getPending("s1");
     expect(pending).not.toBeNull();
-    expect(pending!.questions).toBe(questions);
-    expect(pending!.screen).toBe("直前の行1\n直前の行2");
+    expect(pending?.questions).toBe(questions);
+    expect(pending?.screen).toBe("直前の行1\n直前の行2");
   });
 
   it("screen が null (capture 失敗) でも保持できる", () => {

--- a/packages/server/src/lib/auq-hook-bridge.ts
+++ b/packages/server/src/lib/auq-hook-bridge.ts
@@ -37,6 +37,12 @@ export interface PendingAuq {
   at: number;
   /** tool_input.questions の生データ */
   questions: unknown;
+  /**
+   * hook 受信時の tmux 画面スナップショット (verbatim・無解釈)。
+   * AUQ 表示中は直前の会話が JSONL に存在しないため、カードの
+   * 「直前の画面」表示にはこれが唯一の情報源。capture 失敗時は null
+   */
+  screen: string | null;
 }
 
 const PENDING_TTL_MS = 10 * 60 * 1000;
@@ -115,8 +121,12 @@ export class AuqHookBridge {
   }
 
   /** hook 受信を記録する (同一セッションの古い質問は上書き) */
-  setPending(sessionId: string, questions: unknown): PendingAuq {
-    const entry: PendingAuq = { at: Date.now(), questions };
+  setPending(
+    sessionId: string,
+    questions: unknown,
+    screen: string | null
+  ): PendingAuq {
+    const entry: PendingAuq = { at: Date.now(), questions, screen };
     this.pending.set(sessionId, entry);
     return entry;
   }

--- a/packages/server/src/lib/auq-screen-context.test.ts
+++ b/packages/server/src/lib/auq-screen-context.test.ts
@@ -19,6 +19,18 @@ describe("buildAuqScreenContext", () => {
     expect(buildAuqScreenContext("   \n\n  \t ")).toBeNull();
   });
 
+  it("不正な上限指定でもサイズ上限の不変条件を破らない", () => {
+    // maxChars: 0 は `slice(-0)` が全文を返すため、既定値へ丸める
+    const raw = Array.from({ length: 200 }, (_, i) => `行${i}`).join("\n");
+
+    for (const bad of [0, -1, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const out = buildAuqScreenContext(raw, { maxChars: bad, maxLines: bad });
+      expect(out).not.toBeNull();
+      expect((out as string).length).toBeLessThan(raw.length);
+      expect((out as string).split("\n").length).toBeLessThanOrEqual(40);
+    }
+  });
+
   it("末尾の空行は除去するが、内容は verbatim で保持する", () => {
     const raw = "● 認証方式は2案あります。\n  - JWT\n  - セッション\n\n\n";
     expect(buildAuqScreenContext(raw)).toBe(

--- a/packages/server/src/lib/auq-screen-context.test.ts
+++ b/packages/server/src/lib/auq-screen-context.test.ts
@@ -1,0 +1,59 @@
+/**
+ * auq-screen-context のテスト
+ *
+ * buildAuqScreenContext は tmux capture-pane の生出力を AUQ カードの
+ * 「直前の画面」表示用に整形する純粋関数。verbatim 原則 (内容の解釈・
+ * パースをしない) を守り、行うのは末尾空行の除去とサイズ上限のみ。
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildAuqScreenContext } from "./auq-screen-context.js";
+
+describe("buildAuqScreenContext", () => {
+  it("null 入力は null を返す (capture-pane 失敗時)", () => {
+    expect(buildAuqScreenContext(null)).toBeNull();
+  });
+
+  it("空文字・空白のみの入力は null を返す", () => {
+    expect(buildAuqScreenContext("")).toBeNull();
+    expect(buildAuqScreenContext("   \n\n  \t ")).toBeNull();
+  });
+
+  it("末尾の空行は除去するが、内容は verbatim で保持する", () => {
+    const raw = "● 認証方式は2案あります。\n  - JWT\n  - セッション\n\n\n";
+    expect(buildAuqScreenContext(raw)).toBe(
+      "● 認証方式は2案あります。\n  - JWT\n  - セッション"
+    );
+  });
+
+  it("行内の先頭空白・罫線文字はそのまま残す (解釈しない)", () => {
+    const raw = "╭─────╮\n│ > _ │\n╰─────╯";
+    expect(buildAuqScreenContext(raw)).toBe(raw);
+  });
+
+  it("maxLines を超える場合は末尾側の行だけを残す", () => {
+    const lines = Array.from({ length: 50 }, (_, i) => `line-${i + 1}`);
+    const result = buildAuqScreenContext(lines.join("\n"), { maxLines: 40 });
+    expect(result).toBe(lines.slice(10).join("\n"));
+  });
+
+  it("maxChars を超える場合は古い行から落として上限内に収める", () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `${i}`.repeat(100));
+    const result = buildAuqScreenContext(lines.join("\n"), {
+      maxLines: 40,
+      maxChars: 350,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(350);
+    // 末尾 (最新) 側が残る
+    expect(result!.endsWith("9".repeat(100))).toBe(true);
+    // 行の途中で切らない (行単位で落とす)
+    expect(result).toBe(lines.slice(7).join("\n"));
+  });
+
+  it("単一行が maxChars を超える場合は末尾側を切り出す", () => {
+    const raw = `head-${"x".repeat(200)}`;
+    const result = buildAuqScreenContext(raw, { maxChars: 50 });
+    expect(result).toBe(raw.slice(-50));
+  });
+});

--- a/packages/server/src/lib/auq-screen-context.test.ts
+++ b/packages/server/src/lib/auq-screen-context.test.ts
@@ -71,9 +71,9 @@ describe("buildAuqScreenContext", () => {
       maxChars: 350,
     });
     expect(result).not.toBeNull();
-    expect(result!.length).toBeLessThanOrEqual(350);
+    expect(result?.length).toBeLessThanOrEqual(350);
     // 末尾 (最新) 側が残る
-    expect(result!.endsWith("9".repeat(100))).toBe(true);
+    expect(result?.endsWith("9".repeat(100))).toBe(true);
     // 行の途中で切らない (行単位で落とす)
     expect(result).toBe(lines.slice(7).join("\n"));
   });

--- a/packages/server/src/lib/auq-screen-context.test.ts
+++ b/packages/server/src/lib/auq-screen-context.test.ts
@@ -31,6 +31,21 @@ describe("buildAuqScreenContext", () => {
     }
   });
 
+  it("文字数上限の切り詰めでサロゲートペアを分断しない", () => {
+    // 素の slice(-n) は境界の絵文字を片割れにして壊れた文字を作る
+    const emoji = "🍎"; // U+1F34E = サロゲートペア（2 コード単位）
+    const raw = emoji.repeat(50);
+
+    for (let maxChars = 10; maxChars <= 21; maxChars += 1) {
+      const out = buildAuqScreenContext(raw, { maxChars });
+      expect(out).not.toBeNull();
+      const text = out as string;
+      expect(text.length).toBeLessThanOrEqual(maxChars);
+      // 孤立サロゲートが残っていない = 全コードポイントが元の絵文字
+      expect([...text].every(ch => ch === emoji)).toBe(true);
+    }
+  });
+
   it("末尾の空行は除去するが、内容は verbatim で保持する", () => {
     const raw = "● 認証方式は2案あります。\n  - JWT\n  - セッション\n\n\n";
     expect(buildAuqScreenContext(raw)).toBe(

--- a/packages/server/src/lib/auq-screen-context.ts
+++ b/packages/server/src/lib/auq-screen-context.ts
@@ -1,0 +1,50 @@
+/**
+ * auq-screen-context - AUQ カード「直前の画面」スナップショットの整形
+ *
+ * 背景:
+ *   対話版 claude は AUQ を含むターン全体 (直前のテキスト + tool_use +
+ *   tool_result) を回答確定時にまとめて JSONL へ書くため、質問表示中は
+ *   直前の会話文脈が transcript に存在しない。カードに文脈を出すには
+ *   hook 受信時点の tmux 画面 (= ストリーム済みの直前テキストが表示
+ *   されている) を capture するしかない。
+ *
+ * 原則との境界 (重要):
+ *   「画面テキストのパース全面禁止」の原則が禁じるのは画面を構造に
+ *   *解釈* すること。このモジュールは capture-pane 出力を一切解釈せず
+ *   verbatim のまま表示用に渡す (行う加工は末尾空行の除去とサイズ上限
+ *   のみ)。existence チェック (bridgeStatus) と同じ側の許容範囲であり、
+ *   ここに正規表現での内容抽出等を足してはならない。
+ */
+
+/** hook 受信時に capture-pane へ要求する行数 (scrollback 込み) */
+export const AUQ_SCREEN_CAPTURE_LINES = 60;
+
+const DEFAULT_MAX_LINES = 40;
+const DEFAULT_MAX_CHARS = 4000;
+
+/**
+ * capture-pane の生出力を「直前の画面」表示用に整形する。
+ * 内容の解釈はしない。null / 空白のみは null (カード側は非表示)。
+ */
+export function buildAuqScreenContext(
+  raw: string | null,
+  opts: { maxLines?: number; maxChars?: number } = {}
+): string | null {
+  if (raw === null) return null;
+  const maxLines = opts.maxLines ?? DEFAULT_MAX_LINES;
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+
+  const lines = raw.split("\n");
+  let end = lines.length;
+  while (end > 0 && lines[end - 1].trim() === "") end--;
+  if (end === 0) return null;
+
+  // 直近 (末尾) 側を優先して残す。上限超過は行単位で古い側から落とす
+  let kept = lines.slice(Math.max(0, end - maxLines), end);
+  while (kept.length > 1 && kept.join("\n").length > maxChars) {
+    kept = kept.slice(1);
+  }
+  const text = kept.join("\n");
+  if (text.length > maxChars) return text.slice(-maxChars);
+  return text;
+}

--- a/packages/server/src/lib/auq-screen-context.ts
+++ b/packages/server/src/lib/auq-screen-context.ts
@@ -51,6 +51,20 @@ export function buildAuqScreenContext(
     kept = kept.slice(1);
   }
   const text = kept.join("\n");
-  if (text.length > maxChars) return text.slice(-maxChars);
+  if (text.length > maxChars) return sliceTailByCodePoint(text, maxChars);
   return text;
+}
+
+/**
+ * 末尾から最大 maxChars コード単位を、コードポイント境界を保って切り出す。
+ * 素の `slice(-n)` は境界にサロゲートペア（絵文字等）があると片割れを残し、
+ * 壊れた文字を作る。verbatim で渡すという不変条件に反するため使わない。
+ */
+function sliceTailByCodePoint(text: string, maxChars: number): string {
+  let start = text.length - maxChars;
+  // 下位サロゲートから始まってしまう場合は 1 つ手前（上位サロゲート）へ寄せず、
+  // 1 つ後ろへずらして壊れた片割れを落とす
+  const code = text.charCodeAt(start);
+  if (code >= 0xdc00 && code <= 0xdfff) start += 1;
+  return text.slice(start);
 }

--- a/packages/server/src/lib/auq-screen-context.ts
+++ b/packages/server/src/lib/auq-screen-context.ts
@@ -31,8 +31,14 @@ export function buildAuqScreenContext(
   opts: { maxLines?: number; maxChars?: number } = {}
 ): string | null {
   if (raw === null) return null;
-  const maxLines = opts.maxLines ?? DEFAULT_MAX_LINES;
-  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+  // 上限は有限な正整数へ丸める。0 や負値を通すと末尾切り出しの
+  // `slice(-0)` が全文を返し、サイズ上限の不変条件が破れる
+  const clamp = (value: number | undefined, fallback: number): number =>
+    typeof value === "number" && Number.isFinite(value) && value >= 1
+      ? Math.floor(value)
+      : fallback;
+  const maxLines = clamp(opts.maxLines, DEFAULT_MAX_LINES);
+  const maxChars = clamp(opts.maxChars, DEFAULT_MAX_CHARS);
 
   const lines = raw.split("\n");
   let end = lines.length;

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -472,6 +472,12 @@ export interface ServerToClientEvents {
     at: number;
     /** tool_input.questions の生データ (クライアント側で構造検証する) */
     questions: unknown;
+    /**
+     * hook 受信時の tmux 画面スナップショット (verbatim・無解釈)。
+     * AUQ 表示中は直前の会話が JSONL に無いため、カードの「直前の画面」
+     * 表示に使う。capture 失敗時は null
+     */
+    screen: string | null;
   }) => void;
   "session:restored": (session: ManagedSession) => void;
   "session:restore_failed": (data: {

--- a/packages/web/src/components/AskUserQuestionCard.tsx
+++ b/packages/web/src/components/AskUserQuestionCard.tsx
@@ -318,6 +318,10 @@ export function AskUserQuestionCard({
  */
 function ScreenContextBlock({ text }: { text: string }) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  // text は effect 内で読まないが、本文が差し替わった後に最新行へスクロール
+  // し直すための依存。外すとカードを保ったまま次の質問へ変わったときに
+  // 古いスクロール位置へ留まる
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 上記のとおり意図的
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;

--- a/packages/web/src/components/AskUserQuestionCard.tsx
+++ b/packages/web/src/components/AskUserQuestionCard.tsx
@@ -313,14 +313,15 @@ export function AskUserQuestionCard({
 
 /**
  * 質問直前のターミナル画面の verbatim 表示。
- * 最新行 (末尾) が文脈として最重要なのでマウント時に末尾へスクロールする
+ * 最新行 (末尾) が文脈として最重要なので末尾へスクロールする。
+ * カードを保ったまま次の質問へ差し替わる場合があるので text にも追従する
  */
 function ScreenContextBlock({ text }: { text: string }) {
   const scrollRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, []);
+  }, [text]);
   return (
     <div className="mb-2">
       <div className="text-[11px] text-muted-foreground mb-1">

--- a/packages/web/src/components/AskUserQuestionCard.tsx
+++ b/packages/web/src/components/AskUserQuestionCard.tsx
@@ -35,6 +35,12 @@ interface AskUserQuestionCardProps {
   socket: TypedSocket | null;
   sessionId: string;
   auq: ActiveAuq;
+  /**
+   * hook 受信時の tmux 画面スナップショット (verbatim・無解釈)。
+   * AUQ 表示中は直前の会話が JSONL に書かれないため、質問の文脈は
+   * これでしか提示できない。null なら非表示
+   */
+  screenContext?: string | null;
   onSendKey: (key: SpecialKey) => void;
   /** desync 時の「ターミナルで確認」(ttyd を開く)。未指定なら文言のみ */
   onOpenTerminal?: () => void;
@@ -54,6 +60,7 @@ export function AskUserQuestionCard({
   socket,
   sessionId,
   auq,
+  screenContext,
   onSendKey,
   onOpenTerminal,
 }: AskUserQuestionCardProps) {
@@ -190,6 +197,8 @@ export function AskUserQuestionCard({
         </div>
       )}
 
+      {screenContext && <ScreenContextBlock text={screenContext} />}
+
       {auq.questions.map((q, qi) => {
         const draft = drafts[qi];
         return (
@@ -297,6 +306,33 @@ export function AskUserQuestionCard({
             </button>
           )}
         </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * 質問直前のターミナル画面の verbatim 表示。
+ * 最新行 (末尾) が文脈として最重要なのでマウント時に末尾へスクロールする
+ */
+function ScreenContextBlock({ text }: { text: string }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, []);
+  return (
+    <div className="mb-2">
+      <div className="text-[11px] text-muted-foreground mb-1">
+        直前の画面（ターミナルの表示そのまま）
+      </div>
+      <div
+        ref={scrollRef}
+        className="max-h-36 overflow-y-auto rounded-md border border-border bg-background/60 px-2.5 py-1.5"
+      >
+        <pre className="text-[11px] font-mono whitespace-pre-wrap break-words text-muted-foreground leading-[1.55]">
+          {text}
+        </pre>
       </div>
     </div>
   );

--- a/packages/web/src/components/SplitChatPane.tsx
+++ b/packages/web/src/components/SplitChatPane.tsx
@@ -900,6 +900,8 @@ export function SplitChatPane({
   const [hookAuq, setHookAuq] = useState<{
     at: number;
     auq: ActiveAuq;
+    /** hook 受信時の tmux 画面 (verbatim)。直前の文脈は JSONL に無いため */
+    screen: string | null;
   } | null>(null);
 
   useEffect(() => {
@@ -908,6 +910,7 @@ export function SplitChatPane({
       sessionId: string;
       at: number;
       questions: unknown;
+      screen: string | null;
     }) => {
       if (data.sessionId !== session.id) return;
       const questions = parseAuqInput({ questions: data.questions });
@@ -915,6 +918,7 @@ export function SplitChatPane({
       setHookAuq({
         at: data.at,
         auq: { toolUseId: `hook:${data.at}`, questions },
+        screen: typeof data.screen === "string" ? data.screen : null,
       });
     };
     socket.on("session:auq", handler);
@@ -1337,6 +1341,7 @@ export function SplitChatPane({
           socket={socket}
           sessionId={session.id}
           auq={activeAuq}
+          screenContext={hookAuq?.screen ?? null}
           onSendKey={onSendKey}
           onOpenTerminal={
             onToggleTerminal && !showTerminal ? onToggleTerminal : undefined


### PR DESCRIPTION
## 背景

ローカルブランチ `herdr` に、PR も切られないまま残っていた実装を救出したもの。2026-07-19 の作業で、同ブランチの他 38 コミットは main に入っているが、この 1 本だけ取り残されていた（`git branch --merged` は squash マージを検出できないため見落とされやすい）。

## 問題

対話版 claude は AUQ の tool_use を**回答が確定した瞬間**に tool_result とまとめて JSONL へ書く。つまり質問が表示されている間、直前の会話文脈は transcript に存在しない。結果として AUQ カードには選択肢だけが出て、「何を聞かれているのか」の手がかりが無い。

## 変更点

hook 受信の瞬間（質問ボックス描画の前後）の tmux 画面を capture して、カードに verbatim で添付する。

- `auq-screen-context.ts`: capture-pane の生出力を表示用に整形する純粋関数。**内容の解釈は一切しない**（行うのは末尾空行の除去とサイズ上限のみ）
- `auq-hook-bridge.ts`: pending に screen を保持し、再接続時の再送にも載せる
- `AskUserQuestionCard.tsx`: 末尾（最新行）へスクロールした状態で表示

### 「画面テキストのパース全面禁止」との境界

CLAUDE.md の原則が禁じているのは画面を構造へ**解釈**することで、過去2回の挑戦が破綻した原因もそこにある。このモジュールは capture-pane 出力を解釈せず verbatim のまま渡すだけなので、existence チェック（bridgeStatus）と同じ側の許容範囲に入る。ここに正規表現での内容抽出を足してはならない旨をモジュール冒頭に明記した。

## 検証

- unit: server 全 577 件 PASS
- **実機**: 稼働中のサーバーへ hook を POST し、`session:auq` に screen が 40 行 / 1571 文字で添付されること、中身が実際の tmux 画面（プロンプト行・区切り線・ステータスバー）であることを確認
- `tsc -b` / biome PASS（警告も 65 → 61 に減）・codex P5 ゲート実施

## codex レビューで直したもの

1. **[P1] 全 socket への broadcast** — `io.emit("session:auq", ...)` は端末の生画面（コマンド出力・パス・token を含みうる）を全接続クライアントへ配っていた。JSONL 購読者だけの room 配信に変更。AUQ カードは `SplitChatPane` にしかなく、そこは同じセッションの JSONL を購読するので機能上の欠落は無い。**実機で「対象セッション購読者=受信 / 別セッション購読者=非受信 / 非購読者=非受信」を確認済み**
2. **[P2] `maxChars: 0` で上限が破れる** — `slice(-0)` が全文を返すため、有限な正整数へ丸める
3. **[P2] サロゲートペアの分断** — 末尾切り詰めが境界の絵文字を片割れにして壊れた文字を作っていた（verbatim の不変条件違反）。コードポイント境界を保つよう修正
4. **[P2] スクロールの依存漏れ** — カードを保ったまま画面が差し替わると追従しなかった

## スコープ外にしたもの

codex は「セッション購読前にサーバ側で閲覧権限を検証せよ」も挙げたが、**Ark にはユーザ別の権限モデルがそもそも存在しない**（認証済みクライアントは既に任意セッションの JSONL 全文と ttyd 端末に到達できる）。この PR で塞いだのは「頼んでいないクライアントへ配る」問題までで、権限モデル自体はアプリ全体の設計課題として #296 に切り出した。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - AskUserQuestionカードに、質問直前のターミナル画面を表示できるようになりました。
  - 画面内容はそのまま保持しつつ、表示量を適切に制限します。
  - 画面情報を対象セッションの購読者へ配信し、再接続時の保留中質問にも含めます。
  - 画面情報を取得できない場合は、質問のみを表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->