### PR TITLE
fix(release): 同梱 claude を asarUnpack に含め smoke test を実態に合わせる

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,11 @@ name: release
 # 別 repo (`<user>/homebrew-tap`) の Caskfile も自動更新する (要 HOMEBREW_TAP_TOKEN)。
 #
 # 前提:
-#   - F4 (build-bin) で tmux/ttyd の artifact が揃っている (現状未生成のため
-#     skip 可能な構造にしている)
-#   - F5 (Claude CLI loader) は未実装。.app 単体で動作する状態を想定
+#   - build-bin で tmux/ttyd の artifact が揃っている
+#   - claude は @anthropic-ai/claude-code の platform package を .app へ同梱する
+#     (runtime installer は廃止済み。main.ts の bootstrap が起動時に fail-fast で
+#     app.asar.unpacked 配下の存在を要求する)
 #   - F0:B-1 確定済み: Apple Developer 登録なし (未署名配布)
-#
-# 実 release tag を打つのは F4-F6 完了後。それまでは手動 (workflow_dispatch) で
-# 動作確認のみ実施する想定。
 
 on:
   workflow_dispatch:
@@ -356,21 +354,63 @@ jobs:
             echo "::${END_TOKEN}::"
           done
 
-      - name: Smoke test bundled SDK claude binary
-        # PR #180 の root cause だった「SDK 付属 claude バイナリが asar 内パスで
+      - name: Smoke test bundled claude binary
+        # PR #180 の root cause だった「同梱 claude バイナリが asar 内パスで
         # spawn ENOTDIR」を防ぐため、`.unpacked` 配下に **実行ファイルとして** 配置
         # されていることを `--version` 起動で確認する。
-        # `asarUnpack` ルール変更・SDK バージョン更新で binary 配置が変わった場合に
-        # ここで fail する想定。Ark .app の target は darwin-arm64 のみのためパスは固定。
+        # `asarUnpack` ルール変更・claude-code バージョン更新で binary 配置が変わった
+        # 場合にここで fail する想定。Ark .app の target は darwin-arm64 のみ。
+        #
+        # 探索は main.ts の bootstrap fail-fast と同じ 2 レイアウト (flat / pnpm
+        # isolated) を対象にする。パスを固定で書くと pnpm のバージョン付き
+        # ディレクトリ名に追従できず、実体があるのに fail する。
         # 外部入力 (github.event.*) は使わず固定文字列のみ参照。
         run: |
           set -euo pipefail
-          BIN="packages/desktop/release/mac-arm64/Ark.app/Contents/Resources/app.asar.unpacked/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude"
-          if [ ! -x "$BIN" ]; then
-            echo "::error::Bundled SDK claude binary missing or not executable: $BIN"
-            ls -la "$(dirname "$BIN")" 2>&1 || echo "(directory not found)"
+          UNPACKED="packages/desktop/release/mac-arm64/Ark.app/Contents/Resources/app.asar.unpacked/node_modules"
+          # arch は arm64 に限定する。darwin-x64 でも Rosetta 経由で --version は
+          # 成功しうるため、緩い pattern だと bootstrap が要求する arm64 が
+          # 欠落した成果物を通してしまう。
+          #
+          # 候補は bootstrap (main.ts) が実際に探索する 2 か所だけに限定する。
+          # 別の依存配下にネストされたコピーを拾うと、bootstrap が見る位置には
+          # 実体が無いのに smoke test だけ成功してしまう。
+          #   1. flat:  <nm>/@anthropic-ai/claude-code-darwin-arm64/claude
+          #   2. pnpm:  <nm>/.pnpm/@anthropic-ai+claude-code-darwin-arm64@*/node_modules/
+          #             @anthropic-ai/claude-code-darwin-arm64/claude
+          #
+          # macOS runner の /bin/bash は 3.2 系なので mapfile (bash 4.0+) は使えない。
+          # while read で配列へ積む。
+          PKG="@anthropic-ai/claude-code-darwin-arm64"
+          CANDIDATES=()
+          FLAT="${UNPACKED}/${PKG}/claude"
+          [ -f "$FLAT" ] && CANDIDATES+=("$FLAT")
+          # .pnpm からの深さは <pkg>@<ver>/node_modules/@scope/<name>/claude = 5。
+          # 固定することで、その下にさらにネストしたコピーを拾わない。
+          while IFS= read -r line; do
+            [ -n "$line" ] && CANDIDATES+=("$line")
+          done < <(find "${UNPACKED}/.pnpm" -mindepth 5 -maxdepth 5 -type f -name claude \
+            -path "*/node_modules/${PKG}/claude" 2>/dev/null | sort)
+          if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+            echo "::error::Bundled claude (darwin-arm64) not found at bootstrap-visible paths under ${UNPACKED}"
+            ls -la "$UNPACKED/@anthropic-ai" 2>&1 || echo "(@anthropic-ai not unpacked)"
+            ls -la "$UNPACKED/.pnpm" 2>&1 | head -20 || echo "(.pnpm not unpacked)"
             exit 1
           fi
