### PR TITLE
feat(diagram): graph 型のノードにコメントを付けられるようにする

### DIFF
--- a/packages/server/src/lib/diagram-comment-layer.test.ts
+++ b/packages/server/src/lib/diagram-comment-layer.test.ts
@@ -41,6 +41,20 @@ describe("injectDiagramCommentLayer", () => {
     expect(injectMinifiedCommentLayer(once)).toBe(once);
   });
 
+  it("保存 HTML に混入した旧 runtime を現行コメント層へ置き換える", () => {
+    const persisted = minimalGraph.replace(
+      "</body>",
+      '<script id="ark-diagram-comment-layer" data-ark-comment-mode="graph">oldLayer()</script><div class="ark-comment-layer"><button class="ark-comment-selection-add"></button></div></body>'
+    );
+
+    const recovered = injectMinifiedCommentLayer(persisted, "graph");
+
+    expect(recovered.match(/id="ark-diagram-comment-layer"/gu)).toHaveLength(1);
+    expect(recovered).not.toContain("oldLayer()");
+    expect(recovered).toContain('data-ark-comment-mode="graph"');
+    expect(recovered).toContain('data-ark-harness-ui="1"');
+  });
+
   it("script 属性で doc / graph モードを明示する", () => {
     const injectWithMode = injectMinifiedCommentLayer as (
       html: string,
@@ -65,7 +79,9 @@ describe("injectDiagramCommentLayer", () => {
       injected.indexOf("function updateLayout")
     );
 
-    expect(injected).toContain('graphMode?"[data-model-id]":"[data-ark-id]"');
+    expect(injected).toContain(
+      'graphMode?".ark-harness-graph-node[data-model-id]":"[data-ark-id]"'
+    );
     expect(injected).toContain("anchor.innerText");
     expect(injected).toContain("slice(0,256)");
     expect(composer).toContain("graphMode?{");
@@ -97,8 +113,34 @@ describe("injectDiagramCommentLayer", () => {
     expect(graphSelection).toContain('document.addEventListener("click"');
     expect(graphSelection).toContain("Math.hypot");
     expect(graphSelection).toContain("GRAPH_CLICK_MOVE_LIMIT");
+    expect(injected).toContain(
+      'target.closest(".ark-harness-graph-node[data-model-id]")'
+    );
     expect(graphSelection).not.toContain("preventDefault");
     expect(graphSelection).not.toContain("stopPropagation");
+  });
+
+  it("コメント runtime は graph の保存 HTML から除外される", () => {
+    const injected = injectDiagramCommentLayer(minimalGraph);
+
+    expect(injected).toContain(
+      `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-ark-comment-mode="doc" data-ark-harness-ui="1">`
+    );
+    expect(injected).toContain('style.setAttribute("data-ark-harness-ui","1")');
+    expect(injected).toContain('root.setAttribute("data-ark-harness-ui","1")');
+  });
+
+  it("selection button の再構築時は既存 button を除去する", () => {
+    const injected = injectDiagramCommentLayer(minimalGraph);
+    const createButton = injected.slice(
+      injected.indexOf("function createSelectionAddButton"),
+      injected.indexOf("function graphAnchorFromTarget")
+    );
+
+    expect(createButton).toContain(
+      'root.querySelectorAll(".ark-comment-selection-add")'
+    );
+    expect(createButton).toContain("root.removeChild(button)");
   });
 
   it("同じ data-model-id が入れ子なら最も外側だけを anchor にする", () => {

--- a/packages/server/src/lib/diagram-comment-layer.test.ts
+++ b/packages/server/src/lib/diagram-comment-layer.test.ts
@@ -7,6 +7,8 @@ import {
 
 const minimalDoc =
   '<!doctype html><html><head></head><body><p data-ark-id="s1">本文</p></body></html>';
+const minimalGraph =
+  '<!doctype html><html><head></head><body><article data-model-id="n1"><h2 data-model-id="n1">注文</h2></article></body></html>';
 
 // 部分一致で振る舞いを固定する契約テストは、読みやすいソースを検証する。
 const injectDiagramCommentLayer = (_html: string) => COMMENT_LAYER;
@@ -37,6 +39,75 @@ describe("injectDiagramCommentLayer", () => {
     const once = injectMinifiedCommentLayer(minimalDoc);
 
     expect(injectMinifiedCommentLayer(once)).toBe(once);
+  });
+
+  it("script 属性で doc / graph モードを明示する", () => {
+    const injectWithMode = injectMinifiedCommentLayer as (
+      html: string,
+      mode: "doc" | "graph"
+    ) => string;
+
+    expect(injectWithMode(minimalDoc, "doc")).toContain(
+      'data-ark-comment-mode="doc"'
+    );
+    expect(injectWithMode(minimalGraph, "graph")).toContain(
+      'data-ark-comment-mode="graph"'
+    );
+    expect(COMMENT_LAYER).toContain(
+      'document.currentScript.getAttribute("data-ark-comment-mode")'
+    );
+  });
+
+  it("graph は node ID と可視テキストだけで composer と create payload を作る", () => {
+    const injected = injectDiagramCommentLayer(minimalGraph);
+    const composer = injected.slice(
+      injected.indexOf("function renderComposer"),
+      injected.indexOf("function updateLayout")
+    );
+
+    expect(injected).toContain('graphMode?"[data-model-id]":"[data-ark-id]"');
+    expect(injected).toContain("anchor.innerText");
+    expect(injected).toContain("slice(0,256)");
+    expect(composer).toContain("graphMode?{");
+    expect(composer).toContain("anchorId:anchorId");
+    expect(composer).not.toContain("graphMode?{anchorId:anchorId,anchorQuote");
+    expect(composer).toContain("entry.anchorText");
+  });
+
+  it("graph はテキスト選択と span highlight を動かさず node class を使う", () => {
+    const injected = injectDiagramCommentLayer(minimalGraph);
+
+    expect(injected).toContain(
+      "if(graphMode)buildGraphSelectionAdd();else buildSelectionAdd()"
+    );
+    expect(injected).toContain(
+      "if(graphMode){renderGraphHighlights();return;}"
+    );
+    expect(injected).toContain("ark-comment-node-highlight");
+  });
+
+  it("graph の node click は drag 距離を検査しイベントを止めない", () => {
+    const injected = injectDiagramCommentLayer(minimalGraph);
+    const graphSelection = injected.slice(
+      injected.indexOf("function buildGraphSelectionAdd"),
+      injected.indexOf("function buildAnchors")
+    );
+
+    expect(graphSelection).toContain('document.addEventListener("pointerdown"');
+    expect(graphSelection).toContain('document.addEventListener("click"');
+    expect(graphSelection).toContain("Math.hypot");
+    expect(graphSelection).toContain("GRAPH_CLICK_MOVE_LIMIT");
+    expect(graphSelection).not.toContain("preventDefault");
+    expect(graphSelection).not.toContain("stopPropagation");
+  });
+
+  it("同じ data-model-id が入れ子なら最も外側だけを anchor にする", () => {
+    const injected = injectDiagramCommentLayer(minimalGraph);
+
+    expect(injected).toContain("function hasSameIdAncestor(anchor,anchorId)");
+    expect(injected).toContain(
+      "if(graphMode&&hasSameIdAncestor(anchor,anchorId))return"
+    );
   });
 
   it("ark:diagram-init の transferred port で load/result を相関する", () => {

--- a/packages/server/src/lib/diagram-comment-layer.ts
+++ b/packages/server/src/lib/diagram-comment-layer.ts
@@ -2,12 +2,15 @@ import { createCachedMinifier } from "./injected-minify.js";
 
 export const DIAGRAM_COMMENT_LAYER_MARKER = "ark-diagram-comment-layer";
 
-export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
+export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-ark-comment-mode="doc">
 (function(){
   "use strict";
   var CARD_WIDTH=300;
   var CARD_GAP=10;
   var RAIL_GAP=12;
+  var GRAPH_CLICK_MOVE_LIMIT=5;
+  var mode=document.currentScript.getAttribute("data-ark-comment-mode");
+  var graphMode=mode==="graph";
   var port=null;
   var pinchDistance=null;
   var comments={version:1,target:"",threads:[]};
@@ -34,6 +37,7 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
   var selectedThreadId=null;
   var selectionAddButton=null;
   var selectionCandidate=null;
+  var graphPointerStart=null;
   var threadHighlightResolved=Object.create(null);
   var narrow=false;
 
@@ -302,7 +306,8 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
     root.appendChild(card);
   }
   function renderComposer(){
-    if(!composerAnchorId||!anchorEntry(composerAnchorId))return;
+    var entry=anchorEntry(composerAnchorId);
+    if(!composerAnchorId||!entry)return;
     var anchorId=composerAnchorId;
     var composer=element("section",undefined,"ark-comment-composer");
     composer.setAttribute("data-anchor-id",anchorId);
@@ -322,8 +327,9 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
     });
     header.appendChild(closeButton);
     composer.appendChild(header);
-    if(composerAnchorQuote){
-      composer.appendChild(element("blockquote",composerAnchorQuote,"ark-comment-composer-quote"));
+    var composerText=graphMode?entry.anchorText:composerAnchorQuote;
+    if(composerText){
+      composer.appendChild(element("blockquote",composerText,"ark-comment-composer-quote"));
     }
     var bodyInput=element("textarea",undefined,"ark-comment-input");
     bodyInput.setAttribute("maxlength","4000");
@@ -340,7 +346,10 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
         render();
         return;
       }
-      var payload=composerAnchorQuote?{
+      var payload=graphMode?{
+        anchorId:anchorId,
+        body:bodyInput.value
+      }:composerAnchorQuote?{
         anchorId:anchorId,
         anchorQuote:composerAnchorQuote,
         anchorOccurrence:composerAnchorOccurrence,
@@ -376,6 +385,9 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
       var parent=highlight.parentNode;
       highlight.replaceWith(document.createTextNode(highlight.textContent||""));
       if(parent&&parent.normalize)parent.normalize();
+    });
+    document.querySelectorAll(".ark-comment-node-highlight").forEach(function(anchor){
+      anchor.classList.remove("ark-comment-node-highlight");
     });
     threadHighlightResolved=Object.create(null);
   }
@@ -459,10 +471,17 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
   }
   function renderHighlights(){
     clearHighlights();
+    if(graphMode){renderGraphHighlights();return;}
     comments.threads.forEach(function(thread){
       if(!thread.anchorQuote)return;
       var entry=anchorEntry(thread.anchorId);
       threadHighlightResolved[thread.id]=Boolean(entry&&wrapThreadQuote(thread,entry));
+    });
+  }
+  function renderGraphHighlights(){
+    comments.threads.forEach(function(thread){
+      var entry=anchorEntry(thread.anchorId);
+      if(entry)entry.anchor.classList.add("ark-comment-node-highlight");
     });
   }
   function positionCards(){
@@ -512,7 +531,8 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
   function refreshLayout(){
     updateLayout();
     positionCards();
-    updateSelectionAdd();
+    if(graphMode)positionGraphSelectionAdd();
+    else updateSelectionAdd();
   }
   function cleanupExpandedThreads(){
     var existingThreadIds=new Set(comments.threads.map(function(thread){return thread.id;}));
@@ -606,35 +626,95 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
     selectionAddButton.setAttribute("data-visible","true");
   }
   function buildSelectionAdd(){
-    selectionAddButton=element("button","コメント","ark-comment-selection-add");
-    selectionAddButton.setAttribute("type","button");
-    selectionAddButton.setAttribute("data-visible","false");
-    selectionAddButton.addEventListener("mousedown",function(event){event.preventDefault();});
+    createSelectionAddButton();
     selectionAddButton.addEventListener("click",function(){
       if(!selectionCandidate)return;
       openComposer(selectionCandidate.anchorId,selectionCandidate.anchorQuote,selectionCandidate.anchorOccurrence);
     });
-    root.appendChild(selectionAddButton);
     document.addEventListener("selectionchange",updateSelectionAdd);
     document.addEventListener("mouseup",updateSelectionAdd);
     document.addEventListener("keyup",updateSelectionAdd);
   }
+  function createSelectionAddButton(){
+    selectionAddButton=element("button","コメント","ark-comment-selection-add");
+    selectionAddButton.setAttribute("type","button");
+    selectionAddButton.setAttribute("data-visible","false");
+    selectionAddButton.addEventListener("mousedown",function(event){event.preventDefault();});
+    root.appendChild(selectionAddButton);
+  }
+  function graphAnchorFromTarget(target){
+    if(!target||target.nodeType!==Node.ELEMENT_NODE||root.contains(target))return null;
+    var candidate=target.closest("[data-model-id]");
+    if(!candidate)return null;
+    return anchorEntry(candidate.getAttribute("data-model-id"));
+  }
+  function positionGraphSelectionAdd(){
+    if(!selectionCandidate)return;
+    var entry=anchorEntry(selectionCandidate.anchorId);
+    if(!entry){hideSelectionAdd();return;}
+    var rect=entry.anchor.getBoundingClientRect();
+    selectionAddButton.style.top=Math.max(8,rect.bottom+6)+"px";
+    selectionAddButton.style.left=Math.max(8,Math.min(window.innerWidth-96,rect.left+rect.width/2-40))+"px";
+    selectionAddButton.setAttribute("data-visible","true");
+  }
+  function buildGraphSelectionAdd(){
+    createSelectionAddButton();
+    selectionAddButton.addEventListener("click",function(){
+      if(!selectionCandidate)return;
+      openComposer(selectionCandidate.anchorId,null,null);
+    });
+    document.addEventListener("pointerdown",function(event){
+      var entry=graphAnchorFromTarget(event.target);
+      graphPointerStart=entry?{anchorId:entry.anchorId,x:event.clientX,y:event.clientY}:null;
+    });
+    document.addEventListener("click",function(event){
+      var entry=graphAnchorFromTarget(event.target);
+      if(!entry){hideSelectionAdd();return;}
+      var moved=graphPointerStart&&(
+        graphPointerStart.anchorId!==entry.anchorId||
+        Math.hypot(event.clientX-graphPointerStart.x,event.clientY-graphPointerStart.y)>=GRAPH_CLICK_MOVE_LIMIT
+      );
+      graphPointerStart=null;
+      if(moved){hideSelectionAdd();return;}
+      selectionCandidate={anchorId:entry.anchorId,anchorText:entry.anchorText};
+      selectedAnchorId=entry.anchorId;
+      selectedThreadId=null;
+      setActiveAnchor(entry.anchorId,null);
+      positionGraphSelectionAdd();
+    });
+  }
+  function hasSameIdAncestor(anchor,anchorId){
+    var parent=anchor.parentElement;
+    while(parent){
+      if(parent.getAttribute("data-model-id")===anchorId)return true;
+      parent=parent.parentElement;
+    }
+    return false;
+  }
   function buildAnchors(){
-    document.querySelectorAll("[data-ark-id]").forEach(function(anchor){
-      var anchorId=anchor.getAttribute("data-ark-id");
+    var selector=graphMode?"[data-model-id]":"[data-ark-id]";
+    document.querySelectorAll(selector).forEach(function(anchor){
+      var anchorId=anchor.getAttribute(graphMode?"data-model-id":"data-ark-id");
       if(!anchorId)return;
-      anchors.push({anchor:anchor,anchorId:anchorId});
+      if(graphMode&&hasSameIdAncestor(anchor,anchorId))return;
+      var visibleText=typeof anchor.innerText==="string"?anchor.innerText:anchor.textContent||"";
+      var anchorText=graphMode?visibleText.trim().slice(0,256):null;
+      anchors.push({anchor:anchor,anchorId:anchorId,anchorText:anchorText});
+      if(graphMode){
+        anchor.addEventListener("mouseenter",function(){setActiveAnchor(anchorId,null);});
+        anchor.addEventListener("mouseleave",function(){setActiveAnchor(selectedAnchorId,selectedThreadId);});
+      }
     });
   }
   function build(){
     var style=element("style");
-    style.textContent=".ark-comment-layer{position:fixed;z-index:2147483000;inset:0;pointer-events:none;color:#172033;font:13px/1.5 system-ui,sans-serif}.ark-comment-card{position:fixed;right:12px;width:300px;box-sizing:border-box;border:1px solid #cbd5e1;border-radius:9px;background:#fff;box-shadow:0 3px 14px #0002;padding:11px;pointer-events:auto}.ark-comment-composer{position:fixed;right:12px;width:300px;box-sizing:border-box;border:1px solid #93c5fd;border-radius:9px;background:#fff;box-shadow:0 3px 14px #0002;padding:11px;pointer-events:auto}.ark-comment-card[data-active=true],.ark-comment-composer[data-active=true]{border-color:#3b82f6;box-shadow:0 3px 16px #2563eb33}.ark-comment-card[data-status=resolved]{background:#f8fafc;border-color:#e2e8f0;color:#64748b;opacity:.78}.ark-comment-card[data-unresolved=true]{border-style:dashed}.ark-comment-badge{display:none}.ark-comment-card-content{display:block}.ark-comment-state,.ark-comment-time,.ark-comment-author{display:block;color:#64748b;font-size:11px}.ark-comment-unresolved-anchor{display:block;color:#b45309;font-weight:700}.ark-comment-unresolved-quote,.ark-comment-composer-quote{margin:7px 0;padding:7px;border-left:3px solid #f59e0b;background:#fffbeb;white-space:pre-wrap}.ark-comment-message{border-top:1px solid #e2e8f0;margin-top:8px;padding-top:8px}.ark-comment-body{white-space:pre-wrap}.ark-comment-input{display:block;width:100%;box-sizing:border-box;margin:7px 0;padding:7px;border:1px solid #94a3b8;border-radius:5px;font:inherit}.ark-comment-actions{display:flex;gap:8px;align-items:stretch;flex-wrap:wrap;margin-top:8px}.ark-comment-create,.ark-comment-reply,.ark-comment-resolve,.ark-comment-send{border:0;border-radius:5px;background:#2563eb;color:#fff;padding:7px 10px;cursor:pointer}.ark-comment-delete{border:0;background:transparent;color:#b91c1c;padding:7px 8px;cursor:pointer}.ark-comment-create:disabled,.ark-comment-reply:disabled,.ark-comment-resolve:disabled,.ark-comment-send:disabled,.ark-comment-delete:disabled,.ark-comment-input:disabled{opacity:.5;cursor:default}.ark-comment-error{color:#b91c1c;margin:8px 0 0}.ark-comment-composer-header{display:flex;align-items:center;justify-content:space-between}.ark-comment-close{border:0;background:transparent;color:#64748b;font-size:18px;cursor:pointer}.ark-comment-selection-add{position:fixed;z-index:2147483002;border:0;border-radius:14px;background:#2563eb;color:#fff;padding:5px 10px;box-shadow:0 2px 8px #0003;cursor:pointer;opacity:0;pointer-events:none}.ark-comment-selection-add[data-visible=true]{opacity:1;pointer-events:auto}.ark-comment-highlight{background:#fde68a;border-radius:2px;cursor:pointer}.ark-comment-highlight[data-active=true]{background:#fbbf24;box-shadow:0 0 0 2px #f59e0b55}.ark-comment-anchor-active{background-color:rgba(219,234,254,.45);outline:1px solid rgba(37,99,235,.28);outline-offset:2px}.ark-comment-layer[data-narrow=true] .ark-comment-card{right:8px;width:auto;min-width:34px;padding:0;border:0;background:transparent;box-shadow:none;opacity:1}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=true] .ark-comment-card-content{display:none}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=true] .ark-comment-badge{display:block;width:34px;height:28px;border:0;border-radius:14px;background:#2563eb;color:#fff;box-shadow:0 2px 8px #0003;cursor:pointer}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-status=resolved][data-collapsed=true] .ark-comment-badge{background:#94a3b8}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=false]{width:300px;padding:11px;border:1px solid #cbd5e1;background:#fff;box-shadow:0 3px 14px #0003}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=false] .ark-comment-badge{display:none}";
+    style.textContent=".ark-comment-layer{position:fixed;z-index:2147483000;inset:0;pointer-events:none;color:#172033;font:13px/1.5 system-ui,sans-serif}.ark-comment-card{position:fixed;right:12px;width:300px;box-sizing:border-box;border:1px solid #cbd5e1;border-radius:9px;background:#fff;box-shadow:0 3px 14px #0002;padding:11px;pointer-events:auto}.ark-comment-composer{position:fixed;right:12px;width:300px;box-sizing:border-box;border:1px solid #93c5fd;border-radius:9px;background:#fff;box-shadow:0 3px 14px #0002;padding:11px;pointer-events:auto}.ark-comment-card[data-active=true],.ark-comment-composer[data-active=true]{border-color:#3b82f6;box-shadow:0 3px 16px #2563eb33}.ark-comment-card[data-status=resolved]{background:#f8fafc;border-color:#e2e8f0;color:#64748b;opacity:.78}.ark-comment-card[data-unresolved=true]{border-style:dashed}.ark-comment-badge{display:none}.ark-comment-card-content{display:block}.ark-comment-state,.ark-comment-time,.ark-comment-author{display:block;color:#64748b;font-size:11px}.ark-comment-unresolved-anchor{display:block;color:#b45309;font-weight:700}.ark-comment-unresolved-quote,.ark-comment-composer-quote{margin:7px 0;padding:7px;border-left:3px solid #f59e0b;background:#fffbeb;white-space:pre-wrap}.ark-comment-message{border-top:1px solid #e2e8f0;margin-top:8px;padding-top:8px}.ark-comment-body{white-space:pre-wrap}.ark-comment-input{display:block;width:100%;box-sizing:border-box;margin:7px 0;padding:7px;border:1px solid #94a3b8;border-radius:5px;font:inherit}.ark-comment-actions{display:flex;gap:8px;align-items:stretch;flex-wrap:wrap;margin-top:8px}.ark-comment-create,.ark-comment-reply,.ark-comment-resolve,.ark-comment-send{border:0;border-radius:5px;background:#2563eb;color:#fff;padding:7px 10px;cursor:pointer}.ark-comment-delete{border:0;background:transparent;color:#b91c1c;padding:7px 8px;cursor:pointer}.ark-comment-create:disabled,.ark-comment-reply:disabled,.ark-comment-resolve:disabled,.ark-comment-send:disabled,.ark-comment-delete:disabled,.ark-comment-input:disabled{opacity:.5;cursor:default}.ark-comment-error{color:#b91c1c;margin:8px 0 0}.ark-comment-composer-header{display:flex;align-items:center;justify-content:space-between}.ark-comment-close{border:0;background:transparent;color:#64748b;font-size:18px;cursor:pointer}.ark-comment-selection-add{position:fixed;z-index:2147483002;border:0;border-radius:14px;background:#2563eb;color:#fff;padding:5px 10px;box-shadow:0 2px 8px #0003;cursor:pointer;opacity:0;pointer-events:none}.ark-comment-selection-add[data-visible=true]{opacity:1;pointer-events:auto}.ark-comment-highlight{background:#fde68a;border-radius:2px;cursor:pointer}.ark-comment-highlight[data-active=true]{background:#fbbf24;box-shadow:0 0 0 2px #f59e0b55}.ark-comment-node-highlight{outline:1px solid rgba(245,158,11,.45);outline-offset:2px}.ark-comment-anchor-active{background-color:rgba(219,234,254,.45);outline:1px solid rgba(37,99,235,.28);outline-offset:2px}.ark-comment-layer[data-narrow=true] .ark-comment-card{right:8px;width:auto;min-width:34px;padding:0;border:0;background:transparent;box-shadow:none;opacity:1}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=true] .ark-comment-card-content{display:none}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=true] .ark-comment-badge{display:block;width:34px;height:28px;border:0;border-radius:14px;background:#2563eb;color:#fff;box-shadow:0 2px 8px #0003;cursor:pointer}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-status=resolved][data-collapsed=true] .ark-comment-badge{background:#94a3b8}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=false]{width:300px;padding:11px;border:1px solid #cbd5e1;background:#fff;box-shadow:0 3px 14px #0003}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=false] .ark-comment-badge{display:none}";
     document.head.appendChild(style);
     root=element("div",undefined,"ark-comment-layer");
     root.setAttribute("data-narrow","false");
     document.body.appendChild(root);
-    buildSelectionAdd();
     buildAnchors();
+    if(graphMode)buildGraphSelectionAdd();else buildSelectionAdd();
     render();
   }
   function onPortMessage(event){
@@ -677,7 +757,7 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
     }
     render(completedAction&&completedAction.focusedInput);
   }
-  window.addEventListener("wheel",function(event){
+  if(!graphMode)window.addEventListener("wheel",function(event){
     if(!event.ctrlKey||!port)return;
     event.preventDefault();
     port.postMessage({type:"ark:diagram-pinch",deltaY:event.deltaY});
@@ -706,10 +786,12 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}">
       port.postMessage({type:"ark:diagram-pinch",deltaY:deltaY});
     }
   }
-  window.addEventListener("touchstart",handleTouchStart,{passive:false});
-  window.addEventListener("touchmove",handleTouchMove,{passive:false});
-  window.addEventListener("touchend",resetTouchPinch,{passive:false});
-  window.addEventListener("touchcancel",resetTouchPinch,{passive:false});
+  if(!graphMode){
+    window.addEventListener("touchstart",handleTouchStart,{passive:false});
+    window.addEventListener("touchmove",handleTouchMove,{passive:false});
+    window.addEventListener("touchend",resetTouchPinch,{passive:false});
+    window.addEventListener("touchcancel",resetTouchPinch,{passive:false});
+  }
   window.addEventListener("scroll",positionCards,{passive:true});
   window.addEventListener("resize",refreshLayout);
   var observer=new ResizeObserver(refreshLayout);
@@ -736,10 +818,22 @@ const MINIFIED_COMMENT_LAYER = `${COMMENT_LAYER.slice(
   scriptContentStart
 )}${minifyCommentLayerJavaScript()}${COMMENT_LAYER.slice(scriptContentEnd)}`;
 
-/** 文書型ページだけへ独立したコメント層を注入する。 */
-export function injectDiagramCommentLayer(html: string): string {
+export type DiagramCommentMode = "doc" | "graph";
+
+/** 指定されたページ種別の独立したコメント層を注入する。 */
+export function injectDiagramCommentLayer(
+  html: string,
+  mode: DiagramCommentMode = "doc"
+): string {
   if (html.includes(DIAGRAM_COMMENT_LAYER_MARKER)) return html;
+  const layer =
+    mode === "doc"
+      ? MINIFIED_COMMENT_LAYER
+      : MINIFIED_COMMENT_LAYER.replace(
+          'data-ark-comment-mode="doc"',
+          'data-ark-comment-mode="graph"'
+        );
   const bodyClose = html.toLowerCase().lastIndexOf("</body>");
-  if (bodyClose < 0) return `${html}${MINIFIED_COMMENT_LAYER}`;
-  return `${html.slice(0, bodyClose)}${MINIFIED_COMMENT_LAYER}${html.slice(bodyClose)}`;
+  if (bodyClose < 0) return `${html}${layer}`;
+  return `${html.slice(0, bodyClose)}${layer}${html.slice(bodyClose)}`;
 }

--- a/packages/server/src/lib/diagram-comment-layer.ts
+++ b/packages/server/src/lib/diagram-comment-layer.ts
@@ -2,7 +2,7 @@ import { createCachedMinifier } from "./injected-minify.js";
 
 export const DIAGRAM_COMMENT_LAYER_MARKER = "ark-diagram-comment-layer";
 
-export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-ark-comment-mode="doc">
+export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-ark-comment-mode="doc" data-ark-harness-ui="1">
 (function(){
   "use strict";
   var CARD_WIDTH=300;
@@ -636,6 +636,9 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
     document.addEventListener("keyup",updateSelectionAdd);
   }
   function createSelectionAddButton(){
+    root.querySelectorAll(".ark-comment-selection-add").forEach(function(button){
+      root.removeChild(button);
+    });
     selectionAddButton=element("button","コメント","ark-comment-selection-add");
     selectionAddButton.setAttribute("type","button");
     selectionAddButton.setAttribute("data-visible","false");
@@ -644,7 +647,7 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
   }
   function graphAnchorFromTarget(target){
     if(!target||target.nodeType!==Node.ELEMENT_NODE||root.contains(target))return null;
-    var candidate=target.closest("[data-model-id]");
+    var candidate=target.closest(".ark-harness-graph-node[data-model-id]");
     if(!candidate)return null;
     return anchorEntry(candidate.getAttribute("data-model-id"));
   }
@@ -692,7 +695,7 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
     return false;
   }
   function buildAnchors(){
-    var selector=graphMode?"[data-model-id]":"[data-ark-id]";
+    var selector=graphMode?".ark-harness-graph-node[data-model-id]":"[data-ark-id]";
     document.querySelectorAll(selector).forEach(function(anchor){
       var anchorId=anchor.getAttribute(graphMode?"data-model-id":"data-ark-id");
       if(!anchorId)return;
@@ -707,10 +710,20 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
     });
   }
   function build(){
+    document.querySelectorAll(".ark-comment-layer").forEach(function(existingRoot){
+      existingRoot.remove();
+    });
+    document.querySelectorAll("style").forEach(function(existingStyle){
+      if(existingStyle.textContent.indexOf(".ark-comment-layer{position:fixed;z-index:2147483000")>=0){
+        existingStyle.remove();
+      }
+    });
     var style=element("style");
+    style.setAttribute("data-ark-harness-ui","1");
     style.textContent=".ark-comment-layer{position:fixed;z-index:2147483000;inset:0;pointer-events:none;color:#172033;font:13px/1.5 system-ui,sans-serif}.ark-comment-card{position:fixed;right:12px;width:300px;box-sizing:border-box;border:1px solid #cbd5e1;border-radius:9px;background:#fff;box-shadow:0 3px 14px #0002;padding:11px;pointer-events:auto}.ark-comment-composer{position:fixed;right:12px;width:300px;box-sizing:border-box;border:1px solid #93c5fd;border-radius:9px;background:#fff;box-shadow:0 3px 14px #0002;padding:11px;pointer-events:auto}.ark-comment-card[data-active=true],.ark-comment-composer[data-active=true]{border-color:#3b82f6;box-shadow:0 3px 16px #2563eb33}.ark-comment-card[data-status=resolved]{background:#f8fafc;border-color:#e2e8f0;color:#64748b;opacity:.78}.ark-comment-card[data-unresolved=true]{border-style:dashed}.ark-comment-badge{display:none}.ark-comment-card-content{display:block}.ark-comment-state,.ark-comment-time,.ark-comment-author{display:block;color:#64748b;font-size:11px}.ark-comment-unresolved-anchor{display:block;color:#b45309;font-weight:700}.ark-comment-unresolved-quote,.ark-comment-composer-quote{margin:7px 0;padding:7px;border-left:3px solid #f59e0b;background:#fffbeb;white-space:pre-wrap}.ark-comment-message{border-top:1px solid #e2e8f0;margin-top:8px;padding-top:8px}.ark-comment-body{white-space:pre-wrap}.ark-comment-input{display:block;width:100%;box-sizing:border-box;margin:7px 0;padding:7px;border:1px solid #94a3b8;border-radius:5px;font:inherit}.ark-comment-actions{display:flex;gap:8px;align-items:stretch;flex-wrap:wrap;margin-top:8px}.ark-comment-create,.ark-comment-reply,.ark-comment-resolve,.ark-comment-send{border:0;border-radius:5px;background:#2563eb;color:#fff;padding:7px 10px;cursor:pointer}.ark-comment-delete{border:0;background:transparent;color:#b91c1c;padding:7px 8px;cursor:pointer}.ark-comment-create:disabled,.ark-comment-reply:disabled,.ark-comment-resolve:disabled,.ark-comment-send:disabled,.ark-comment-delete:disabled,.ark-comment-input:disabled{opacity:.5;cursor:default}.ark-comment-error{color:#b91c1c;margin:8px 0 0}.ark-comment-composer-header{display:flex;align-items:center;justify-content:space-between}.ark-comment-close{border:0;background:transparent;color:#64748b;font-size:18px;cursor:pointer}.ark-comment-selection-add{position:fixed;z-index:2147483002;border:0;border-radius:14px;background:#2563eb;color:#fff;padding:5px 10px;box-shadow:0 2px 8px #0003;cursor:pointer;opacity:0;pointer-events:none}.ark-comment-selection-add[data-visible=true]{opacity:1;pointer-events:auto}.ark-comment-highlight{background:#fde68a;border-radius:2px;cursor:pointer}.ark-comment-highlight[data-active=true]{background:#fbbf24;box-shadow:0 0 0 2px #f59e0b55}.ark-comment-node-highlight{outline:1px solid rgba(245,158,11,.45);outline-offset:2px}.ark-comment-anchor-active{background-color:rgba(219,234,254,.45);outline:1px solid rgba(37,99,235,.28);outline-offset:2px}.ark-comment-layer[data-narrow=true] .ark-comment-card{right:8px;width:auto;min-width:34px;padding:0;border:0;background:transparent;box-shadow:none;opacity:1}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=true] .ark-comment-card-content{display:none}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=true] .ark-comment-badge{display:block;width:34px;height:28px;border:0;border-radius:14px;background:#2563eb;color:#fff;box-shadow:0 2px 8px #0003;cursor:pointer}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-status=resolved][data-collapsed=true] .ark-comment-badge{background:#94a3b8}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=false]{width:300px;padding:11px;border:1px solid #cbd5e1;background:#fff;box-shadow:0 3px 14px #0003}.ark-comment-layer[data-narrow=true] .ark-comment-card[data-collapsed=false] .ark-comment-badge{display:none}";
     document.head.appendChild(style);
     root=element("div",undefined,"ark-comment-layer");
+    root.setAttribute("data-ark-harness-ui","1");
     root.setAttribute("data-narrow","false");
     document.body.appendChild(root);
     buildAnchors();
@@ -825,7 +838,21 @@ export function injectDiagramCommentLayer(
   html: string,
   mode: DiagramCommentMode = "doc"
 ): string {
-  if (html.includes(DIAGRAM_COMMENT_LAYER_MARKER)) return html;
+  const markerIndex = html.indexOf(DIAGRAM_COMMENT_LAYER_MARKER);
+  if (markerIndex >= 0) {
+    // graph の保存 HTML に旧コメント層の runtime root が混入した版だけを回復する。
+    // 正常な注入済み HTML は従来どおり byte-for-byte で返し、二重注入しない。
+    if (!/<div\b[^>]*class=["'][^"']*\bark-comment-layer\b/iu.test(html)) {
+      return html;
+    }
+    const scriptStart = html.lastIndexOf("<script", markerIndex);
+    const scriptClose = html.indexOf("</script>", markerIndex);
+    if (scriptStart >= 0 && scriptClose >= 0) {
+      html = `${html.slice(0, scriptStart)}${html.slice(scriptClose + 9)}`;
+    } else {
+      return html;
+    }
+  }
   const layer =
     mode === "doc"
       ? MINIFIED_COMMENT_LAYER

--- a/packages/server/src/lib/diagram-comments-handler.ts
+++ b/packages/server/src/lib/diagram-comments-handler.ts
@@ -61,7 +61,7 @@ export interface DiagramCommentsHandlerDeps {
   sendMessage: (sessionId: string, message: string) => void;
 }
 
-/** get でも mutation と同じ doc/anchor trust boundary を通す。 */
+/** get でも mutation と同じ diagram/anchor trust boundary を通す。 */
 export async function getDiagramCommentsForDoc(
   worktreeReal: string,
   relPath: string
@@ -74,12 +74,11 @@ export async function getDiagramCommentsForDoc(
       error: diagram.error,
     };
   }
-  if (diagram.model.type !== "doc") {
-    return { ok: false, code: "NOT_DOC", error: "文書型の図ではありません" };
-  }
-  const anchors = validateDiagramDocAnchors(diagram.raw, diagram.model);
-  if (!anchors.ok) {
-    return { ok: false, code: "ANCHOR_NOT_FOUND", error: anchors.error };
+  if (diagram.model.type === "doc") {
+    const anchors = validateDiagramDocAnchors(diagram.raw, diagram.model);
+    if (!anchors.ok) {
+      return { ok: false, code: "ANCHOR_NOT_FOUND", error: anchors.error };
+    }
   }
   return readDiagramCommentsFile(worktreeReal, relPath);
 }

--- a/packages/server/src/lib/diagram-comments.test.ts
+++ b/packages/server/src/lib/diagram-comments.test.ts
@@ -17,6 +17,7 @@ import {
   resolveDiagramComment,
   resolveDiagramCommentsPath,
 } from "./diagram-comments.js";
+import { getDiagramCommentsForDoc } from "./diagram-comments-handler.js";
 
 let worktree: string;
 
@@ -967,7 +968,7 @@ describe("comment mutations", () => {
     ).toBe(false);
   });
 
-  it("doc 以外を NOT_DOC にする", async () => {
+  it("graph node は quote/occurrence なしでコメントを作成する", async () => {
     const graphModel = {
       version: 1,
       nodes: [{ id: "s1-p1", label: "Graph" }],
@@ -979,9 +980,26 @@ describe("comment mutations", () => {
       `<script type="application/json" id="ark-diagram-model">${JSON.stringify(graphModel)}</script><div data-model-id="s1-p1"></div>`
     );
 
-    await expect(
-      createDiagramComment(worktree, relPath, "s1-p1", "本文")
-    ).resolves.toMatchObject({ ok: false, code: "NOT_DOC" });
+    const result = await createDiagramComment(
+      worktree,
+      relPath,
+      "s1-p1",
+      "本文"
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.comments.threads[0]).toMatchObject({
+        anchorId: "s1-p1",
+        anchorText: "Graph",
+      });
+      expect(result.comments.threads[0]).not.toHaveProperty("anchorQuote");
+      expect(result.comments.threads[0]).not.toHaveProperty("anchorOccurrence");
+
+      await expect(
+        getDiagramCommentsForDoc(worktree, relPath)
+      ).resolves.toEqual(result);
+    }
   });
 
   it("resolve は open thread だけを resolved にし、再実行は冪等", async () => {

--- a/packages/server/src/lib/diagram-comments.ts
+++ b/packages/server/src/lib/diagram-comments.ts
@@ -414,7 +414,7 @@ async function withMutationQueue<T>(
   }
 }
 
-async function readCurrentDoc(
+async function readCurrentDiagram(
   worktreeReal: string,
   relPath: string
 ): Promise<
@@ -429,12 +429,11 @@ async function readCurrentDoc(
       error: diagram.error,
     };
   }
-  if (diagram.model.type !== "doc") {
-    return { ok: false, code: "NOT_DOC", error: "文書型の図ではありません" };
-  }
-  const anchors = validateDiagramDocAnchors(diagram.raw, diagram.model);
-  if (!anchors.ok) {
-    return { ok: false, code: "ANCHOR_NOT_FOUND", error: anchors.error };
+  if (diagram.model.type === "doc") {
+    const anchors = validateDiagramDocAnchors(diagram.raw, diagram.model);
+    if (!anchors.ok) {
+      return { ok: false, code: "ANCHOR_NOT_FOUND", error: anchors.error };
+    }
   }
   return diagram;
 }
@@ -514,7 +513,7 @@ async function writeDiagramCommentsFile(
   }
 }
 
-/** 最新の doc/sidecar を再検証して単発コメントを追加する。 */
+/** 最新の diagram/sidecar を再検証して単発コメントを追加する。 */
 export async function createDiagramComment(
   worktreeReal: string,
   relPath: string,
@@ -526,7 +525,7 @@ export async function createDiagramComment(
   const resolved = resolveDiagramCommentsPath(worktreeReal, relPath);
   if (!resolved.ok) return resolved;
   return withMutationQueue(resolved.commentsAbsPath, async () => {
-    const diagram = await readCurrentDoc(worktreeReal, relPath);
+    const diagram = await readCurrentDiagram(worktreeReal, relPath);
     if (!diagram.ok) return diagram;
     const anchor = diagram.model.nodes.find(node => node.id === anchorId);
     if (anchor === undefined) {
@@ -625,7 +624,7 @@ export async function createDiagramComment(
   });
 }
 
-/** 最新の doc/sidecar を再検証して既存 thread へメッセージを追加する。 */
+/** 最新の diagram/sidecar を再検証して既存 thread へメッセージを追加する。 */
 export async function appendDiagramCommentMessage(
   worktreeReal: string,
   relPath: string,
@@ -635,7 +634,7 @@ export async function appendDiagramCommentMessage(
   const resolved = resolveDiagramCommentsPath(worktreeReal, relPath);
   if (!resolved.ok) return resolved;
   return withMutationQueue(resolved.commentsAbsPath, async () => {
-    const diagram = await readCurrentDoc(worktreeReal, relPath);
+    const diagram = await readCurrentDiagram(worktreeReal, relPath);
     if (!diagram.ok) return diagram;
     const current = await readDiagramCommentsFile(worktreeReal, relPath);
     if (!current.ok) return current;
@@ -709,7 +708,7 @@ export async function appendDiagramCommentMessage(
   });
 }
 
-/** 最新の doc/sidecar を再検証して thread を解決済みにする。 */
+/** 最新の diagram/sidecar を再検証して thread を解決済みにする。 */
 export async function resolveDiagramComment(
   worktreeReal: string,
   relPath: string,
@@ -718,7 +717,7 @@ export async function resolveDiagramComment(
   const resolved = resolveDiagramCommentsPath(worktreeReal, relPath);
   if (!resolved.ok) return resolved;
   return withMutationQueue(resolved.commentsAbsPath, async () => {
-    const diagram = await readCurrentDoc(worktreeReal, relPath);
+    const diagram = await readCurrentDiagram(worktreeReal, relPath);
     if (!diagram.ok) return diagram;
     const current = await readDiagramCommentsFile(worktreeReal, relPath);
     if (!current.ok) return current;
@@ -797,7 +796,7 @@ async function removeEmptyDiagramCommentsFile(
   }
 }
 
-/** 最新の doc/sidecar を再検証して thread を物理削除する。 */
+/** 最新の diagram/sidecar を再検証して thread を物理削除する。 */
 export async function deleteDiagramComment(
   worktreeReal: string,
   relPath: string,
@@ -815,7 +814,7 @@ export async function deleteDiagramComment(
     };
   }
   return withMutationQueue(resolved.commentsAbsPath, async () => {
-    const diagram = await readCurrentDoc(worktreeReal, relPath);
+    const diagram = await readCurrentDiagram(worktreeReal, relPath);
     if (!diagram.ok) return diagram;
     const current = await readDiagramCommentsFile(worktreeReal, relPath);
     if (!current.ok) return current;

--- a/packages/server/src/lib/diagram-reader.test.ts
+++ b/packages/server/src/lib/diagram-reader.test.ts
@@ -18,6 +18,9 @@ const MODEL = JSON.stringify({
   nodes: [{ id: "order", label: "Order" }],
 });
 
+const occurrences = (value: string, token: string) =>
+  value.split(token).length - 1;
+
 beforeEach(() => {
   wt = fs.realpathSync(
     fs.mkdtempSync(path.join(os.tmpdir(), "ark-diagram-read-"))
@@ -57,7 +60,7 @@ describe("readDiagram", () => {
     }
   });
 
-  it("graph の ext と配信時 harness を返す", async () => {
+  it("graph の ext と配信時 harness・コメント層を返す", async () => {
     const graphModel = JSON.stringify({
       version: 1,
       nodes: [
@@ -82,9 +85,11 @@ describe("readDiagram", () => {
       expect(result.model.nodes[0]?.ext).toEqual({ x: 40, y: 50 });
       expect(result.model.nodes[1]?.ext).toEqual({ x: 360, y: 180 });
       expect(result.html).toContain(DIAGRAM_CSP);
-      expect(result.html).toContain(DIAGRAM_HARNESS_MARKER);
-      expect(result.html).not.toContain(DIAGRAM_COMMENT_LAYER_MARKER);
+      expect(occurrences(result.html, DIAGRAM_HARNESS_MARKER)).toBe(1);
+      expect(occurrences(result.html, DIAGRAM_COMMENT_LAYER_MARKER)).toBe(1);
+      expect(result.html).toContain('data-ark-comment-mode="graph"');
       expect(result.html).toContain('data-ark-container="graph"');
+      expect(Buffer.byteLength(result.html, "utf8")).toBeLessThan(128 * 1024);
     }
   });
 
@@ -107,8 +112,9 @@ describe("readDiagram", () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.html).toContain(DIAGRAM_CSP);
-      expect(result.html).toContain(DIAGRAM_COMMENT_LAYER_MARKER);
-      expect(result.html).not.toContain(DIAGRAM_HARNESS_MARKER);
+      expect(occurrences(result.html, DIAGRAM_COMMENT_LAYER_MARKER)).toBe(1);
+      expect(occurrences(result.html, DIAGRAM_HARNESS_MARKER)).toBe(0);
+      expect(result.html).toContain('data-ark-comment-mode="doc"');
     }
   });
 

--- a/packages/server/src/lib/diagram-reader.ts
+++ b/packages/server/src/lib/diagram-reader.ts
@@ -121,15 +121,15 @@ export async function readDiagram(
     return { ok: false, status: 422, error: graphKinds.error };
   }
   // 内蔵図種の投影生成 → CSP → 専用層の順。doc 本文は自前 HTML が正なので
-  // 編集ハーネスを混ぜず、コメント層だけを載せる。
+  // コメント層だけ、graph は編集ハーネスとコメント層の両方を載せる。
   const projected = injectCsp(injectBuiltinProjection(read.raw, model.model));
   return {
     ok: true,
     absPath: read.absPath,
     html:
       model.model.type === "doc"
-        ? injectDiagramCommentLayer(projected)
-        : injectHarness(projected),
+        ? injectDiagramCommentLayer(projected, "doc")
+        : injectDiagramCommentLayer(injectHarness(projected), "graph"),
     model: model.model,
   };
 }


### PR DESCRIPTION
Closes #320

graph 型の図で、**ノードにコメントを付けられる**ようにする。

## なぜ必要か

コメントは `type: "doc"` のページ限定だった。しかし設計レビューで言いたいことの多くはノードに紐づく。

- 「この集約の不変条件が違う」
- 「この状態遷移は事由で分岐するはず」

実際にボードで要件定義を回したところ、**指摘したい場所に書けない**ことが繰り返し問題になった。決定を別の doc に文章で書き、影響先のノードへ手で運ぶ運用になっていた。

## 前提: サイズの制約は #325 で解消済み

以前は「両方注入すると重すぎる」ことが壁だったが、注入コードを minify したため**ハーネスとコメント層を両方載せても以前のハーネス 1 つより軽い**。実測で graph ページの注入は 94,841 bytes（上限 131,072）。**注入サイズ上限テストは緩めていない。**

## 設計

**アンカーは `anchorId` だけで足りる。** doc はテキスト選択という不安定な対象を `anchorId` + `anchorQuote` + `anchorOccurrence` で表しているが、graph はノードが id を持つ。sidecar のスキーマは quote と occurrence が optional なので、**スキーマ変更なしで表現できる**。

**ハーネスは変更していない。** ハーネスはノードの選択とドラッグを持つが、そこへ相乗りすると結合が増える。コメント層が独立してノードの click を監視し、既存の「コメント」ボタンをノードの近くに出す。ハーネスのイベントは止めない。

**ドラッグの後にはボタンを出さない。** `pointerdown` の位置と対象を覚え、`click` 時に 5px 以上動いていたら抑制する。これが無いとノードを動かすたびにボタンが出る。

**モードは明示的に渡す。** 注入する `<script>` に `data-ark-comment-mode` を付け、層がそれを読む。DOM から推測しない。

## 実機で潰した不具合

ユニットテストは 1,064 件すべて緑だったが、**実ブラウザで触ったら動かなかった**。

**[1] ノードをクリックしてもボタンが出なかった。**
`pointerdown` が field 要素を、`click` がノードを指しており、`anchorId` が一致せず「ドラッグした」と誤判定されていた。click 対象を `.ark-harness-graph-node[data-model-id]` へ正規化し、座標差だけでドラッグを判定するようにした。

**[2] コメント層が保存 HTML に焼き込まれていた。**
ハーネスは DOM を直列化して図を保存する。コメント層がその対象に含まれており、**保存のたびに authored な `.diagram.html` へ注入コードが書き込まれ、開くたびに増殖していた**（実測でボタンが 4 個）。

これは出荷していれば**ユーザーの図ファイルを壊していた**。ハーネスは自身の UI を `data-ark-harness-ui` で除外しているので、コメント層の `<script>` / `<style>` / root `<div>` にも同じ印を付け、**既存の除外機構に乗せた**。独自の除外ロジックは足していない。あわせて、既に混入した HTML を配信時に回復する経路と、実行時に古い root / button を掃除する処理を入れた。

## 検証

`pnpm check` / `pnpm test`（1,067 件）/ `pnpm build` すべて green。

**実ブラウザで操作して確認した。**

- ノードのクリックで「コメント」ボタンが**1 個だけ**出る（`data-visible="true"`）
- そこからコンポーザを開いて作成すると sidecar に永続化される。thread は `anchorId: "customer"` / `anchorText: "Customer"` を持ち、**`anchorQuote` と `anchorOccurrence` を持たない**
- **ノードをドラッグした後はボタンが出ない**
- コメント 0 件・非操作時のコメント層由来の可視要素は 0（常設 chrome ゼロを維持）
- JS エラーなし

**保存に混入しないことは実 DOM で確認した。** コンポーザを開いた状態で、コメント層の全要素（`<script>` / root / button / composer）が `[data-ark-harness-ui]` の**内側にあり、印の外にある要素は 0**。専用 style も同様。`buildSubmissionHtml` は `[data-ark-harness-ui]` を削除するため、混入する経路が無い。

なお、実在する図が汚染されていないことも確認済み（本リポジトリの 8 枚と別リポジトリで運用中の 10 枚。汚染していたのは検証用に作った使い捨てファイル 1 件のみ）。

## 既知の割り切り

コメント層が `.ark-harness-graph-node` というハーネス由来の class に依存する。graph ページではハーネスが必ず注入されるので成立するが、結合であることは事実。ハーネスに手を入れない方針とのトレードオフとして受け入れた。
