### PR TITLE
fix(hooks): worktree での push を検出しマーカーの照合先を揃える

### DIFF
--- a/.claude/hooks/post-push-monitor.sh
+++ b/.claude/hooks/post-push-monitor.sh
@@ -62,9 +62,15 @@ CHECK_SCRIPT="$PROJECT_DIR/.claude/hooks/check-ci-coderabbit.sh"
 
 if $IS_GIT_PUSH; then
   UNRESOLVED_CONTEXT=""
-  TARGET_REPO_DIR=$(push_marker_resolve_repo_dir "$HOOK_INPUT_CWD" "$COMMAND" "$HOOK_CWD")
-  PUSH_HEAD=$(git -C "$TARGET_REPO_DIR" rev-parse HEAD)
-  printf '%s\n%s\n' "$PUSH_HEAD" "$TARGET_REPO_DIR" > "$PROJECT_DIR/.claude/push-completed.marker"
+  TARGET_REPO_DIR=""
+  PUSH_HEAD=""
+  if ! TARGET_REPO_DIR=$(push_marker_resolve_repo_dir "$HOOK_INPUT_CWD" "$COMMAND" "$HOOK_CWD"); then
+    echo "push-marker: push 対象のリポジトリを解決できないためマーカーを更新しません" >&2
+  elif ! PUSH_HEAD=$(git -C "$TARGET_REPO_DIR" rev-parse HEAD 2>/dev/null); then
+    echo "push-marker: push 対象の HEAD を解決できないためマーカーを更新しません" >&2
+  else
+    printf '%s\n%s\n' "$PUSH_HEAD" "$TARGET_REPO_DIR" > "$PROJECT_DIR/.claude/push-completed.marker"
+  fi
 
   source "$PROJECT_DIR/.claude/hooks/fetch-unresolved-threads.sh"
   fetch_unresolved_threads

--- a/.claude/hooks/post-push-monitor.sh
+++ b/.claude/hooks/post-push-monitor.sh
@@ -63,7 +63,8 @@ CHECK_SCRIPT="$PROJECT_DIR/.claude/hooks/check-ci-coderabbit.sh"
 if $IS_GIT_PUSH; then
   UNRESOLVED_CONTEXT=""
   TARGET_REPO_DIR=$(push_marker_resolve_repo_dir "$HOOK_INPUT_CWD" "$COMMAND" "$HOOK_CWD")
-  git -C "$TARGET_REPO_DIR" rev-parse HEAD > "$PROJECT_DIR/.claude/push-completed.marker"
+  PUSH_HEAD=$(git -C "$TARGET_REPO_DIR" rev-parse HEAD)
+  printf '%s\n%s\n' "$PUSH_HEAD" "$TARGET_REPO_DIR" > "$PROJECT_DIR/.claude/push-completed.marker"
 
   source "$PROJECT_DIR/.claude/hooks/fetch-unresolved-threads.sh"
   fetch_unresolved_threads

--- a/.claude/hooks/post-push-monitor.sh
+++ b/.claude/hooks/post-push-monitor.sh
@@ -6,16 +6,18 @@ set -eo pipefail
 
 STDIN_INPUT=$(cat)
 COMMAND=$(echo "$STDIN_INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+HOOK_INPUT_CWD=$(echo "$STDIN_INPUT" | jq -r '.cwd // ""' 2>/dev/null) || HOOK_INPUT_CWD=""
+HOOK_CWD=$(pwd -P)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./push-marker-utils.sh
+source "$SCRIPT_DIR/push-marker-utils.sh"
 
 IS_GIT_PUSH=false
 IS_GH_PR_CREATE=false
 
-if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+(.+[[:space:]]+)?push([[:space:]]|$) ]] && ! [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+(stash|submodule)[[:space:]] ]]; then
-  IS_GIT_PUSH=true
-  if [[ "$COMMAND" =~ (^|[[:space:]])(-n|--dry-run)([[:space:]]|$) ]]; then
-    exit 0
-  fi
-fi
+push_marker_detect_git_push "$COMMAND"
+IS_GIT_PUSH=$PUSH_MARKER_IS_GIT_PUSH
+$PUSH_MARKER_IS_DRY_RUN && exit 0
 
 if [[ "$COMMAND" =~ ^[[:space:]]*gh[[:space:]]+(.+[[:space:]]+)?pr[[:space:]]+create([[:space:]]|$) ]]; then
   IS_GH_PR_CREATE=true
@@ -60,7 +62,8 @@ CHECK_SCRIPT="$PROJECT_DIR/.claude/hooks/check-ci-coderabbit.sh"
 
 if $IS_GIT_PUSH; then
   UNRESOLVED_CONTEXT=""
-  git rev-parse HEAD > "$PROJECT_DIR/.claude/push-completed.marker"
+  TARGET_REPO_DIR=$(push_marker_resolve_repo_dir "$HOOK_INPUT_CWD" "$COMMAND" "$HOOK_CWD")
+  git -C "$TARGET_REPO_DIR" rev-parse HEAD > "$PROJECT_DIR/.claude/push-completed.marker"
 
   source "$PROJECT_DIR/.claude/hooks/fetch-unresolved-threads.sh"
   fetch_unresolved_threads

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -272,7 +272,6 @@ if $IS_PR_COMMENT; then
   SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
   # shellcheck source=./push-marker-utils.sh
   source "$SCRIPT_DIR/push-marker-utils.sh"
-  TARGET_REPO_DIR=$(push_marker_resolve_repo_dir "$HOOK_INPUT_CWD" "$COMMAND" "$HOOK_CWD")
   MARKER="$PROJECT_DIR/.claude/push-completed.marker"
   if [ ! -f "$MARKER" ]; then
     echo "BLOCKED: push完了前にCodeRabbit返信はできません" >&2
