### PR TITLE
fix(diagram): 手書き投影の data-kind とモデルの kind の不一致を配信時に検出する

### DIFF
--- a/packages/server/src/lib/diagram-doc-anchors.test.ts
+++ b/packages/server/src/lib/diagram-doc-anchors.test.ts
@@ -68,6 +68,35 @@ describe("validateDiagramDocAnchors", () => {
     expect(validateDiagramDocAnchors(html, model("doc"))).toEqual({ ok: true });
   });
 
+  it("data-ark-id の数値文字参照をデコードして node と照合する", () => {
+    const html =
+      '<section data-ark-id="&#X73;1"><p data-ark-id="s1-p1"></p><div data-ark-id="s1-t1-r1"></div></section>';
+
+    expect(validateDiagramDocAnchors(html, model("doc"))).toEqual({ ok: true });
+  });
+
+  it("script 内の </scriptx> を raw-text の終端として扱わない", () => {
+    const html = `
+      <section data-ark-id="s1">
+        <p data-ark-id="s1-p1"></p>
+        <div data-ark-id="s1-t1-r1"></div>
+        <script>
+          const marker = "</scriptx>";
+          const sample = '<i data-ark-id="unknown">';
+        </script>
+      </section>
+    `;
+
+    expect(validateDiagramDocAnchors(html, model("doc"))).toEqual({ ok: true });
+  });
+
+  it("空白が続く </style x> を raw-text の終端として扱う", () => {
+    const html =
+      '<style>.sample { color: red; }</style x><section data-ark-id="s1"><p data-ark-id="s1-p1"></p><div data-ark-id="s1-t1-r1"></div></section>';
+
+    expect(validateDiagramDocAnchors(html, model("doc"))).toEqual({ ok: true });
+  });
+
   it("別の属性値に含まれる data-ark-id を anchor と数えない", () => {
     const emptyModel = { ...model("doc"), nodes: [] };
 

--- a/packages/server/src/lib/diagram-doc-anchors.ts
+++ b/packages/server/src/lib/diagram-doc-anchors.ts
@@ -1,3 +1,7 @@
+import {
+  type DiagramHtmlAttribute,
+  scanDiagramHtmlStartTags,
+} from "./diagram-html-scan.js";
 import type { DiagramModel } from "./diagram-model.js";
 
 export type DiagramDocAnchorValidation =
@@ -6,84 +10,18 @@ export type DiagramDocAnchorValidation =
 
 const ATTRIBUTE_NAME = "data-ark-id";
 
-function tagEnd(html: string, start: number): number {
-  let quote: '"' | "'" | null = null;
-  for (let index = start; index < html.length; index += 1) {
-    const char = html[index];
-    if (quote !== null) {
-      if (char === quote) quote = null;
-      continue;
-    }
-    if (char === '"' || char === "'") quote = char;
-    else if (char === ">") return index;
-  }
-  return html.length - 1;
-}
-
-function attributeValues(tag: string): string[] {
+function attributeValues(attributes: DiagramHtmlAttribute[]): string[] {
   const values: string[] = [];
-  let index = tag.match(/^[^\s/>]+/u)?.[0].length ?? 0;
-  while (index < tag.length) {
-    while (/\s/u.test(tag[index] ?? "")) index += 1;
-    if (index >= tag.length || tag[index] === "/") break;
-    const name = tag.slice(index).match(/^[^\s"'=<>`/]+/u)?.[0];
-    if (name === undefined) {
-      index += 1;
-      continue;
-    }
-    index += name.length;
-    while (/\s/u.test(tag[index] ?? "")) index += 1;
-    let value = "";
-    if (tag[index] === "=") {
-      index += 1;
-      while (/\s/u.test(tag[index] ?? "")) index += 1;
-      const quote = tag[index];
-      if (quote === '"' || quote === "'") {
-        const end = tag.indexOf(quote, index + 1);
-        if (end < 0) {
-          index = tag.length;
-        } else {
-          value = tag.slice(index + 1, end);
-          index = end + 1;
-        }
-      } else {
-        value = tag.slice(index).match(/^[^\s"'=<>`]+/u)?.[0] ?? "";
-        index += value.length;
-      }
-    }
-    if (name.toLowerCase() === ATTRIBUTE_NAME) values.push(value);
+  for (const attribute of attributes) {
+    if (attribute.name === ATTRIBUTE_NAME) values.push(attribute.value);
   }
   return values;
 }
 
 function extractAnchorIds(html: string): string[] {
   const ids: string[] = [];
-  const lower = html.toLowerCase();
-  let index = 0;
-  while (index < html.length) {
-    const open = html.indexOf("<", index);
-    if (open < 0) break;
-    if (html.startsWith("<!--", open)) {
-      const end = html.indexOf("-->", open + 4);
-      index = end < 0 ? html.length : end + 3;
-      continue;
-    }
-    const name = html.slice(open + 1).match(/^([a-z][\w:-]*)/iu)?.[1];
-    if (name === undefined) {
-      index = open + 1;
-      continue;
-    }
-    const end = tagEnd(html, open + 1);
-    const normalizedName = name.toLowerCase();
-    if (normalizedName === "script" || normalizedName === "style") {
-      const close = lower.indexOf(`</${normalizedName}`, end + 1);
-      if (close < 0) break;
-      const closeEnd = html.indexOf(">", close + normalizedName.length + 2);
-      index = closeEnd < 0 ? html.length : closeEnd + 1;
-      continue;
-    }
-    ids.push(...attributeValues(html.slice(open + 1, end)));
-    index = end + 1;
+  for (const tag of scanDiagramHtmlStartTags(html)) {
+    ids.push(...attributeValues(tag.attributes));
   }
   return ids;
 }

--- a/packages/server/src/lib/diagram-graph-kinds.test.ts
+++ b/packages/server/src/lib/diagram-graph-kinds.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { validateDiagramGraphKinds } from "./diagram-graph-kinds.js";
+import type { DiagramModel } from "./diagram-model.js";
+
+function model(): DiagramModel {
+  return {
+    version: 1,
+    nodes: [
+      { id: "x", label: "X", kind: "b" },
+      { id: "without-kind", label: "Kind 未定義" },
+    ],
+    edges: [],
+    groups: [],
+  };
+}
+
+describe("validateDiagramGraphKinds", () => {
+  it("投影の data-kind が model の node.kind と異なる場合は違反にする", () => {
+    const result = validateDiagramGraphKinds(
+      '<article data-model-id="x" data-kind="a">X</article>',
+      model()
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("同じ node の複数投影のうち片方だけ異なる場合も違反にする", () => {
+    const result = validateDiagramGraphKinds(
+      '<article data-model-id="x" data-kind="b"><h2 data-model-id="x" data-kind="a">X</h2></article>',
+      model()
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("data-kind を持たない data-model-id 要素は違反にしない", () => {
+    expect(
+      validateDiagramGraphKinds('<li data-model-id="x">field</li>', model())
+    ).toEqual({ ok: true });
+  });
+
+  it("node として解決できない data-model-id は違反にしない", () => {
+    const html =
+      '<path data-model-id="edge-1" data-kind="edge"></path>' +
+      '<li data-model-id="x--f1" data-kind="field"></li>' +
+      '<i data-model-id="unknown" data-kind="mystery"></i>';
+
+    expect(validateDiagramGraphKinds(html, model())).toEqual({ ok: true });
+  });
+
+  it("node.kind が未定義の要素は違反にしない", () => {
+    expect(
+      validateDiagramGraphKinds(
+        '<article data-model-id="without-kind" data-kind="note"></article>',
+        model()
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it("すべての data-kind が node.kind と一致する図は成功する", () => {
+    const html =
+      '<article data-model-id="x" data-kind="b">' +
+      '<h2 data-model-id="x" data-kind="b">X</h2>' +
+      '<li data-model-id="x--f1">field</li></article>';
+
+    expect(validateDiagramGraphKinds(html, model())).toEqual({ ok: true });
+  });
+
+  it("エラーに node id と model・投影両側の値を含める", () => {
+    const result = validateDiagramGraphKinds(
+      '<article data-model-id="x" data-kind="a">X</article>',
+      model()
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("x");
+      expect(result.error).toContain("a");
+      expect(result.error).toContain("b");
+      expect(result.error).toContain("model");
+      expect(result.error).toContain("投影");
+    }
+  });
+});

--- a/packages/server/src/lib/diagram-graph-kinds.test.ts
+++ b/packages/server/src/lib/diagram-graph-kinds.test.ts
@@ -81,4 +81,21 @@ describe("validateDiagramGraphKinds", () => {
       expect(result.error).toContain("投影");
     }
   });
+
+  it("不一致が複数ある場合は最初の数件と総数を示す", () => {
+    const html = Array.from(
+      { length: 6 },
+      (_, index) => `<i data-model-id="x" data-kind="a${index + 1}"></i>`
+    ).join("");
+
+    const result = validateDiagramGraphKinds(html, model());
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("6件");
+      expect(result.error).toContain('data-kind="a1"');
+      expect(result.error).toContain('data-kind="a5"');
+      expect(result.error).not.toContain('data-kind="a6"');
+    }
+  });
 });

--- a/packages/server/src/lib/diagram-graph-kinds.test.ts
+++ b/packages/server/src/lib/diagram-graph-kinds.test.ts
@@ -66,6 +66,44 @@ describe("validateDiagramGraphKinds", () => {
     expect(validateDiagramGraphKinds(html, model())).toEqual({ ok: true });
   });
 
+  it("data-model-id の数値文字参照をデコードして node と照合する", () => {
+    const result = validateDiagramGraphKinds(
+      '<article data-model-id="&#x78;" data-kind="a">X</article>',
+      model()
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
+  it("data-kind の数値文字参照をデコードして kind と照合する", () => {
+    expect(
+      validateDiagramGraphKinds(
+        '<article data-model-id="x" data-kind="&#98;">X</article>',
+        model()
+      )
+    ).toEqual({ ok: true });
+  });
+
+  it("script 内の </scriptx> を raw-text の終端として扱わない", () => {
+    const html = `
+      <script>
+        const marker = "</scriptx>";
+        const sample = '<i data-model-id="x" data-kind="a">';
+      </script>
+    `;
+
+    expect(validateDiagramGraphKinds(html, model())).toEqual({ ok: true });
+  });
+
+  it("空白が続く </style x> を raw-text の終端として扱う", () => {
+    const result = validateDiagramGraphKinds(
+      '<style>.sample { color: red; }</style x><i data-model-id="x" data-kind="a"></i>',
+      model()
+    );
+
+    expect(result.ok).toBe(false);
+  });
+
   it("エラーに node id と model・投影両側の値を含める", () => {
     const result = validateDiagramGraphKinds(
       '<article data-model-id="x" data-kind="a">X</article>',

--- a/packages/server/src/lib/diagram-graph-kinds.ts
+++ b/packages/server/src/lib/diagram-graph-kinds.ts
@@ -1,0 +1,143 @@
+import type { DiagramModel } from "./diagram-model.js";
+
+export type DiagramGraphKindValidation =
+  | { ok: true }
+  | { ok: false; error: string };
+
+const MODEL_ID_ATTRIBUTE = "data-model-id";
+const KIND_ATTRIBUTE = "data-kind";
+const MAX_REPORTED_MISMATCHES = 5;
+
+interface ProjectionKind {
+  modelId: string;
+  kind: string;
+}
+
+function tagEnd(html: string, start: number): number {
+  let quote: '"' | "'" | null = null;
+  for (let index = start; index < html.length; index += 1) {
+    const char = html[index];
+    if (quote !== null) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    else if (char === ">") return index;
+  }
+  return html.length - 1;
+}
+
+function projectionKind(tag: string): ProjectionKind | null {
+  let modelId: string | undefined;
+  let kind: string | undefined;
+  let index = tag.match(/^[^\s/>]+/u)?.[0].length ?? 0;
+  while (index < tag.length) {
+    while (/\s/u.test(tag[index] ?? "")) index += 1;
+    if (index >= tag.length || tag[index] === "/") break;
+    const name = tag.slice(index).match(/^[^\s"'=<>`/]+/u)?.[0];
+    if (name === undefined) {
+      index += 1;
+      continue;
+    }
+    index += name.length;
+    while (/\s/u.test(tag[index] ?? "")) index += 1;
+    let value = "";
+    if (tag[index] === "=") {
+      index += 1;
+      while (/\s/u.test(tag[index] ?? "")) index += 1;
+      const quote = tag[index];
+      if (quote === '"' || quote === "'") {
+        const end = tag.indexOf(quote, index + 1);
+        if (end < 0) {
+          index = tag.length;
+        } else {
+          value = tag.slice(index + 1, end);
+          index = end + 1;
+        }
+      } else {
+        value = tag.slice(index).match(/^[^\s"'=<>`]+/u)?.[0] ?? "";
+        index += value.length;
+      }
+    }
+    const normalizedName = name.toLowerCase();
+    if (normalizedName === MODEL_ID_ATTRIBUTE && modelId === undefined) {
+      modelId = value;
+    } else if (normalizedName === KIND_ATTRIBUTE && kind === undefined) {
+      kind = value;
+    }
+  }
+  return modelId === undefined || kind === undefined ? null : { modelId, kind };
+}
+
+function extractProjectionKinds(html: string): ProjectionKind[] {
+  const projections: ProjectionKind[] = [];
+  const lower = html.toLowerCase();
+  let index = 0;
+  while (index < html.length) {
+    const open = html.indexOf("<", index);
+    if (open < 0) break;
+    if (html.startsWith("<!--", open)) {
+      const end = html.indexOf("-->", open + 4);
+      index = end < 0 ? html.length : end + 3;
+      continue;
+    }
+    const name = html.slice(open + 1).match(/^([a-z][\w:-]*)/iu)?.[1];
+    if (name === undefined) {
+      index = open + 1;
+      continue;
+    }
+    const end = tagEnd(html, open + 1);
+    const normalizedName = name.toLowerCase();
+    if (normalizedName === "script" || normalizedName === "style") {
+      const close = lower.indexOf(`</${normalizedName}`, end + 1);
+      if (close < 0) break;
+      const closeEnd = html.indexOf(">", close + normalizedName.length + 2);
+      index = closeEnd < 0 ? html.length : closeEnd + 1;
+      continue;
+    }
+    const projection = projectionKind(html.slice(open + 1, end));
+    if (projection !== null) projections.push(projection);
+    index = end + 1;
+  }
+  return projections;
+}
+
+/** model node の kind と手書き graph 投影の data-kind が同期していることを検証する。 */
+export function validateDiagramGraphKinds(
+  html: string,
+  model: DiagramModel
+): DiagramGraphKindValidation {
+  const nodeKinds = new Map(
+    model.nodes
+      .filter(node => node.kind !== undefined)
+      .map(node => [node.id, node.kind] as const)
+  );
+  const mismatches: Array<{
+    nodeId: string;
+    modelKind: string;
+    projectionKind: string;
+  }> = [];
+
+  for (const projection of extractProjectionKinds(html)) {
+    const modelKind = nodeKinds.get(projection.modelId);
+    if (modelKind === undefined || modelKind === projection.kind) continue;
+    mismatches.push({
+      nodeId: projection.modelId,
+      modelKind,
+      projectionKind: projection.kind,
+    });
+  }
+
+  if (mismatches.length === 0) return { ok: true };
+  const details = mismatches
+    .slice(0, MAX_REPORTED_MISMATCHES)
+    .map(
+      mismatch =>
+        `node ${mismatch.nodeId}: model の kind="${mismatch.modelKind}", 投影の data-kind="${mismatch.projectionKind}"`
+    )
+    .join("; ");
+  return {
+    ok: false,
+    error: `graph 投影の data-kind が model の node.kind と同期されていません（${mismatches.length}件）: ${details}`,
+  };
+}

--- a/packages/server/src/lib/diagram-graph-kinds.ts
+++ b/packages/server/src/lib/diagram-graph-kinds.ts
@@ -1,3 +1,7 @@
+import {
+  type DiagramHtmlAttribute,
+  scanDiagramHtmlStartTags,
+} from "./diagram-html-scan.js";
 import type { DiagramModel } from "./diagram-model.js";
 
 export type DiagramGraphKindValidation =
@@ -13,57 +17,16 @@ interface ProjectionKind {
   kind: string;
 }
 
-function tagEnd(html: string, start: number): number {
-  let quote: '"' | "'" | null = null;
-  for (let index = start; index < html.length; index += 1) {
-    const char = html[index];
-    if (quote !== null) {
-      if (char === quote) quote = null;
-      continue;
-    }
-    if (char === '"' || char === "'") quote = char;
-    else if (char === ">") return index;
-  }
-  return html.length - 1;
-}
-
-function projectionKind(tag: string): ProjectionKind | null {
+function projectionKind(
+  attributes: DiagramHtmlAttribute[]
+): ProjectionKind | null {
   let modelId: string | undefined;
   let kind: string | undefined;
-  let index = tag.match(/^[^\s/>]+/u)?.[0].length ?? 0;
-  while (index < tag.length) {
-    while (/\s/u.test(tag[index] ?? "")) index += 1;
-    if (index >= tag.length || tag[index] === "/") break;
-    const name = tag.slice(index).match(/^[^\s"'=<>`/]+/u)?.[0];
-    if (name === undefined) {
-      index += 1;
-      continue;
-    }
-    index += name.length;
-    while (/\s/u.test(tag[index] ?? "")) index += 1;
-    let value = "";
-    if (tag[index] === "=") {
-      index += 1;
-      while (/\s/u.test(tag[index] ?? "")) index += 1;
-      const quote = tag[index];
-      if (quote === '"' || quote === "'") {
-        const end = tag.indexOf(quote, index + 1);
-        if (end < 0) {
-          index = tag.length;
-        } else {
-          value = tag.slice(index + 1, end);
-          index = end + 1;
-        }
-      } else {
-        value = tag.slice(index).match(/^[^\s"'=<>`]+/u)?.[0] ?? "";
-        index += value.length;
-      }
-    }
-    const normalizedName = name.toLowerCase();
-    if (normalizedName === MODEL_ID_ATTRIBUTE && modelId === undefined) {
-      modelId = value;
-    } else if (normalizedName === KIND_ATTRIBUTE && kind === undefined) {
-      kind = value;
+  for (const attribute of attributes) {
+    if (attribute.name === MODEL_ID_ATTRIBUTE && modelId === undefined) {
+      modelId = attribute.value;
+    } else if (attribute.name === KIND_ATTRIBUTE && kind === undefined) {
+      kind = attribute.value;
     }
   }
   return modelId === undefined || kind === undefined ? null : { modelId, kind };
@@ -71,33 +34,9 @@ function projectionKind(tag: string): ProjectionKind | null {
 
 function extractProjectionKinds(html: string): ProjectionKind[] {
   const projections: ProjectionKind[] = [];
-  const lower = html.toLowerCase();
-  let index = 0;
-  while (index < html.length) {
-    const open = html.indexOf("<", index);
-    if (open < 0) break;
-    if (html.startsWith("<!--", open)) {
-      const end = html.indexOf("-->", open + 4);
-      index = end < 0 ? html.length : end + 3;
-      continue;
-    }
-    const name = html.slice(open + 1).match(/^([a-z][\w:-]*)/iu)?.[1];
-    if (name === undefined) {
-      index = open + 1;
-      continue;
-    }
-    const end = tagEnd(html, open + 1);
-    const normalizedName = name.toLowerCase();
-    if (normalizedName === "script" || normalizedName === "style") {
-      const close = lower.indexOf(`</${normalizedName}`, end + 1);
-      if (close < 0) break;
-      const closeEnd = html.indexOf(">", close + normalizedName.length + 2);
-      index = closeEnd < 0 ? html.length : closeEnd + 1;
-      continue;
-    }
-    const projection = projectionKind(html.slice(open + 1, end));
+  for (const tag of scanDiagramHtmlStartTags(html)) {
+    const projection = projectionKind(tag.attributes);
     if (projection !== null) projections.push(projection);
-    index = end + 1;
   }
   return projections;
 }

--- a/packages/server/src/lib/diagram-html-scan.test.ts
+++ b/packages/server/src/lib/diagram-html-scan.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { scanDiagramHtmlStartTags } from "./diagram-html-scan.js";
+
+describe("scanDiagramHtmlStartTags", () => {
+  it("数値文字参照と対応対象の名前付き文字参照をデコードする", () => {
+    const [tag] = scanDiagramHtmlStartTags(
+      '<DIV data-value="&#97;&#x62;&#X43;&amp;&lt;&gt;&quot;&apos;&nbsp;&copy;" data-plain=unquoted>'
+    );
+
+    expect(tag).toEqual({
+      name: "div",
+      attributes: [
+        { name: "data-value", value: "abC&<>\"'\u00a0&copy;" },
+        { name: "data-plain", value: "unquoted" },
+      ],
+    });
+  });
+});

--- a/packages/server/src/lib/diagram-html-scan.ts
+++ b/packages/server/src/lib/diagram-html-scan.ts
@@ -1,0 +1,157 @@
+export interface DiagramHtmlAttribute {
+  name: string;
+  value: string;
+}
+
+export interface DiagramHtmlStartTag {
+  name: string;
+  attributes: DiagramHtmlAttribute[];
+}
+
+const NAMED_CHARACTER_REFERENCES: Readonly<Record<string, string>> = {
+  amp: "&",
+  apos: "'",
+  gt: ">",
+  lt: "<",
+  nbsp: "\u00a0",
+  quot: '"',
+};
+
+function decodeCharacterReferences(value: string): string {
+  return value.replace(
+    /&(?:#([0-9]+);|#[xX]([0-9a-fA-F]+);|(amp|lt|gt|quot|apos|nbsp);)/gu,
+    (
+      reference,
+      decimal: string | undefined,
+      hex: string | undefined,
+      named: string | undefined
+    ) => {
+      if (named !== undefined) return NAMED_CHARACTER_REFERENCES[named];
+      const digits = decimal ?? hex;
+      if (digits === undefined) return reference;
+      const codePoint = Number.parseInt(digits, hex === undefined ? 10 : 16);
+      if (
+        codePoint === 0 ||
+        codePoint > 0x10ffff ||
+        (codePoint >= 0xd800 && codePoint <= 0xdfff)
+      ) {
+        return "\ufffd";
+      }
+      return String.fromCodePoint(codePoint);
+    }
+  );
+}
+
+function tagEnd(html: string, start: number): number {
+  let quote: '"' | "'" | null = null;
+  for (let index = start; index < html.length; index += 1) {
+    const char = html[index];
+    if (quote !== null) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    else if (char === ">") return index;
+  }
+  return html.length - 1;
+}
+
+function attributes(tag: string): DiagramHtmlAttribute[] {
+  const result: DiagramHtmlAttribute[] = [];
+  let index = tag.match(/^[^\s/>]+/u)?.[0].length ?? 0;
+  while (index < tag.length) {
+    while (/\s/u.test(tag[index] ?? "")) index += 1;
+    if (index >= tag.length || tag[index] === "/") break;
+    const name = tag.slice(index).match(/^[^\s"'=<>`/]+/u)?.[0];
+    if (name === undefined) {
+      index += 1;
+      continue;
+    }
+    index += name.length;
+    while (/\s/u.test(tag[index] ?? "")) index += 1;
+    let value = "";
+    if (tag[index] === "=") {
+      index += 1;
+      while (/\s/u.test(tag[index] ?? "")) index += 1;
+      const quote = tag[index];
+      if (quote === '"' || quote === "'") {
+        const end = tag.indexOf(quote, index + 1);
+        if (end < 0) {
+          index = tag.length;
+        } else {
+          value = tag.slice(index + 1, end);
+          index = end + 1;
+        }
+      } else {
+        value = tag.slice(index).match(/^[^\s"'=<>`]+/u)?.[0] ?? "";
+        index += value.length;
+      }
+    }
+    result.push({
+      name: name.toLowerCase(),
+      value: decodeCharacterReferences(value),
+    });
+  }
+  return result;
+}
+
+function rawTextClose(
+  html: string,
+  lower: string,
+  start: number,
+  name: string
+): number {
+  const prefix = `</${name}`;
+  let index = start;
+  while (index < html.length) {
+    const close = lower.indexOf(prefix, index);
+    if (close < 0) return -1;
+    const boundary = html[close + prefix.length];
+    if (boundary === "/" || boundary === ">" || /\s/u.test(boundary ?? "")) {
+      return close;
+    }
+    index = close + prefix.length;
+  }
+  return -1;
+}
+
+/**
+ * lint に必要な開始タグと属性だけを走査する軽量 HTML スキャナ。
+ * 名前付き文字参照は指定された基本6種だけを対象とする。id・kind は
+ * kebab-case の識別子なので、巨大な完全実体表は持たない。未対応の実体は
+ * 入力のまま残す。
+ */
+export function scanDiagramHtmlStartTags(html: string): DiagramHtmlStartTag[] {
+  const tags: DiagramHtmlStartTag[] = [];
+  const lower = html.toLowerCase();
+  let index = 0;
+  while (index < html.length) {
+    const open = html.indexOf("<", index);
+    if (open < 0) break;
+    if (html.startsWith("<!--", open)) {
+      const end = html.indexOf("-->", open + 4);
+      index = end < 0 ? html.length : end + 3;
+      continue;
+    }
+    const name = html.slice(open + 1).match(/^([a-z][\w:-]*)/iu)?.[1];
+    if (name === undefined) {
+      index = open + 1;
+      continue;
+    }
+    const end = tagEnd(html, open + 1);
+    const normalizedName = name.toLowerCase();
+    if (normalizedName === "script" || normalizedName === "style") {
+      const close = rawTextClose(html, lower, end + 1, normalizedName);
+      if (close < 0) break;
+      const closeEnd = html.indexOf(">", close + normalizedName.length + 2);
+      index = closeEnd < 0 ? html.length : closeEnd + 1;
+      continue;
+    }
+    tags.push({
+      name: normalizedName,
+      attributes: attributes(html.slice(open + 1, end)),
+    });
+    index = end + 1;
+  }
+  return tags;
+}

--- a/packages/server/src/lib/diagram-reader.test.ts
+++ b/packages/server/src/lib/diagram-reader.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DIAGRAM_COMMENT_LAYER_MARKER } from "./diagram-comment-layer.js";
 import { DIAGRAM_CSP } from "./diagram-file.js";
 import { DIAGRAM_HARNESS_MARKER } from "./diagram-harness.js";
-import { readDiagram } from "./diagram-reader.js";
+import { readDiagram, readDiagramModel } from "./diagram-reader.js";
 
 let wt: string;
 let dir: string;
@@ -232,6 +232,50 @@ describe("readDiagram", () => {
       expect(result.html).toContain(DIAGRAM_CSP);
       expect(result.html).toContain(DIAGRAM_HARNESS_MARKER);
     }
+  });
+
+  it("投影 data-kind が model の node.kind と異なる graph は 422 で拒否する", async () => {
+    const kindModel = JSON.stringify({
+      version: 1,
+      nodes: [{ id: "command", label: "Command", kind: "command" }],
+      edges: [],
+      groups: [],
+    });
+    write(
+      "mismatched-kind.diagram.html",
+      '<article data-model-id="command" data-kind="event">Command</article>',
+      kindModel
+    );
+
+    const result = await readDiagram(wt, "mismatched-kind.diagram.html");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(422);
+      expect(result.error).toContain("command");
+    }
+  });
+
+  it("投影 data-kind が不一致でも readDiagramModel はモデルを返す", async () => {
+    const kindModel = JSON.stringify({
+      version: 1,
+      nodes: [{ id: "command", label: "Command", kind: "command" }],
+      edges: [],
+      groups: [],
+    });
+    write(
+      "mismatched-kind-model.diagram.html",
+      '<article data-model-id="command" data-kind="event">Command</article>',
+      kindModel
+    );
+
+    const result = await readDiagramModel(
+      wt,
+      "mismatched-kind-model.diagram.html"
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.model.nodes[0]?.kind).toBe("command");
   });
 
   it("存在しないファイルは 404 を返す", async () => {

--- a/packages/server/src/lib/diagram-reader.ts
+++ b/packages/server/src/lib/diagram-reader.ts
@@ -15,6 +15,7 @@ import { injectBuiltinProjection } from "./diagram-builtin.js";
 import { injectDiagramCommentLayer } from "./diagram-comment-layer.js";
 import { validateDiagramDocAnchors } from "./diagram-doc-anchors.js";
 import { extractModel, injectCsp } from "./diagram-file.js";
+import { validateDiagramGraphKinds } from "./diagram-graph-kinds.js";
 import { injectHarness } from "./diagram-harness.js";
 import type { DiagramModel } from "./diagram-model.js";
 import { DIAGRAM_DIR, resolveDiagramPath } from "./diagram-path.js";
@@ -115,6 +116,10 @@ export async function readDiagram(
   if (!model.ok) return { ok: false, status: 422, error: model.error };
   const anchors = validateDiagramDocAnchors(read.raw, model.model);
   if (!anchors.ok) return { ok: false, status: 422, error: anchors.error };
+  const graphKinds = validateDiagramGraphKinds(read.raw, model.model);
+  if (!graphKinds.ok) {
+    return { ok: false, status: 422, error: graphKinds.error };
+  }
   // 内蔵図種の投影生成 → CSP → 専用層の順。doc 本文は自前 HTML が正なので
   // 編集ハーネスを混ぜず、コメント層だけを載せる。
   const projected = injectCsp(injectBuiltinProjection(read.raw, model.model));


### PR DESCRIPTION
Closes #321

手書き投影の graph 図で、`node.kind` と投影の `data-kind` が食い違っていることを配信時に検出する。

## 何が問題だったか

手書き投影では `kind` を変えるのにモデルと投影の両方を同期させる必要があるが、**片側だけ直しても何も検出されなかった**。

ドッグフーディング中に実際に踏んだ。4 ノードの `kind` を変える作業で、1 ノードあたり 5 箇所（モデルの `kind` と `label`、`<article>` の `data-kind`、`<h2>` の `data-kind`、`<h2>` のテキスト）の編集が必要になり、モデル側の置換が書式に合わず失敗した。結果、**投影だけ更新されて `data-kind` の不一致が 8 箇所発生**した。自前の検証を書いていなければ「見た目は確定済み、モデルは未確定」というズレたファイルが残っていた。

規約（`.claude/skills/diagram-authoring/SKILL.md`）は「node の投影 root の `data-kind` は model の `node.kind` と同じ値にする」と定めており、ハーネスもモデル直接編集の反映時に同期する。**しかしファイルを直接編集する経路にはこの保護が無い。** Claude が図を書くとき、人間がエディタで直すときはハーネスを通らない。

## やったこと

`validateDiagramDocAnchors`（doc の anchor lint）と同じ流儀で `validateDiagramGraphKinds` を追加し、`readDiagram`（配信）から呼ぶ。違反は 422 で拒否する。

**`readDiagramModel` には入れない。** 後者に入れると違反ページが図の一覧から丸ごと消えるため（#300 で確定した方針と同じ）。

## 検証の範囲を絞った理由

`data-model-id` と `data-kind` を**両方持つ要素**だけを対象にし、値がモデルと食い違う場合のみ違反とする。

対象外にしたもの:

- `data-kind` を持たない `data-model-id` 要素（field の `<li>` など）
- node として解決できない `data-model-id`（edge id、field id、未知の id）
- `kind` が未定義の node

これは配信を止める検証なので、範囲を広げると既存の図を壊しうる。今回の目的は「両方あるのに食い違っている」の検出であって、1 対 1 の強制ではない。

## 既存の図を壊さないことの確認

**実在する 18 枚の `.diagram.html` に対して実行し、違反 0 件**を確認した。内訳は本リポジトリの 8 枚（`_examples` 7 + `order-flow-design`）と、別リポジトリで運用中の 10 枚。

## 事故の再現で検出できることの確認

実ファイルを使い、両方向の不整合を作って検出できることを確認した。

- 投影だけ `story-open` に戻す（モデルは `story`）→ 検出
- モデルだけ `story-done` に変える（投影は `story`）→ 検出

エラーメッセージは「壊れている」ではなく「同期されていない」とし、**どの node の・どちら側が・どう違うか**を出す。1 ノードに `<article>` と `<h2>` の 2 要素がある場合は 2 件として数える。

```
graph 投影の data-kind が model の node.kind と同期されていません（2件）:
node h02: model の kind="story", 投影の data-kind="story-open"; ...
```

## この検証の位置づけ

この二重管理は、図の上で直接 `kind` を変えられれば（直接操作の編集レイヤ）根本的に消える。本 PR は**それが入るまでの安全網**であり、入った後も手書き編集の経路には残り続ける価値がある。

## 検証

`pnpm check` / `pnpm test`（1046 件）/ `pnpm build` すべて green。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 図のHTML表示とモデル間で、ノード種別が一致しているか検証できるようになりました。
  - 不一致や未解決の要素がある場合、問題箇所を含む検証結果を確認できます。
- **不具合修正**
  - 不正なノード種別を含む図の読み込み時に、HTTP 422エラーを返すようになりました。
  - モデル情報の読み込みは、表示側の不一致があっても継続できます。
- **テスト**
  - 一致、不一致、複数投影、未定義種別などの検証ケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->