### PR TITLE
fix(release): artifact 展開後に tmux/ttyd の実行ビットを復元する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,14 @@ jobs:
           name: ark-bin-macos-arm64
           path: packages/desktop/build-assets
 
+      # actions/upload-artifact は zip 化の際に file mode を保持しないため、
+      # download 後の tmux / ttyd は 644 (実行ビット無し) で展開される。
+      # electron-builder はそのまま .app へ同梱するので、配布物から
+      # bundled tmux/ttyd を exec できなくなる。ここで復元する。
+      # 参照: https://github.com/actions/upload-artifact#permission-loss
+      - name: Restore executable bit on bundled binaries
+        run: chmod +x packages/desktop/build-assets/bin/tmux packages/desktop/build-assets/bin/ttyd
+
       # 同梱バイナリが揃っていることを electron-builder 起動前に assert する
       # (build-bin の verify step を二重チェック)。
       - name: Verify bundled binaries


### PR DESCRIPTION
## 問題

v1.4.0 のリリースが「Verify bundled binaries」で失敗した。バイナリ自体は存在するのに実行ビットが落ちていた:

```
##[error]Bundled tmux missing or not executable at packages/desktop/build-assets/bin/tmux
-rw-r--r--  1 runner  staff  1312728  tmux
-rw-r--r--  1 runner  staff  7417448  ttyd
```

`actions/upload-artifact` は zip 化の際に file mode を保持しない。build-bin ジョブが実行可能な状態で作った tmux / ttyd が、download 側では 644 で展開される。

**verify step が無ければ気づかずに出荷されていた。** electron-builder はそのまま .app へ同梱するので、配布物から bundled tmux/ttyd を exec できない壊れたアプリになっていたはず。verify が正しく止めてくれた形。

## 変更点

download 直後に `chmod +x` を挟む。`bin/` の中身は tmux と ttyd の 2 つだけで、`licenses/` と `Frameworks/` は実行ビット不要（build-bin.yml の upload 対象を確認済み）。

step 順序は `Download → Restore executable bit → Verify` になる。

## 検証

- ワークフロー YAML を parse して step の挿入位置を確認
- `bin/` に置かれるのが tmux / ttyd だけであることを build-bin.yml で確認
- codex P5 ゲート PASS

macOS runner でしか再現しないため、実証はマージ後の v1.4.0 タグ再打ちで行う。Release は upload 前に失敗しているので未作成（`gh release view v1.4.0` → not found）。タグを打ち直せば再実行できる。