@@ -296,8 +295,20 @@ if $IS_PR_COMMENT; then
   fi
   # push時のcommit SHAと現在のHEADが一致するか検証（バックグラウンドpush対策）
   MARKER_HEAD=$(head -1 "$MARKER" 2>/dev/null) || MARKER_HEAD=""
-  CURRENT_HEAD=$(git -C "$TARGET_REPO_DIR" rev-parse HEAD 2>/dev/null) || CURRENT_HEAD=""
-  if [ -n "$CURRENT_HEAD" ] && [ "$MARKER_HEAD" != "$CURRENT_HEAD" ]; then
+  MARKER_REPO_DIR=$(sed -n '2p' "$MARKER" 2>/dev/null) || MARKER_REPO_DIR=""
+  if [ -n "$MARKER_REPO_DIR" ]; then
+    TARGET_REPO_DIR="$MARKER_REPO_DIR"
+  else
+    # 旧形式（SHA 1行のみ）のマーカーは返信コマンドから照合先を解決する。
+    TARGET_REPO_DIR=$(push_marker_resolve_repo_dir "$HOOK_INPUT_CWD" "$COMMAND" "$HOOK_CWD") || TARGET_REPO_DIR=""
+  fi
+  if [ -z "$TARGET_REPO_DIR" ] || ! CURRENT_HEAD=$(git -C "$TARGET_REPO_DIR" rev-parse HEAD 2>/dev/null); then
+    echo "BLOCKED: pushしたリポジトリのHEADを確認できません" >&2
+    echo "  WHY: 照合対象のディレクトリが存在しないか、Gitリポジトリではない" >&2
+    echo "  FIX: 対象リポジトリでgit pushを再実行してください" >&2
+    exit 2
+  fi
+  if [ "$MARKER_HEAD" != "$CURRENT_HEAD" ]; then
     echo "BLOCKED: push後に新しいコミットが追加されています" >&2
     echo "  WHY: マーカーのSHA(${MARKER_HEAD:0:8})と現在のHEAD(${CURRENT_HEAD:0:8})が不一致" >&2
     echo "  FIX: 最新の変更をgit pushしてから返信してください" >&2

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -267,6 +267,12 @@ fi
 if $IS_PR_COMMENT; then
   # push完了マーカーの確認（60秒以内に作成されたものが必要）
   PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+  HOOK_INPUT_CWD=$(echo "$STDIN_INPUT" | jq -r '.cwd // ""' 2>/dev/null) || HOOK_INPUT_CWD=""
+  HOOK_CWD=$(pwd -P)
+  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+  # shellcheck source=./push-marker-utils.sh
+  source "$SCRIPT_DIR/push-marker-utils.sh"
+  TARGET_REPO_DIR=$(push_marker_resolve_repo_dir "$HOOK_INPUT_CWD" "$COMMAND" "$HOOK_CWD")
   MARKER="$PROJECT_DIR/.claude/push-completed.marker"
   if [ ! -f "$MARKER" ]; then
     echo "BLOCKED: push完了前にCodeRabbit返信はできません" >&2
@@ -290,7 +296,7 @@ if $IS_PR_COMMENT; then
   fi
   # push時のcommit SHAと現在のHEADが一致するか検証（バックグラウンドpush対策）
   MARKER_HEAD=$(head -1 "$MARKER" 2>/dev/null) || MARKER_HEAD=""
-  CURRENT_HEAD=$(git rev-parse HEAD 2>/dev/null) || CURRENT_HEAD=""
+  CURRENT_HEAD=$(git -C "$TARGET_REPO_DIR" rev-parse HEAD 2>/dev/null) || CURRENT_HEAD=""
   if [ -n "$CURRENT_HEAD" ] && [ "$MARKER_HEAD" != "$CURRENT_HEAD" ]; then
     echo "BLOCKED: push後に新しいコミットが追加されています" >&2
     echo "  WHY: マーカーのSHA(${MARKER_HEAD:0:8})と現在のHEAD(${CURRENT_HEAD:0:8})が不一致" >&2

--- a/.claude/hooks/push-marker-utils.sh
+++ b/.claude/hooks/push-marker-utils.sh
@@ -80,13 +80,108 @@ _push_marker_split_shell_command() {
   PUSH_MARKER_SEGMENTS+=("$current")
 }
 
