### PR TITLE
feat(board): コメント機能と作図規約を全セッションへ届ける

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -42,6 +42,9 @@ extraResources:
     to: app/web
     filter:
       - "**/*"
+  # board_authoring_guide が packaged 環境で参照する作図規約。
+  - from: ../server/dist/diagram-authoring-guide.md
+    to: app/diagram-authoring-guide.md
   # tray.ts:resolveTrayIconPath() は packaged 時に
   # `process.resourcesPath/build-assets/tray-icon.png` を参照する。
   # ここで配置していないと nativeImage.createEmpty() fallback で

--- a/packages/desktop/src/main.test.ts
+++ b/packages/desktop/src/main.test.ts
@@ -1,0 +1,73 @@
+import path from "node:path";
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+const electronApp = vi.hoisted(() => ({
+  isPackaged: false,
+  setName: vi.fn(),
+  getPath: vi.fn((name: string) => `/tmp/ark-${name}`),
+  whenReady: vi.fn(() => new Promise<void>(() => {})),
+  on: vi.fn(),
+  quit: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: electronApp,
+  BrowserWindow: class {},
+  ipcMain: { handle: vi.fn() },
+  Menu: { buildFromTemplate: vi.fn(), setApplicationMenu: vi.fn() },
+  shell: { openExternal: vi.fn() },
+}));
+
+vi.mock("electron-log", () => ({
+  default: {
+    transports: { file: { resolvePathFn: vi.fn() } },
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("./menu.js", () => ({ buildAppMenu: vi.fn() }));
+vi.mock("./tray.js", () => ({
+  createTray: vi.fn(),
+  destroyTray: vi.fn(),
+}));
+
+import { resolveDiagramAuthoringGuidePath } from "./main.js";
+
+const originalResourcesPath = Object.getOwnPropertyDescriptor(
+  process,
+  "resourcesPath"
+);
+
+afterAll(() => {
+  if (originalResourcesPath) {
+    Object.defineProperty(process, "resourcesPath", originalResourcesPath);
+  } else {
+    Reflect.deleteProperty(process, "resourcesPath");
+  }
+});
+
+describe("resolveDiagramAuthoringGuidePath", () => {
+  it("packaged 時は process.resourcesPath 配下の同梱パスを返す", () => {
+    electronApp.isPackaged = true;
+    Object.defineProperty(process, "resourcesPath", {
+      configurable: true,
+      value: "/Applications/Ark.app/Contents/Resources",
+    });
+
+    expect(resolveDiagramAuthoringGuidePath()).toBe(
+      path.join(
+        "/Applications/Ark.app/Contents/Resources",
+        "app",
+        "diagram-authoring-guide.md"
+      )
+    );
+  });
+
+  it("unpackaged 時は undefined を返す", () => {
+    electronApp.isPackaged = false;
+
+    expect(resolveDiagramAuthoringGuidePath()).toBeUndefined();
+  });
+});

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -206,6 +206,18 @@ function resolveWebStaticDir(): string | undefined {
   return path.resolve(__dirname, "../../web/dist");
 }
 
+/**
+ * `.app` の Resources/ に同梱された作図規約のパスを解決する。
+ *
+ * packaged 時だけ electron-builder の `extraResources` による配置先を返す。
+ * dev / unpackaged では server 側の既存解決（dist 隣接 → リポジトリ正本）に
+ * 委ねるため undefined を返す。
+ */
+export function resolveDiagramAuthoringGuidePath(): string | undefined {
+  if (!app.isPackaged) return undefined;
+  return path.join(process.resourcesPath, "app", "diagram-authoring-guide.md");
+}
+
 async function bootstrap(): Promise<void> {
   // === fail-fast 前提条件チェック (bootstrap 副作用前) ===
   // 配布物不整合 (.app 同梱 claude binary 欠落) は ここで検知する。
@@ -414,6 +426,7 @@ async function bootstrap(): Promise<void> {
   serverHandle = await startServer({
     port,
     webStaticDir: resolveWebStaticDir(),
+    diagramAuthoringGuidePath: resolveDiagramAuthoringGuidePath(),
     // Electron は ephemeral port で毎回 port が変わるため、
     // `/tmp/ark-tunnel-state.json` の port を信用して proxy すると
     // 存在しない port を指してリモートアクセスが切れる。

--- a/packages/server/build.mjs
+++ b/packages/server/build.mjs
@@ -1,5 +1,9 @@
 import { build } from "esbuild";
-import { readFile } from "node:fs/promises";
+import { copyFile, readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
 
 // package.json の dependencies を読み込み、@ark/* (ワークスペース内パッケージ) を除外して external とする。
 // これにより @ark/shared 等のワークスペース依存はバンドルに inline され、
@@ -23,3 +27,11 @@ await build({
   external: externals,
   outExtension: { ".js": ".js" },
 });
+
+await copyFile(
+  path.resolve(
+    packageDir,
+    "../../.claude/skills/diagram-authoring/SKILL.md",
+  ),
+  path.resolve(packageDir, "dist/diagram-authoring-guide.md"),
+);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -48,6 +48,7 @@ import {
   BoardMcpServer,
   BoardSessionRegistry,
   listDiagramCommentPaths,
+  readDiagramAuthoringGuide,
 } from "./lib/board-mcp-server.js";
 import { rememberFifoEntry } from "./lib/bounded-fifo-map.js";
 import {
@@ -152,6 +153,8 @@ export {
  * - `webStaticDir`: 本番モード時に静的配信する Web ビルド成果物のパス。
  *   未指定時は CLI 起動時の旧パス互換 (`<__dirname>/../../web/dist`) で解決する。
  *   Electron からは `app/web` のような同梱パスを渡す。
+ * - `diagramAuthoringGuidePath`: `.diagram.html` 作図規約の同梱パス。
+ *   Electron packaged 版から明示し、未指定時は server 側の既存解決に委ねる。
  */
 export interface StartServerOptions {
   port?: number;
@@ -161,6 +164,7 @@ export interface StartServerOptions {
   publicDomain?: string;
   allowedRepos?: string[];
   webStaticDir?: string;
+  diagramAuthoringGuidePath?: string;
   /**
    * 将来 Electron から実データ保存ディレクトリ (`app.getPath('userData')`)
    * を渡すための予約オプション。Phase 2 では未使用 (Phase 3 で本実装予定)。
@@ -751,6 +755,8 @@ export async function startServer(
   const boardRegistry = new BoardSessionRegistry();
   const boardMcp = new BoardMcpServer();
   const boardDeps: BoardMcpDeps = {
+    readAuthoringGuide: () =>
+      readDiagramAuthoringGuide(undefined, options.diagramAuthoringGuidePath),
     async listDiagramPaths(worktreePath) {
       const resolved = resolveManagedWorktreeDetailed(worktreePath);
       if (!resolved.ok) {

--- a/packages/server/src/lib/board-mcp-server.test.ts
+++ b/packages/server/src/lib/board-mcp-server.test.ts
@@ -4,15 +4,28 @@
  * 旧 board_write（Excalidraw scene への直接書き込み）のテストは撤去済み（B-1）。
  */
 
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { DIAGRAM_DIR } from "@ark/shared";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   BoardSessionRegistry,
   createBoardMcpServer,
   handleBoardComments,
   handleBoardOpen,
+  readDiagramAuthoringGuide,
 } from "./board-mcp-server.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
 
 const comments = {
   ok: true as const,
@@ -206,18 +219,64 @@ describe("handleBoardComments", () => {
   });
 });
 
+describe("readDiagramAuthoringGuide", () => {
+  function createRuntimeDir(): { root: string; runtimeDir: string } {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "ark-board-guide-"));
+    tempDirs.push(root);
+    const runtimeDir = path.join(root, "packages/server/dist/lib");
+    fs.mkdirSync(runtimeDir, { recursive: true });
+    return { root, runtimeDir };
+  }
+
+  it("dist/lib から dist の配布用ガイドを読む", async () => {
+    const { runtimeDir } = createRuntimeDir();
+    fs.writeFileSync(
+      path.resolve(runtimeDir, "../diagram-authoring-guide.md"),
+      "dist guide"
+    );
+
+    await expect(readDiagramAuthoringGuide(runtimeDir)).resolves.toBe(
+      "dist guide"
+    );
+  });
+
+  it("dist のガイドが無ければリポジトリの SKILL.md を読む", async () => {
+    const { root, runtimeDir } = createRuntimeDir();
+    const skillPath = path.join(
+      root,
+      ".claude/skills/diagram-authoring/SKILL.md"
+    );
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+    fs.writeFileSync(skillPath, "source guide");
+
+    await expect(readDiagramAuthoringGuide(runtimeDir)).resolves.toBe(
+      "source guide"
+    );
+  });
+
+  it("配布用ガイドも SKILL.md も無ければ理由を含むエラーになる", async () => {
+    const { runtimeDir } = createRuntimeDir();
+
+    await expect(readDiagramAuthoringGuide(runtimeDir)).rejects.toThrow(
+      /diagram-authoring-guide\.md.*SKILL\.md/s
+    );
+  });
+});
+
 describe("createBoardMcpServer", () => {
-  it("board_open metadata を shared の正準 directory から生成する", () => {
+  it("3 ツールを登録し board_authoring_guide は注入した規約全文を返す", async () => {
     const registerTool = vi.spyOn(McpServer.prototype, "registerTool");
+    const readAuthoringGuide = vi.fn(async () => "authoring guide body");
     const deps = {
       openDiagram: vi.fn(async () => ({ ok: true })),
       listDiagramPaths: vi.fn(async () => []),
       getDiagramComments: vi.fn(async () => comments),
+      readAuthoringGuide,
     };
 
     createBoardMcpServer(deps, "/wt");
 
-    expect(registerTool).toHaveBeenCalledTimes(2);
+    expect(registerTool).toHaveBeenCalledTimes(3);
     const [, config] = registerTool.mock.calls[0] ?? [];
     const metadata = config as
       | {
@@ -232,5 +291,38 @@ describe("createBoardMcpServer", () => {
       "docs/diagrams"
     );
     expect(registerTool.mock.calls[1]?.[0]).toBe("board_comments");
+    expect(registerTool.mock.calls[2]?.[0]).toBe("board_authoring_guide");
+
+    const handler = registerTool.mock.calls[2]?.[2] as unknown as (
+      args: Record<string, never>
+    ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+    await expect(handler({})).resolves.toEqual({
+      content: [{ type: "text", text: "authoring guide body" }],
+    });
+    expect(readAuthoringGuide).toHaveBeenCalledOnce();
+  });
+
+  it("board_authoring_guide の読み出し失敗理由を返す", async () => {
+    const registerTool = vi.spyOn(McpServer.prototype, "registerTool");
+    createBoardMcpServer(
+      {
+        openDiagram: vi.fn(async () => ({ ok: true })),
+        listDiagramPaths: vi.fn(async () => []),
+        getDiagramComments: vi.fn(async () => comments),
+        readAuthoringGuide: vi.fn(async () => {
+          throw new Error("ガイドが見つかりません");
+        }),
+      },
+      "/wt"
+    );
+
+    const handler = registerTool.mock.calls[2]?.[2] as unknown as (
+      args: Record<string, never>
+    ) => Promise<{ content: Array<{ type: string; text: string }> }>;
+    const result = await handler({});
+
+    expect(result.content[0]?.text).toBe(
+      "board_authoring_guide 失敗: ガイドが見つかりません"
+    );
   });
 });

--- a/packages/server/src/lib/board-mcp-server.test.ts
+++ b/packages/server/src/lib/board-mcp-server.test.ts
@@ -240,6 +240,42 @@ describe("readDiagramAuthoringGuide", () => {
     );
   });
 
+  it("明示された同梱パスを dist と正本より優先して読む", async () => {
+    const { root, runtimeDir } = createRuntimeDir();
+    const configuredPath = path.join(root, "packaged/authoring-guide.md");
+    fs.mkdirSync(path.dirname(configuredPath), { recursive: true });
+    fs.writeFileSync(configuredPath, "packaged guide");
+    fs.writeFileSync(
+      path.resolve(runtimeDir, "../diagram-authoring-guide.md"),
+      "dist guide"
+    );
+    const skillPath = path.join(
+      root,
+      ".claude/skills/diagram-authoring/SKILL.md"
+    );
+    fs.mkdirSync(path.dirname(skillPath), { recursive: true });
+    fs.writeFileSync(skillPath, "source guide");
+
+    await expect(
+      readDiagramAuthoringGuide(runtimeDir, configuredPath)
+    ).resolves.toBe("packaged guide");
+  });
+
+  it("明示された同梱パスが無ければ dist の配布用ガイドへフォールバックする", async () => {
+    const { root, runtimeDir } = createRuntimeDir();
+    fs.writeFileSync(
+      path.resolve(runtimeDir, "../diagram-authoring-guide.md"),
+      "dist guide"
+    );
+
+    await expect(
+      readDiagramAuthoringGuide(
+        runtimeDir,
+        path.join(root, "packaged/authoring-guide.md")
+      )
+    ).resolves.toBe("dist guide");
+  });
+
   it("dist のガイドが無ければリポジトリの SKILL.md を読む", async () => {
     const { root, runtimeDir } = createRuntimeDir();
     const skillPath = path.join(
@@ -260,6 +296,15 @@ describe("readDiagramAuthoringGuide", () => {
     await expect(readDiagramAuthoringGuide(runtimeDir)).rejects.toThrow(
       /diagram-authoring-guide\.md.*SKILL\.md/s
     );
+  });
+
+  it("明示パスを含む全経路で読めなければ理由を含むエラーになる", async () => {
+    const { root, runtimeDir } = createRuntimeDir();
+    const configuredPath = path.join(root, "packaged/authoring-guide.md");
+
+    await expect(
+      readDiagramAuthoringGuide(runtimeDir, configuredPath)
+    ).rejects.toThrow(/packaged\/authoring-guide\.md.*SKILL\.md/s);
   });
 });
 

--- a/packages/server/src/lib/board-mcp-server.ts
+++ b/packages/server/src/lib/board-mcp-server.ts
@@ -115,12 +115,27 @@ export type BoardCommentsResult = {
 };
 
 /**
- * 配布物にコピーされた作図規約を読み、dev 実行時だけリポジトリの正本へ
- * フォールバックする。runtimeDir はパス解決テストで差し替えるための引数。
+ * 明示された同梱パス、server の配布物、リポジトリの正本の順で作図規約を読む。
+ * runtimeDir はパス解決テストで差し替えるための引数。
  */
 export async function readDiagramAuthoringGuide(
-  runtimeDir = __dirname
+  runtimeDir = __dirname,
+  authoringGuidePath?: string
 ): Promise<string> {
+  let configuredError: unknown;
+  if (authoringGuidePath) {
+    try {
+      return await fs.promises.readFile(authoringGuidePath, "utf-8");
+    } catch (error) {
+      configuredError = error;
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw new Error(
+          `作図規約を読み出せません: ${authoringGuidePath}: ${getErrorMessage(error)}`
+        );
+      }
+    }
+  }
+
   const distributedPath = path.resolve(
     runtimeDir,
     path.basename(runtimeDir) === "lib" ? ".." : ".",
@@ -146,8 +161,11 @@ export async function readDiagramAuthoringGuide(
   try {
     return await fs.promises.readFile(sourcePath, "utf-8");
   } catch (sourceError) {
+    const configuredDetail = authoringGuidePath
+      ? `同梱指定 ${authoringGuidePath}: ${getErrorMessage(configuredError)} / `
+      : "";
     throw new Error(
-      `作図規約を読み出せません。配布用 ${distributedPath}: ${getErrorMessage(distributedError)} / 正本 ${sourcePath}: ${getErrorMessage(sourceError)}`
+      `作図規約を読み出せません。${configuredDetail}配布用 ${distributedPath}: ${getErrorMessage(distributedError)} / 正本 ${sourcePath}: ${getErrorMessage(sourceError)}`
     );
   }
 }

--- a/packages/server/src/lib/board-mcp-server.ts
+++ b/packages/server/src/lib/board-mcp-server.ts
@@ -19,6 +19,7 @@
 import fs from "node:fs";
 import { createServer, type Server as HttpServer } from "node:http";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import type {
   DiagramCommentsResponse,
   DiagramCommentThread,
@@ -29,6 +30,10 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import express from "express";
 import { z } from "zod";
 import { getErrorMessage } from "./errors.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const AUTHORING_GUIDE_FILENAME = "diagram-authoring-guide.md";
+const AUTHORING_GUIDE_SOURCE_PATH = ".claude/skills/diagram-authoring/SKILL.md";
 
 /** text content だけの CallToolResult を生成するヘルパー */
 function textResult(text: string) {
@@ -72,6 +77,8 @@ export interface BoardMcpDeps {
     worktreePath: string,
     relPath: string
   ): Promise<DiagramCommentsResponse>;
+  /** `.diagram.html` の作図・文書規約を返す。 */
+  readAuthoringGuide?(): Promise<string>;
 }
 
 export interface BoardOpenInput {
@@ -106,6 +113,44 @@ export type BoardCommentsResult = {
     | { path: string; error: string }
   >;
 };
+
+/**
+ * 配布物にコピーされた作図規約を読み、dev 実行時だけリポジトリの正本へ
+ * フォールバックする。runtimeDir はパス解決テストで差し替えるための引数。
+ */
+export async function readDiagramAuthoringGuide(
+  runtimeDir = __dirname
+): Promise<string> {
+  const distributedPath = path.resolve(
+    runtimeDir,
+    path.basename(runtimeDir) === "lib" ? ".." : ".",
+    AUTHORING_GUIDE_FILENAME
+  );
+  let distributedError: unknown;
+  try {
+    return await fs.promises.readFile(distributedPath, "utf-8");
+  } catch (error) {
+    distributedError = error;
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw new Error(
+        `作図規約を読み出せません: ${distributedPath}: ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  const sourcePath = path.resolve(
+    runtimeDir,
+    "../../../..",
+    AUTHORING_GUIDE_SOURCE_PATH
+  );
+  try {
+    return await fs.promises.readFile(sourcePath, "utf-8");
+  } catch (sourceError) {
+    throw new Error(
+      `作図規約を読み出せません。配布用 ${distributedPath}: ${getErrorMessage(distributedError)} / 正本 ${sourcePath}: ${getErrorMessage(sourceError)}`
+    );
+  }
+}
 
 /** board_open の純ロジック（HTTP/MCP から分離してテスト可能にする）。 */
 export async function handleBoardOpen(
@@ -274,6 +319,27 @@ export function createBoardMcpServer(
             diagrams: [],
             error: `board_comments 失敗: ${getErrorMessage(error)}`,
           })
+        );
+      }
+    }
+  );
+
+  server.registerTool(
+    "board_authoring_guide",
+    {
+      description:
+        ".diagram.html を書く前に必ず呼ぶ。図・文書の生成規約（type と kind の語彙、data-ark-id の対応、label の書き方、figure のキャプション）を返す。",
+      inputSchema: {},
+    },
+    async () => {
+      try {
+        const guide = await (
+          deps.readAuthoringGuide ?? readDiagramAuthoringGuide
+        )();
+        return textResult(guide);
+      } catch (error) {
+        return textResult(
+          `board_authoring_guide 失敗: ${getErrorMessage(error)}`
         );
       }
     }

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -705,6 +705,7 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
 
     const prompt =
       mockedTmux.setClaudeAppendSystemPrompt.mock.calls.at(-1)?.[0];
+    expect(prompt).not.toContain("\n");
     expect(prompt).toContain(DIAGRAM_DIR);
     expect(prompt).not.toContain("docs/diagrams");
     expect(prompt).toContain("書き込む直前");

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -712,6 +712,8 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
     expect(prompt).toContain("存在しない場合");
     expect(prompt).toContain("board_open");
     expect(prompt).toContain("board_comments");
+    expect(prompt).toContain("board_authoring_guide");
+    expect(prompt).not.toContain("diagram-authoring skill");
     expect(prompt).toContain('model の type を "doc"');
     expect(prompt).toContain("本文をテキスト選択してコメントを付けられる");
     expect(prompt).toContain(

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -650,11 +650,13 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
     createdWorktrees = [];
   });
 
-  it("setBoardMcp 未呼び出しなら setClaudeMcpConfigPath(null) が呼ばれ、mcp-config は書かれない", async () => {
+  it("setBoardMcp 未呼び出しなら MCP config と append system prompt が null になる", async () => {
     await orchestrator.startSession("wt-1", "/path/to/work", "/repo");
 
     expect(mockedTmux.setClaudeMcpConfigPath).toHaveBeenCalledWith(null);
     expect(mockedTmux.setClaudeMcpConfigPath).toHaveBeenCalledTimes(1);
+    expect(mockedTmux.setClaudeAppendSystemPrompt).toHaveBeenCalledWith(null);
+    expect(mockedTmux.setClaudeAppendSystemPrompt).toHaveBeenCalledTimes(1);
   });
 
   it("setBoardMcp 後の新規セッションで per-session token を生成し、mcp-config を書いて registry に登録する", async () => {
@@ -695,7 +697,7 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
     expect(mode).toBe(0o600);
   });
 
-  it("新規セッションの作図 prompt は正準 directory を書込時だけ作り、書込後に board_open するよう指示する", async () => {
+  it("新規セッションの prompt はボード上の図・文書とコメントの往復手順を案内する", async () => {
     const registry = new BoardSessionRegistry();
     orchestrator.setBoardMcp(fakeBoardMcp, registry);
 
@@ -707,8 +709,13 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
     expect(prompt).not.toContain("docs/diagrams");
     expect(prompt).toContain("書き込む直前");
     expect(prompt).toContain("存在しない場合");
-    expect(prompt).toContain("書いた後");
     expect(prompt).toContain("board_open");
+    expect(prompt).toContain("board_comments");
+    expect(prompt).toContain('model の type を "doc"');
+    expect(prompt).toContain("本文をテキスト選択してコメントを付けられる");
+    expect(prompt).toContain(
+      "引用された箇所を直してから board_open で開き直す"
+    );
   });
 
   it("既存セッション再利用パスでは token を発行しない (setClaudeMcpConfigPath も呼ばれない)", async () => {

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -197,16 +197,21 @@ export class SessionOrchestrator extends EventEmitter {
       { mode: 0o600 }
     );
     tmuxManager.setClaudeMcpConfigPath(cfgPath);
-    // 図解要求でモデルが .diagram.html を書いて board_open を呼ぶよう促す
-    // （description だけでは弱いため）。旧 board_write（Excalidraw 直接書き込み）
-    // は B-1 で撤去済み。生成規約自体は diagram-authoring skill が持つ。
+    // ボードの図・文書機能に加え、コメント機能の存在と、コメントを受けて
+    // 修正・再表示する往復手順を全セッションへ伝える。
+    // 生成規約自体は diagram-authoring skill が持つ。
     tmuxManager.setClaudeAppendSystemPrompt(
-      "あなたはこのセッションのボードペインに図ファイルを開かせる board_open ツールを持っている。" +
-        "ユーザーが「図解して」「図で説明して」「ボードに描いて」「フロー図/構成図にして」等、" +
-        "図解・作図・可視化・図示を求めたら、チャットに mermaid や ASCII 図を出すのではなく、" +
-        `${DIAGRAM_DIR}/ 配下に *.diagram.html を書くこと（作図規約は diagram-authoring skill を参照）。` +
-        "書き込む直前に parent directory が存在しない場合だけ作成し、" +
-        "書いた後は必ず board_open ツールでこのセッションのボードペインに開かせること。"
+      [
+        "このセッションにはボードペインがあり、図と文書を表示できる。board_open（ボードに開く）と board_comments（人間が付けたコメントを読む）の 2 つのツールを持っている。",
+        "",
+        `ユーザーが「図解して」「図で説明して」「フロー図/構成図にして」等、図解・作図・可視化を求めたら、チャットに mermaid や ASCII 図を出すのではなく、${DIAGRAM_DIR}/ 配下に *.diagram.html を書き、board_open で開くこと。`,
+        "",
+        '設計メモ・仕様・調査結果など「人に読ませる文書」も同じ形式で書ける。model の type を "doc" にすると、ユーザーが本文をテキスト選択してコメントを付けられる、レビュー可能な文書になる。',
+        "",
+        "ユーザーが「コメントした」「図を見て」等と言ったら、board_comments で未解決コメントを読み、引用された箇所を直してから board_open で開き直すこと。",
+        "",
+        "書き込む直前に parent directory が存在しない場合だけ作成する。作図・文書の規約（type と kind の語彙、data-ark-id の対応、label の書き方）は diagram-authoring skill に従う。",
+      ].join("\n")
     );
     return { token, cfgPath };
   }

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -200,18 +200,16 @@ export class SessionOrchestrator extends EventEmitter {
     // ボードの図・文書機能に加え、コメント機能の存在と、コメントを受けて
     // 修正・再表示する往復手順を全セッションへ伝える。
     // 生成規約自体は diagram-authoring skill が持つ。
+    // tmux send-keys に -l がなく、改行は Enter キーとして解釈されるため、
+    // append-system-prompt に渡す文字列は必ず 1 行にする。
     tmuxManager.setClaudeAppendSystemPrompt(
       [
         "このセッションにはボードペインがあり、図と文書を表示できる。board_open（ボードに開く）と board_comments（人間が付けたコメントを読む）の 2 つのツールを持っている。",
-        "",
         `ユーザーが「図解して」「図で説明して」「フロー図/構成図にして」等、図解・作図・可視化を求めたら、チャットに mermaid や ASCII 図を出すのではなく、${DIAGRAM_DIR}/ 配下に *.diagram.html を書き、board_open で開くこと。`,
-        "",
         '設計メモ・仕様・調査結果など「人に読ませる文書」も同じ形式で書ける。model の type を "doc" にすると、ユーザーが本文をテキスト選択してコメントを付けられる、レビュー可能な文書になる。',
-        "",
         "ユーザーが「コメントした」「図を見て」等と言ったら、board_comments で未解決コメントを読み、引用された箇所を直してから board_open で開き直すこと。",
-        "",
         "書き込む直前に parent directory が存在しない場合だけ作成する。作図・文書の規約（type と kind の語彙、data-ark-id の対応、label の書き方）は diagram-authoring skill に従う。",
-      ].join("\n")
+      ].join(" ")
     );
     return { token, cfgPath };
   }

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -199,16 +199,15 @@ export class SessionOrchestrator extends EventEmitter {
     tmuxManager.setClaudeMcpConfigPath(cfgPath);
     // ボードの図・文書機能に加え、コメント機能の存在と、コメントを受けて
     // 修正・再表示する往復手順を全セッションへ伝える。
-    // 生成規約自体は diagram-authoring skill が持つ。
     // tmux send-keys に -l がなく、改行は Enter キーとして解釈されるため、
     // append-system-prompt に渡す文字列は必ず 1 行にする。
     tmuxManager.setClaudeAppendSystemPrompt(
       [
-        "このセッションにはボードペインがあり、図と文書を表示できる。board_open（ボードに開く）と board_comments（人間が付けたコメントを読む）の 2 つのツールを持っている。",
+        "このセッションにはボードペインがあり、図と文書を表示できる。board_open（ボードに開く）、board_comments（人間が付けたコメントを読む）、board_authoring_guide（作図・文書規約を読む）の 3 つのツールを持っている。",
         `ユーザーが「図解して」「図で説明して」「フロー図/構成図にして」等、図解・作図・可視化を求めたら、チャットに mermaid や ASCII 図を出すのではなく、${DIAGRAM_DIR}/ 配下に *.diagram.html を書き、board_open で開くこと。`,
         '設計メモ・仕様・調査結果など「人に読ませる文書」も同じ形式で書ける。model の type を "doc" にすると、ユーザーが本文をテキスト選択してコメントを付けられる、レビュー可能な文書になる。',
         "ユーザーが「コメントした」「図を見て」等と言ったら、board_comments で未解決コメントを読み、引用された箇所を直してから board_open で開き直すこと。",
-        "書き込む直前に parent directory が存在しない場合だけ作成する。作図・文書の規約（type と kind の語彙、data-ark-id の対応、label の書き方）は diagram-authoring skill に従う。",
+        "書き込む直前に parent directory が存在しない場合だけ作成する。.diagram.html を書く前に必ず board_authoring_guide で規約を取得し、その内容に従う。",
       ].join(" ")
     );
     return { token, cfgPath };


### PR DESCRIPTION
図解ボードのコメント機能を、**Ark が起動する全セッション**で使える状態にする。

## 何が問題だったか

コメント機能（#305 / #308）はサーバー側の機能なので、どの worktree のセッションでも動く。しかし**存在も使い方も、どのセッションにも伝わっていなかった**。

- 全セッションへ注入している `--append-system-prompt` は **board_open のことしか書いていなかった**。`type: "doc"` で書けば人間が本文を選択してコメントできること、`board_comments` でそれを読めることを、モデルが知る経路が無い
- 作図規約（`.claude/skills/diagram-authoring/SKILL.md`）は **Ark リポジトリの中にしか無い**。他リポジトリのセッションでは doc 型の書き方（`type` / `kind` の語彙、`data-ark-id` の 1 対 1 対応、`label` の抜粋、figure のキャプション）を知らず、正しい `.diagram.html` を書けない

結果として、実質 Ark リポジトリ専用の機能になっていた。

## 変更

### 1. システムプロンプトの刷新

board_open だけの案内を、次の 5 点に書き換えた。

1. ツールが `board_open` / `board_comments` / `board_authoring_guide` の 3 つあること
2. 図解・作図・可視化を求められたときの動き（従来どおり）
3. **設計メモ・仕様・調査結果など「人に読ませる文書」も同じ形式で書けること。`type` を `"doc"` にするとレビュー可能な文書になること**
4. **「コメントした」と言われたら `board_comments` → 引用された箇所を直す → `board_open` で開き直す、という往復手順**
5. 規約は `board_authoring_guide` で取得すること

**注入文字列に改行を入れてはいけない。** 起動コマンドは `tmux send-keys` に `-l` 無しで送られるため、改行は Enter キーとして解釈される。実機で確認した限り現状はシェルがクォート継続状態になって助かっているが、偶然の性質に依存させない。理由をコードコメントに書き、`\n` を含まないことをテストで固定した。

### 2. 規約を MCP ツールで配る

Ark は既に全セッションへ per-session の board MCP を注入しているので、規約もその経路で配る。ユーザー側の配線（`~/.claude/skills/` への配置等）に依存させない。

- `board_authoring_guide`（引数なし）が規約全文を返す
- **正本は `.claude/skills/diagram-authoring/SKILL.md` のまま**。内容を複製した第 2 のソースは作らず、ビルド時に `packages/server/dist/` へコピーするだけ
- 解決順は **option → `dist` 隣接 → リポジトリ正本**。どれも読めなければエラーを返す（空文字や省略版を返す silent fallback は作らない）
- **packaged（Electron）対応**: desktop の build は `@ark/server` を `desktop/dist/main.js` にバンドルする方式で `packages/server/dist` を取り込まないため、`extraResources` で規約を配置し、desktop 側が解決してサーバーへ option で渡す（`webStaticDir` と同じ流儀）

規約は 29KB あるためシステムプロンプトへの埋め込みは採らなかった。図を書くときにだけ取得する。

## 検証

`pnpm check` / `pnpm test`（997 件）/ `pnpm build` すべて green。`pnpm build` 後に `dist/diagram-authoring-guide.md`（29,375 bytes）が生成されることを確認した。

加えて**実際に新規セッションを起動**して確認した（プレビュー環境）。

- 起動コマンドに `--append-system-prompt` が壊れず含まれる
- 文面に `board_comments` が入っている
- シェルの継続入力（`quote>`）が発生しない
- claude が正常に起動し、シェルエラーが出ない

Refs #300
