### PR TITLE
feat(board): モバイルでも図解ボードを表示・操作できるようにする

### DIFF
--- a/packages/server/src/lib/diagram-comment-layer.test.ts
+++ b/packages/server/src/lib/diagram-comment-layer.test.ts
@@ -306,6 +306,31 @@ describe("injectDiagramCommentLayer", () => {
     expect(injected).not.toContain("orphaned");
   });
 
+  it("2 点タッチだけを既存 pinch deltaY へ変換し、終了時に状態を戻す", () => {
+    const injected = injectDiagramCommentLayer(minimalDoc);
+    const touchHandlers = injected.slice(
+      injected.indexOf("function handleTouchStart"),
+      injected.indexOf('window.addEventListener("touchstart"')
+    );
+
+    expect(injected).toContain('addEventListener("wheel"');
+    expect(injected).toContain("ctrlKey");
+    expect(injected).toContain('addEventListener("touchstart"');
+    expect(injected).toContain('addEventListener("touchmove"');
+    expect(injected).toContain('addEventListener("touchend"');
+    expect(injected).toContain("touches.length!==2");
+    expect(injected).toContain("Math.hypot");
+    expect(injected).toContain("Math.log");
+    expect(injected).toContain("var deltaY=-400*Math.log");
+    expect(injected).toContain("pinchDistance=null");
+    expect(touchHandlers.indexOf("touches.length!==2")).toBeLessThan(
+      touchHandlers.indexOf("event.preventDefault()")
+    );
+    expect(
+      injected.match(/\{passive:false\}/gu)?.length
+    ).toBeGreaterThanOrEqual(3);
+  });
+
   it("未解決 card だけに → Claude を出し、既存 result 契約で送信済みにする", () => {
     const injected = injectDiagramCommentLayer(minimalDoc);
 

--- a/packages/server/src/lib/diagram-comment-layer.test.ts
+++ b/packages/server/src/lib/diagram-comment-layer.test.ts
@@ -312,6 +312,13 @@ describe("injectDiagramCommentLayer", () => {
       injected.indexOf("function handleTouchStart"),
       injected.indexOf('window.addEventListener("touchstart"')
     );
+    const touchStartHandler = touchHandlers.slice(
+      touchHandlers.indexOf("function handleTouchStart"),
+      touchHandlers.indexOf("function handleTouchMove")
+    );
+    const touchMoveHandler = touchHandlers.slice(
+      touchHandlers.indexOf("function handleTouchMove")
+    );
 
     expect(injected).toContain('addEventListener("wheel"');
     expect(injected).toContain("ctrlKey");
@@ -326,6 +333,12 @@ describe("injectDiagramCommentLayer", () => {
     expect(touchHandlers.indexOf("touches.length!==2")).toBeLessThan(
       touchHandlers.indexOf("event.preventDefault()")
     );
+    for (const handler of [touchStartHandler, touchMoveHandler]) {
+      expect(handler).toContain("if(!port){resetTouchPinch();return;}");
+      expect(handler.indexOf("if(!port)")).toBeLessThan(
+        handler.indexOf("event.preventDefault()")
+      );
+    }
     expect(
       injected.match(/\{passive:false\}/gu)?.length
     ).toBeGreaterThanOrEqual(3);

--- a/packages/server/src/lib/diagram-comment-layer.ts
+++ b/packages/server/src/lib/diagram-comment-layer.ts
@@ -7,6 +7,7 @@ const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
   var CARD_GAP=10;
   var RAIL_GAP=12;
   var port=null;
+  var pinchDistance=null;
   var comments={version:1,target:"",threads:[]};
   var pendingRequestId=null;
   var pendingAction=null;
@@ -585,6 +586,32 @@ const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
     event.preventDefault();
     port.postMessage({type:"ark:diagram-pinch",deltaY:event.deltaY});
   },{passive:false});
+  function touchDistance(event){
+    var first=event.touches[0];
+    var second=event.touches[1];
+    return Math.hypot(first.clientX-second.clientX,first.clientY-second.clientY);
+  }
+  function resetTouchPinch(){pinchDistance=null;}
+  function handleTouchStart(event){
+    if(event.touches.length!==2){resetTouchPinch();return;}
+    pinchDistance=touchDistance(event);
+    event.preventDefault();
+  }
+  function handleTouchMove(event){
+    if(event.touches.length!==2){resetTouchPinch();return;}
+    var nextDistance=touchDistance(event);
+    event.preventDefault();
+    if(pinchDistance===null){pinchDistance=nextDistance;return;}
+    var deltaY=-400*Math.log(nextDistance/pinchDistance);
+    pinchDistance=nextDistance;
+    if(port&&Number.isFinite(deltaY)&&deltaY!==0){
+      port.postMessage({type:"ark:diagram-pinch",deltaY:deltaY});
+    }
+  }
+  window.addEventListener("touchstart",handleTouchStart,{passive:false});
+  window.addEventListener("touchmove",handleTouchMove,{passive:false});
+  window.addEventListener("touchend",resetTouchPinch,{passive:false});
+  window.addEventListener("touchcancel",resetTouchPinch,{passive:false});
   window.addEventListener("scroll",positionCards,{passive:true});
   window.addEventListener("resize",refreshLayout);
   var observer=new ResizeObserver(refreshLayout);

--- a/packages/server/src/lib/diagram-comment-layer.ts
+++ b/packages/server/src/lib/diagram-comment-layer.ts
@@ -593,11 +593,13 @@ const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
   }
   function resetTouchPinch(){pinchDistance=null;}
   function handleTouchStart(event){
+    if(!port){resetTouchPinch();return;}
     if(event.touches.length!==2){resetTouchPinch();return;}
     pinchDistance=touchDistance(event);
     event.preventDefault();
   }
   function handleTouchMove(event){
+    if(!port){resetTouchPinch();return;}
     if(event.touches.length!==2){resetTouchPinch();return;}
     var nextDistance=touchDistance(event);
     event.preventDefault();

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -192,6 +192,33 @@ describe("injectHarness", () => {
     expect(out.match(new RegExp(DIAGRAM_HARNESS_MARKER, "g"))).toHaveLength(1);
   });
 
+  it("wheel pinch を維持し、2 点タッチだけを同じ deltaY で親へ渡す", () => {
+    const out = injectHarness(
+      page(
+        '<div data-ark-container="graph"><div data-model-id="node"></div></div>'
+      )
+    );
+    const touchHandlers = out.slice(
+      out.indexOf("function handleTouchStart"),
+      out.indexOf('window.addEventListener("touchstart"')
+    );
+
+    expect(out).toContain('addEventListener("wheel"');
+    expect(out).toContain("ctrlKey");
+    expect(out).toContain('addEventListener("touchstart"');
+    expect(out).toContain('addEventListener("touchmove"');
+    expect(out).toContain('addEventListener("touchend"');
+    expect(out).toContain("touches.length!==2");
+    expect(out).toContain("Math.hypot");
+    expect(out).toContain("Math.log");
+    expect(out).toContain("var deltaY=-400*Math.log");
+    expect(out).toContain("pinchDistance=null");
+    expect(touchHandlers.indexOf("touches.length!==2")).toBeLessThan(
+      touchHandlers.indexOf("event.preventDefault()")
+    );
+    expect(out.match(/\{passive:false\}/gu)?.length).toBeGreaterThanOrEqual(3);
+  });
+
   it("group layout kernel を function literal で一度だけ注入する", () => {
     const out = injectHarness(
       page(

--- a/packages/server/src/lib/diagram-harness.test.ts
+++ b/packages/server/src/lib/diagram-harness.test.ts
@@ -202,6 +202,13 @@ describe("injectHarness", () => {
       out.indexOf("function handleTouchStart"),
       out.indexOf('window.addEventListener("touchstart"')
     );
+    const touchStartHandler = touchHandlers.slice(
+      touchHandlers.indexOf("function handleTouchStart"),
+      touchHandlers.indexOf("function handleTouchMove")
+    );
+    const touchMoveHandler = touchHandlers.slice(
+      touchHandlers.indexOf("function handleTouchMove")
+    );
 
     expect(out).toContain('addEventListener("wheel"');
     expect(out).toContain("ctrlKey");
@@ -216,6 +223,12 @@ describe("injectHarness", () => {
     expect(touchHandlers.indexOf("touches.length!==2")).toBeLessThan(
       touchHandlers.indexOf("event.preventDefault()")
     );
+    for (const handler of [touchStartHandler, touchMoveHandler]) {
+      expect(handler).toContain("if(!submitPort){resetTouchPinch();return;}");
+      expect(handler.indexOf("if(!submitPort)")).toBeLessThan(
+        handler.indexOf("event.preventDefault()")
+      );
+    }
     expect(out.match(/\{passive:false\}/gu)?.length).toBeGreaterThanOrEqual(3);
   });
 

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -3443,6 +3443,33 @@ const RAW_HARNESS_JS = `(function () {
   init();
 
   window.addEventListener("wheel",function(e){if(!e.ctrlKey||!submitPort)return;e.preventDefault();submitPort.postMessage({type:"ark:diagram-pinch",deltaY:e.deltaY})},{passive:false});
+  var pinchDistance=null;
+  function touchDistance(event){
+    var first=event.touches[0];
+    var second=event.touches[1];
+    return Math.hypot(first.clientX-second.clientX,first.clientY-second.clientY);
+  }
+  function resetTouchPinch(){pinchDistance=null;}
+  function handleTouchStart(event){
+    if(event.touches.length!==2){resetTouchPinch();return;}
+    pinchDistance=touchDistance(event);
+    event.preventDefault();
+  }
+  function handleTouchMove(event){
+    if(event.touches.length!==2){resetTouchPinch();return;}
+    var nextDistance=touchDistance(event);
+    event.preventDefault();
+    if(pinchDistance===null){pinchDistance=nextDistance;return;}
+    var deltaY=-400*Math.log(nextDistance/pinchDistance);
+    pinchDistance=nextDistance;
+    if(submitPort&&Number.isFinite(deltaY)&&deltaY!==0){
+      submitPort.postMessage({type:"ark:diagram-pinch",deltaY:deltaY});
+    }
+  }
+  window.addEventListener("touchstart",handleTouchStart,{passive:false});
+  window.addEventListener("touchmove",handleTouchMove,{passive:false});
+  window.addEventListener("touchend",resetTouchPinch,{passive:false});
+  window.addEventListener("touchcancel",resetTouchPinch,{passive:false});
   window.addEventListener("message", function onMessage(event) {
     // event.origin は検証しない: sandbox iframe は不透明オリジンで
     // event.origin === "null" になる（実測済み）。port を持っていること

--- a/packages/server/src/lib/diagram-harness.ts
+++ b/packages/server/src/lib/diagram-harness.ts
@@ -3451,11 +3451,13 @@ const RAW_HARNESS_JS = `(function () {
   }
   function resetTouchPinch(){pinchDistance=null;}
   function handleTouchStart(event){
+    if(!submitPort){resetTouchPinch();return;}
     if(event.touches.length!==2){resetTouchPinch();return;}
     pinchDistance=touchDistance(event);
     event.preventDefault();
   }
   function handleTouchMove(event){
+    if(!submitPort){resetTouchPinch();return;}
     if(event.touches.length!==2){resetTouchPinch();return;}
     var nextDistance=touchDistance(event);
     event.preventDefault();

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -32,7 +32,7 @@ import { DiagramSwitcher } from "./DiagramSwitcher";
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
-interface DiagramPaneProps {
+export interface DiagramPaneProps {
   sessionId: string;
   worktreePath: string;
   relPath?: string;

--- a/packages/web/src/components/MobileLayout.test.tsx
+++ b/packages/web/src/components/MobileLayout.test.tsx
@@ -1,0 +1,95 @@
+import type { ManagedSession } from "@ark/shared";
+import { type ComponentProps, createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { MobileLayout } from "./MobileLayout";
+import type { ViewerTab } from "./TerminalPane";
+
+vi.mock("@/components/frontline/FrontLineGame", () => ({
+  FrontLineGame: () => null,
+}));
+vi.mock("@/components/frontline/MobileControls", () => ({
+  MobileControls: () => null,
+}));
+
+const session: ManagedSession = {
+  id: "session-1",
+  worktreeId: "worktree-1",
+  worktreePath: "/repo/worktree",
+  status: "active",
+  createdAt: new Date("2026-08-11T00:00:00Z"),
+  tmuxSessionName: "ark-session-1",
+  ttydPort: 7680,
+  ttydUrl: "/ttyd/session-1/",
+};
+
+const tabs: ViewerTab[] = [
+  { type: "terminal", id: "terminal" },
+  {
+    type: "diagram",
+    id: "diagram-1",
+    worktreePath: session.worktreePath,
+    relPath: ".claude/diagrams/mobile.diagram.html",
+  },
+];
+
+function createProps(): ComponentProps<typeof MobileLayout> {
+  return {
+    socket: null,
+    sessions: new Map([[session.id, session]]),
+    worktrees: [],
+    repoList: [],
+    repoPath: null,
+    onStartSession: vi.fn(),
+    onDeleteSession: vi.fn(),
+    onDeleteWorktree: vi.fn(),
+    onSendMessage: vi.fn(),
+    onSendKey: vi.fn(),
+    onSelectSession: vi.fn(),
+    onNewSession: vi.fn(),
+    beaconMessages: [],
+    beaconStreaming: false,
+    beaconStreamText: "",
+    onBeaconSend: vi.fn(),
+    onBeaconStopAndReset: vi.fn(),
+    isSocketConnected: true,
+    activeBrowserSession: null,
+    onSelectBrowser: vi.fn(),
+    isRemote: false,
+    messageShortcuts: [],
+    onCreateShortcut: vi.fn(),
+    onUpdateShortcut: vi.fn(),
+    onDeleteShortcut: vi.fn(),
+    selectedSessionId: session.id,
+    activeTab: "session",
+    sessionSubView: "detail",
+    onChangeActiveTab: vi.fn(),
+    onChangeSessionSubView: vi.fn(),
+    sessionsLoaded: true,
+    sessionStatuses: new Map(),
+    sessionAwaitingTexts: new Map(),
+    getTabsForSession: vi.fn(() => tabs),
+    getActiveTabForSession: vi.fn(() => 0),
+    handleTabSelect: vi.fn(),
+    handleTabClose: vi.fn(),
+    openDiagramTab: vi.fn(),
+    listDiagrams: vi.fn(async () => []),
+    deleteDiagram: vi.fn(),
+    getDiagramComments: vi.fn(),
+    createDiagramComment: vi.fn(),
+    resolveDiagramComment: vi.fn(),
+    deleteDiagramComment: vi.fn(),
+    sendDiagramComment: vi.fn(),
+  } as ComponentProps<typeof MobileLayout>;
+}
+
+describe("MobileLayout diagram wiring", () => {
+  it("Dashboard の図タブ状態と DiagramPane transport を MobileSessionView へ渡す", () => {
+    const markup = renderToStaticMarkup(
+      createElement(MobileLayout, createProps())
+    );
+
+    expect(markup).toContain('aria-label="表示する図"');
+    expect(markup).toContain("mobile.diagram.html");
+  });
+});

--- a/packages/web/src/components/MobileLayout.test.tsx
+++ b/packages/web/src/components/MobileLayout.test.tsx
@@ -73,6 +73,7 @@ function createProps(): ComponentProps<typeof MobileLayout> {
     handleTabSelect: vi.fn(),
     handleTabClose: vi.fn(),
     openDiagramTab: vi.fn(),
+    diagramOpenRequest: null,
     listDiagrams: vi.fn(async () => []),
     deleteDiagram: vi.fn(),
     getDiagramComments: vi.fn(),

--- a/packages/web/src/components/MobileLayout.tsx
+++ b/packages/web/src/components/MobileLayout.tsx
@@ -32,6 +32,7 @@ import { MobileChatView } from "@/components/MobileChatView";
 import { MobileSessionList } from "@/components/MobileSessionList";
 import { MobileSessionView } from "@/components/MobileSessionView";
 import type { ViewerTab } from "@/components/TerminalPane";
+import type { DiagramOpenRequest } from "@/lib/mobile-session-view-mode";
 
 // MobileTab / SessionSubView は配列を真実源にし、union 型を派生させる。
 // こうしないと runtime 検証配列と型が二重化し、union に値を足したとき配列更新を
@@ -100,6 +101,8 @@ interface MobileLayoutProps {
     worktreePath: string,
     relPath: string
   ) => void;
+  /** diagram:open のたびに sequence が増えるモバイル表示用の明示通知 */
+  diagramOpenRequest: DiagramOpenRequest | null;
   // 図ペイン transport（PC の SplitViewPane と同じ集合）
   listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
   deleteDiagram: (
@@ -199,6 +202,7 @@ export function MobileLayout({
   handleTabSelect,
   handleTabClose,
   openDiagramTab,
+  diagramOpenRequest,
   listDiagrams,
   deleteDiagram,
   getDiagramComments,
@@ -404,6 +408,7 @@ export function MobileLayout({
                 }
                 tabs={getTabsForSession(sessionId)}
                 activeTabIndex={getActiveTabForSession(sessionId)}
+                diagramOpenRequest={diagramOpenRequest}
                 onTabSelect={idx => handleTabSelect(sessionId, idx)}
                 onTabClose={idx => handleTabClose(sessionId, idx)}
                 isConnected={isSocketConnected}

--- a/packages/web/src/components/MobileLayout.tsx
+++ b/packages/web/src/components/MobileLayout.tsx
@@ -90,7 +90,7 @@ interface MobileLayoutProps {
   }>;
   onCopyBuffer?: (sessionId: string) => Promise<string | null>;
   onNewSession: () => void;
-  // Dashboard が所有するビューアタブ状態（diagram:open / 復元と同じ instance）
+  // ビューアタブ状態は Dashboard から props で受け取り、ここでは useViewerTabs を呼ばない
   getTabsForSession: (sessionId: string) => ViewerTab[];
   getActiveTabForSession: (sessionId: string) => number;
   handleTabSelect: (sessionId: string, index: number) => void;

--- a/packages/web/src/components/MobileLayout.tsx
+++ b/packages/web/src/components/MobileLayout.tsx
@@ -12,6 +12,9 @@ import type {
   BrowserSession,
   ChatMessage,
   ClientToServerEvents,
+  DiagramCommentsResponse,
+  DiagramDeleteResponse,
+  DiagramListItem,
   ManagedSession,
   MessageShortcut,
   ServerToClientEvents,
@@ -28,7 +31,7 @@ import { MobileControls } from "@/components/frontline/MobileControls";
 import { MobileChatView } from "@/components/MobileChatView";
 import { MobileSessionList } from "@/components/MobileSessionList";
 import { MobileSessionView } from "@/components/MobileSessionView";
-import { useViewerTabs } from "../hooks/useViewerTabs";
+import type { ViewerTab } from "@/components/TerminalPane";
 
 // MobileTab / SessionSubView は配列を真実源にし、union 型を派生させる。
 // こうしないと runtime 検証配列と型が二重化し、union に値を足したとき配列更新を
@@ -87,15 +90,50 @@ interface MobileLayoutProps {
   }>;
   onCopyBuffer?: (sessionId: string) => Promise<string | null>;
   onNewSession: () => void;
-  // ファイルビューワー
-  readFile: (sessionId: string, filePath: string) => void;
-  fileContent: {
-    filePath: string;
-    content: string;
-    mimeType: string;
-    size: number;
-    error?: string;
-  } | null;
+  // Dashboard が所有するビューアタブ状態（diagram:open / 復元と同じ instance）
+  getTabsForSession: (sessionId: string) => ViewerTab[];
+  getActiveTabForSession: (sessionId: string) => number;
+  handleTabSelect: (sessionId: string, index: number) => void;
+  handleTabClose: (sessionId: string, index: number) => void;
+  openDiagramTab: (
+    sessionId: string,
+    worktreePath: string,
+    relPath: string
+  ) => void;
+  // 図ペイン transport（PC の SplitViewPane と同じ集合）
+  listDiagrams: (worktreePath: string) => Promise<DiagramListItem[]>;
+  deleteDiagram: (
+    sessionId: string,
+    relPath: string,
+    expectedTracked: boolean
+  ) => Promise<DiagramDeleteResponse>;
+  getDiagramComments: (
+    sessionId: string,
+    relPath: string
+  ) => Promise<DiagramCommentsResponse>;
+  createDiagramComment: (
+    sessionId: string,
+    relPath: string,
+    anchorId: string,
+    body: string,
+    anchorQuote?: string,
+    anchorOccurrence?: number
+  ) => Promise<DiagramCommentsResponse>;
+  resolveDiagramComment: (
+    sessionId: string,
+    relPath: string,
+    threadId: string
+  ) => Promise<DiagramCommentsResponse>;
+  deleteDiagramComment: (
+    sessionId: string,
+    relPath: string,
+    threadId: string
+  ) => Promise<DiagramCommentsResponse>;
+  sendDiagramComment: (
+    sessionId: string,
+    relPath: string,
+    threadId: string
+  ) => Promise<DiagramCommentsResponse>;
   // Beaconチャット
   beaconMessages: ChatMessage[];
   beaconStreaming: boolean;
@@ -120,7 +158,6 @@ interface MobileLayoutProps {
   // ブラウザ（noVNC）
   activeBrowserSession: BrowserSession | null;
   onSelectBrowser: () => void;
-  navigateBrowser: (url: string) => void;
   isRemote: boolean;
   // メッセージショートカット
   messageShortcuts: MessageShortcut[];
@@ -157,8 +194,18 @@ export function MobileLayout({
   onUploadFile,
   onCopyBuffer,
   onNewSession,
-  readFile,
-  fileContent,
+  getTabsForSession,
+  getActiveTabForSession,
+  handleTabSelect,
+  handleTabClose,
+  openDiagramTab,
+  listDiagrams,
+  deleteDiagram,
+  getDiagramComments,
+  createDiagramComment,
+  resolveDiagramComment,
+  deleteDiagramComment,
+  sendDiagramComment,
   beaconMessages,
   beaconStreaming,
   beaconStreamText,
@@ -175,7 +222,6 @@ export function MobileLayout({
   onOpenMcpManager,
   activeBrowserSession,
   onSelectBrowser,
-  navigateBrowser,
   isRemote,
   messageShortcuts,
   onCreateShortcut,
@@ -208,41 +254,6 @@ export function MobileLayout({
   // ブラウザビューを一度でも開いたかどうかのフラグ
   // 一度開いたらdisplay:hiddenで切り替え、BrowserPaneの再マウント（WebSocket再接続）を防ぐ
   const [hasBrowserOpened, setHasBrowserOpened] = useState(false);
-
-  const handleOpenUrl = useCallback(
-    (url: string) => {
-      if (isRemote) {
-        onSelectBrowser();
-        onChangeActiveTab("browser");
-        setHasBrowserOpened(true);
-        navigateBrowser(url);
-      } else {
-        const a = document.createElement("a");
-        a.href = url;
-        a.target = "_blank";
-        a.rel = "noopener noreferrer";
-        a.click();
-      }
-    },
-    [isRemote, onSelectBrowser, navigateBrowser, onChangeActiveTab]
-  );
-
-  // タブ状態管理（共通フック）
-  const {
-    getTabsForSession,
-    getActiveTabForSession,
-    handleTabSelect,
-    handleTabClose,
-  } = useViewerTabs(
-    selectedSessionId,
-    sessions,
-    readFile,
-    fileContent,
-    handleOpenUrl,
-    // モバイルでは MobileLayout 側がリンクタップ受信を担う (Dashboard 側は無効化)。
-    // 排他制御を呼び出し側両方で明示することで意図を契約レベルで完結させる。
-    true
-  );
 
   // セッションを選択して詳細画面に遷移
   const handleOpenSession = useCallback(
@@ -395,6 +406,17 @@ export function MobileLayout({
                 activeTabIndex={getActiveTabForSession(sessionId)}
                 onTabSelect={idx => handleTabSelect(sessionId, idx)}
                 onTabClose={idx => handleTabClose(sessionId, idx)}
+                isConnected={isSocketConnected}
+                listDiagrams={listDiagrams}
+                deleteDiagram={deleteDiagram}
+                getDiagramComments={getDiagramComments}
+                createDiagramComment={createDiagramComment}
+                resolveDiagramComment={resolveDiagramComment}
+                deleteDiagramComment={deleteDiagramComment}
+                sendDiagramComment={sendDiagramComment}
+                onSelectDiagram={(relPath, worktreePath) =>
+                  openDiagramTab(sessionId, worktreePath, relPath)
+                }
                 messageShortcuts={messageShortcuts}
                 onCreateShortcut={onCreateShortcut}
                 onUpdateShortcut={onUpdateShortcut}

--- a/packages/web/src/components/MobileSessionView.test.tsx
+++ b/packages/web/src/components/MobileSessionView.test.tsx
@@ -1,0 +1,56 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeMobileSessionViewMode,
+  writeSavedViewMode,
+} from "../lib/mobile-session-view-mode";
+import {
+  MOBILE_SESSION_VIEW_MODES,
+  MobileSessionViewModeToggle,
+} from "./MobileSessionViewModeToggle";
+
+describe("mobile session view mode", () => {
+  it("chat / terminal / board を正規化し、不正値は chat へ戻す", () => {
+    expect(MOBILE_SESSION_VIEW_MODES.map(option => option.value)).toEqual([
+      "chat",
+      "terminal",
+      "board",
+    ]);
+    expect(normalizeMobileSessionViewMode("chat")).toBe("chat");
+    expect(normalizeMobileSessionViewMode("terminal")).toBe("terminal");
+    expect(normalizeMobileSessionViewMode("board")).toBe("board");
+    expect(normalizeMobileSessionViewMode("unknown")).toBe("chat");
+    expect(normalizeMobileSessionViewMode(null)).toBe("chat");
+  });
+
+  it("board を永続化する", () => {
+    const storage = { setItem: vi.fn() };
+
+    writeSavedViewMode("board", storage);
+
+    expect(storage.setItem).toHaveBeenCalledWith(
+      "ark-mobile-session-view",
+      "board"
+    );
+  });
+
+  it("現在モードが分かる 3 択トグルを表示する", () => {
+    const markup = renderToStaticMarkup(
+      createElement(MobileSessionViewModeToggle, {
+        value: "board",
+        onChange: vi.fn(),
+      })
+    );
+
+    expect(markup.match(/<button/g)).toHaveLength(3);
+    expect(markup).toContain("💬");
+    expect(markup).toContain("会話");
+    expect(markup).toContain("🖥");
+    expect(markup).toContain("端末");
+    expect(markup).toContain("📐");
+    expect(markup).toContain("図");
+    expect(markup).toContain('aria-pressed="true"');
+    expect(markup).toContain('aria-label="図"');
+  });
+});

--- a/packages/web/src/components/MobileSessionView.test.tsx
+++ b/packages/web/src/components/MobileSessionView.test.tsx
@@ -2,7 +2,9 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import {
-  getViewModeForActiveTab,
+  createDiagramOpenRequest,
+  getViewModeForDiagramOpenRequest,
+  getViewModeForViewerTab,
   normalizeMobileSessionViewMode,
   writeSavedViewMode,
 } from "../lib/mobile-session-view-mode";
@@ -36,19 +38,55 @@ describe("mobile session view mode", () => {
     );
   });
 
-  it.each([
-    { activeTabType: "diagram", expected: "board", label: "図" },
-    { activeTabType: "file", expected: "terminal", label: "ファイル" },
-    { activeTabType: "html", expected: "terminal", label: "HTML" },
-  ] as const)(
-    "active な $label タブに合わせて $expected モードへ切り替える",
-    ({ activeTabType, expected }) => {
-      expect(getViewModeForActiveTab(activeTabType)).toBe(expected);
+  it("同じ図を続けて開いても通知が変化し、毎回 board へ切り替える", () => {
+    const first = createDiagramOpenRequest(
+      null,
+      "session-1",
+      ".claude/diagrams/mobile.diagram.html"
+    );
+    const second = createDiagramOpenRequest(
+      first,
+      "session-1",
+      ".claude/diagrams/mobile.diagram.html"
+    );
+
+    expect(second.sequence).toBeGreaterThan(first.sequence);
+    expect(getViewModeForDiagramOpenRequest("session-1", first, null)).toBe(
+      "board"
+    );
+    expect(
+      getViewModeForDiagramOpenRequest("session-1", second, first.sequence)
+    ).toBe("board");
+  });
+
+  it("別セッション向け、処理済み、通知なしでは表示モードを変えない", () => {
+    const request = createDiagramOpenRequest(
+      null,
+      "session-2",
+      ".claude/diagrams/mobile.diagram.html"
+    );
+
+    expect(
+      getViewModeForDiagramOpenRequest("session-1", request, null)
+    ).toBeNull();
+    expect(
+      getViewModeForDiagramOpenRequest("session-2", request, request.sequence)
+    ).toBeNull();
+    // reload 復元は diagram:open 通知を作らない。
+    expect(
+      getViewModeForDiagramOpenRequest("session-1", null, null)
+    ).toBeNull();
+  });
+
+  it.each(["file", "html"] as const)(
+    "active な %s ビューワータブでは従来どおり terminal へ切り替える",
+    activeTabType => {
+      expect(getViewModeForViewerTab(activeTabType)).toBe("terminal");
     }
   );
 
   it("terminal タブでは表示モードを変えない", () => {
-    expect(getViewModeForActiveTab("terminal")).toBeNull();
+    expect(getViewModeForViewerTab("terminal")).toBeNull();
   });
 
   it("現在モードが分かる 3 択トグルを表示する", () => {

--- a/packages/web/src/components/MobileSessionView.test.tsx
+++ b/packages/web/src/components/MobileSessionView.test.tsx
@@ -2,6 +2,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 import {
+  getViewModeForActiveTab,
   normalizeMobileSessionViewMode,
   writeSavedViewMode,
 } from "../lib/mobile-session-view-mode";
@@ -33,6 +34,21 @@ describe("mobile session view mode", () => {
       "ark-mobile-session-view",
       "board"
     );
+  });
+
+  it.each([
+    { activeTabType: "diagram", expected: "board", label: "図" },
+    { activeTabType: "file", expected: "terminal", label: "ファイル" },
+    { activeTabType: "html", expected: "terminal", label: "HTML" },
+  ] as const)(
+    "active な $label タブに合わせて $expected モードへ切り替える",
+    ({ activeTabType, expected }) => {
+      expect(getViewModeForActiveTab(activeTabType)).toBe(expected);
+    }
+  );
+
+  it("terminal タブでは表示モードを変えない", () => {
+    expect(getViewModeForActiveTab("terminal")).toBeNull();
   });
 
   it("現在モードが分かる 3 択トグルを表示する", () => {

--- a/packages/web/src/components/MobileSessionView.tsx
+++ b/packages/web/src/components/MobileSessionView.tsx
@@ -53,7 +53,9 @@ import { fileToBase64, validateFile } from "../hooks/useFileUpload";
 import { useTerminalLinkInjection } from "../hooks/useTerminalLinkInjection";
 import { useVisualViewport } from "../hooks/useVisualViewport";
 import {
-  getViewModeForActiveTab,
+  type DiagramOpenRequest,
+  getViewModeForDiagramOpenRequest,
+  getViewModeForViewerTab,
   type MobileSessionViewMode,
   readSavedViewMode,
   writeSavedViewMode,
@@ -118,6 +120,7 @@ export interface MobileSessionViewProps extends MobileDiagramPaneProps {
   onCopyBuffer?: () => Promise<string | null>;
   tabs: ViewerTab[];
   activeTabIndex: number;
+  diagramOpenRequest: DiagramOpenRequest | null;
   onTabSelect: (index: number) => void;
   onTabClose: (index: number) => void;
   messageShortcuts: MessageShortcut[];
@@ -142,6 +145,7 @@ export function MobileSessionView({
   onCopyBuffer,
   tabs,
   activeTabIndex,
+  diagramOpenRequest,
   onTabSelect,
   onTabClose,
   messageShortcuts,
@@ -170,13 +174,34 @@ export function MobileSessionView({
     setViewMode(next);
   }, []);
 
-  // 図タブが active になったら board モードへ切り替え、board_open とタブ選択の
-  // 両方に追従する。他のビューワータブは従来どおり terminal モードで可視化する。
+  // diagram:open の明示通知がこのセッション向けに変化したときだけ board を開く。
+  const handledDiagramOpenSequenceRef = useRef<number | null>(null);
+  useEffect(() => {
+    const nextViewMode = getViewModeForDiagramOpenRequest(
+      session.id,
+      diagramOpenRequest,
+      handledDiagramOpenSequenceRef.current
+    );
+    handledDiagramOpenSequenceRef.current =
+      diagramOpenRequest?.sequence ?? null;
+    if (nextViewMode) setViewMode(nextViewMode);
+  }, [diagramOpenRequest, session.id]);
+
+  // ファイル/HTML のビューワータブは従来どおり terminal モードで可視化する。
   const activeTabType = tabs[activeTabIndex]?.type;
   useEffect(() => {
-    const nextViewMode = getViewModeForActiveTab(activeTabType);
+    const nextViewMode = getViewModeForViewerTab(activeTabType);
     if (nextViewMode) setViewMode(nextViewMode);
   }, [activeTabType]);
+
+  // モバイルのタブバーでユーザー自身が図を選んだ場合も board を開く。
+  const handleViewerTabSelect = useCallback(
+    (index: number) => {
+      onTabSelect(index);
+      if (tabs[index]?.type === "diagram") setViewMode("board");
+    },
+    [onTabSelect, tabs]
+  );
   // 全ての添付ファイル（画像/非画像）を共通でプレビューダイアログに集約する
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
   const [uploadMessage, setUploadMessage] = useState("");
@@ -521,7 +546,7 @@ export function MobileSessionView({
         <ViewerTabBar
           tabs={tabs}
           activeTabIndex={activeTabIndex}
-          onTabSelect={onTabSelect}
+          onTabSelect={handleViewerTabSelect}
           onTabClose={onTabClose}
         />
 

--- a/packages/web/src/components/MobileSessionView.tsx
+++ b/packages/web/src/components/MobileSessionView.tsx
@@ -53,6 +53,7 @@ import { fileToBase64, validateFile } from "../hooks/useFileUpload";
 import { useTerminalLinkInjection } from "../hooks/useTerminalLinkInjection";
 import { useVisualViewport } from "../hooks/useVisualViewport";
 import {
+  getViewModeForActiveTab,
   type MobileSessionViewMode,
   readSavedViewMode,
   writeSavedViewMode,
@@ -169,18 +170,12 @@ export function MobileSessionView({
     setViewMode(next);
   }, []);
 
-  // ファイル/HTML/キャンバスのビューワータブが開かれた（active が terminal 以外に
-  // なった）ら、ターミナルモードへ自動で切り替えてビューワーを可視化する。
-  // 会話内のファイルリンクや「キャンバスで開く」タップに追従する。
+  // 図タブが active になったら board モードへ切り替え、board_open とタブ選択の
+  // 両方に追従する。他のビューワータブは従来どおり terminal モードで可視化する。
   const activeTabType = tabs[activeTabIndex]?.type;
   useEffect(() => {
-    if (
-      activeTabType &&
-      activeTabType !== "terminal" &&
-      activeTabType !== "diagram"
-    ) {
-      setViewMode("terminal");
-    }
+    const nextViewMode = getViewModeForActiveTab(activeTabType);
+    if (nextViewMode) setViewMode(nextViewMode);
   }, [activeTabType]);
   // 全ての添付ファイル（画像/非画像）を共通でプレビューダイアログに集約する
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);

--- a/packages/web/src/components/MobileSessionView.tsx
+++ b/packages/web/src/components/MobileSessionView.tsx
@@ -84,7 +84,7 @@ interface PendingFile {
   size: number;
 }
 
-interface MobileSessionViewProps extends Partial<MobileDiagramPaneProps> {
+export interface MobileSessionViewProps extends MobileDiagramPaneProps {
   /** 会話ビュー（SplitChatPane）の JSONL 購読・AUQ 受信に使う */
   socket: TypedSocket | null;
   /** この詳細が現在表示中か。会話ビューの購読を表示中に限定する */
@@ -762,31 +762,21 @@ export function MobileSessionView({
           viewMode === "board" ? "flex-1 flex flex-col min-h-0" : "hidden"
         }
       >
-        {isConnected !== undefined &&
-          listDiagrams &&
-          deleteDiagram &&
-          getDiagramComments &&
-          createDiagramComment &&
-          resolveDiagramComment &&
-          deleteDiagramComment &&
-          sendDiagramComment &&
-          onSelectDiagram && (
-            <DiagramPane
-              socket={socket}
-              isConnected={isConnected}
-              listDiagrams={listDiagrams}
-              deleteDiagram={deleteDiagram}
-              getDiagramComments={getDiagramComments}
-              createDiagramComment={createDiagramComment}
-              resolveDiagramComment={resolveDiagramComment}
-              deleteDiagramComment={deleteDiagramComment}
-              sendDiagramComment={sendDiagramComment}
-              sessionId={session.id}
-              worktreePath={session.worktreePath}
-              relPath={tabs.find(tab => tab.type === "diagram")?.relPath}
-              onSelectDiagram={onSelectDiagram}
-            />
-          )}
+        <DiagramPane
+          socket={socket}
+          isConnected={isConnected}
+          listDiagrams={listDiagrams}
+          deleteDiagram={deleteDiagram}
+          getDiagramComments={getDiagramComments}
+          createDiagramComment={createDiagramComment}
+          resolveDiagramComment={resolveDiagramComment}
+          deleteDiagramComment={deleteDiagramComment}
+          sendDiagramComment={sendDiagramComment}
+          sessionId={session.id}
+          worktreePath={session.worktreePath}
+          relPath={tabs.find(tab => tab.type === "diagram")?.relPath}
+          onSelectDiagram={onSelectDiagram}
+        />
       </div>
 
       {/* 添付ファイル選択用の隠しinput

--- a/packages/web/src/components/MobileSessionView.tsx
+++ b/packages/web/src/components/MobileSessionView.tsx
@@ -52,30 +52,27 @@ import { Textarea } from "@/components/ui/textarea";
 import { fileToBase64, validateFile } from "../hooks/useFileUpload";
 import { useTerminalLinkInjection } from "../hooks/useTerminalLinkInjection";
 import { useVisualViewport } from "../hooks/useVisualViewport";
+import {
+  type MobileSessionViewMode,
+  readSavedViewMode,
+  writeSavedViewMode,
+} from "../lib/mobile-session-view-mode";
+import { DiagramPane, type DiagramPaneProps } from "./DiagramPane";
 import { FileViewerPane } from "./FileViewerPane";
 import { HtmlViewerPane } from "./HtmlViewerPane";
 import { MessageShortcutManagerDialog } from "./MessageShortcutManagerDialog";
 import { MessageShortcutMenu } from "./MessageShortcutMenu";
+import { MobileSessionViewModeToggle } from "./MobileSessionViewModeToggle";
 import { SplitChatPane } from "./SplitChatPane";
 import type { ViewerTab } from "./TerminalPane";
 import { ViewerTabBar } from "./ViewerTabBar";
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
-const STORAGE_KEY_MOBILE_VIEW = "ark-mobile-session-view";
-
-/** モバイルセッションの表示モード（会話 / ターミナル）。既定は会話。 */
-type MobileSessionViewMode = "chat" | "terminal";
-
-function readSavedViewMode(): MobileSessionViewMode {
-  try {
-    return localStorage.getItem(STORAGE_KEY_MOBILE_VIEW) === "terminal"
-      ? "terminal"
-      : "chat";
-  } catch {
-    return "chat";
-  }
-}
+type MobileDiagramPaneProps = Omit<
+  DiagramPaneProps,
+  "sessionId" | "worktreePath" | "relPath"
+>;
 
 /** プレビューダイアログに蓄積する添付ファイル */
 interface PendingFile {
@@ -87,7 +84,7 @@ interface PendingFile {
   size: number;
 }
 
-interface MobileSessionViewProps {
+interface MobileSessionViewProps extends Partial<MobileDiagramPaneProps> {
   /** 会話ビュー（SplitChatPane）の JSONL 購読・AUQ 受信に使う */
   socket: TypedSocket | null;
   /** この詳細が現在表示中か。会話ビューの購読を表示中に限定する */
@@ -150,24 +147,26 @@ export function MobileSessionView({
   onCreateShortcut,
   onUpdateShortcut,
   onDeleteShortcut,
+  isConnected,
+  listDiagrams,
+  deleteDiagram,
+  getDiagramComments,
+  createDiagramComment,
+  resolveDiagramComment,
+  deleteDiagramComment,
+  sendDiagramComment,
+  onSelectDiagram,
 }: MobileSessionViewProps) {
   const { height: viewportHeight, isKeyboardVisible } = useVisualViewport();
   const [inputValue, setInputValue] = useState("");
   const [iframeKey, setIframeKey] = useState(0);
-  // 表示モード（会話 / ターミナル）。既定は会話。最後の選択を localStorage に永続化。
+  // 表示モード（会話 / ターミナル / 図）。既定は会話。最後の選択を永続化。
   const [viewMode, setViewMode] =
     useState<MobileSessionViewMode>(readSavedViewMode);
 
-  const toggleViewMode = useCallback(() => {
-    setViewMode(prev => {
-      const next = prev === "chat" ? "terminal" : "chat";
-      try {
-        localStorage.setItem(STORAGE_KEY_MOBILE_VIEW, next);
-      } catch {
-        // ignore
-      }
-      return next;
-    });
+  const handleViewModeChange = useCallback((next: MobileSessionViewMode) => {
+    writeSavedViewMode(next);
+    setViewMode(next);
   }, []);
 
   // ファイル/HTML/キャンバスのビューワータブが開かれた（active が terminal 以外に
@@ -175,7 +174,11 @@ export function MobileSessionView({
   // 会話内のファイルリンクや「キャンバスで開く」タップに追従する。
   const activeTabType = tabs[activeTabIndex]?.type;
   useEffect(() => {
-    if (activeTabType && activeTabType !== "terminal") {
+    if (
+      activeTabType &&
+      activeTabType !== "terminal" &&
+      activeTabType !== "diagram"
+    ) {
       setViewMode("terminal");
     }
   }, [activeTabType]);
@@ -422,16 +425,10 @@ export function MobileSessionView({
           </span>
         </div>
         <div className="flex items-center gap-1 shrink-0">
-          {/* 会話 / ターミナル 表示切替 */}
-          <button
-            type="button"
-            onClick={toggleViewMode}
-            className="flex items-center gap-1 rounded-md bg-muted px-2 py-1.5 font-medium text-foreground text-xs shrink-0 hover:bg-muted/70"
-            title={viewMode === "chat" ? "ターミナルに切替" : "会話に切替"}
-          >
-            <span>{viewMode === "chat" ? "🖥" : "💬"}</span>
-            <span>{viewMode === "chat" ? "端末" : "会話"}</span>
-          </button>
+          <MobileSessionViewModeToggle
+            value={viewMode}
+            onChange={handleViewModeChange}
+          />
           <MessageShortcutMenu
             shortcuts={messageShortcuts}
             onSendMessage={onSendMessage}
@@ -756,6 +753,40 @@ export function MobileSessionView({
             </Button>
           </div>
         </form>
+      </div>
+
+      {/* 図モード: DiagramPane は他モードでもマウントしたまま hidden で切り替える。
+          MessageChannel port と iframe の接続をモード切替で張り直さない。 */}
+      <div
+        className={
+          viewMode === "board" ? "flex-1 flex flex-col min-h-0" : "hidden"
+        }
+      >
+        {isConnected !== undefined &&
+          listDiagrams &&
+          deleteDiagram &&
+          getDiagramComments &&
+          createDiagramComment &&
+          resolveDiagramComment &&
+          deleteDiagramComment &&
+          sendDiagramComment &&
+          onSelectDiagram && (
+            <DiagramPane
+              socket={socket}
+              isConnected={isConnected}
+              listDiagrams={listDiagrams}
+              deleteDiagram={deleteDiagram}
+              getDiagramComments={getDiagramComments}
+              createDiagramComment={createDiagramComment}
+              resolveDiagramComment={resolveDiagramComment}
+              deleteDiagramComment={deleteDiagramComment}
+              sendDiagramComment={sendDiagramComment}
+              sessionId={session.id}
+              worktreePath={session.worktreePath}
+              relPath={tabs.find(tab => tab.type === "diagram")?.relPath}
+              onSelectDiagram={onSelectDiagram}
+            />
+          )}
       </div>
 
       {/* 添付ファイル選択用の隠しinput

--- a/packages/web/src/components/MobileSessionViewModeToggle.tsx
+++ b/packages/web/src/components/MobileSessionViewModeToggle.tsx
@@ -1,0 +1,47 @@
+import type { MobileSessionViewMode } from "../lib/mobile-session-view-mode";
+
+export const MOBILE_SESSION_VIEW_MODES: ReadonlyArray<{
+  value: MobileSessionViewMode;
+  icon: string;
+  label: string;
+}> = [
+  { value: "chat", icon: "💬", label: "会話" },
+  { value: "terminal", icon: "🖥", label: "端末" },
+  { value: "board", icon: "📐", label: "図" },
+];
+
+interface MobileSessionViewModeToggleProps {
+  value: MobileSessionViewMode;
+  onChange: (mode: MobileSessionViewMode) => void;
+}
+
+export function MobileSessionViewModeToggle({
+  value,
+  onChange,
+}: MobileSessionViewModeToggleProps) {
+  return (
+    <fieldset className="flex items-center rounded-md border-0 bg-muted p-0.5 shrink-0">
+      <legend className="sr-only">表示モード</legend>
+      {MOBILE_SESSION_VIEW_MODES.map(option => {
+        const selected = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-label={option.label}
+            aria-pressed={selected}
+            onClick={() => onChange(option.value)}
+            className={`flex items-center gap-0.5 rounded px-1.5 py-1 text-[11px] font-medium transition-colors ${
+              selected
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <span aria-hidden="true">{option.icon}</span>
+            <span>{option.label}</span>
+          </button>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/packages/web/src/lib/mobile-session-view-mode.ts
+++ b/packages/web/src/lib/mobile-session-view-mode.ts
@@ -7,6 +7,8 @@ export const MOBILE_SESSION_VIEW_MODE_VALUES = [
 export type MobileSessionViewMode =
   (typeof MOBILE_SESSION_VIEW_MODE_VALUES)[number];
 
+type MobileActiveTabType = "terminal" | "file" | "html" | "diagram";
+
 interface ViewModeStorageReader {
   getItem(key: string): string | null;
 }
@@ -16,6 +18,14 @@ interface ViewModeStorageWriter {
 }
 
 export const STORAGE_KEY_MOBILE_VIEW = "ark-mobile-session-view";
+
+export function getViewModeForActiveTab(
+  activeTabType: MobileActiveTabType | undefined
+): MobileSessionViewMode | null {
+  if (activeTabType === "diagram") return "board";
+  if (activeTabType && activeTabType !== "terminal") return "terminal";
+  return null;
+}
 
 export function normalizeMobileSessionViewMode(
   value: unknown

--- a/packages/web/src/lib/mobile-session-view-mode.ts
+++ b/packages/web/src/lib/mobile-session-view-mode.ts
@@ -9,6 +9,12 @@ export type MobileSessionViewMode =
 
 type MobileActiveTabType = "terminal" | "file" | "html" | "diagram";
 
+export interface DiagramOpenRequest {
+  sessionId: string;
+  relPath: string;
+  sequence: number;
+}
+
 interface ViewModeStorageReader {
   getItem(key: string): string | null;
 }
@@ -19,11 +25,37 @@ interface ViewModeStorageWriter {
 
 export const STORAGE_KEY_MOBILE_VIEW = "ark-mobile-session-view";
 
-export function getViewModeForActiveTab(
+export function createDiagramOpenRequest(
+  previous: DiagramOpenRequest | null,
+  sessionId: string,
+  relPath: string
+): DiagramOpenRequest {
+  return {
+    sessionId,
+    relPath,
+    sequence: (previous?.sequence ?? 0) + 1,
+  };
+}
+
+export function getViewModeForDiagramOpenRequest(
+  sessionId: string,
+  request: DiagramOpenRequest | null,
+  handledSequence: number | null
+): MobileSessionViewMode | null {
+  if (
+    request &&
+    request.sessionId === sessionId &&
+    request.sequence !== handledSequence
+  ) {
+    return "board";
+  }
+  return null;
+}
+
+export function getViewModeForViewerTab(
   activeTabType: MobileActiveTabType | undefined
 ): MobileSessionViewMode | null {
-  if (activeTabType === "diagram") return "board";
-  if (activeTabType && activeTabType !== "terminal") return "terminal";
+  if (activeTabType === "file" || activeTabType === "html") return "terminal";
   return null;
 }
 

--- a/packages/web/src/lib/mobile-session-view-mode.ts
+++ b/packages/web/src/lib/mobile-session-view-mode.ts
@@ -1,0 +1,53 @@
+export const MOBILE_SESSION_VIEW_MODE_VALUES = [
+  "chat",
+  "terminal",
+  "board",
+] as const;
+
+export type MobileSessionViewMode =
+  (typeof MOBILE_SESSION_VIEW_MODE_VALUES)[number];
+
+interface ViewModeStorageReader {
+  getItem(key: string): string | null;
+}
+
+interface ViewModeStorageWriter {
+  setItem(key: string, value: string): void;
+}
+
+export const STORAGE_KEY_MOBILE_VIEW = "ark-mobile-session-view";
+
+export function normalizeMobileSessionViewMode(
+  value: unknown
+): MobileSessionViewMode {
+  return MOBILE_SESSION_VIEW_MODE_VALUES.includes(
+    value as MobileSessionViewMode
+  )
+    ? (value as MobileSessionViewMode)
+    : "chat";
+}
+
+export function readSavedViewMode(
+  storage?: ViewModeStorageReader
+): MobileSessionViewMode {
+  try {
+    const source = storage ?? window.localStorage;
+    return normalizeMobileSessionViewMode(
+      source.getItem(STORAGE_KEY_MOBILE_VIEW)
+    );
+  } catch {
+    return "chat";
+  }
+}
+
+export function writeSavedViewMode(
+  mode: MobileSessionViewMode,
+  storage?: ViewModeStorageWriter
+): void {
+  try {
+    const target = storage ?? window.localStorage;
+    target.setItem(STORAGE_KEY_MOBILE_VIEW, mode);
+  } catch {
+    // Storage unavailable (SSR / private mode / quota) must not break navigation.
+  }
+}

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -232,6 +232,8 @@ export default function Dashboard() {
     [isRemote, isMobile, handleSelectBrowser, navigateBrowser]
   );
 
+  // PC / モバイル共通の単一インスタンス。MobileLayout で再度呼ぶとリンクタップの
+  // ハンドラが二重登録され、URL オープンが 2 回走るため、ここだけで管理する。
   const {
     getTabsForSession,
     getActiveTabForSession,

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -214,6 +214,10 @@ export default function Dashboard() {
   const handleOpenUrl = useCallback(
     (url: string) => {
       if (isRemote) {
+        if (isMobile) {
+          handleSelectBrowser();
+          setMobileActiveTab("browser");
+        }
         navigateBrowser(url);
         setSelectedSessionId("browser");
         setHasBrowserOpened(true);
@@ -225,7 +229,7 @@ export default function Dashboard() {
         a.click();
       }
     },
-    [isRemote, navigateBrowser]
+    [isRemote, isMobile, handleSelectBrowser, navigateBrowser]
   );
 
   const {
@@ -241,7 +245,7 @@ export default function Dashboard() {
     readFile,
     fileContent,
     handleOpenUrl,
-    !isMobile
+    true
   );
 
   // diagram:open を受けて図タブを開く。worktreePath はサーバーから送られない
@@ -635,8 +639,18 @@ export default function Dashboard() {
           onUploadFile={uploadFile}
           onCopyBuffer={copyBuffer}
           onNewSession={handleNewSession}
-          readFile={readFile}
-          fileContent={fileContent}
+          getTabsForSession={getTabsForSession}
+          getActiveTabForSession={getActiveTabForSession}
+          handleTabSelect={handleTabSelect}
+          handleTabClose={handleTabClose}
+          openDiagramTab={openDiagramTab}
+          listDiagrams={listDiagrams}
+          deleteDiagram={deleteDiagram}
+          getDiagramComments={getDiagramComments}
+          createDiagramComment={createDiagramComment}
+          resolveDiagramComment={resolveDiagramComment}
+          deleteDiagramComment={deleteDiagramComment}
+          sendDiagramComment={sendDiagramComment}
           beaconMessages={beaconMessages}
           beaconStreaming={beaconStreaming}
           beaconStreamText={beaconStreamText}
@@ -652,7 +666,6 @@ export default function Dashboard() {
           multiProfileSupported={capabilities.multiProfileSupported}
           activeBrowserSession={activeBrowserSession}
           onSelectBrowser={handleSelectBrowser}
-          navigateBrowser={navigateBrowser}
           isRemote={isRemote}
           onOpenMcpManager={() => setShowMcpManager(true)}
           messageShortcuts={messageShortcuts}

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -47,6 +47,10 @@ import { useIsMobile } from "@/hooks/useMobile";
 import { useSettings } from "@/hooks/useSettings";
 import { useSocket } from "@/hooks/useSocket";
 import { useViewerTabs } from "@/hooks/useViewerTabs";
+import {
+  createDiagramOpenRequest,
+  type DiagramOpenRequest,
+} from "@/lib/mobile-session-view-mode";
 import { getBaseName } from "@/utils/pathUtils";
 import {
   findRepoForSession,
@@ -180,6 +184,8 @@ export default function Dashboard() {
   const [mobileActiveTab, setMobileActiveTab] = useState<MobileTab>("session");
   const [mobileSessionSubView, setMobileSessionSubView] =
     useState<SessionSubView>("list");
+  const [diagramOpenRequest, setDiagramOpenRequest] =
+    useState<DiagramOpenRequest | null>(null);
   // ブラウザビューを一度でも開いたかどうかのフラグ
   // 一度開いたら常に描画してdisplay:hiddenで切り替え、BrowserPaneの再マウント（VNC再接続）を防ぐ
   const [hasBrowserOpened, setHasBrowserOpened] = useState(false);
@@ -259,6 +265,9 @@ export default function Dashboard() {
       const session = sessions.get(data.sessionId);
       if (!session?.worktreePath) return;
       openDiagramTab(data.sessionId, session.worktreePath, data.relPath);
+      setDiagramOpenRequest(previous =>
+        createDiagramOpenRequest(previous, data.sessionId, data.relPath)
+      );
     };
     socket.on("diagram:open", onDiagramOpen);
     return () => {
@@ -646,6 +655,7 @@ export default function Dashboard() {
           handleTabSelect={handleTabSelect}
           handleTabClose={handleTabClose}
           openDiagramTab={openDiagramTab}
+          diagramOpenRequest={diagramOpenRequest}
           listDiagrams={listDiagrams}
           deleteDiagram={deleteDiagram}
           getDiagramComments={getDiagramComments}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(import.meta.dirname, "packages/web/src"),
+    },
+  },
   oxc: {
     jsx: {
       runtime: "automatic",


### PR DESCRIPTION
図解ボードをモバイルでも表示・操作できるようにする。これまで PC 限定だった。

## 変更

### A. board モードを足す

`MobileSessionView` の `viewMode` は `chat` / `terminal` の 2 値で、ヘッダの 1 ボタンで反転していた。ここに `board` を加え、**現在のモードが一目で分かる 3 択トグル**（💬会話 / 🖥端末 / 📐図）に置き換えた。localStorage からの復元は未知値を安全な既定へ倒す既存の流儀を維持する。

board モードでは **PC と同じ `DiagramPane`** を表示する。モバイル専用に作り直すと、コメント層との MessageChannel ハンドシェイクや図の切り替えを二重に保守することになるため。出し分けは chat / terminal と同じ **`hidden` 方式**にした。条件付きレンダリングでアンマウントすると **port が毎回張り直しになる**。

### B. 配線をモバイルへ通す

`Dashboard` は `useViewerTabs(..., !isMobile)` でビューアタブを丸ごと無効化し、代わりに `MobileLayout` が自前で同じ hook を呼んでいた（呼び出し側両方で排他を明示する設計）。

これを **Dashboard の単一インスタンスへ集約**し、タブ状態と図操作一式を props でモバイルへ渡す形にした。これにより `diagram:open`（Claude の `board_open`）と `lastDiagramPath` の復元がモバイルでも効く。

**`MobileLayout` で再度 `useViewerTabs` を呼ぶと、リンクタップのハンドラが二重登録され URL オープンが 2 回走る。** 元の設計にあった排他の意図が失われないよう、この理由を両ファイルのコメントに残した。

### C. タッチのピンチズーム

ピンチは `diagram-comment-layer.ts`（doc）と `diagram-harness.ts`（graph）の**両方**が `wheel` + `ctrlKey` で親へ転送していたが、**タッチのピンチはこの経路に乗らない**。両方に 2 本指ピンチを追加した。

- タッチが **2 点のときだけ**扱い、1 本指のスクロールとテキスト選択を邪魔しない
- 指間距離の比から `deltaY` 相当を算出し、**符号とスケール感を `wheel` 経路に揃える**（ピンチアウトで拡大）
- `{ passive: false }` で登録し、2 本指のときのみ `preventDefault()`（ブラウザ自身のピンチズームと二重に効かせない）
- 既存の `wheel` + `ctrlKey` 経路はそのまま維持（PC の挙動を変えない）

## コメント機能について

注入層はサーバー側で HTML に埋め込まれるため、**モバイルでも同じものが配信される**。コメント・解決・削除・「→ Claude」はそのまま使える。狭い画面では既存の畳みバッジとアンカー下配置が効く。閲覧専用にする方が抑制の実装分だけ高くつくため、機能はそのまま通した。

## 検証

`pnpm check` / `pnpm test`（1003 件）/ `pnpm build` すべて green。

加えて **iPhone 13 エミュレーション（タッチ有効）で実アプリを操作**して確認した。

- 3 択トグルが描画され、📐図 で board へ切り替わる
- ボードが表示される（図の切替ドロップダウン込み）
- テキスト選択で「コメント」ボタンが出る
- **2 本指ピンチでズームが 100% → 140% に変化**（指の距離比 1.4 がそのままズーム 1.4）
- ページエラーなし

**実機でしか確認できない項目**として、iOS Safari の選択メニュー（コピー / 調べる）と「コメント」ボタンの競合が残る。

## 注意: 注入サイズの余裕が減った

ハーネスの注入サイズが **129,716 / 131,072 bytes** になり、**残り 1,356 bytes（1%）**。次にハーネスへ機能を足すと上限に当たる。別途対処が必要。

Refs #300


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * モバイルセッションで「会話・端末・図」を切り替えられる表示モードを追加しました。
  * 図の閲覧、選択、タブ操作、コメントの作成・解決・削除に対応しました。
  * モバイル環境でもリモートURLをブラウザ表示できるようになりました。
  * タッチ操作による2本指ピンチズームに対応しました。

* **改善**
  * 選択したモバイル表示モードを保存し、次回も復元します。
  * 図タブを開いた際、意図せずターミナルへ切り替わらないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->