### PR TITLE
fix(diagram): コメント sidecar が正当な ISO timestamp を弾いていたのを修正

### DIFF
--- a/packages/server/src/lib/diagram-comments.test.ts
+++ b/packages/server/src/lib/diagram-comments.test.ts
@@ -33,6 +33,12 @@ afterEach(() => {
 
 const target = "order-flow.diagram.html";
 const timestamp = "2026-08-09T01:02:03.456Z";
+const acceptedTimestamps = [
+  "2026-08-10T12:18:59.377337Z",
+  "2026-08-10T12:18:59Z",
+  "2026-08-10T12:18:59.377Z",
+  "2026-08-10T21:18:59.377337+09:00",
+] as const;
 
 function comments(overrides: Record<string, unknown> = {}) {
   return {
@@ -127,6 +133,48 @@ describe("parseDiagramComments", () => {
       comments: authorless,
     });
   });
+
+  it.each(acceptedTimestamps)(
+    "ISO timestamp %s を表現を変えずに受け付ける",
+    value => {
+      const thread = comments().threads[0];
+      const sidecar = comments({
+        threads: [
+          {
+            ...thread,
+            createdAt: value,
+            messages: [{ ...thread.messages[0], at: value }],
+          },
+        ],
+      });
+
+      expect(parseDiagramComments(JSON.stringify(sidecar), target)).toEqual({
+        ok: true,
+        comments: sidecar,
+      });
+    }
+  );
+
+  it.each(["2026-08-10 12:18:59", "not-a-date", "", 1])(
+    "不正な timestamp %j を拒否する",
+    value => {
+      const thread = comments().threads[0];
+      const sidecar = comments({
+        threads: [
+          {
+            ...thread,
+            createdAt: value,
+            messages: [{ ...thread.messages[0], at: value }],
+          },
+        ],
+      });
+
+      const result = parseDiagramComments(JSON.stringify(sidecar), target);
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.code).toBe("INVALID_SIDECAR");
+    }
+  );
 
   it.each([
     ["壊れた JSON", "{"],
@@ -781,6 +829,39 @@ describe("comment mutations", () => {
     }
     expect(again).toEqual(resolved);
   });
+
+  it.each(acceptedTimestamps)(
+    "resolve 後も timestamp %s の表現を維持する",
+    async value => {
+      writeDoc();
+      const thread = comments().threads[0];
+      const sidecarPath = path.join(
+        worktree,
+        ".claude/diagrams/order-flow.comments.json"
+      );
+      fs.writeFileSync(
+        sidecarPath,
+        JSON.stringify(
+          comments({
+            threads: [
+              {
+                ...thread,
+                createdAt: value,
+                messages: [{ ...thread.messages[0], at: value }],
+              },
+            ],
+          })
+        )
+      );
+
+      const result = await resolveDiagramComment(worktree, relPath, thread.id);
+
+      expect(result.ok).toBe(true);
+      const saved = JSON.parse(fs.readFileSync(sidecarPath, "utf8"));
+      expect(saved.threads[0].createdAt).toBe(value);
+      expect(saved.threads[0].messages[0].at).toBe(value);
+    }
+  );
 
   it("未知 thread を THREAD_NOT_FOUND にする", async () => {
     writeDoc();

--- a/packages/server/src/lib/diagram-comments.test.ts
+++ b/packages/server/src/lib/diagram-comments.test.ts
@@ -38,6 +38,7 @@ const acceptedTimestamps = [
   "2026-08-10T12:18:59Z",
   "2026-08-10T12:18:59.377Z",
   "2026-08-10T21:18:59.377337+09:00",
+  "2026-08-10T07:18:59.377337-05:00",
 ] as const;
 
 function comments(overrides: Record<string, unknown> = {}) {

--- a/packages/server/src/lib/diagram-comments.ts
+++ b/packages/server/src/lib/diagram-comments.ts
@@ -96,7 +96,9 @@ function timestamp(
 ): { ok: true; value: string } | { ok: false; error: string } {
   if (
     typeof value !== "string" ||
-    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/u.test(value) ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/u.test(
+      value
+    ) ||
     !Number.isFinite(Date.parse(value))
   ) {
     return { ok: false, error: `${name} は ISO timestamp が必要です` };


### PR DESCRIPTION
図解コメントの sidecar 検証が、正当な ISO 8601 timestamp を弾いていた。

## 症状

`.comments.json` の `at` に**小数 4 桁以上**（マイクロ秒精度）の値が含まれると、`parseDiagramComments` が

```
threads[0].messages[1].at は ISO timestamp が必要です
```

を返し、`INVALID_SIDECAR` になる。**その文書のコメントが全件読めなくなる**。1 件の書式差でファイル全体が失われるうえ、読めないので UI から削除も解決もできず、復旧手段が無い。

## 原因

`diagram-comments.ts` の `timestamp()` が小数秒を**最大 3 桁**しか許していなかった。

```
/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/u
```

ISO 8601 は小数秒の桁数を制限しておらず、マイクロ秒精度（`2026-08-10T12:18:59.377337Z`）は多くの実装が普通に出力する。`Date.parse` も問題なく解釈できる。

sidecar は Ark の書き込み経路（常に `toISOString()`）以外に、**人間の手編集や、`board_comments` を読んだ Claude による追記**からも書かれうるファイルであり、正当な ISO 8601 を受け入れられないのは検証側の欠陥だった。

## 修正

- 小数秒の桁数制限を撤廃する
- タイムゾーンは `Z` に加えて `+HH:MM` / `-HH:MM` のオフセットも受け入れる（手書きの値は現地時刻で書かれうる）
- `Date.parse` が有限値であることの確認は維持する
- **受け入れた値はそのままの表現で保存する**（正規化して書き換えない）。Ark が既存ファイルの表現を勝手に変えないため
- 書き込み側が `toISOString()` を使う挙動は変更しない

不正な値（`2026-08-10 12:18:59` / `not-a-date` / 空文字 / 数値）は従来どおり弾く。

## 検証

`pnpm check` / `pnpm test`（986 件）/ `pnpm build` すべて green。

加えて、**実際にこの症状を起こしていた sidecar** に対して、修正版サーバーを pm2 で起動し `diagram:comments:get` を実行して確認した。

- 修正前: `INVALID_SIDECAR`、読めたスレッド 0 件
- 修正後: `ok`、**2 スレッド・各 2 メッセージ**が復元。マイクロ秒の値は元の表現のまま保持

Refs #300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ISO形式のタイムスタンプで、UTC（`Z`）に加えて時差オフセット（例：`+09:00`）を利用できるようになりました。
  * 小数秒を任意の桁数で受け付けるようになりました。
  * コメント解決後も、スレッドとメッセージのタイムスタンプ表現が保持されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->