+          # flat / pnpm isolated のどちらか一方に 1 件だけあるのが期待レイアウト。
+          # 複数出たら取り違えの可能性があるので明示的に fail させる。
+          if [ "${#CANDIDATES[@]}" -ne 1 ]; then
+            echo "::error::Expected exactly 1 bundled claude, found ${#CANDIDATES[@]}"
+            printf '  %s\n' "${CANDIDATES[@]}"
+            exit 1
+          fi
+          BIN="${CANDIDATES[0]}"
+          if [ ! -x "$BIN" ]; then
+            echo "::error::Bundled claude is not executable: $BIN"
+            ls -la "$(dirname "$BIN")"
+            exit 1
+          fi
+          echo "Found bundled claude: $BIN"
           # `--version` は network / auth 不要で即終了する safe な smoke 用 subcommand。
           # 壊れたバイナリ / dyld loader 問題で hang した場合に job timeout (60min) まで
           # 走らせないよう、background + sleep race で 15s で kill する。
@@ -398,7 +438,7 @@ jobs:
           kill "$KILLER_PID" 2>/dev/null || true
           wait "$KILLER_PID" 2>/dev/null || true
           if [ "$BIN_EXIT" -ne 0 ]; then
-            echo "::error::Bundled SDK claude --version failed or timed out (exit=$BIN_EXIT)"
+            echo "::error::Bundled claude --version failed or timed out (exit=$BIN_EXIT)"
             # bundled binary 出力に workflow command が混入する可能性に備えて escape。
             END_TOKEN="ark-claude-version-$(uuidgen)"
             echo "::stop-commands::${END_TOKEN}"
@@ -411,7 +451,7 @@ jobs:
           VERSION=$(head -1 "$OUT_FILE")
           END_TOKEN="ark-claude-version-ok-$(uuidgen)"
           echo "::stop-commands::${END_TOKEN}"
-          echo "Bundled SDK claude binary OK: ${VERSION}"
+          echo "Bundled claude binary OK: ${VERSION}"
           echo "::${END_TOKEN}::"
 
       - name: Compute artifact metadata

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -97,6 +97,21 @@ asar: true
 # native module / 動的ロード対象は asar 内では動かないため unpack する。
 # better-sqlite3 は SQLite の .node binding を持ち、playwright-core は
 # Chromium バイナリの起動経路で fs アクセスをする。
+# 同梱 claude は asar 内のパスからは spawn できない (ENOTDIR) ため必ず unpack する。
+# main.ts の bootstrap が app.asar.unpacked 配下の
+# `@anthropic-ai/claude-code-<platform>-<arch>/claude` を fail-fast で要求しており
+# (flat / pnpm isolated の両レイアウトを探索)、ここに無いと .app が起動しない。
+# wrapper 側 (@anthropic-ai/claude-code) も同じ経路から解決するので併せて unpack する。
+#
+# `.pnpm` はドット始まりのため minimatch の `**` に一致しない。pnpm の isolated
+# レイアウト (`node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg>/**`) を確実に拾うには
+# `.pnpm` を literal で書いた pattern も並べる必要がある (実測で確認)。
 asarUnpack:
   - "**/node_modules/better-sqlite3/**"
+  - "**/node_modules/.pnpm/**/node_modules/better-sqlite3/**"
   - "**/node_modules/playwright-core/**"
