### PR TITLE
chore(release): v1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-code-ark",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "MIT",
   "private": true,

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/desktop",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/main.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/server",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/shared",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "main": "./src/types.ts",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ark/web",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## リリース v1.4.0

v1.3.0（2026-05-13）から **72 コミット・約 3 ヶ月分**。5 パッケージのバージョンを 1.4.0 へ揃える。

主軸は**図解ボード機能一式**（27 コミット）。v1.3.0 時点では存在しなかった機能がまるごと入る。

### 図解ボード

- `.diagram.html`（意味モデル JSON + HTML 投影）を右ペインに表示し、Claude が `board_open` で開く
- **直接編集**: ノード / エッジの追加・削除、kind ピッカー、カーディナリティと向き、edge ラベル、ノード本体ドラッグでの移動、ズーム / パン
- **自動レイアウト**: LR / TB、group（集約境界・スイムレーン）対応、手動座標との混在
- **意味差分の還流**: 編集内容を自然文で Claude へ返す（ラベル・フィールド・kind・ノート本文・構造変更）
- **内蔵図種**: `er` / `event-storming` / `flow` / `state` / `context-map` の 5 種。モデル JSON だけで描け、HTML も CSS も書かない
- 図スイッチャ（複数図の切り替え）、図の削除、自動保存

### その他

- AUQ カードに直前のターミナル画面を verbatim 添付（質問時に JSONL へ書かれない文脈を補う）
- 全セッションを UI から再起動
- 生成ファイルのチャットインライン DL / サムネ表示
- モバイル向けフォントのセルフホスト化（外部フォント由来の真っ白問題の解消）
- flow-x / flow-loop / 非同期ゲートによる自走基盤の強化
- CI にユニットテストを追加（742 → 743 件）
- 依存ライブラリを semver 範囲内で一括更新

## 検証

- `pnpm check` / `pnpm test`（743 件）/ `pnpm build` すべて PASS
- マージ元の main で CI 全ステップ成功を確認済み
- codex P5 ゲート PASS

## マージ後の手順

このPRをマージしたら `v1.4.0` タグを打つ。release ワークフローが tmux/ttyd 同梱バイナリのビルド → .app 生成 → GitHub Releases への upload → Homebrew tap の Caskfile 更新まで行う。
