### PR TITLE
ci: ユニットテストを CI で実行する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,11 @@ jobs:
       - name: Type check
         run: pnpm check
 
+      # ユニットテスト（server / shared / web の *.test.ts をルート vitest 設定で一括実行）。
+      # 以前は CI にテストの step が無く、意味差分の契約を変えた #289 が
+      # e2e を 4 件壊したまま緑で通っていた。ここで落ちるようにする。
+      - name: Test
+        run: pnpm test
+
       - name: Build
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "preview": "pnpm --filter @ark/web preview",
     "test:e2e": "playwright test",
     "check": "biome check . && tsc -b",
+    "test": "vitest run",
     "format": "biome check --write .",
     "lint": "biome lint ."
   },


### PR DESCRIPTION
## 問題

CI には型チェック（`pnpm check` = `biome check . && tsc -b`）とビルドはあったが、**テストの step が一つも無かった**。

実害が出ている。意味差分の契約を変えた #289 が、e2e を 4 件壊したまま緑で通り、翌日まで気づかれなかった。ユニットテスト 742 件も CI では一度も走っていない。

## 変更点

- ルートに `test` スクリプト（`vitest run`）を追加
- CI の Type check と Build の間に Test step を追加

ルートの `vitest.config.ts` は `packages/server` / `packages/shared` / `packages/web` の `*.test.ts(x)` をすべて拾うので、追加設定なしで 742 件が対象になる（実行 34 秒）。

## 検証

新しい step が本当に壊れを捕まえるか、意図的な回帰で確かめた。`diagram-diff.ts` の生成文言を1語だけ変える（「種別」→「分類」）と:

- `pnpm check`（biome + tsc）: **素通り**（型は変わらないため）
- `pnpm test`: **3 件で失敗**

```
FAIL  diagram-diff.test.ts > describeModelDiff > kind の変更を述べる
FAIL  diagram-diff.test.ts > ext の変更は無視し kind の変更は種別変更として述べる
FAIL  diagram-diff.test.ts > CRUD と既存 field / endpoint / 種別編集が共存し…
Test Files  1 failed | 51 passed (52)
Tests  3 failed | 739 passed (742)
```

仕込みを戻して 742 件 PASS に復帰することも確認済み。codex P5 ゲート PASS。

## この PR に入れないもの

**e2e（playwright）は含めない。** 現状の spec には稼働中の Ark サーバー（`localhost:4001`）に依存するものと、`page.setContent` で完結するものが混在している。CI で回すには前者を切り分けるか、ワークフロー内でサーバーを起動する必要があり、この PR のスコープを超える。別途対応する。