+  - "**/node_modules/.pnpm/**/node_modules/playwright-core/**"
+  - "**/node_modules/@anthropic-ai/claude-code/**"
+  - "**/node_modules/@anthropic-ai/claude-code-*/**"
+  - "**/node_modules/.pnpm/**/@anthropic-ai/claude-code/**"
+  - "**/node_modules/.pnpm/**/@anthropic-ai/claude-code-*/**"

--- a/packages/desktop/src/asar-unpack-patterns.test.ts
+++ b/packages/desktop/src/asar-unpack-patterns.test.ts
@@ -1,0 +1,89 @@
+/**
+ * electron-builder の asarUnpack pattern が、実際の依存レイアウトを拾うかを固定する。
+ *
+ * ここが外れると `.app` は無言で壊れる:
+ * - 同梱 claude は asar 内パスから spawn できない (ENOTDIR)。main.ts の bootstrap は
+ *   `app.asar.unpacked` 配下の存在を起動時に fail-fast で要求するので、unpack 漏れ =
+ *   アプリが起動しない
+ * - native module (better-sqlite3) も asar 内では読めない
+ *
+ * 罠は `.pnpm` がドット始まりであること。minimatch の `**` は既定でドット始まりの
+ * セグメントに一致しないため、`**\/node_modules/<pkg>/**` だけでは pnpm の isolated
+ * レイアウトを拾えない。v1.4.0 のリリースはこれに起因して失敗した。
+ */
+
+import fs from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CONFIG_PATH = path.resolve(HERE, "../electron-builder.yml");
+
+/**
+ * matcher は electron-builder（app-builder-lib）が解決するものと同一実装を使う。
+ * 自前に依存させた minimatch で検証すると、builder 側がバージョンや実装を
+ * 変えたときにテストだけが通る状態になる。
+ *
+ * pnpm の strict なレイアウトでは「直接依存を1つずつ辿る」必要があるため、
+ * electron-builder（desktop の devDependency）→ app-builder-lib → minimatch と
+ * 段階的に解決する。途中が変わったら resolve が失敗して気づける。
+ */
+const require = createRequire(import.meta.url);
+const builderRequire = createRequire(
+  require.resolve("electron-builder/package.json")
+);
+const appBuilderLibRequire = createRequire(
+  builderRequire.resolve("app-builder-lib/package.json")
+);
+const { minimatch } = appBuilderLibRequire("minimatch") as {
+  minimatch: (target: string, pattern: string) => boolean;
+};
+
+/** electron-builder.yml の asarUnpack 配列を読む（YAML 依存を足さない簡易 parse） */
+function readAsarUnpackPatterns(): string[] {
+  const lines = fs.readFileSync(CONFIG_PATH, "utf-8").split("\n");
+  const start = lines.findIndex(line => line.trim() === "asarUnpack:");
+  if (start === -1) throw new Error("asarUnpack が見つかりません");
+  const patterns: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    const matched = line.match(/^\s+-\s+"(.+)"\s*$/);
+    if (!matched) break;
+    patterns.push(matched[1] as string);
+  }
+  return patterns;
+}
+
+/** 配布物で unpack されていないと壊れるパス（flat / pnpm isolated の両レイアウト） */
+const MUST_UNPACK = [
+  // 同梱 claude（main.ts の bootstrap が起動時に要求する）
+  "node_modules/@anthropic-ai/claude-code-darwin-arm64/claude",
+  "node_modules/.pnpm/@anthropic-ai+claude-code-darwin-arm64@2.1.226/node_modules/@anthropic-ai/claude-code-darwin-arm64/claude",
+  "node_modules/@anthropic-ai/claude-code/cli.js",
+  "node_modules/.pnpm/@anthropic-ai+claude-code@2.1.226/node_modules/@anthropic-ai/claude-code/cli.js",
+  // native module
+  "node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+  "node_modules/.pnpm/better-sqlite3@12.11.1/node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+  // Chromium 起動経路で fs アクセスをするため asar 内では動かない
+  "node_modules/playwright-core/cli.js",
+  "node_modules/.pnpm/playwright-core@1.62.1/node_modules/playwright-core/cli.js",
+];
+
+describe("asarUnpack pattern", () => {
+  const patterns = readAsarUnpackPatterns();
+
+  it.each(MUST_UNPACK)("unpack 対象に含める: %s", target => {
+    expect(patterns.some(pattern => minimatch(target, pattern))).toBe(true);
+  });
+
+  it("無関係な依存まで unpack しない", () => {
+    const untouched = [
+      "node_modules/react/index.js",
+      "node_modules/.pnpm/react@19.2.8/node_modules/react/index.js",
+    ];
+    for (const target of untouched) {
+      expect(patterns.some(pattern => minimatch(target, pattern))).toBe(false);
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       "packages/server/src/**/*.test.ts",
       "packages/shared/src/**/*.test.ts",
       "packages/web/src/**/*.test.{ts,tsx}",
+      "packages/desktop/src/**/*.test.ts",
     ],
     environment: "node",
   },


### PR DESCRIPTION
## 問題

v1.4.0 のリリース再実行が「Smoke test bundled SDK claude binary」で失敗した。調べると **配布物側に2つの不具合**があった。

### 1. asarUnpack に claude が一つも無い

`main.ts` の bootstrap は、起動時 fail-fast で `app.asar.unpacked` 配下の `@anthropic-ai/claude-code-<platform>-<arch>/claude` を要求する（runtime installer 廃止後、同梱が唯一の保証経路）。

しかし `asarUnpack` は better-sqlite3 と playwright-core だけで、**claude は asar 内に取り込まれていた**。この .app は起動しない。

### 2. smoke test が旧 Agent SDK のパスを見ている

本プロジェクトは対話版 CLI（`@anthropic-ai/claude-code`）を使う方針で Agent SDK は使わない（CLAUDE.md）。SDK 時代のパスが残っていたため、**1 の不具合を検出できないまま別の理由で落ちていた**。

### 3. `.pnpm` の取りこぼし（既存パターンにも同じ穴）

minimatch の `**` はドット始まりのセグメントに一致しない。`**/node_modules/<pkg>/**` だけでは pnpm の isolated レイアウトを拾えず、これは better-sqlite3 / playwright-core の既存エントリにも同じく当てはまっていた。literal `.pnpm` の pattern を併記した。

## 検証

macOS でしか実行できない箇所なので、**判定ロジックを疑似ツリーで再現して確認**した。

asarUnpack の glob（回帰テスト・9 件）:

| ケース | 結果 |
| --- | --- |
| flat / pnpm の claude・better-sqlite3・playwright-core | 一致する |
| 無関係な依存（react） | 一致しない |
| 修正前の設定へ戻す | 5 件落ちる |

smoke test の探索（疑似 unpacked ツリー）:

| ケース | 結果 |
| --- | --- |
| flat に arm64 | OK |
| pnpm isolated に arm64 | OK |
| darwin-x64 だけ | 拒否（Rosetta で `--version` が通ってしまうため arch を限定） |
| 実行ビット無し | 拒否 |
| 別依存配下にネストしたコピーだけ | 拒否（bootstrap が見ない位置） |
| flat と pnpm の両方に存在 | 拒否（取り違えの疑い） |

そのほか `pnpm check` / `pnpm test`（752 件）PASS、codex P5 ゲート PASS（4 周）。

## codex レビューで直したもの

1. **[P1] arch 非限定 + `head -1` で非決定的** — darwin-x64 を掴んでも Rosetta で `--version` が成功し、arm64 欠落の壊れた成果物を通しうる。arm64 に限定し、候補がちょうど 1 件であることを検証
2. **[P1] `mapfile` は macOS runner の bash 3.2 に無い** — 必ず `command not found` で落ちる。`while IFS= read -r` に置換
3. **[P1] bootstrap より広い範囲を探索** — 別依存配下のネストしたコピーを拾うと、bootstrap が見る位置に実体が無いのに smoke test だけ成功する。flat と `.pnpm/*/node_modules` の 2 か所だけに限定（深さ固定）
4. **[P2] テストが playwright-core を検査していない** — 必須ケースに追加
5. **[P2] テストが自前の minimatch を使っていた** — electron-builder → app-builder-lib → minimatch と依存を辿って**同一実装**を解決するよう変更。builder 側が変わったら resolve が失敗して気づける