-_push_marker_is_git_push_segment() {
-  local segment
-  segment="$(_push_marker_trim "$1")"
+_push_marker_tokenize_segment() {
+  local input="$1"
+  local token=""
+  local quote=""
+  local escaped=false
+  local started=false
+  local char
+  local i
 
-  [[ "$segment" =~ ^git[[:space:]]+(.+[[:space:]]+)?push([[:space:]]|$) ]] || return 1
-  [[ "$segment" =~ ^git[[:space:]]+(stash|submodule)([[:space:]]|$) ]] && return 1
+  PUSH_MARKER_TOKENS=()
+
+  for ((i = 0; i < ${#input}; i++)); do
+    char="${input:i:1}"
+
+    if $escaped; then
+      token+="$char"
+      escaped=false
+      started=true
+      continue
+    fi
+
+    if [ "$quote" = "'" ]; then
+      if [ "$char" = "'" ]; then
+        quote=""
+      else
+        token+="$char"
+      fi
+      continue
+    fi
+
+    if [ "$quote" = '"' ]; then
+      if [ "$char" = "\\" ]; then
+        escaped=true
+      elif [ "$char" = '"' ]; then
+        quote=""
+      else
+        token+="$char"
+      fi
+      continue
+    fi
+
+    case "$char" in
+      "'"|'"')
+        quote="$char"
+        started=true
+        ;;
+      \\)
+        escaped=true
+        started=true
+        ;;
+      [[:space:]])
+        if $started; then
+          PUSH_MARKER_TOKENS+=("$token")
+          token=""
+          started=false
+        fi
+        ;;
+      *)
+        token+="$char"
+        started=true
+        ;;
+    esac
+  done
+
+  [ -z "$quote" ] && ! $escaped || return 1
+  $started && PUSH_MARKER_TOKENS+=("$token")
   return 0
+}
+
+_push_marker_is_git_push_segment() {
+  local segment token
+  local i=1
+
+  segment="$(_push_marker_trim "$1")"
+  _push_marker_tokenize_segment "$segment" || return 1
+  [ "${#PUSH_MARKER_TOKENS[@]}" -gt 1 ] || return 1
+  [ "${PUSH_MARKER_TOKENS[0]}" = "git" ] || return 1
+
+  while [ "$i" -lt "${#PUSH_MARKER_TOKENS[@]}" ]; do
+    token="${PUSH_MARKER_TOKENS[$i]}"
+    case "$token" in
+      -C|-c|--git-dir|--work-tree|--exec-path|--namespace|--super-prefix|--config-env)
+        i=$((i + 2))
+        ;;
+      --git-dir=*|--work-tree=*|--exec-path=*|--namespace=*|--super-prefix=*|--config-env=*)
+        i=$((i + 1))
+        ;;
+      --)
+        i=$((i + 1))
+        break
+        ;;
+      -*)
+        i=$((i + 1))
+        ;;
+      *)
+        break
+        ;;
+    esac
+  done
+
+  [ "$i" -lt "${#PUSH_MARKER_TOKENS[@]}" ] || return 1
+  [ "${PUSH_MARKER_TOKENS[$i]}" = "push" ]
 }
 
 push_marker_detect_git_push() {

--- a/.claude/hooks/push-marker-utils.sh
+++ b/.claude/hooks/push-marker-utils.sh
@@ -1,0 +1,261 @@
+#!/bin/bash
+
+# push 完了マーカーの検出・SHA 解決で共有するヘルパー。
+# コマンド文字列を eval せず、クォート外の && / || / ; だけを区切りとして扱う。
+
+_push_marker_trim() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+_push_marker_split_shell_command() {
+  local command="$1"
+  local current=""
+  local quote=""
+  local escaped=false
+  local char next
+  local i
+
+  PUSH_MARKER_SEGMENTS=()
+  PUSH_MARKER_SEPARATORS=()
+
+  for ((i = 0; i < ${#command}; i++)); do
+    char="${command:i:1}"
+
+    if $escaped; then
+      current+="$char"
+      escaped=false
+      continue
+    fi
+
+    if [ "$quote" = "'" ]; then
+      current+="$char"
+      [ "$char" = "'" ] && quote=""
+      continue
+    fi
+
+    if [ "$quote" = '"' ]; then
+      current+="$char"
+      if [ "$char" = "\\" ]; then
+        escaped=true
+      elif [ "$char" = '"' ]; then
+        quote=""
+      fi
+      continue
+    fi
+
+    case "$char" in
+      "'"|'"')
+        quote="$char"
+        current+="$char"
+        ;;
+      \\)
+        escaped=true
+        current+="$char"
+        ;;
+      ';')
+        PUSH_MARKER_SEGMENTS+=("$current")
+        PUSH_MARKER_SEPARATORS+=(";")
+        current=""
+        ;;
+      '&'|'|')
+        next="${command:i+1:1}"
+        if [ "$next" = "$char" ]; then
+          PUSH_MARKER_SEGMENTS+=("$current")
+          PUSH_MARKER_SEPARATORS+=("${char}${char}")
+          current=""
+          i=$((i + 1))
+        else
+          current+="$char"
+        fi
+        ;;
+      *)
+        current+="$char"
+        ;;
+    esac
+  done
+
+  PUSH_MARKER_SEGMENTS+=("$current")
+}
+
+_push_marker_is_git_push_segment() {
+  local segment
+  segment="$(_push_marker_trim "$1")"
+
+  [[ "$segment" =~ ^git[[:space:]]+(.+[[:space:]]+)?push([[:space:]]|$) ]] || return 1
+  [[ "$segment" =~ ^git[[:space:]]+(stash|submodule)([[:space:]]|$) ]] && return 1
+  return 0
+}
+
+push_marker_detect_git_push() {
+  local command="$1"
+  local segment
+
+  # shellcheck disable=SC2034 # 呼び出し元へ返す出力変数
+  PUSH_MARKER_IS_GIT_PUSH=false
+  # shellcheck disable=SC2034 # 呼び出し元へ返す出力変数
+  PUSH_MARKER_IS_DRY_RUN=false
+  _push_marker_split_shell_command "$command"
+
+  for segment in "${PUSH_MARKER_SEGMENTS[@]}"; do
+    if _push_marker_is_git_push_segment "$segment"; then
+      # shellcheck disable=SC2034 # 呼び出し元へ返す出力変数
+      PUSH_MARKER_IS_GIT_PUSH=true
+      if [[ "$segment" =~ (^|[[:space:]])(-n|--dry-run)([[:space:]]|$) ]]; then
+        # shellcheck disable=SC2034 # 呼び出し元へ返す出力変数
+        PUSH_MARKER_IS_DRY_RUN=true
+      fi
+      return 0
+    fi
+  done
+}
+
+_push_marker_parse_cd_argument() {
+  local segment rest char
+  local quote=""
+  local escaped=false
+  local started=false
+  local trailing=false
+  local i
+
+  segment="$(_push_marker_trim "$1")"
+  [[ "$segment" =~ ^cd([[:space:]]|$) ]] || return 1
+  rest="${segment#cd}"
+  rest="$(_push_marker_trim "$rest")"
+
+  if [[ "$rest" =~ ^--[[:space:]]+ ]]; then
+    rest="${rest#--}"
+    rest="$(_push_marker_trim "$rest")"
+  fi
+
+  PUSH_MARKER_CD_ARG=""
+  PUSH_MARKER_CD_EXPAND_TILDE=false
+
+  if [ -z "$rest" ]; then
+    PUSH_MARKER_CD_ARG="${HOME:-}"
+    [ -n "$PUSH_MARKER_CD_ARG" ]
+    return
+  fi
+
+  for ((i = 0; i < ${#rest}; i++)); do
+    char="${rest:i:1}"
+
+    if $trailing; then
+      [[ "$char" =~ [[:space:]] ]] || return 1
+      continue
+    fi
+
+    if $escaped; then
+      PUSH_MARKER_CD_ARG+="$char"
+      escaped=false
+      started=true
+      continue
+    fi
+
+    if [ "$quote" = "'" ]; then
+      if [ "$char" = "'" ]; then
+        quote=""
+      else
+        PUSH_MARKER_CD_ARG+="$char"
+      fi
+      continue
+    fi
+
+    if [ "$quote" = '"' ]; then
+      if [ "$char" = "\\" ]; then
+        escaped=true
+      elif [ "$char" = '"' ]; then
+        quote=""
+      else
+        PUSH_MARKER_CD_ARG+="$char"
+      fi
+      continue
+    fi
+
+    case "$char" in
+      "'"|'"')
+        quote="$char"
+        started=true
+        ;;
+      \\)
+        escaped=true
+        started=true
+        ;;
+      [[:space:]])
+        $started && trailing=true
+        ;;
+      *)
+        if ! $started && [ "$char" = '~' ]; then
+          PUSH_MARKER_CD_EXPAND_TILDE=true
+        fi
+        PUSH_MARKER_CD_ARG+="$char"
+        started=true
+        ;;
+    esac
+  done
+
+  [ -z "$quote" ] && ! $escaped && $started
+}
+
+_push_marker_resolve_cd_dir() {
+  local segment="$1"
+  local base_dir="$2"
+  local cd_arg candidate
+  local tilde_prefix=$'\x7e/'
+
+  _push_marker_parse_cd_argument "$segment" || return 1
+  cd_arg="$PUSH_MARKER_CD_ARG"
+
+  if $PUSH_MARKER_CD_EXPAND_TILDE; then
+    if [ "$cd_arg" = '~' ]; then
+      cd_arg="${HOME:-}"
+    elif [ "${cd_arg:0:2}" = "$tilde_prefix" ]; then
+      cd_arg="${HOME:-}/${cd_arg:2}"
+    fi
+  fi
+
+  [ -n "$cd_arg" ] || return 1
+  if [[ "$cd_arg" = /* ]]; then
+    candidate="$cd_arg"
+  else
+    candidate="$base_dir/$cd_arg"
+  fi
+
+  [ -d "$candidate" ] || return 1
+  (cd "$candidate" && pwd -P)
+}
+
+push_marker_resolve_repo_dir() {
+  local input_cwd="$1"
+  local command="$2"
+  local fallback_cwd="$3"
+  local current_dir="$fallback_cwd"
+  local segment resolved_dir
+  local found_cd=false
+
+  # Claude Code の hook 共通入力に cwd がある場合は最優先する。
+  if [ -n "$input_cwd" ]; then
+    printf '%s' "$input_cwd"
+    return 0
+  fi
+
+  _push_marker_split_shell_command "$command"
+  for segment in "${PUSH_MARKER_SEGMENTS[@]}"; do
+    if resolved_dir="$(_push_marker_resolve_cd_dir "$segment" "$current_dir")"; then
+      current_dir="$resolved_dir"
+      found_cd=true
+    fi
+    if _push_marker_is_git_push_segment "$segment"; then
+      printf '%s' "$current_dir"
+      return 0
+    fi
+  done
+
+  if $found_cd; then
+    printf '%s' "$current_dir"
+  else
+    printf '%s' "$fallback_cwd"
+  fi
+}

--- a/.claude/hooks/push-marker-utils.sh
+++ b/.claude/hooks/push-marker-utils.sh
@@ -231,16 +231,22 @@ push_marker_resolve_repo_dir() {
   local input_cwd="$1"
   local command="$2"
   local fallback_cwd="$3"
-  local current_dir="$fallback_cwd"
+  local input_dir=""
+  local fallback_dir=""
+  local current_dir=""
   local segment resolved_dir
   local found_cd=false
 
-  # Claude Code の hook 共通入力に cwd がある場合は最優先する。
-  if [ -n "$input_cwd" ]; then
-    printf '%s' "$input_cwd"
-    return 0
+  if [ -d "$input_cwd" ]; then
+    input_dir=$(cd "$input_cwd" && pwd -P)
+    current_dir="$input_dir"
+  fi
+  if [ -d "$fallback_cwd" ]; then
+    fallback_dir=$(cd "$fallback_cwd" && pwd -P)
+    [ -n "$current_dir" ] || current_dir="$fallback_dir"
   fi
 
+  # コマンド中の cd は、hook 入力の cwd より実際の実行場所を具体的に示す。
   _push_marker_split_shell_command "$command"
   for segment in "${PUSH_MARKER_SEGMENTS[@]}"; do
     if resolved_dir="$(_push_marker_resolve_cd_dir "$segment" "$current_dir")"; then
@@ -248,14 +254,21 @@ push_marker_resolve_repo_dir() {
       found_cd=true
     fi
     if _push_marker_is_git_push_segment "$segment"; then
-      printf '%s' "$current_dir"
-      return 0
+      if [ -n "$current_dir" ]; then
+        printf '%s' "$current_dir"
+        return 0
+      fi
+      return 1
     fi
   done
 
   if $found_cd; then
     printf '%s' "$current_dir"
+  elif [ -n "$input_dir" ]; then
+    printf '%s' "$input_dir"
+  elif [ -n "$fallback_dir" ]; then
+    printf '%s' "$fallback_dir"
   else
-    printf '%s' "$fallback_cwd"
+    return 1
   fi
 }

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -55,13 +55,14 @@ HOOK_PROJECT="$TMP_TEST_DIR/hook-project"
 REPO_MAIN="$TMP_TEST_DIR/main-repo"
 REPO_WORKTREE="$TMP_TEST_DIR/work tree"
 REPO_WITHOUT_HEAD="$TMP_TEST_DIR/repo-without-head"
+NON_GIT_DIR="$TMP_TEST_DIR/non-git-dir"
 TEST_HOME="$TMP_TEST_DIR/home"
 REPO_TILDE="$TEST_HOME/tilde-repo"
 MARKER="$HOOK_PROJECT/.claude/push-completed.marker"
 POST_STDERR="$TMP_TEST_DIR/post.stderr"
 
 mkdir -p "$HOOK_PROJECT/.claude/hooks" "$REPO_MAIN" "$REPO_WORKTREE" \
-  "$REPO_WITHOUT_HEAD" "$REPO_TILDE"
+  "$REPO_WITHOUT_HEAD" "$NON_GIT_DIR" "$REPO_TILDE"
 
 # post hook のマーカー書き込み後の処理だけを無害な fixture に差し替える。
 printf '%s\n' \
@@ -189,6 +190,11 @@ assert_marker_absent "HEAD を解決できない場合はマーカーを書か�
 assert_eq "HEAD を解決できなくても post hook は正常終了する" \
   "0" "$POST_STATUS"
 assert_eq "HEAD を解決できなくても監視の起動 JSON を出力する" \
+  "PostToolUse" "$(printf '%s\n' "$POST_OUTPUT" | jq -r '.hookSpecificOutput.hookEventName // ""' 2>/dev/null)"
+
+run_post "git push" "$NON_GIT_DIR"
+assert_marker_absent "非 Git ディレクトリが cwd の場合はマーカーを書かない"
+assert_eq "非 Git ディレクトリが cwd でも監視の起動 JSON を出力する" \
   "PostToolUse" "$(printf '%s\n' "$POST_OUTPUT" | jq -r '.hookSpecificOutput.hookEventName // ""' 2>/dev/null)"
 
 echo ""

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+# post-push-monitor / pre-bash-guard の push マーカー worktree 回帰テスト
+set -uo pipefail
+
+TESTS=0
+PASSES=0
+FAILURES=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  TESTS=$((TESTS + 1))
+  if [ "$expected" = "$actual" ]; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+assert_marker_absent() {
+  local description="$1"
+  TESTS=$((TESTS + 1))
+  if [ ! -e "$MARKER" ]; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HOOK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+POST_HOOK="$HOOK_DIR/post-push-monitor.sh"
+PRE_HOOK="$HOOK_DIR/pre-bash-guard.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq 未インストールのため test-push-marker.sh をスキップ" >&2
+  exit 0
+fi
+
+TMP_TEST_DIR=$(mktemp -d "/tmp/test-push-marker.XXXXXX")
+trap 'rm -rf "$TMP_TEST_DIR"' EXIT
+
+HOOK_PROJECT="$TMP_TEST_DIR/hook-project"
+REPO_MAIN="$TMP_TEST_DIR/main-repo"
+REPO_WORKTREE="$TMP_TEST_DIR/work tree"
+TEST_HOME="$TMP_TEST_DIR/home"
+REPO_TILDE="$TEST_HOME/tilde-repo"
+MARKER="$HOOK_PROJECT/.claude/push-completed.marker"
+
+mkdir -p "$HOOK_PROJECT/.claude/hooks" "$REPO_MAIN" "$REPO_WORKTREE" "$REPO_TILDE"
+
+# post hook のマーカー書き込み後の処理だけを無害な fixture に差し替える。
+printf '%s\n' \
+  'UNRESOLVED_THREADS_ERROR=false' \
+  'UNRESOLVED_THREADS_COUNT=0' \
+  'UNRESOLVED_THREADS_JSON="[]"' \
+  'fetch_unresolved_threads() { :; }' \
+  > "$HOOK_PROJECT/.claude/hooks/fetch-unresolved-threads.sh"
+printf '%s\n' '#!/bin/bash' 'printf '\''{"status":"success"}\n'\''' \
+  > "$HOOK_PROJECT/.claude/hooks/check-ci-coderabbit.sh"
+chmod +x "$HOOK_PROJECT/.claude/hooks/check-ci-coderabbit.sh"
+
+init_repo() {
+  local repo="$1"
+  local content="$2"
+  git -C "$repo" init -q
+  git -C "$repo" config user.name "Push Marker Test"
+  git -C "$repo" config user.email "push-marker@example.invalid"
+  printf '%s\n' "$content" > "$repo/fixture.txt"
+  git -C "$repo" add fixture.txt
+  git -C "$repo" commit -qm "fixture"
+}
+
+init_repo "$REPO_MAIN" "main"
+init_repo "$REPO_WORKTREE" "worktree"
+init_repo "$REPO_TILDE" "tilde"
+
+MAIN_HEAD=$(git -C "$REPO_MAIN" rev-parse HEAD)
+WORKTREE_HEAD=$(git -C "$REPO_WORKTREE" rev-parse HEAD)
+TILDE_HEAD=$(git -C "$REPO_TILDE" rev-parse HEAD)
+
+run_post() {
+  local command="$1"
+  local input_cwd="${2-}"
+  local input
+
+  rm -f "$MARKER"
+  if [ -n "$input_cwd" ]; then
+    input=$(jq -n --arg command "$command" --arg cwd "$input_cwd" \
+      '{cwd: $cwd, tool_input: {command: $command}}')
+  else
+    input=$(jq -n --arg command "$command" '{tool_input: {command: $command}}')
+  fi
+
+  (cd "$REPO_MAIN" && printf '%s\n' "$input" | \
+    HOME="$TEST_HOME" CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$POST_HOOK" >/dev/null)
+}
+
+echo "=== post-push-monitor: push 検出と SHA ==="
+
+run_post "cd '$REPO_WORKTREE' && git push"
+assert_eq "cd <worktree> && git push は cd 先の HEAD を記録する" \
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+run_post "git push" "$REPO_MAIN"
+assert_eq "先頭の git push は従来どおり検出する" \
+  "$MAIN_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+run_post "cd '$REPO_WORKTREE'; git push"
+assert_eq "セミコロン後の git push も検出する" \
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+run_post "false || git push"
+assert_eq "OR 連結後の git push も検出する" \
+  "$MAIN_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+run_post "cd '$REPO_WORKTREE' && git stash push -m x"
+assert_marker_absent "cd 先の git stash push は除外する"
+
+run_post "git submodule foreach git push"
+assert_marker_absent "git submodule 内の push は除外する"
+
+run_post "git push --dry-run" "$REPO_MAIN"
+assert_marker_absent "git push --dry-run はマーカーを書かない"
+
+run_post "git push -n" "$REPO_MAIN"
+assert_marker_absent "git push -n はマーカーを書かない"
+
+run_post "cd ~/tilde-repo && git push"
+assert_eq "クォートなしの ~ を展開して cd 先の HEAD を記録する" \
+  "$TILDE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+run_post "cd '$REPO_WORKTREE' && git push" "$REPO_MAIN"
+assert_eq "stdin の cwd をコマンド中の cd より優先する" \
+  "$MAIN_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+echo ""
+echo "=== pre-bash-guard: マーカー SHA 照合 ==="
+
+printf '%s\n' "$WORKTREE_HEAD" > "$MARKER"
+COMMENT_INPUT=$(jq -n --arg command "cd '$REPO_WORKTREE' && gh pr comment 1 --body ok" \
+  '{tool_input: {command: $command}}')
+(cd "$REPO_MAIN" && printf '%s\n' "$COMMENT_INPUT" | \
+  CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$PRE_HOOK" >/dev/null 2>&1)
+assert_eq "コメント時も cd 先の HEAD とマーカーを照合する" "0" "$?"
+
+printf '%s\n' "$MAIN_HEAD" > "$MARKER"
+set +e
+(cd "$REPO_MAIN" && printf '%s\n' "$COMMENT_INPUT" | \
+  CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$PRE_HOOK" >/dev/null 2>&1)
+MISMATCH_STATUS=$?
+set -e
+assert_eq "cd 先と異なる SHA のマーカーはブロックする" "2" "$MISMATCH_STATUS"
+
+echo ""
+echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"
+[ "$FAILURES" -eq 0 ]

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -131,6 +131,22 @@ assert_marker_absent "cd 先の git stash push は除外する"
 run_post "git submodule foreach git push"
 assert_marker_absent "git submodule 内の push は除外する"
 
+run_post "git -C '$REPO_WORKTREE' stash push -m x"
+assert_marker_absent "git -C <dir> stash push は除外する"
+
+run_post "git -c core.pager=cat --no-pager stash push -m x"
+assert_marker_absent "複数のグローバルオプション後の stash push は除外する"
+
+run_post "git --git-dir '$REPO_MAIN/.git' submodule foreach git push"
+assert_marker_absent "値が分離した --git-dir 後の submodule は除外する"
+
+run_post "git --work-tree='$REPO_MAIN' --exec-path=/tmp submodule foreach git push"
+assert_marker_absent "値が結合したグローバルオプション後の submodule は除外する"
+
+run_post "git -C '$REPO_WORKTREE' push"
+assert_eq "グローバルオプション後の git push は検出する" \
+  "$MAIN_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
 run_post "git push --dry-run" "$REPO_MAIN"
 assert_marker_absent "git push --dry-run はマーカーを書かない"
 

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -54,11 +54,14 @@ trap 'rm -rf "$TMP_TEST_DIR"' EXIT
 HOOK_PROJECT="$TMP_TEST_DIR/hook-project"
 REPO_MAIN="$TMP_TEST_DIR/main-repo"
 REPO_WORKTREE="$TMP_TEST_DIR/work tree"
+REPO_WITHOUT_HEAD="$TMP_TEST_DIR/repo-without-head"
 TEST_HOME="$TMP_TEST_DIR/home"
 REPO_TILDE="$TEST_HOME/tilde-repo"
 MARKER="$HOOK_PROJECT/.claude/push-completed.marker"
+POST_STDERR="$TMP_TEST_DIR/post.stderr"
 
-mkdir -p "$HOOK_PROJECT/.claude/hooks" "$REPO_MAIN" "$REPO_WORKTREE" "$REPO_TILDE"
+mkdir -p "$HOOK_PROJECT/.claude/hooks" "$REPO_MAIN" "$REPO_WORKTREE" \
+  "$REPO_WITHOUT_HEAD" "$REPO_TILDE"
 
 # post hook のマーカー書き込み後の処理だけを無害な fixture に差し替える。
 printf '%s\n' \
@@ -85,6 +88,7 @@ init_repo() {
 init_repo "$REPO_MAIN" "main"
 init_repo "$REPO_WORKTREE" "worktree"
 init_repo "$REPO_TILDE" "tilde"
+git -C "$REPO_WITHOUT_HEAD" init -q
 
 MAIN_HEAD=$(git -C "$REPO_MAIN" rev-parse HEAD)
 WORKTREE_HEAD=$(git -C "$REPO_WORKTREE" rev-parse HEAD)
@@ -103,8 +107,13 @@ run_post() {
     input=$(jq -n --arg command "$command" '{tool_input: {command: $command}}')
   fi
 
-  (cd "$REPO_MAIN" && printf '%s\n' "$input" | \
-    HOME="$TEST_HOME" CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$POST_HOOK" >/dev/null)
+  if POST_OUTPUT=$(cd "$REPO_MAIN" && printf '%s\n' "$input" | \
+    HOME="$TEST_HOME" CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$POST_HOOK" \
+    2>"$POST_STDERR"); then
+    POST_STATUS=0
+  else
+    POST_STATUS=$?
+  fi
 }
 
 echo "=== post-push-monitor: push 検出と SHA ==="
@@ -174,6 +183,13 @@ assert_eq "存在しない cd 先は採用せず stdin の cwd に戻る" \
 run_post "git push" "$TMP_TEST_DIR/missing-cwd"
 assert_eq "存在しない stdin の cwd は採用せず hook の cwd に戻る" \
   "$MAIN_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+run_post "git push" "$REPO_WITHOUT_HEAD"
+assert_marker_absent "HEAD を解決できない場合はマーカーを書かない"
+assert_eq "HEAD を解決できなくても post hook は正常終了する" \
+  "0" "$POST_STATUS"
+assert_eq "HEAD を解決できなくても監視の起動 JSON を出力する" \
+  "PostToolUse" "$(printf '%s\n' "$POST_OUTPUT" | jq -r '.hookSpecificOutput.hookEventName // ""' 2>/dev/null)"
 
 echo ""
 echo "=== pre-bash-guard: マーカー SHA 照合 ==="

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -142,7 +142,21 @@ assert_eq "クォートなしの ~ を展開して cd 先の HEAD を記録す�
   "$TILDE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
 
 run_post "cd '$REPO_WORKTREE' && git push" "$REPO_MAIN"
-assert_eq "stdin の cwd をコマンド中の cd より優先する" \
+assert_eq "stdin の cwd が main でもコマンド中の cd を優先する" \
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+assert_eq "マーカーの2行目に push したリポジトリを記録する" \
+  "$REPO_WORKTREE" "$(sed -n '2p' "$MARKER" 2>/dev/null)"
+
+run_post "git push" "$REPO_WORKTREE"
+assert_eq "コマンド中に cd がなければ stdin の cwd を使う" \
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+run_post "cd '$TMP_TEST_DIR/missing-repo' && git push" "$REPO_MAIN"
+assert_eq "存在しない cd 先は採用せず stdin の cwd に戻る" \
+  "$MAIN_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+
+run_post "git push" "$TMP_TEST_DIR/missing-cwd"
+assert_eq "存在しない stdin の cwd は採用せず hook の cwd に戻る" \
   "$MAIN_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
 
 echo ""
@@ -153,7 +167,7 @@ COMMENT_INPUT=$(jq -n --arg command "cd '$REPO_WORKTREE' && gh pr comment 1 --bo
   '{tool_input: {command: $command}}')
 (cd "$REPO_MAIN" && printf '%s\n' "$COMMENT_INPUT" | \
   CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$PRE_HOOK" >/dev/null 2>&1)
-assert_eq "コメント時も cd 先の HEAD とマーカーを照合する" "0" "$?"
+assert_eq "2行目がない旧形式でも cd 先の HEAD と照合する" "0" "$?"
 
 printf '%s\n' "$MAIN_HEAD" > "$MARKER"
 set +e
@@ -162,6 +176,21 @@ set +e
 MISMATCH_STATUS=$?
 set -e
 assert_eq "cd 先と異なる SHA のマーカーはブロックする" "2" "$MISMATCH_STATUS"
+
+printf '%s\n%s\n' "$WORKTREE_HEAD" "$REPO_WORKTREE" > "$MARKER"
+COMMENT_WITHOUT_CD_INPUT=$(jq -n --arg command "gh pr comment 1 --body ok" \
+  --arg cwd "$REPO_MAIN" '{cwd: $cwd, tool_input: {command: $command}}')
+(cd "$REPO_MAIN" && printf '%s\n' "$COMMENT_WITHOUT_CD_INPUT" | \
+  CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$PRE_HOOK" >/dev/null 2>&1)
+assert_eq "返信コマンドに cd がなくてもマーカーのリポジトリで照合する" "0" "$?"
+
+printf '%s\n%s\n' "$WORKTREE_HEAD" "$TMP_TEST_DIR/deleted-repo" > "$MARKER"
+set +e
+(cd "$REPO_MAIN" && printf '%s\n' "$COMMENT_WITHOUT_CD_INPUT" | \
+  CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$PRE_HOOK" >/dev/null 2>&1)
+HEAD_FAILURE_STATUS=$?
+set -e
+assert_eq "照合先で git rev-parse が失敗したらブロックする" "2" "$HEAD_FAILURE_STATUS"
 
 echo ""
 echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"


### PR DESCRIPTION
Closes #315

worktree で作業している PR に対して、CodeRabbit への返信が**常にブロックされる**問題を直す。

## 何が起きていたか

```
BLOCKED: pushマーカーが古くなっています（211191秒前、有効期限60秒）
```

`/flow` も `/flow-x` も worktree を作って作業する設計なので、**この 2 つの skill を使う限り CodeRabbit 返信は構造的に不可能**だった。CLAUDE.md の「CodeRabbit のコメントには対応済み・不要問わず必ず返信すること」を満たせない状態が続いていた。

## 原因 1: push 検出がコマンド先頭に固定されていた

`post-push-monitor.sh` の検出は `^[[:space:]]*git[[:space:]]+...push` で、コマンドが `git` で**始まる**ことを要求していた。Bash ツールは呼び出しごとに cwd をプロジェクトディレクトリへ戻すため、worktree で push するには `cd <worktree> && git push` と書くしかなく、この形は一致しない。結果 `IS_GIT_PUSH=false` になり、**マーカーが一度も更新されない**。実測でマーカーは 58 時間前の SHA のまま残っていた。

**修正**: クォート境界を尊重してコマンドを `&&` / `||` / `;` で分割し、**いずれかのセグメントが `git ... push`** なら push とみなす。コマンド文字列は eval しない。除外（`git stash push` / `git submodule ... push` / `--dry-run`）もセグメント単位で判定する。

## 原因 2: SHA を取るリポジトリが不定だった

マーカーを書く側も照合する側も `git rev-parse HEAD` を hook の cwd で実行しており、worktree で push しても記録・照合されるのは main の HEAD になり得た。原因 1 だけ直すと「main の HEAD 同士を比べるだけ」になり、**ガードが何も検証しなくなる**。

**修正**: push が実行されたディレクトリを解決し、そこで SHA を取る。解決の優先順位は

1. **コマンド中の有効な `cd`**（実際に push が走った場所）
2. hook 入力の `cwd`
3. hook 自身の cwd

各段で存在を検証し、ディレクトリでなければ次の段へ落とす。

**hook 入力の `cwd` は `cd` より優先しない。** 実測すると `.cwd` はセッションのディレクトリであり、コマンド内の `cd` を反映しない:

```
cwd     = .../claude-code-manager
command = cd .../ark-fix-push-marker && git status --short | head -1; echo probe
```

これを最優先にすると `cd` の解析が到達しないコードになり、原因 2 が形を変えて残る。

## 照合側が push のリポジトリを再現できない問題

`pre-bash-guard.sh` は**返信コマンド**（`gh api ... replies` 等）から照合先を解決する。返信コマンドに `cd` が付いていなければ main に落ちるため、マーカーが worktree の HEAD を持っていると必ず不一致になる。「返信のたびに `cd <worktree> &&` を付ける」運用に依存させたくない。

**修正**: マーカーの 1 行目に SHA、**2 行目に push 対象リポジトリのディレクトリ**を書き、照合側はそれを読んで `git -C <dir> rev-parse HEAD` する。2 行目が無い旧形式のマーカーは従来どおりコマンドから解決する（後方互換）。

## fail-open の是正

```bash
CURRENT_HEAD=$(git -C "$TARGET_REPO_DIR" rev-parse HEAD 2>/dev/null) || CURRENT_HEAD=""
if [ -n "$CURRENT_HEAD" ] && [ "$MARKER_HEAD" != "$CURRENT_HEAD" ]; then
```

`git -C` が失敗すると `CURRENT_HEAD` が空になり、**SHA 照合ごと飛ばして返信が通っていた**。ディレクトリが消えている・git リポジトリでない場合に素通しになる。SHA を決定できない場合は**ブロックする**（マーカー不在・読み取り失敗が既にブロックしているのと揃える）。

## 変えていないもの

60 秒の有効期限 / SHA 一致の要求 / マーカー不在時のブロック / 先送り表現の検出 / PR 作成ガードのフラグ手動作成禁止 / 危険コマンドのブロック群（`rm -rf`・`git reset --hard`・`git clean -f`・`--force`・`--no-verify`・`chmod 777`・`resolveReviewThread` 等）。

## 検証

`.claude/hooks/tests/test-push-marker.sh` を新設し 18 件。`pnpm check` / `pnpm test`（1036 件）も green。

加えて**実スクリプトに hook 入力を流して往復を確認**した。

- worktree での push を模擬 → マーカーに **worktree の SHA とディレクトリ**が記録される
- **`cd` 無しの返信コマンドが通る**（塞がっていた本体）
- worktree に新しいコミットを積むと `BLOCKED: push後に新しいコミットが追加されています`（保証は維持）
- マーカーの参照先が存在しないと `BLOCKED: pushしたリポジトリのHEADを確認できません`（fail-closed）

## 別途見つけたもの（この PR では直さない）

PR 作成ガードは、コマンド文字列にフラグ名が**含まれている**だけで発火する。そのため、このフラグについて**説明を書いただけ**の `gh pr create --body` すらブロックされる（この PR 本文がまさにそれで、ヒアドキュメントでは push できなかった）。マーカー名に言及することと作成することを区別できていないが、安全側の誤検知なので別途扱う。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Git push の検出精度を向上しました。
  * 複数の作業ディレクトリや `cd` を含むコマンドでも、対象リポジトリを正しく判定できるようになりました。
  * push 後のコメント・返信操作で、対象リポジトリと HEAD の不一致をより確実に検出します。

* **バグ修正**
  * 対象リポジトリを特定できない場合や Git リポジトリでない場合に、誤って操作を許可する問題を修正しました。

* **テスト**
  * push 検出、リポジトリ判定、マーカー処理、除外条件の回帰テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->