### PR TITLE
fix(diagram): コメント操作でページが勝手にスクロールしないようにする

### DIFF
--- a/packages/server/src/lib/diagram-comment-layer.test.ts
+++ b/packages/server/src/lib/diagram-comment-layer.test.ts
@@ -945,11 +945,21 @@ describe("injectDiagramCommentLayer", () => {
     );
     expect(render).not.toContain("document.activeElement");
     expect(render).toContain("focusedInput.threadId");
-    expect(render).toContain("restoredInput.focus()");
+    expect(render).toContain("restoredInput.focus({preventScroll:true})");
     expect(render).toContain("restoredInput.setSelectionRange(");
     expect(injected).toContain(
       "render(completedAction&&completedAction.focusedInput)"
     );
+  });
+
+  it("すべてのフォーカス操作でページをスクロールさせない", () => {
+    const injected = injectDiagramCommentLayer(minimalDoc);
+    const focusCalls = [...injected.matchAll(/\.focus\(([^)]*)\)/gu)];
+
+    expect(focusCalls.length).toBeGreaterThan(0);
+    for (const focusCall of focusCalls) {
+      expect(focusCall[1]).toContain("preventScroll:true");
+    }
   });
 
   it("返信下書きを thread ごとに render 間で保持し成功時だけ消す", () => {

--- a/packages/server/src/lib/diagram-comment-layer.ts
+++ b/packages/server/src/lib/diagram-comment-layer.ts
@@ -200,7 +200,7 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
     hideSelectionAdd();
     render();
     var input=root.querySelector(".ark-comment-composer .ark-comment-input");
-    if(input)input.focus();
+    if(input)input.focus({preventScroll:true});
   }
   function visibleThreads(){
     return showResolved?comments.threads:comments.threads.filter(function(thread){return thread.status==="open";});
@@ -732,7 +732,7 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
       }
       if(restoredInput){
         var restoredLength=restoredInput.value.length;
-        restoredInput.focus();
+        restoredInput.focus({preventScroll:true});
         restoredInput.setSelectionRange(
           Math.min(focusedInput.selectionStart,restoredLength),
           Math.min(focusedInput.selectionEnd,restoredLength)


### PR DESCRIPTION
コメント操作でページが勝手にスクロールする問題を直す。

## 症状

> コメントしたら画面がスクロールするのやめて

テキストを選択して「コメント」を押すと、ページが飛ぶ。

## 原因

`focus()` は既定で対象を画面内へスクロールする。コメント層には 2 箇所ある。

- `openComposer` の末尾でコンポーザの入力欄へフォーカスする箇所
- `render()` 後にフォーカスとキャレット位置を復元する箇所

コンポーザは**アンカーの近く（多くはすぐ下）に文書座標で置かれる**ため、選択位置が画面の下寄りだとフォーカスのたびにページが飛ぶ。

**これは #327 でカードをドキュメント追従にした副作用でもある。** 以前は `position:fixed` でカードがビューポート内に強制的に収まっていたため、フォーカスしてもスクロールが起きにくかった。文書座標に置くようにしたことで、画面外に出うる位置へフォーカスが当たるようになった。

## 修正

両方の `focus()` に `{ preventScroll: true }` を渡す。キャレットは入力欄に入るが、ページは動かない。

**フォーカスを当てること自体はやめない。** コンポーザを開いた直後に入力欄へ入るのも、受動的な再取得（Claude が返信したとき等）で入力先を失わないための復元も、どちらも必要な挙動である。スクロールだけを止める。

## 検証

`pnpm check` / `pnpm test`（1,097 件）/ `pnpm build` すべて green。

実ブラウザで、画面の下寄りの要素を選んでコンポーザを開き、スクロール量を測った。

```
scrollY: 選択前 1196 → 選択後 1196 → コンポーザ表示後 1196
スクロール量: 0px ／ フォーカス: true
```

**ページは 1px も動かず、入力欄にフォーカスが入っている。**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * コメント入力欄へのフォーカス時に自動スクロールが発生しないよう改善しました。
  * 再描画後に入力欄へフォーカスを復元する際も、現在の表示位置を維持します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->