### PR TITLE
docs: Ark ループエンジニアリング実装 spec を追加 (#332)

### DIFF
--- a/.claude/skills/flow-loop/SKILL.md
+++ b/.claude/skills/flow-loop/SKILL.md
@@ -124,3 +124,4 @@ phase は flow-x の run state (`progress.phase`)。async モードで park す�
 - `../flow-x/SKILL.md` — 実行エンジン (`--async-gates` の非同期ゲート仕様は flow-x 側に定義)
 - `../../lib/state-io.sh` — run state (flow / flow-x と共用。loop は読み取りが主)
 - `../../lib/check-cr-threads.sh` / `../../lib/deploy-watch.sh` / `../../lib/cleanup.sh` — P7 / P12 / abort で再利用
+- `../../../docs/superpowers/specs/ark-loop-implementation-spec.md` — 1セッション内認知維持ループの下層 spec

--- a/docs/superpowers/plans/2026-08-18-issue-332.md
+++ b/docs/superpowers/plans/2026-08-18-issue-332.md
@@ -20,7 +20,7 @@
 - `.claude/lib/state-io.sh:11-16,65-178` は運転 state を `progress` / `kpi` / `context` に分離する。`phase_history`、`warnings`、`gate_findings_seen` は `.claude/lib/state-io.sh:99-119` の `progress`、worktree や Issue は `.claude/lib/state-io.sh:141-161` の `context` に属する。
 - `.claude/settings.json:12-80` には SessionStart 2件、PreToolUse 2件、PostToolUse 2件、Stop 1件が登録済みである。`.claude/hooks/stop-gate.sh:1-8` は現在 `exit 0` の no-op であり、P4 は登録先を増やさずこの実体を置き換える。
 - `.claude/hooks/pre-edit-guard.sh:11-17` は `.claude/hooks/` と settings の直接編集を保護する。issue-332 ではそれらを変更せず、後続 Issue が明示されたスコープと人間確認の下で扱う。
-- `.claude/` 内には `TodoWrite` の使用例も native todo state との同期実装もない。したがって既存互換を壊さず単一正本を導入できる。
+- Claude Code の native task state も `~/.claude/tasks/session-<id>/<n>.json` と `.lock` により永続化・排他され、hook や別 process から読め、process 再起動後も残る。保存先の session ID は会話 transcript と別体系で、対応付けは可能だが自明ではない。
 - `gh issue view 332`〜`336` で、`loop-engineering`、`P0`〜`P4`、`loop-exclude` ラベルがすでに存在し、#332〜#336 に付与済みであることを確認済み。issue-332 でラベル変更は行わない。
 - 既存 spec は `# タイトル` から目的・設計判断・アーキテクチャ・コンポーネント・安全装置・検証・非ゴールへ展開する簡潔な Markdown 形式である。対象 spec のファイル名だけは後続 Issue の固定参照に合わせ、日付 prefix を付けない。
 
@@ -60,8 +60,9 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 
 - [ ] `§3-1 config と環境変数` に、`ARK_SESSION_ID`、`ARK_SESSION_DIR`、`ARK_CACHE_DIR`、`ARK_RECITE_INTERVAL`（既定10）、`ARK_KNOWLEDGE_DIR` の導出、未設定なら全 hook が即成功終了する隔離契約、`[loop.summarize] llm = false` の既定を記す。
 - [ ] `§3-2 file ownership` に、`task.md` は session 内の進捗正本、`artifacts/` は大きい中間成果、`raw.log` は append-only 原記録、`summary.md` と `handoff.md` は再生成可能な派生、`failures.md` は人間キュレーション済み read-only 配布物、`failures-inbox.md` は昇格待ちと定義する。
-- [ ] `§3-3 native todo との関係` で選択肢 (a) を採用し、loop 有効セッションでは `task.md` を唯一の正本にして `TodoWrite`／native Task todo state に作業項目を複製しないと決める。根拠を、hook／別セッションから読める、再起動で残る、同期競合がない、現在の `.claude/` に先行利用がない、の4点で示す。
-- [ ] 選択肢 (a) には Claude Code の native todo が提供するユーザー可視の進捗表示を失うコストがあること、それでも hook／再起動／別セッションで一貫して扱える単一正本を優先するため採用することを同節に1〜2行で残す。
+- [ ] `§3-3 native todo との関係` で選択肢 (a) を採用し、loop 有効セッションでは `task.md` を唯一の正本にして `TodoWrite`／native Task todo state に作業項目を複製しないと決める。根拠を、native schema が Goal／Constraints／`← NOW` と更新不変条件を構造化できないこと、正本化すると §2-1 の agent 非依存な adapter 境界を壊すこと、native の保存形式は変更されうる内部実装で公開契約ではないこと、の3点で示す。
+- [ ] native task state も JSON file と `.lock` により永続化・排他され、hook／別 process から読めて再起動後も残る事実を明記する。native state 単体の排他と選択肢 (c) の双方向同期の整合性を区別し、native task session ID と会話 transcript session ID の対応付けは可能だが自明でないと補足する。
+- [ ] 選択肢 (a) には Claude Code の native todo が提供するユーザー可視の進捗表示を失うコストがあること、それでも recitation schema と adapter 境界を満たす安定した単一正本を優先するため採用することを同節に1〜2行で残す。
 - [ ] 同節から導かれる拘束を明記する。P1 の `recite-todo.sh` は `task.md` だけを読み native todo を参照・更新しない。P2 の `loop-rules.md` は native todo の使用禁止、Plan status と `← NOW` の更新、Goal／Constraints の不変条件を含む。native todo が必要な作業は loop を無効化するか、task.md へ移してから続ける。
 - [ ] `§3-4 flow state との所有権表` に、`flow-progress-*.json` は phase／gate／safety／warning 等の制御面、`artifacts/` は内容面と分離し、相互コピー・双方向同期・flow state schema 追加をしないと書く。接続は WORK_ID／session path の参照だけに留める。
 

--- a/docs/superpowers/plans/2026-08-18-issue-332.md
+++ b/docs/superpowers/plans/2026-08-18-issue-332.md
@@ -51,7 +51,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 
 - [ ] `§2-1 配布物` に `ark/loop/{templates,hooks,scripts,adapters/claude-code}` を定義し、`templates`・規約・file format は agent 非依存、settings 注入と hook JSON は Claude Code adapter に閉じ込め、将来の `adapters/codex/` は AGENTS.md 注入と wrapper だけで追加できる構造とする。
 - [ ] `§2-2 XDG runtime` に `${XDG_CONFIG_HOME:-$HOME/.config}/ark/loop/config.toml`、`${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/sessions/$ARK_SESSION_ID/`、`${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/knowledge/`、`${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/` を正規配置として記す。
-- [ ] session data の木を `task.md`、`artifacts/index.md`、`errors/raw.log`、`errors/summary.md`、`handoff.md`、cache の `step_count` と one-shot stop flag、knowledge の `failures.md` と `failures-inbox.md` まで具体化する。永続 data と再生成可能 cache を混ぜない。
+- [ ] session data の木を `task.md`、`artifacts/index.md`、`errors/raw.log`、`errors/summary.md`、`handoff.md`、one-shot stop flag、cache の `step_count`、knowledge の `failures.md` と `failures-inbox.md` まで具体化する。正しさに関わる状態を cache に置かない。
 - [ ] `§2-3 対象 repo への影響` に、実行時の一時変更は `.claude/settings.local.json` と repo `.gitignore` の明示エントリだけ、成果物本体は XDG data 配下とし、終了／次回 init で収束させると書く。
 
 ## Task 4: §3 で config、file ownership、task の唯一正本を決める
@@ -97,16 +97,16 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → 孤児 backup 検出時の settings.local 復元 → session directory と ID 作成 → config 読込と環境変数 export → template 展開 → knowledge copy → settings.local 再退避・注入、と固定する。
+- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → session ID 生成と per-repo owner 取得 → 消滅 owner の孤児 settings 復元 → session directory 作成 → config 読込と Ark への値返却 → template 展開 → knowledge copy → settings.local 再退避・注入、と固定する。別 session の owner が生存中なら loop を無効化して続行する。
 - [ ] settings.local の退避／復元は `mv` ベースで冪等にし、teardown を通らない kill が通常系であること、2回連続 kill でも「元設定1個または注入設定＋backup1個」の解釈可能な状態から元設定へ収束すると書く。
-- [ ] repo `.gitignore` に `.claude/settings.local.json` を重複なく明示し、グローバル ignore に依存しないこと、対象 repo にそれ以外の永続変更を残さないことを書く。
+- [ ] repo `.gitignore` に `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の2 entry を重複なく明示し、グローバル ignore に依存しないこと、対象 repo にそれ以外の永続変更を残さないことを書く。
 - [ ] `--restart` は既存 session の `errors/summary.md` を `{{PREV_FAILURE_SUMMARY}}` に埋め、通常 init は空の定型文を入れる。`step_count` は新 session ごとに0から始め、同じ init の再実行では task 正本を上書きしないと書く。
 
 ## Task 9: §6-2 に teardown、handoff、resume 境界を書く
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§6-2 session-teardown.sh` の順序を、機械 summary 生成 → handoff 更新 → failures-inbox 追記 → settings.local 注入物の除去と original 復元 → transient flag cleanup とし、各段階を再実行可能にする。
+- [ ] `§6-2 session-teardown.sh` の順序を、機械 summary 生成 → handoff 更新 → failures-inbox 追記 → owner の場合だけ settings.local 注入物の除去と original 復元 → transient flag と owner marker の cleanup とし、各段階を再実行可能にする。
 - [ ] `handoff.md` の固定項目を Goal、完了／未完了 Plan、現在の `← NOW`、artifact path＋要約、直近 error summary path、次の最小 action、WORK_ID／session ID とする。artifact 本文や flow JSON の複製はしない。
 - [ ] `handoff.md` は次のモデルへ意味的文脈を渡す data plane、`/flow --resume` は `.claude/lib/state-io.sh` の phase／gate を復元する control plane と定義する。競合時は flow state が phase の正本、handoff は助言情報であり、自動マージも相互上書きもしない。
 - [ ] teardown 未実行なら次回 init が summary／handoff／settings 復元を同じ順序で補償し、最終的に teardown 実行済みと同じ repo 状態へ収束すると書く。
@@ -116,7 +116,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
 - [ ] `§6-3 summarize-errors.sh` の既定を、JSONL を tool＋error_type で決定的に集計し、件数、最初／最後の行番号、`詳細: errors/raw.log:L{n}-L{m}` を持つ `summary.md` を生成する機械的 compaction とする。同じ input から同じ本文を得る。
-- [ ] `config.toml [loop.summarize] llm = true` のときだけ Haiku API に機械 summary と参照を渡し、「禁止手」付き要約を追加する。config コメントに API 従量課金とプラン枠外であることを明記し、API key 不在、timeout、非0終了、invalid output はすべて機械 summary を保ったまま成功 fallback とする。
+- [ ] `config.toml [loop.summarize] llm = true` のときだけ config で指定した `model` の API に機械 summary と参照を渡し、「禁止手」付き要約を追加する。実装にモデル名を直書きせず、config コメントに API 従量課金とプラン枠外であることを明記し、API key 不在、timeout、非0終了、invalid output はすべて機械 summary を保ったまま成功 fallback とする。
 - [ ] LLM 出力にも raw.log 行参照を必須とし、原ログを削除・書換えしないこと、`task.md.tmpl` への継承は summary 本文の上限付き抜粋＋raw path で行うことを書く。
 
 ## Task 11: §7 に knowledge flow、flow-loop 接続、足場撤去基準を書く
@@ -148,4 +148,4 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - `.claude/skills/flow-loop/SKILL.md` から spec への相互参照が1行だけ追加されている。
 - `task.md` が唯一の正本であり、P1 の recite と P2 の loop-rules に派生制約が明記されている。
 - 1セッション内認知維持層と複数セッション運転層の所有権、課金原則、知識化と隔離の関係、人間判断を既定として定量計測を補強材料に留める足場撤去 gate が固定されている。
-- 実装差分は Markdown 2ファイルだけで、Ark アプリ本体および hook/settings 実装には変更がない。
+- 実装対象 2ファイル（spec と `flow-loop` の `SKILL.md`）に加えて、この plan を成果物としてコミットし、Task 12 の検証対象3 path 以外の Ark アプリ本体および hook/settings 実装には変更がない。

--- a/docs/superpowers/plans/2026-08-18-issue-332.md
+++ b/docs/superpowers/plans/2026-08-18-issue-332.md
@@ -1,0 +1,151 @@
+# issue-332: Ark ループエンジニアリング実装 spec の作成 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Manus の context engineering を Ark の1セッション内認知維持層へ導入する実装契約を §1〜§7 に固定し、後続 Issue #333〜#336 の参照をすべて解決する。
+
+**Issue:** 332 (GitHub Issue 紐付けあり)
+
+**Architecture:** `ark-loop-implementation-spec.md` を、基礎契約（§1〜§3）、hook（§4）、テンプレート／規約／アダプタ（§5）、ライフサイクル script（§6）、横断知識・既存 flow 接続・足場撤去（§7）の7節で構成する。後続 Issue が参照する枝番を変更せず、セッション内の認知状態と、既存 `flow` / `flow-x` / `flow-loop` が保持する複数セッション運転 state の責務を明示的に分離する。成果物は spec と `flow-loop` からの相互参照1行だけとし、`server/`・`client/`・`shared/` および hook 実装には触れない。
+
+**Tech Stack:** Markdown ドキュメント / bash hooks / Claude Code settings.json（実装は後続 Issue）
+
+---
+
+## 実装時に固定する調査結果
+
+- `CLAUDE.md:19,163` は Agent SDK / `claude -p` ではなく対話版 Claude を使ってプラン枠課金を維持する。`CLAUDE.md:104` は plan/spec をコミット対象の設計成果物とし、`CLAUDE.md:114-116` は `flow` / `flow-x` / `flow-loop` の運転責務を定義している。
+- `.claude/skills/flow-loop/SKILL.md:11-15` は `flow-loop` を `flow-x` の外殻、`.claude/skills/flow-loop/SKILL.md:67-73` はハーネス自改修を `loop-exclude` 対象、`.claude/skills/flow-loop/SKILL.md:107-112` はブレーカー等の安全装置と定義している。相互参照の追加位置は同ファイルの「関連ファイル」`.claude/skills/flow-loop/SKILL.md:120-126` とする。
+- `.claude/skills/flow-x/SKILL.md:148-189` は非同期 gate と tick の接続、`.claude/skills/flow/SKILL.md:13-28,57-169` は `--resume` が永続 state から phase を復元する契約を持つ。
+- `.claude/lib/state-io.sh:11-16,65-178` は運転 state を `progress` / `kpi` / `context` に分離する。`phase_history`、`warnings`、`gate_findings_seen` は `.claude/lib/state-io.sh:99-119` の `progress`、worktree や Issue は `.claude/lib/state-io.sh:141-161` の `context` に属する。
+- `.claude/settings.json:12-80` には SessionStart 2件、PreToolUse 2件、PostToolUse 2件、Stop 1件が登録済みである。`.claude/hooks/stop-gate.sh:1-8` は現在 `exit 0` の no-op であり、P4 は登録先を増やさずこの実体を置き換える。
+- `.claude/hooks/pre-edit-guard.sh:11-17` は `.claude/hooks/` と settings の直接編集を保護する。issue-332 ではそれらを変更せず、後続 Issue が明示されたスコープと人間確認の下で扱う。
+- `.claude/` 内には `TodoWrite` の使用例も native todo state との同期実装もない。したがって既存互換を壊さず単一正本を導入できる。
+- `gh issue view 332`〜`336` で、`loop-engineering`、`P0`〜`P4`、`loop-exclude` ラベルがすでに存在し、#332〜#336 に付与済みであることを確認済み。issue-332 でラベル変更は行わない。
+- 既存 spec は `# タイトル` から目的・設計判断・アーキテクチャ・コンポーネント・安全装置・検証・非ゴールへ展開する簡潔な Markdown 形式である。対象 spec のファイル名だけは後続 Issue の固定参照に合わせ、日付 prefix を付けない。
+
+各チェックボックスは2〜5分で完了できる単位とする。
+
+Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に書き、実装手順の再掲や散文を増やさない。
+
+## Task 1: spec の固定目次と Issue トレーサビリティを作る
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md` (new)
+
+- [ ] タイトル、目的、対象／非対象を置き、変更対象を後続 Issue が実装する `ark/loop/` と Claude Code adapter に限定する。issue-332 自体では Markdown 以外を実装しないこと、Ark アプリ本体の `server/`・`client/`・`shared/` は非対象であることを明記する。
+- [ ] 本文見出しを `§1 概要と設計原則`、`§2 配置と XDG ディレクトリ契約`、`§3 設定・状態・正本`、`§4 hook 契約`、`§5 テンプレート・ループ規約・アダプタ`、`§6 セッションライフサイクル script`、`§7 横断知識・flow 接続・足場撤去` の順で作る。
+- [ ] 冒頭に参照表を置き、#333 は `§1, §2, §3, §4-1, §5-1, §5-3, §6-1`、#334 は `§5-2`、#335 は `§4-2, §6-3, task.md.tmpl の {{PREV_FAILURE_SUMMARY}}`、#336 は `§4-3, §6-2, §7` と、一字一句同じ参照を載せる。
+
+## Task 2: §1 で理論、課金原則、二層構造を固定する
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§1-1 目的と非ゴール` に、ゴールドリフト、lost-in-the-middle、compaction 後の失敗再発を減らす「現在のモデル向けの撤去可能な足場」であり、この spec 自体も不要になれば撤去する足場であること、推論スタック、独自 agent runtime、動的 tool masking、Ark UI の追加は行わないと書く。
+- [ ] `§1-2 Manus 原則の写像` に、安定 prefix／append-only、tool を消さず Claude Code の `allowed-tools` で制約、filesystem 外部メモリ、固定長 recitation、失敗保持、レビュー観点ローテーション、compaction-first／summarization-last の実装対応を表で記す。出典 URL 2件も明記する。
+- [ ] `§1-3 層の定義` に、本 spec は「1セッション内の認知維持ループ」、`/flow-loop` は「複数セッション・PR・CI・deploy をまたぐ運転ループ」であり、前者が後者の下層として補完し、phase・gate・安全装置を奪わないと書く。
+- [ ] `§1-4 課金と単純性` に、機械的 compaction を既定、LLM 要約を明示 opt-in のみとし、API 課金を伴うこと、失敗時は機械処理へ戻ることを設計原則として置く。各足場は独立に無効化・撤去可能でなければならないと書く。
+
+## Task 3: §2 で配置、XDG、adapter 境界を固定する
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§2-1 配布物` に `ark/loop/{templates,hooks,scripts,adapters/claude-code}` を定義し、`templates`・規約・file format は agent 非依存、settings 注入と hook JSON は Claude Code adapter に閉じ込め、将来の `adapters/codex/` は AGENTS.md 注入と wrapper だけで追加できる構造とする。
+- [ ] `§2-2 XDG runtime` に `${XDG_CONFIG_HOME:-$HOME/.config}/ark/loop/config.toml`、`${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/sessions/$ARK_SESSION_ID/`、`${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/knowledge/`、`${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/` を正規配置として記す。
+- [ ] session data の木を `task.md`、`artifacts/index.md`、`errors/raw.log`、`errors/summary.md`、`handoff.md`、cache の `step_count` と one-shot stop flag、knowledge の `failures.md` と `failures-inbox.md` まで具体化する。永続 data と再生成可能 cache を混ぜない。
+- [ ] `§2-3 対象 repo への影響` に、実行時の一時変更は `.claude/settings.local.json` と repo `.gitignore` の明示エントリだけ、成果物本体は XDG data 配下とし、終了／次回 init で収束させると書く。
+
+## Task 4: §3 で config、file ownership、task の唯一正本を決める
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§3-1 config と環境変数` に、`ARK_SESSION_ID`、`ARK_SESSION_DIR`、`ARK_CACHE_DIR`、`ARK_RECITE_INTERVAL`（既定10）、`ARK_KNOWLEDGE_DIR` の導出、未設定なら全 hook が即成功終了する隔離契約、`[loop.summarize] llm = false` の既定を記す。
+- [ ] `§3-2 file ownership` に、`task.md` は session 内の進捗正本、`artifacts/` は大きい中間成果、`raw.log` は append-only 原記録、`summary.md` と `handoff.md` は再生成可能な派生、`failures.md` は人間キュレーション済み read-only 配布物、`failures-inbox.md` は昇格待ちと定義する。
+- [ ] `§3-3 native todo との関係` で選択肢 (a) を採用し、loop 有効セッションでは `task.md` を唯一の正本にして `TodoWrite`／native Task todo state に作業項目を複製しないと決める。根拠を、hook／別セッションから読める、再起動で残る、同期競合がない、現在の `.claude/` に先行利用がない、の4点で示す。
+- [ ] 選択肢 (a) には Claude Code の native todo が提供するユーザー可視の進捗表示を失うコストがあること、それでも hook／再起動／別セッションで一貫して扱える単一正本を優先するため採用することを同節に1〜2行で残す。
+- [ ] 同節から導かれる拘束を明記する。P1 の `recite-todo.sh` は `task.md` だけを読み native todo を参照・更新しない。P2 の `loop-rules.md` は native todo の使用禁止、Plan status と `← NOW` の更新、Goal／Constraints の不変条件を含む。native todo が必要な作業は loop を無効化するか、task.md へ移してから続ける。
+- [ ] `§3-4 flow state との所有権表` に、`flow-progress-*.json` は phase／gate／safety／warning 等の制御面、`artifacts/` は内容面と分離し、相互コピー・双方向同期・flow state schema 追加をしないと書く。接続は WORK_ID／session path の参照だけに留める。
+
+## Task 5: §4-1 に固定長 recitation と既存 hook 共存を書く
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§4 hook 共通契約` に、hook input は非信頼データ、全 script は環境変数未設定時に no-op、session cache 以外へカウンタを共有しない、エラーで本来の tool result を握りつぶさない、追加 hook の fast path 合計を100ms以内とする原則を置く。
+- [ ] 現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持し、後続では論理順を `capture-error` → 既存の該当 hook（Bash は post-push-monitor、Write/Edit は post-edit-lint）→ `recite-todo` とすること、実 Claude Code の直列実行契約を #333/#335 で実機確認し計測値を PR に残すことを書く。
+- [ ] `§4-1 recite-todo.sh` に、成功した tool step ごとに session-local counter を増やし、既定10 step ごとに Goal 1行、`← NOW` 行、未完了件数だけを `additionalContext` へ出すと定義する。task 全文、timestamp、artifact 本文、native todo は注入せず、概念上は1回200 token以下、実装上の代理指標として UTF-8 で600 bytes以下を #333 で検証すると spec に明記する。
+- [ ] compaction 直後でも task 正本から同じ固定長形式を再構成し、prefix を変動させないこと、interval 変更と hook 無効化だけで recitation 足場を単独撤去できることを書く。
+
+## Task 6: §4-2 と §4-3 に失敗捕捉と Stop 契約を書く
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§4-2 capture-error.sh` に、PostToolUse の失敗だけを `errors/raw.log` へ1物理行の JSONL（`at`, `tool`, `error_type`, `exit_code`, `message`）で append し、改行は JSON escape、message は上限付き、成功時は書き込まないと固定する。1 entry 1行により `L{n}-L{n}` 参照を安定させる。
+- [ ] capture は分類・要約・禁止手生成を行わず、原エラーを消さないこと、同一 tool event の capture が recite より先に完了すること、hook input の実 field 名は #335 で実ダンプを fixture 化して確定することを書く。
+- [ ] `§4-3 Stop` に、新規 Stop 登録ではなく `.claude/hooks/stop-gate.sh` の実体を `on-stop.sh` 相当へ置換する契約を書く。未完了 Plan があれば session-local one-shot flag で1回だけ継続を要求し、2回目は通して無限 Stop loop を防ぐ。
+- [ ] Stop 通過時は `handoff.md` を生成するが、teardown 完了を前提にしないこと、tmux kill／pm2 restart／process crash では次回 init が同じ収束処理を担うことを書く。
+
+## Task 7: §5 に task template、10規約、review rotation、adapter を書く
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§5-1 task.md.tmpl` に `Goal`、`Constraints`、`Previous failure summary: {{PREV_FAILURE_SUMMARY}}`、checkbox 付き `Plan`、ちょうど1個の `← NOW`、artifact 参照欄を定義する。Goal／Constraints は init 後編集禁止、進捗項目と NOW だけを更新可能とする。
+- [ ] `§5-2 loop-rules.md` のタスク管理3則を「task.md だけを正本にする」「tool step の前後で status／NOW を現実に合わせる」「Goal／Constraints を書き換えず逸脱時は停止」と固定する。
+- [ ] 同節のエラー3則を「失敗 action と原文を raw.log に残す」「再試行前に直前失敗と既知の禁止手を読む」「回復結果と再発性のある知見を inbox 候補にする」、外部化4則を「20行超の中間成果は artifact 化」「index に path＋1行要約を append」「本文再掲より path 参照を優先」「可逆 compaction 後にのみ不可逆 summary」と固定する。
+- [ ] review 用 `task-review.md.tmpl` は diff 全読、規約／artifact／握りつぶし／Goal 逸脱、再発指摘の inbox 候補化を観点に持ち、session ID から生成した順列で提示順だけを変える。観点集合は減らさず、同一 session 内では順序を安定させると書く。
+- [ ] `§5-3 Claude Code adapter` に、settings.local の退避／注入、hook matcher、`additionalContext`、agent 非依存 template との境界、将来 Codex adapter が native todo 同期を持ち込んではならないことを書く。
+
+## Task 8: §6-1 に冪等 session-init 契約を書く
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → 孤児 backup 検出時の settings.local 復元 → session directory と ID 作成 → config 読込と環境変数 export → template 展開 → knowledge copy → settings.local 再退避・注入、と固定する。
+- [ ] settings.local の退避／復元は `mv` ベースで冪等にし、teardown を通らない kill が通常系であること、2回連続 kill でも「元設定1個または注入設定＋backup1個」の解釈可能な状態から元設定へ収束すると書く。
+- [ ] repo `.gitignore` に `.claude/settings.local.json` を重複なく明示し、グローバル ignore に依存しないこと、対象 repo にそれ以外の永続変更を残さないことを書く。
+- [ ] `--restart` は既存 session の `errors/summary.md` を `{{PREV_FAILURE_SUMMARY}}` に埋め、通常 init は空の定型文を入れる。`step_count` は新 session ごとに0から始め、同じ init の再実行では task 正本を上書きしないと書く。
+
+## Task 9: §6-2 に teardown、handoff、resume 境界を書く
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§6-2 session-teardown.sh` の順序を、機械 summary 生成 → handoff 更新 → failures-inbox 追記 → settings.local 注入物の除去と original 復元 → transient flag cleanup とし、各段階を再実行可能にする。
+- [ ] `handoff.md` の固定項目を Goal、完了／未完了 Plan、現在の `← NOW`、artifact path＋要約、直近 error summary path、次の最小 action、WORK_ID／session ID とする。artifact 本文や flow JSON の複製はしない。
+- [ ] `handoff.md` は次のモデルへ意味的文脈を渡す data plane、`/flow --resume` は `.claude/lib/state-io.sh` の phase／gate を復元する control plane と定義する。競合時は flow state が phase の正本、handoff は助言情報であり、自動マージも相互上書きもしない。
+- [ ] teardown 未実行なら次回 init が summary／handoff／settings 復元を同じ順序で補償し、最終的に teardown 実行済みと同じ repo 状態へ収束すると書く。
+
+## Task 10: §6-3 に compaction-first の error summary を書く
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§6-3 summarize-errors.sh` の既定を、JSONL を tool＋error_type で決定的に集計し、件数、最初／最後の行番号、`詳細: errors/raw.log:L{n}-L{m}` を持つ `summary.md` を生成する機械的 compaction とする。同じ input から同じ本文を得る。
+- [ ] `config.toml [loop.summarize] llm = true` のときだけ Haiku API に機械 summary と参照を渡し、「禁止手」付き要約を追加する。config コメントに API 従量課金とプラン枠外であることを明記し、API key 不在、timeout、非0終了、invalid output はすべて機械 summary を保ったまま成功 fallback とする。
+- [ ] LLM 出力にも raw.log 行参照を必須とし、原ログを削除・書換えしないこと、`task.md.tmpl` への継承は summary 本文の上限付き抜粋＋raw path で行うことを書く。
+
+## Task 11: §7 に knowledge flow、flow-loop 接続、足場撤去基準を書く
+
+**Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `§7-1 failures 横断共有` に、host knowledge の `failures.md` だけを curated 正本とし、session 開始時に read-only copy、session 終了時は `failures-inbox.md` へ候補追記、人間が重複・機密・再現性を確認して inbox からのみ昇格させる流れを書く。
+- [ ] `§7-2 flow-loop 接続` に、ブレーカー／`loop-exclude` は失敗 run を隔離する安全側、`failures.md` は失敗を知識化して再発を防ぐ学習側と定義する。ブレーカー event に failures.md の配布・参照有無を記録し、知識注入 cohort で consecutive halt／breaker／loop-exclude 頻度が下がるか測るが、知識側がブレーカーを解除・迂回してはならないと書く。
+- [ ] 同節に対応表を置き、`artifacts/` ↔ `flow-progress-*.json` は data plane／control plane、`handoff.md` ↔ `/flow --resume` は意味文脈／phase 復元、`failures.md` ↔ breaker・`loop-exclude` は学習／隔離と整理する。重複内容を同期しないことを各行に記す。
+- [ ] `§7-3 足場撤去プロトコル` の既定 gate を人間の判断とし、1要素ずつ実セッションで無効化して数日運用し、体感上または明らかな劣化がなければ撤去してよいと定義する。定量計測は取得できる場合の補強材料に留め、統計的有意性を撤去条件にしない。
+- [ ] 軽量な観察指標として、recite はゴールドリフト、summary 継承は同種 error 再発、artifact/index は長出力後の参照回収失敗、review rotation は観点漏れ、Stop/handoff は再開後の誤 action／未完了放置を見ると書く。既定方針は「疑わしきは外す」とし、外せないまま保守するより撤去後に問題が出たら git 履歴から復元する方が安いことを根拠として添える。
+
+## Task 12: 相互参照を張り、節番号とスコープを検証する
+
+**Files:** `.claude/skills/flow-loop/SKILL.md`, `docs/superpowers/specs/ark-loop-implementation-spec.md`
+
+- [ ] `.claude/skills/flow-loop/SKILL.md` の「関連ファイル」末尾に、`../../../docs/superpowers/specs/ark-loop-implementation-spec.md` を「1セッション内認知維持ループの下層 spec」と説明する1行を加える。flow-loop の手順、allowed-tools、安全装置は変更しない。
+- [ ] `rg -n '^## §[1-7]|^### §(4-[123]|5-[123]|6-[123])' docs/superpowers/specs/ark-loop-implementation-spec.md` で §1〜§7 と全参照枝番が一意に存在することを確認する。
+- [ ] `rg -n '§1, §2, §3, §4-1, §5-1, §5-3, §6-1|§5-2|§4-2, §6-3|§4-3, §6-2, §7|\{\{PREV_FAILURE_SUMMARY\}\}' docs/superpowers/specs/ark-loop-implementation-spec.md` で #333〜#336 の参照 map と placeholder 名を確認する。
+- [ ] `rg -n '機械的|opt-in|task.md.*唯一|TodoWrite|artifacts/|flow-progress-|handoff.md|--resume|failures.md|breaker|loop-exclude|撤去|疑わしきは外す|git 履歴' docs/superpowers/specs/ark-loop-implementation-spec.md` で5追補と撤去 gate が欠落していないことを確認する。
+- [ ] `git diff --name-only` が `docs/superpowers/specs/ark-loop-implementation-spec.md` と `.claude/skills/flow-loop/SKILL.md`（および事前承認済み plan）のみを示し、`server/`・`client/`・`shared/`・`.claude/hooks/`・`.claude/settings.json` に差分がないことを確認する。
+- [ ] `gh issue view 332 --json labels` と #333〜#336 の同じ読み取りで `loop-engineering`、`P0`〜`P4`、`loop-exclude` の存在を再確認し、ラベル API の write は行わない。
+
+---
+
+## 完了条件
+
+- `docs/superpowers/specs/ark-loop-implementation-spec.md` が存在し、#333〜#336 の全節参照と `{{PREV_FAILURE_SUMMARY}}` 契約が解決している。
+- `.claude/skills/flow-loop/SKILL.md` から spec への相互参照が1行だけ追加されている。
+- `task.md` が唯一の正本であり、P1 の recite と P2 の loop-rules に派生制約が明記されている。
+- 1セッション内認知維持層と複数セッション運転層の所有権、課金原則、知識化と隔離の関係、人間判断を既定として定量計測を補強材料に留める足場撤去 gate が固定されている。
+- 実装差分は Markdown 2ファイルだけで、Ark アプリ本体および hook/settings 実装には変更がない。

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -59,6 +59,57 @@ recitation、error capture、summary、handoff、knowledge 配布は個別に無
 
 ## §2 配置と XDG ディレクトリ契約
 
+### §2-1 配布物
+
+配布物の境界は次で固定する。
+
+```text
+ark/loop/
+├── templates/
+├── hooks/
+├── scripts/
+└── adapters/
+    └── claude-code/
+```
+
+`templates/`、ループ規約、file format は agent 非依存とする。settings 注入、hook matcher、hook 入出力 JSON の解釈は `adapters/claude-code/` に閉じ込める。将来の `adapters/codex/` は同じ正本と format を使い、AGENTS.md 注入と実行 wrapper だけを追加すればよい構造とする。
+
+### §2-2 XDG runtime
+
+正規配置は次のとおりとする。
+
+- config: `${XDG_CONFIG_HOME:-$HOME/.config}/ark/loop/config.toml`
+- session data: `${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/sessions/$ARK_SESSION_ID/`
+- host knowledge: `${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/knowledge/`
+- session cache: `${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/`
+
+```text
+${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/
+├── sessions/$ARK_SESSION_ID/
+│   ├── task.md
+│   ├── artifacts/
+│   │   └── index.md
+│   ├── errors/
+│   │   ├── raw.log
+│   │   └── summary.md
+│   └── handoff.md
+└── knowledge/
+    ├── failures.md
+    └── failures-inbox.md
+
+${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/
+├── step_count
+└── stop_once
+```
+
+session data と knowledge は永続 data であり、cache は消失しても再生成できる counter と one-shot Stop flag だけを持つ。両者を相互に代用しない。
+
+### §2-3 対象 repo への影響
+
+実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と、repo `.gitignore` の `.claude/settings.local.json` 明示 entry だけとする。認知維持の成果物本体は XDG data 配下に置く。
+
+正常終了は settings 注入物を除去し、異常終了は次回 init が同じ復元を行う。どちらも元の repo 設定へ収束し、それ以外の永続変更を残さない。
+
 ## §3 設定・状態・正本
 
 ## §4 hook 契約

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -44,6 +44,7 @@ Manus の context engineering を Ark が起動する1セッション内の認�
 
 - https://manus.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus
 - https://www.youtube.com/watch?v=6_BcCthVvb8
+- https://rlancemartin.github.io/2025/10/15/manus/
 
 ### §1-3 層の定義
 
@@ -81,6 +82,7 @@ ark/loop/
 - config: `${XDG_CONFIG_HOME:-$HOME/.config}/ark/loop/config.toml`
 - session data: `${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/sessions/$ARK_SESSION_ID/`
 - host knowledge: `${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/knowledge/`
+- repo state: `${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/repos/$ARK_REPO_KEY/`
 - session cache: `${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/`
 
 ```text
@@ -95,20 +97,23 @@ ${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/
 │   ├── knowledge/
 │   │   └── failures.md
 │   └── handoff.md
-└── knowledge/
-    ├── failures.md
-    └── failures-inbox.md
+├── knowledge/
+│   ├── failures.md
+│   └── failures-inbox.md
+└── repos/$ARK_REPO_KEY/
+    ├── settings.local.json.ark-loop-original
+    └── settings.local.json.ark-loop-no-original
 
 ${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/
 ├── step_count
 └── stop_once
 ```
 
-session data と knowledge は永続 data であり、cache は消失しても再生成できる counter と one-shot Stop flag だけを持つ。両者を相互に代用しない。
+session data、knowledge、repo state は永続 data であり、cache は消失しても再生成できる counter と one-shot Stop flag だけを持つ。両者を相互に代用しない。`ARK_REPO_KEY` は対象 repo の canonical な絶対パスの UTF-8 bytes に対する SHA-256 lowercase hex とし、session ID に依存させない。
 
 ### §2-3 対象 repo への影響
 
-実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と、repo `.gitignore` の `.claude/settings.local.json` 明示 entry だけとする。認知維持の成果物本体は XDG data 配下に置く。
+実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と、repo `.gitignore` の `.claude/settings.local.json` 明示 entry だけとする。認知維持の成果物本体と settings の backup / marker は XDG data 配下に置き、対象 repo 内に backup / marker を作らない。
 
 正常終了は settings 注入物を除去し、異常終了は次回 init が同じ復元を行う。どちらも元の repo 設定へ収束し、それ以外の永続変更を残さない。
 
@@ -125,8 +130,9 @@ session data と knowledge は永続 data であり、cache は消失しても�
 | `ARK_CACHE_DIR` | §2-2 の session cache root + `$ARK_SESSION_ID` |
 | `ARK_RECITE_INTERVAL` | config 値。未指定時は `10` |
 | `ARK_KNOWLEDGE_DIR` | §2-2 の host knowledge path |
+| `ARK_REPO_KEY` | 対象 repo の canonical な絶対パスから §2-2 の規則で導出 |
 
-`ARK_SESSION_DIR` または必要な session 変数が未設定なら、全 hook は入力へ副作用を与えず即座に成功終了する。これにより Ark 外で起動した Claude Code を隔離する。config の既定は `[loop.summarize] llm = false` とする。
+`ARK_SESSION_DIR` または必要な session 変数が未設定なら、全 hook は入力へ副作用を与えず即座に成功終了する。これにより Ark 外で起動した Claude Code を隔離する。config の既定は `[loop.summarize] llm = false` とする。同 table の `model = "<model-id>"` は LLM 要約に使う小型・低コストモデルの API model ID とし、`llm = true` の場合は必須、未指定または空なら機械 summary への成功 fallback とする。
 
 ### §3-2 file ownership
 
@@ -274,15 +280,17 @@ adapter は §3-3 の単一正本を変えてはならない。将来の Codex a
 
 init の順序を次で固定する。
 
-1. XDG path を解決する。
-2. `.claude/settings.local.json.ark-loop-original` という孤児 backup を検出したら、注入設定を除去して original を `mv` で復元する。
+1. XDG path と対象 repo の canonical な絶対パスを解決し、§2-2 の `ARK_REPO_KEY` と repo state directory を導出する。
+2. repo state directory の孤児 backup または元設定なし marker を検出したら、注入設定から元の有無へ復元する。
 3. session ID を生成または再取得し、session directory と cache directory を作る。
 4. config を読み、§3-1 の環境変数を export する。
 5. 新規 session に限って template を展開する。
 6. host の `failures.md` を session へ read-only copy する。
 7. 現在の settings.local を再退避し、loop settings を注入する。
 
-settings.local の退避と復元は同一 filesystem 上の `mv` を使い、各境界で存在確認する。teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、「元設定1個」または「注入設定1個と backup 1個」だけが存在する解釈可能な状態を保ち、次回 init の手順2で元設定へ収束させる。元設定がなかった場合は専用 marker でその事実を保持し、復元時に settings.local を残さない。
+backup は repo state directory の `settings.local.json.ark-loop-original`、元設定なし marker は同 directory の `settings.local.json.ark-loop-no-original` とし、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。元設定がある場合は XDG 側の一時 file へ copy してから同 filesystem 上の `mv` で backup を確定し、元設定がない場合は XDG 側で marker を原子的に確定した後、repo 側の一時 file から loop settings を `.claude/settings.local.json` へ `mv` する。復元時は backup を repo 側の一時 file へ copy してから同 filesystem 上の `mv` で settings.local を置換し、置換成功後だけ backup を除去する。marker の場合は注入 file の除去成功後だけ marker を除去する。各境界で存在確認し、repo と XDG data が異なる filesystem でも rename に依存しない。
+
+teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、backup があればそれを元設定の正本、marker があれば元設定なしの正本として解釈し、次回 init の手順2で元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても孤児 backup / marker を発見して復元できる。
 
 repo `.gitignore` には `.claude/settings.local.json` を完全一致の1行として重複なく追加し、グローバル ignore に依存しない。対象 repo にそれ以外の永続変更を残さない。
 
@@ -295,7 +303,7 @@ teardown の順序を次で固定し、各段階を単独で再実行可能に�
 1. 機械的 error summary を生成する。
 2. `handoff.md` を更新する。
 3. 再発性のある候補を host の `failures-inbox.md` へ重複なく追記する。
-4. settings.local の loop 注入物を除去し、original を `mv` で復元する。元設定なし marker の場合は注入 file を除去する。
+4. settings.local の loop 注入物を除去し、repo state directory の backup から §6-1 の原子的手順で original を復元する。元設定なし marker の場合は注入 file を除去し、成功後に marker を除去する。
 5. `stop_once` 等の transient flag を cleanup する。
 
 `handoff.md` の固定項目は Goal、完了 Plan、未完了 Plan、現在の `← NOW`、artifact path と1行要約、直近の error summary path、次の最小 action、WORK_ID、session ID とする。artifact 本文と flow JSON は複製しない。
@@ -308,7 +316,7 @@ teardown が未実行なら、次回 init は summary、handoff、settings 復�
 
 既定の summary は LLM を呼ばない機械的 compaction とする。JSONL を `tool`、次に `error_type` の bytewise 昇順で決定的に集計し、各 group に件数、最初の行番号、最後の行番号、`詳細: errors/raw.log:L{n}-L{m}` を出す。同じ bytes の input からは時刻や locale に依存しない同じ本文を生成する。
 
-`config.toml` の `[loop.summarize] llm = true` のときだけ、Haiku API に機械 summary と raw 行参照を渡し、「禁止手」付き要約を機械 summary の後へ追加する。config の該当行の直前には `# API 従量課金が発生し、Claude プラン枠の対象外` と記す。API key 不在、5秒 timeout、非0終了、JSON schema 不一致、raw 行参照欠落を含む invalid output は、すべて機械 summary を保持したまま成功 fallback とする。
+`config.toml` の `[loop.summarize] llm = true` のときだけ、同 table の `model` で指定した小型・低コストモデルの API に機械 summary と raw 行参照を渡し、「禁止手」付き要約を機械 summary の後へ追加する。実装にモデル名を直書きしない。config の `llm` 行の直前には `# API 従量課金が発生し、Claude プラン枠の対象外` と記す。API key 不在、model 未指定、5秒 timeout、非0終了、JSON schema 不一致、raw 行参照欠落を含む invalid output は、すべて機械 summary を保持したまま成功 fallback とする。
 
 LLM 出力の各項目にも `errors/raw.log:L{n}-L{m}` 形式の参照を必須とする。`raw.log` は削除も書換えもしない。次 session の `task.md.tmpl` への継承は summary 本文の UTF-8 で最大2000 bytesの抜粋と raw path だけとし、原ログ全体を注入しない。
 

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -112,6 +112,56 @@ session data と knowledge は永続 data であり、cache は消失しても�
 
 ## §3 設定・状態・正本
 
+### §3-1 config と環境変数
+
+`session-init.sh` は config を読み、次を同じ process tree の hook へ export する。
+
+| 変数 | 導出契約 |
+| --- | --- |
+| `ARK_SESSION_ID` | init が新規生成する衝突しない session ID。再実行時は既存 ID を保持 |
+| `ARK_SESSION_DIR` | §2-2 の session data root + `$ARK_SESSION_ID` |
+| `ARK_CACHE_DIR` | §2-2 の session cache root + `$ARK_SESSION_ID` |
+| `ARK_RECITE_INTERVAL` | config 値。未指定時は `10` |
+| `ARK_KNOWLEDGE_DIR` | §2-2 の host knowledge path |
+
+`ARK_SESSION_DIR` または必要な session 変数が未設定なら、全 hook は入力へ副作用を与えず即座に成功終了する。これにより Ark 外で起動した Claude Code を隔離する。config の既定は `[loop.summarize] llm = false` とする。
+
+### §3-2 file ownership
+
+| file | 所有権と更新規則 |
+| --- | --- |
+| `task.md` | session 内の進捗の唯一の正本。init と作業 agent が契約された欄だけを更新 |
+| `artifacts/` | context に保持しない大きな中間成果。`index.md` が path と要約の目次 |
+| `errors/raw.log` | capture hook だけが追記する append-only 原記録 |
+| `errors/summary.md` | raw log から再生成可能な派生物 |
+| `handoff.md` | task、artifact index、error summary から再生成可能な派生物 |
+| `knowledge/failures.md` | 人間がキュレーションした host 正本。session へ read-only 配布 |
+| `knowledge/failures-inbox.md` | session の候補を受け取る昇格待ち。配布正本として扱わない |
+
+### §3-3 native todo との関係
+
+選択肢 (a) を採用する。loop 有効セッションでは `task.md` を唯一の正本とし、作業項目を `TodoWrite` または native Task todo state に複製しない。hook と別セッションから読めること、process 再起動後も残ること、双方向の同期競合がないこと、現行 `.claude/` に先行利用がないことを優先する。
+
+この選択は Claude Code の native todo が提供するユーザー可視の進捗表示を失う。そのコストを受け入れ、hook、再起動、別セッションで一貫して扱える単一正本を選ぶ。
+
+この判断から次を拘束する。
+
+- P1 の `recite-todo.sh` は `task.md` だけを読み、native todo を参照も更新もしない。
+- P2 の `loop-rules.md` は native todo の使用禁止、Plan status と `← NOW` の現実に合わせた更新、Goal / Constraints の不変条件を含む。
+- native todo が必要な作業は loop を無効化するか、項目を `task.md` へ移してから loop を継続する。
+- 将来 adapter も native todo との同期を追加してはならない。
+
+### §3-4 flow state との所有権表
+
+現行 `.claude/lib/state-io.sh:99-119` の progress は phase、gate 相当、safety、warning 等の制御面を、同 `:141-161` の context は WORK_ID、Issue、worktree 等の運転参照を持つ。本層はこの schema を拡張しない。
+
+| 正本 | plane | 境界 |
+| --- | --- | --- |
+| `flow-progress-*.json` および flow state | control plane | phase、gate、safety、warning、run context |
+| session `task.md` / `artifacts/` / `errors/` | data plane | 目標、進捗、作業内容、失敗原記録 |
+
+両 plane の内容を相互コピー、双方向同期、自動マージしない。接続は WORK_ID と session path の参照だけに留め、flow state schema に認知維持用 field を追加しない。
+
 ## §4 hook 契約
 
 ## §5 テンプレート・ループ規約・アダプタ

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -9,7 +9,7 @@ Manus の context engineering を Ark が起動する1セッション内の認�
 ## 対象と非対象
 
 - 対象: 後続 Issue #333〜#336 が実装する `ark/loop/`、XDG runtime、Claude Code adapter。
-- 非対象: Ark アプリ本体の `server/`、`client/`、`shared/`、既存 flow の運転仕様、Issue #332 での hook・settings・script 実装。
+- 非対象: Ark アプリ本体の `packages/server/`、`packages/web/`、`packages/shared/`、`packages/desktop/`、既存 flow の運転仕様、Issue #332 での hook・settings・script 実装。
 
 ## Issue 参照表
 
@@ -96,20 +96,23 @@ ${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/
 │   │   └── summary.md
 │   ├── knowledge/
 │   │   └── failures.md
-│   └── handoff.md
+│   ├── handoff.md
+│   └── stop_once
 ├── knowledge/
 │   ├── failures.md
 │   └── failures-inbox.md
 └── repos/$ARK_REPO_KEY/
+    ├── owner
     ├── settings.local.json.ark-loop-original
     └── settings.local.json.ark-loop-no-original
 
 ${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/
-├── step_count
-└── stop_once
+└── step_count
 ```
 
-session data、knowledge、repo state は永続 data であり、cache は消失しても再生成できる counter と one-shot Stop flag だけを持つ。両者を相互に代用しない。`ARK_REPO_KEY` は対象 repo の canonical な絶対パスの UTF-8 bytes に対する SHA-256 lowercase hex とし、session ID に依存させない。
+session data、knowledge、repo state は永続 data であり、cache は消失しても再生成できる `step_count` だけを持つ。cache に正しさに関わる状態を置かず、永続 data と相互に代用しない。`ARK_REPO_KEY` は対象 repo の canonical な絶対パスの UTF-8 bytes に対する SHA-256 lowercase hex とし、session ID に依存させない。
+
+XDG 配下の session data、repo state、cache の各 directory は mode `0700`、その file は mode `0600` とする。使用前に各 path が期待する regular directory / regular file であり symlink でないことと、owner・mode を検証する。repo 内の `.claude/settings.local.json` も読み取り前に symlink でないことを検証する。検証は既存 `.claude/lib/flow-state-dir.sh` の secure default 規則に準拠し、不一致時は使用しない。
 
 ### §2-3 対象 repo への影響
 
@@ -121,7 +124,7 @@ session data、knowledge、repo state は永続 data であり、cache は消失
 
 ### §3-1 config と環境変数
 
-`session-init.sh` は config を読み、次を同じ process tree の hook へ export する。
+`session-init.sh` は Ark が tmux session を作成する前に実行し、config を読んで session ID と次の値を Ark へ返す。Ark は `CLAUDE_CONFIG_DIR` と同じ経路で `tmux new-session -e KEY=VALUE` により tmux session へ注入し、その子 process の Claude Code と hook が継承する。
 
 | 変数 | 導出契約 |
 | --- | --- |
@@ -131,6 +134,8 @@ session data、knowledge、repo state は永続 data であり、cache は消失
 | `ARK_RECITE_INTERVAL` | config 値。未指定時は `10` |
 | `ARK_KNOWLEDGE_DIR` | §2-2 の host knowledge path |
 | `ARK_REPO_KEY` | 対象 repo の canonical な絶対パスから §2-2 の規則で導出 |
+
+tmux session は起動時の環境を生存中保持するため、稼働中 session の loop 設定は変更せず、反映には session の再起動を必要とする。将来 tmux 以外の adapter を追加する場合は、同じ継承を保証する別の伝播手段を adapter が定義する。
 
 `ARK_SESSION_DIR` または必要な session 変数が未設定なら、全 hook は入力へ副作用を与えず即座に成功終了する。これにより Ark 外で起動した Claude Code を隔離する。config の既定は `[loop.summarize] llm = false` とする。同 table の `model = "<model-id>"` は LLM 要約に使う小型・低コストモデルの API model ID とし、`llm = true` の場合は必須、未指定または空なら機械 summary への成功 fallback とする。
 
@@ -212,7 +217,7 @@ capture は入力にある型の正規化以外の分類、要約、「禁止手
 
 新しい Stop hook は登録しない。現行 `.claude/settings.json:72-80` の登録先を保ち、現在 no-op の `.claude/hooks/stop-gate.sh:1-8` の実体を `on-stop.sh` 相当へ置換する。
 
-未完了 Plan があり、`ARK_CACHE_DIR/stop_once` がなければ flag を原子的に作成して1回だけ継続を要求する。同じ session の2回目以降は未完了でも Stop を通し、flag は teardown まで保持して無限 Stop loop を防ぐ。
+未完了 Plan があり、`ARK_SESSION_DIR/stop_once` がなければ flag を原子的に作成して1回だけ継続を要求する。同じ session の2回目以降は未完了でも Stop を通し、flag は teardown まで保持して無限 Stop loop を防ぐ。
 
 Stop 通過時は `handoff.md` を生成するが、Stop hook は teardown 完了を保証しない。tmux kill、pm2 restart、process crash を含め、teardown を通らない終了では次回 init が同じ収束処理を担う。
 
@@ -281,16 +286,16 @@ adapter は §3-3 の単一正本を変えてはならない。将来の Codex a
 init の順序を次で固定する。
 
 1. XDG path と対象 repo の canonical な絶対パスを解決し、§2-2 の `ARK_REPO_KEY` と repo state directory を導出する。
-2. repo state directory の孤児 backup / 元設定なし marker、および repo 側の `.claude/settings.local.json.ark-loop-tmp` を検出したら、backup / marker が示す元の有無へ復元し、repo 側の一時 file を回収する。
-3. session ID を生成または再取得し、session directory と cache directory を作る。
-4. config を読み、§3-1 の環境変数を export する。
+2. session ID を生成または再取得し、session ID と Ark が管理する owner process の PID を持つ repo state directory の `owner` marker を検査する。別 session の owner が生存中なら孤児回収と settings 注入を行わず、loop を無効化して起動を続ける。
+3. owner が存在しないか消滅している場合は ownership を原子的に取得し、同じ session が owner の場合は保持する。owner だけが孤児 backup / 元設定なし marker と repo 側の `.claude/settings.local.json.ark-loop-tmp` を元の有無へ復元・回収してから、session directory と cache directory を作る。
+4. config を読み、§3-1 の値を Ark へ返す。
 5. 新規 session に限って template を展開する。
 6. host の `failures.md` を session へ read-only copy する。
 7. 現在の settings.local を再退避し、loop settings を注入する。
 
-backup は repo state directory の `settings.local.json.ark-loop-original`、元設定なし marker は同 directory の `settings.local.json.ark-loop-no-original` とし、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。repo 側の一時 file は `.claude/settings.local.json.ark-loop-tmp` の固定名とし、`mktemp` 等による可変名を使わない。元設定がある場合は XDG 側の一時 file へ copy してから同 filesystem 上の `mv` で backup を確定し、元設定がない場合は XDG 側で marker を原子的に確定した後、repo 側の一時 file から loop settings を `.claude/settings.local.json` へ `mv` する。復元時は backup を repo 側の一時 file へ copy してから同 filesystem 上の `mv` で settings.local を置換し、置換成功後だけ backup を除去する。marker の場合は注入 file の除去成功後だけ marker を除去する。復元中に残った repo 側の一時 file は中間状態でしかないため、孤児回収では backup / marker が示す正本の状態へ収束させたうえで無条件に削除する。各境界で存在確認し、repo と XDG data が異なる filesystem でも rename に依存しない。
+`owner` marker の取得・生存確認・消滅 owner からの引継ぎは per-repo で排他的に行う。同じ session の再実行だけは既存 ownership を継続できる。backup は repo state directory の `settings.local.json.ark-loop-original`、元設定なし marker は同 directory の `settings.local.json.ark-loop-no-original` とし、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。repo 側の一時 file は `.claude/settings.local.json.ark-loop-tmp` の固定名とし、`mktemp` 等による可変名を使わない。元設定がある場合は XDG 側の一時 file へ copy してから同 filesystem 上の `mv` で backup を確定し、元設定がない場合は XDG 側で marker を原子的に確定した後、repo 側の一時 file から loop settings を `.claude/settings.local.json` へ `mv` する。復元時は backup を repo 側の一時 file へ copy してから同 filesystem 上の `mv` で settings.local を置換し、置換成功後だけ backup を除去する。marker の場合は注入 file の除去成功後だけ marker を除去する。復元中に残った repo 側の一時 file は中間状態でしかないため、孤児回収では backup / marker が示す正本の状態へ収束させたうえで無条件に削除する。各境界で存在確認し、repo と XDG data が異なる filesystem でも rename に依存しない。
 
-teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、backup があればそれを元設定の正本、marker があれば元設定なしの正本として解釈し、次回 init の手順2で元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても孤児 backup / marker を発見して復元できる。
+teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、backup があればそれを元設定の正本、marker があれば元設定なしの正本として解釈し、次回 init の手順3で元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても孤児 backup / marker を発見して復元できる。
 
 repo `.gitignore` には `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` を完全一致の2行としてそれぞれ重複なく追加し、グローバル ignore に依存しない。対象 repo にそれ以外の永続変更を残さない。
 
@@ -303,8 +308,8 @@ teardown の順序を次で固定し、各段階を単独で再実行可能に�
 1. 機械的 error summary を生成する。
 2. `handoff.md` を更新する。
 3. 再発性のある候補を host の `failures-inbox.md` へ重複なく追記する。
-4. settings.local の loop 注入物を除去し、repo state directory の backup から §6-1 の原子的手順で original を復元する。元設定なし marker の場合は注入 file を除去し、成功後に marker を除去する。
-5. `stop_once` 等の transient flag を cleanup する。
+4. 自分の session ID が repo state directory の `owner` marker と一致する場合に限り、settings.local の loop 注入物を除去し、backup から §6-1 の原子的手順で original を復元する。元設定なし marker の場合は注入 file を除去し、成功後に marker を除去する。
+5. `stop_once` 等の transient flag を cleanup し、手順4の復元・除去が成功した自分が owner の場合に限って `owner` marker を除去する。
 
 `handoff.md` の固定項目は Goal、完了 Plan、未完了 Plan、現在の `← NOW`、artifact path と1行要約、直近の error summary path、次の最小 action、WORK_ID、session ID とする。artifact 本文と flow JSON は複製しない。
 

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -153,9 +153,17 @@ tmux session は起動時の環境を生存中保持するため、稼働中 ses
 
 ### §3-3 native todo との関係
 
-選択肢 (a) を採用する。loop 有効セッションでは `task.md` を唯一の正本とし、作業項目を `TodoWrite` または native Task todo state に複製しない。hook と別セッションから読めること、process 再起動後も残ること、双方向の同期競合がないこと、現行 `.claude/` に先行利用がないことを優先する。
+選択肢 (a) を採用する。loop 有効セッションでは `task.md` を唯一の正本とし、作業項目を `TodoWrite` または native Task todo state に複製しない。Claude Code の native task state も `~/.claude/tasks/session-<id>/<n>.json` に `id`、`subject`、`description`、`activeForm`、`status`、`blocks`、`blockedBy` を持つ JSON file として永続化され、同 directory の `.lock` による排他がある。したがって hook や別 process から読め、process 再起動後も残る。
 
-この選択は Claude Code の native todo が提供するユーザー可視の進捗表示を失う。そのコストを受け入れ、hook、再起動、別セッションで一貫して扱える単一正本を選ぶ。
+それでも `task.md` を正本とする根拠は次の3点である。
+
+1. native schema には Goal、Constraints、`← NOW` に対応する field がなく、§4-1 の recitation と、§5-1 が固定する更新可能欄の不変条件を構造で表現できない。
+2. native task state は Claude Code 固有の内部形式である。これを正本にすると、agent 非依存の template、ループ規約、file format と Claude Code 固有処理を分け、将来の `adapters/codex/` も同じ正本を共有する §2-1 の adapter 境界を壊す。
+3. `~/.claude/tasks/` の directory 構成と JSON schema は公開契約ではなく、version 間で変わりうる。`task.md` は本 spec が定義し固定できる契約である。
+
+native 側の `.lock` は native state 単体の排他を提供するが、選択肢 (c) の2つの表現間の整合性までは保証しないため、双方向同期は導入しない。native task の保存先の `session-<id>` は会話 transcript の session ID と別体系であり、実機でも `session-e4e83ed6` と `b32015e5-...` の不一致を確認した。hook から辿るには対応付けが必要で、解決可能だが自明ではない。
+
+この選択は Claude Code の native todo が提供するユーザー可視の進捗表示を失う。そのコストを受け入れ、recitation schema と adapter 境界を満たす安定した単一正本を選ぶ。
 
 この判断から次を拘束する。
 

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -164,7 +164,107 @@ session data と knowledge は永続 data であり、cache は消失しても�
 
 ## §4 hook 契約
 
+hook input は非信頼データとして parse し、path、文字列、数値を検証する。全 script は loop 用環境変数が未設定なら no-op で成功し、counter を session cache 以外で共有せず、自身の失敗で本来の tool result を握りつぶさない。追加 hook の counter 更新などの fast path は合計100ms以内とする。
+
+現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持する。後続実装での論理順は、同一 tool event ごとに次とする。
+
+1. `capture-error`
+2. 既存の該当 hook（Bash は `post-push-monitor.sh`、Write / Edit は `post-edit-lint.sh`）
+3. `recite-todo`
+
+Claude Code が配列内の command hook を実際に直列実行するかは #333 と #335 で実機確認し、既存分を含む計測値を両 PR に残す。直列性が成立しなければ、この論理順を保証する単一 dispatcher に adapter 内で束ねる。
+
+### §4-1 recite-todo.sh
+
+成功した tool step ごとに `ARK_CACHE_DIR/step_count` を排他的に1増加させ、`ARK_RECITE_INTERVAL`（既定10）step ごとに次の固定形式だけを `additionalContext` へ出す。
+
+```text
+Goal: <1行>
+NOW: <← NOW の付いた1行>
+Remaining: <未完了件数>
+```
+
+task 全文、timestamp、artifact 本文、native todo は注入しない。概念上は1回200 token以下とし、tokenizer に依存しない実装上の代理指標として UTF-8 で600 bytes以下であることを #333 で検証する。
+
+compaction 直後も `task.md` 正本から同じ key、同じ順序、同じ行数で再構成し、変動する prefix を加えない。interval の変更と hook の無効化だけで、他の足場に触れず recitation を撤去できなければならない。
+
+### §4-2 capture-error.sh
+
+PostToolUse の失敗 event だけを `errors/raw.log` へ、次の field を持つ1物理行の JSONL として append する。
+
+```json
+{"at":"RFC3339","tool":"tool name","error_type":"input field or tool_error","exit_code":1,"message":"escaped message"}
+```
+
+`at`、`tool`、`error_type`、`exit_code`、`message` は常に同じ key 順で出力する。message の改行は JSON escape し、UTF-8 で4096 bytesを上限として code point 境界で切る。成功 event は書き込まない。1 entry を必ず1行に収め、`L{n}-L{n}` の参照を安定させる。
+
+capture は入力にある型の正規化以外の分類、要約、「禁止手」の生成を行わず、原 tool error の表示・終了状態を変更しない。同一 tool event の capture は recite より先に完了させる。hook input の実 field 名と成功・失敗判定は #335 で実機ダンプを fixture 化して確定し、fixture にない field を推測して補わない。
+
+### §4-3 Stop
+
+新しい Stop hook は登録しない。現行 `.claude/settings.json:72-80` の登録先を保ち、現在 no-op の `.claude/hooks/stop-gate.sh:1-8` の実体を `on-stop.sh` 相当へ置換する。
+
+未完了 Plan があり、`ARK_CACHE_DIR/stop_once` がなければ flag を原子的に作成して1回だけ継続を要求する。同じ session の2回目以降は未完了でも Stop を通し、flag は teardown まで保持して無限 Stop loop を防ぐ。
+
+Stop 通過時は `handoff.md` を生成するが、Stop hook は teardown 完了を保証しない。tmux kill、pm2 restart、process crash を含め、teardown を通らない終了では次回 init が同じ収束処理を担う。
+
 ## §5 テンプレート・ループ規約・アダプタ
+
+### §5-1 task.md.tmpl
+
+通常 task の schema は次で固定する。
+
+```markdown
+# Task
+
+## Goal
+<1行>
+
+## Constraints
+- <不変条件>
+
+Previous failure summary: {{PREV_FAILURE_SUMMARY}}
+
+## Plan
+- [ ] <未完了項目> ← NOW
+- [ ] <未完了項目>
+
+## Artifacts
+- <path> — <1行要約>
+```
+
+Plan には checkbox を使い、`← NOW` は常にちょうど1個だけ置く。全項目完了時は完了した最後の項目に残す。Goal と Constraints は init 後に編集してはならず、作業中に更新できるのは Plan の項目、status、`← NOW` と artifact 参照だけとする。
+
+`task-review.md.tmpl` は、diff 全ファイルの通読、規約遵守、artifact / index の整合、エラー握りつぶし、Goal 逸脱、再発性のある指摘の inbox 候補化を、同じ checkbox schema の Plan に持つ。session ID の SHA-256 を seed にした決定的な順列で提示順だけを変え、観点集合を削らず、同一 session 内では順序を安定させる。
+
+### §5-2 loop-rules.md
+
+規約は次の10則で固定する。
+
+タスク管理:
+
+1. `task.md` だけを正本にし、native todo を使用しない。
+2. 各 tool step の前後で Plan status と `← NOW` を現実に合わせる。
+3. Goal / Constraints を書き換えず、逸脱が必要なら作業を停止する。
+
+エラー:
+
+1. 失敗 action と原文を `errors/raw.log` に残す。
+2. 再試行前に直前の失敗と既知の禁止手を読む。
+3. 回復結果と再発性のある知見を `failures-inbox.md` 候補にする。
+
+外部化:
+
+1. 20行を超える中間成果は `artifacts/` に外部化する。
+2. `artifacts/index.md` に path と1行要約を append する。
+3. artifact 本文の再掲より path 参照を優先する。
+4. 可逆な compaction を尽くした後にだけ不可逆な summary を行う。
+
+### §5-3 Claude Code adapter
+
+Claude Code adapter だけが、既存 `.claude/settings.local.json` の退避・loop settings の注入・復元、hook matcher、hook input JSON、`additionalContext` output、Claude Code の `allowed-tools` を扱う。agent 非依存の template、規約、session file format に Claude Code 固有 key を入れない。
+
+adapter は §3-3 の単一正本を変えてはならない。将来の Codex adapter も AGENTS.md と wrapper の接続に留め、native todo 同期や別の進捗正本を持ち込んではならない。
 
 ## §6 セッションライフサイクル script
 

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -1,0 +1,35 @@
+# Ark ループエンジニアリング実装 spec
+
+> ステータス: 確定 / Issue #332
+
+## 目的
+
+Manus の context engineering を Ark が起動する1セッション内の認知維持層へ写像し、後続 Issue が実装時に守る契約を固定する。実装対象は `ark/loop/` の配布物と Claude Code adapter に限定する。Issue #332 ではこの Markdown spec と既存 skill からの参照だけを変更し、実行コードは実装しない。
+
+## 対象と非対象
+
+- 対象: 後続 Issue #333〜#336 が実装する `ark/loop/`、XDG runtime、Claude Code adapter。
+- 非対象: Ark アプリ本体の `server/`、`client/`、`shared/`、既存 flow の運転仕様、Issue #332 での hook・settings・script 実装。
+
+## Issue 参照表
+
+| Issue | 固定参照 |
+| --- | --- |
+| #333 | §1, §2, §3, §4-1, §5-1, §5-3, §6-1 |
+| #334 | §5-2 |
+| #335 | §4-2, §6-3, task.md.tmpl の `{{PREV_FAILURE_SUMMARY}}` |
+| #336 | §4-3, §6-2, §7 |
+
+## §1 概要と設計原則
+
+## §2 配置と XDG ディレクトリ契約
+
+## §3 設定・状態・正本
+
+## §4 hook 契約
+
+## §5 テンプレート・ループ規約・アダプタ
+
+## §6 セッションライフサイクル script
+
+## §7 横断知識・flow 接続・足場撤去

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -113,9 +113,9 @@ session data、knowledge、repo state は永続 data であり、cache は消失
 
 ### §2-3 対象 repo への影響
 
-実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と、repo `.gitignore` の `.claude/settings.local.json` 明示 entry だけとする。認知維持の成果物本体と settings の backup / marker は XDG data 配下に置き、対象 repo 内に backup / marker を作らない。
+実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json`、固定名の `.claude/settings.local.json.ark-loop-tmp`、repo `.gitignore` の `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の明示 entry だけとする。認知維持の成果物本体と settings の backup / marker は XDG data 配下に置き、対象 repo 内に backup / marker を作らない。
 
-正常終了は settings 注入物を除去し、異常終了は次回 init が同じ復元を行う。どちらも元の repo 設定へ収束し、それ以外の永続変更を残さない。
+正常終了は settings 注入物と repo 側の一時 file を除去し、異常終了は次回 init が同じ復元と除去を行う。どちらも元の repo 設定へ収束し、それ以外の永続変更を残さない。#333 の完了条件は、対象 repo に `.claude/settings.local.json` と repo `.gitignore` への上記2 entry の追記以外の変更が入らず、repo 側の一時 file が残存しないこととする。
 
 ## §3 設定・状態・正本
 
@@ -281,18 +281,18 @@ adapter は §3-3 の単一正本を変えてはならない。将来の Codex a
 init の順序を次で固定する。
 
 1. XDG path と対象 repo の canonical な絶対パスを解決し、§2-2 の `ARK_REPO_KEY` と repo state directory を導出する。
-2. repo state directory の孤児 backup または元設定なし marker を検出したら、注入設定から元の有無へ復元する。
+2. repo state directory の孤児 backup / 元設定なし marker、および repo 側の `.claude/settings.local.json.ark-loop-tmp` を検出したら、backup / marker が示す元の有無へ復元し、repo 側の一時 file を回収する。
 3. session ID を生成または再取得し、session directory と cache directory を作る。
 4. config を読み、§3-1 の環境変数を export する。
 5. 新規 session に限って template を展開する。
 6. host の `failures.md` を session へ read-only copy する。
 7. 現在の settings.local を再退避し、loop settings を注入する。
 
-backup は repo state directory の `settings.local.json.ark-loop-original`、元設定なし marker は同 directory の `settings.local.json.ark-loop-no-original` とし、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。元設定がある場合は XDG 側の一時 file へ copy してから同 filesystem 上の `mv` で backup を確定し、元設定がない場合は XDG 側で marker を原子的に確定した後、repo 側の一時 file から loop settings を `.claude/settings.local.json` へ `mv` する。復元時は backup を repo 側の一時 file へ copy してから同 filesystem 上の `mv` で settings.local を置換し、置換成功後だけ backup を除去する。marker の場合は注入 file の除去成功後だけ marker を除去する。各境界で存在確認し、repo と XDG data が異なる filesystem でも rename に依存しない。
+backup は repo state directory の `settings.local.json.ark-loop-original`、元設定なし marker は同 directory の `settings.local.json.ark-loop-no-original` とし、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。repo 側の一時 file は `.claude/settings.local.json.ark-loop-tmp` の固定名とし、`mktemp` 等による可変名を使わない。元設定がある場合は XDG 側の一時 file へ copy してから同 filesystem 上の `mv` で backup を確定し、元設定がない場合は XDG 側で marker を原子的に確定した後、repo 側の一時 file から loop settings を `.claude/settings.local.json` へ `mv` する。復元時は backup を repo 側の一時 file へ copy してから同 filesystem 上の `mv` で settings.local を置換し、置換成功後だけ backup を除去する。marker の場合は注入 file の除去成功後だけ marker を除去する。復元中に残った repo 側の一時 file は中間状態でしかないため、孤児回収では backup / marker が示す正本の状態へ収束させたうえで無条件に削除する。各境界で存在確認し、repo と XDG data が異なる filesystem でも rename に依存しない。
 
 teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、backup があればそれを元設定の正本、marker があれば元設定なしの正本として解釈し、次回 init の手順2で元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても孤児 backup / marker を発見して復元できる。
 
-repo `.gitignore` には `.claude/settings.local.json` を完全一致の1行として重複なく追加し、グローバル ignore に依存しない。対象 repo にそれ以外の永続変更を残さない。
+repo `.gitignore` には `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` を完全一致の2行としてそれぞれ重複なく追加し、グローバル ignore に依存しない。対象 repo にそれ以外の永続変更を残さない。
 
 `--restart <session-id>` は指定 session の `errors/summary.md` から UTF-8 で最大2000 bytesの抜粋と `errors/raw.log` の path を `{{PREV_FAILURE_SUMMARY}}` に埋める。通常 init は固定文 `なし（通常起動）` を埋める。`step_count` は新 session ごとに0から始めるが、同じ init の再実行では既存 `task.md` と進捗を上書きしない。
 

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -92,6 +92,8 @@ ${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/
 │   ├── errors/
 │   │   ├── raw.log
 │   │   └── summary.md
+│   ├── knowledge/
+│   │   └── failures.md
 │   └── handoff.md
 └── knowledge/
     ├── failures.md
@@ -268,4 +270,80 @@ adapter は §3-3 の単一正本を変えてはならない。将来の Codex a
 
 ## §6 セッションライフサイクル script
 
+### §6-1 session-init.sh
+
+init の順序を次で固定する。
+
+1. XDG path を解決する。
+2. `.claude/settings.local.json.ark-loop-original` という孤児 backup を検出したら、注入設定を除去して original を `mv` で復元する。
+3. session ID を生成または再取得し、session directory と cache directory を作る。
+4. config を読み、§3-1 の環境変数を export する。
+5. 新規 session に限って template を展開する。
+6. host の `failures.md` を session へ read-only copy する。
+7. 現在の settings.local を再退避し、loop settings を注入する。
+
+settings.local の退避と復元は同一 filesystem 上の `mv` を使い、各境界で存在確認する。teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、「元設定1個」または「注入設定1個と backup 1個」だけが存在する解釈可能な状態を保ち、次回 init の手順2で元設定へ収束させる。元設定がなかった場合は専用 marker でその事実を保持し、復元時に settings.local を残さない。
+
+repo `.gitignore` には `.claude/settings.local.json` を完全一致の1行として重複なく追加し、グローバル ignore に依存しない。対象 repo にそれ以外の永続変更を残さない。
+
+`--restart <session-id>` は指定 session の `errors/summary.md` から UTF-8 で最大2000 bytesの抜粋と `errors/raw.log` の path を `{{PREV_FAILURE_SUMMARY}}` に埋める。通常 init は固定文 `なし（通常起動）` を埋める。`step_count` は新 session ごとに0から始めるが、同じ init の再実行では既存 `task.md` と進捗を上書きしない。
+
+### §6-2 session-teardown.sh
+
+teardown の順序を次で固定し、各段階を単独で再実行可能にする。
+
+1. 機械的 error summary を生成する。
+2. `handoff.md` を更新する。
+3. 再発性のある候補を host の `failures-inbox.md` へ重複なく追記する。
+4. settings.local の loop 注入物を除去し、original を `mv` で復元する。元設定なし marker の場合は注入 file を除去する。
+5. `stop_once` 等の transient flag を cleanup する。
+
+`handoff.md` の固定項目は Goal、完了 Plan、未完了 Plan、現在の `← NOW`、artifact path と1行要約、直近の error summary path、次の最小 action、WORK_ID、session ID とする。artifact 本文と flow JSON は複製しない。
+
+`handoff.md` は次のモデルへ意味的文脈を渡す data plane である。`/flow --resume` は現行 `.claude/skills/flow/SKILL.md:152-168` と `.claude/lib/state-io.sh` に従って phase / gate を復元する control plane である。競合時は flow state を phase の正本とし、handoff は助言情報として扱う。自動マージも相互上書きもしない。
+
+teardown が未実行なら、次回 init は summary、handoff、settings 復元をこの順で補償してから新しい注入へ進む。最終的な repo 状態は teardown 実行済みの場合と同じでなければならない。
+
+### §6-3 summarize-errors.sh
+
+既定の summary は LLM を呼ばない機械的 compaction とする。JSONL を `tool`、次に `error_type` の bytewise 昇順で決定的に集計し、各 group に件数、最初の行番号、最後の行番号、`詳細: errors/raw.log:L{n}-L{m}` を出す。同じ bytes の input からは時刻や locale に依存しない同じ本文を生成する。
+
+`config.toml` の `[loop.summarize] llm = true` のときだけ、Haiku API に機械 summary と raw 行参照を渡し、「禁止手」付き要約を機械 summary の後へ追加する。config の該当行の直前には `# API 従量課金が発生し、Claude プラン枠の対象外` と記す。API key 不在、5秒 timeout、非0終了、JSON schema 不一致、raw 行参照欠落を含む invalid output は、すべて機械 summary を保持したまま成功 fallback とする。
+
+LLM 出力の各項目にも `errors/raw.log:L{n}-L{m}` 形式の参照を必須とする。`raw.log` は削除も書換えもしない。次 session の `task.md.tmpl` への継承は summary 本文の UTF-8 で最大2000 bytesの抜粋と raw path だけとし、原ログ全体を注入しない。
+
 ## §7 横断知識・flow 接続・足場撤去
+
+### §7-1 failures 横断共有
+
+host knowledge の `failures.md` だけを curated 正本とする。session 開始時に `$ARK_SESSION_DIR/knowledge/failures.md` へ copy して read-only にし、実行中の agent と hook は書き換えない。session 終了時は候補を host の `failures-inbox.md` へ追記する。
+
+昇格は人間だけが行う。人間は inbox の候補について重複、機密情報、再現性を確認し、採用した項目を inbox から `failures.md` へ移す。session output や raw log から直接 `failures.md` へ昇格する経路を作らない。
+
+### §7-2 flow-loop 接続
+
+現行 `.claude/skills/flow-loop/SKILL.md:67-73,107-112` のブレーカーと `loop-exclude` は失敗 run を止める隔離側、`failures.md` は失敗を知識化して次の run で避ける学習側である。学習側はブレーカー、kill switch、`loop-exclude`、flow-x の safety を解除も迂回もしない。
+
+ブレーカー event には配布した `failures.md` の SHA-256 と、その run が file を参照したかを記録する。知識注入 cohort について consecutive halt、breaker 発動、`loop-exclude` 適用の頻度が下がるかを観察する。この計測は安全装置の作動条件を変更しない。
+
+| 認知維持層 | flow / flow-loop | 関係と同期禁止 |
+| --- | --- | --- |
+| `artifacts/`（data plane） | `flow-progress-*.json`（control plane） | 作業内容と運転状態を分離し、内容を重複保存・同期しない |
+| `handoff.md`（意味文脈） | `/flow --resume`（phase 復元） | resume の判断は flow state を正とし、自動マージ・相互上書きしない |
+| `failures.md`（学習） | breaker / `loop-exclude`（隔離） | 知識は再発を減らすだけで、安全状態やラベルを同期・解除しない |
+
+### §7-3 足場撤去プロトコル
+
+撤去 gate の既定は人間の判断とする。recitation、summary 継承、artifact / index、review rotation、Stop / handoff のうち1要素だけを実セッションで無効化し、少なくとも3日かつ3セッション運用する。人間の体感上または明らかな劣化がなければ撤去してよい。
+
+定量計測を取得できる場合も判断の補強材料に留め、統計的有意性、最低 sample 数、閾値達成を撤去条件にしない。軽量な観察指標は次とする。
+
+| 足場 | 観察する劣化 |
+| --- | --- |
+| recitation | ゴールドリフトと Goal から外れた action |
+| summary 継承 | 同種 error の再発 |
+| artifact / index | 長出力後の path・根拠の参照回収失敗 |
+| review rotation | 固定順の後半を含む観点漏れ |
+| Stop / handoff | 再開後の誤 action と未完了 Plan の放置 |
+
+既定方針は「疑わしきは外す」とする。効果が不明な足場を保守し続けるより、撤去後に問題が確認された時点で git 履歴から復元する方が安い。撤去判断、観察期間、見えた劣化だけを commit または Issue に残す。

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -22,6 +22,41 @@ Manus の context engineering を Ark が起動する1セッション内の認�
 
 ## §1 概要と設計原則
 
+### §1-1 目的と非ゴール
+
+本層は、長い tool loop で起きるゴールドリフト（goal drift）、lost-in-the-middle、compaction 後の失敗再発を減らすための、現在のモデル向けの撤去可能な足場である。この spec 自体も、モデルまたはホスト機能の進歩で不要になれば撤去する。
+
+推論スタック、独自 agent runtime、動的 tool masking、Ark UI は追加しない。Claude Code の既存 loop と filesystem に限定し、モデルの能力そのものは変更しない。
+
+### §1-2 Manus 原則の写像
+
+| Manus 原則 | Ark で守る契約 |
+| --- | --- |
+| 安定 prefix / append-only | 固定 template と決定的な直列化を使い、時刻などの変動値を recitation に入れない。原記録は追記し、過去 entry を書き換えない |
+| Mask, don't remove | tool 定義を途中で消さず、Claude Code の `allowed-tools` でセッション開始時から制約する。動的 masking は実装しない |
+| filesystem 外部メモリ | 長い内容は `artifacts/` と `errors/raw.log` に保存し、context には path と固定長要約を置く |
+| attention through recitation | `task.md` の Goal、現在地、未完了件数だけを一定間隔で固定長注入する |
+| keep the wrong stuff in | 原エラーを append-only JSONL に残し、再試行前と次セッションから参照可能にする |
+| don't get few-shotted | review 観点の集合を固定したまま提示順だけを session ごとに変える |
+| compaction-first / summarization-last | path と行参照を残す可逆な機械処理を先に行い、不可逆な LLM 要約は明示 opt-in の最終手段にする |
+
+出典:
+
+- https://manus.im/blog/Context-Engineering-for-AI-Agents-Lessons-from-Building-Manus
+- https://www.youtube.com/watch?v=6_BcCthVvb8
+
+### §1-3 層の定義
+
+本 spec は、tool step、compaction、再起動に対して認知状態を保つ「1セッション内の認知維持ループ」を定義する。`/flow-loop` は Issue の pick から PR、CI、deploy までを複数セッションにまたがって進める「複数セッション・PR・CI・deploy をまたぐ運転ループ」である。
+
+認知維持層は運転ループの下層として補完するだけで、`flow` / `flow-x` / `flow-loop` の phase、gate、安全装置、再開判断を奪わない。
+
+### §1-4 課金と単純性
+
+機械的 compaction を既定とし、LLM 要約はユーザーが明示した opt-in でのみ有効にする。LLM 要約は API 従量課金を伴い、失敗時は機械処理へ戻る。
+
+recitation、error capture、summary、handoff、knowledge 配布は個別に無効化・撤去できなければならず、いずれかの撤去が他の足場や flow の運転を壊してはならない。
+
 ## §2 配置と XDG ディレクトリ契約
 
 ## §3 設定・状態・正本


### PR DESCRIPTION
Manus の context engineering を Ark の「1セッション内の認知維持ループ」へ写像した実装 spec を追加する。後続 Issue #333〜#336 はこの spec を節番号で参照しており、本 PR が全件の DoR 前提になる。

Closes #332

## 変更

| ファイル | 内容 |
| --- | --- |
| `docs/superpowers/specs/ark-loop-implementation-spec.md` | 新規 357 行。§1〜§7 の実装契約 |
| `docs/superpowers/plans/2026-08-18-issue-332.md` | 実装計画（設計成果物としてコミット） |
| `.claude/skills/flow-loop/SKILL.md` | 「関連ファイル」に spec への相互参照 1 行 |

コードは変更しない（Markdown のみ、509 行追加・0 削除）。

## spec の構成と後続 Issue の参照

| Issue | 参照 |
| --- | --- |
| #333 (P1) | §1, §2, §3, §4-1, §5-1, §5-3, §6-1 |
| #334 (P2) | §5-2 |
| #335 (P3) | §4-2, §6-3, `{{PREV_FAILURE_SUMMARY}}` |
| #336 (P4) | §4-3, §6-2, §7 |

参照される 13 節すべてが一意に解決することを確認済み。

## 設計上の決定

- **層の分離**: 本 spec は「1セッション内の認知維持ループ」。既存 `/flow-loop` の「複数セッション・PR・CI・deploy をまたぐ運転ループ」とは層が異なり、下層として補完する。phase / gate / 安全装置は奪わない
- **`task.md` を唯一の正本**: ネイティブ Todo（`TodoWrite` / Task）と二重管理にしない。ユーザー可視の進捗表示を失うコストを受け入れ、hook・再起動・別セッションで一貫して読める単一正本を採る
- **課金原則**: error summary は機械的 compaction が既定。LLM 要約は `config.toml` で明示 opt-in のときだけ動き、モデル ID も config 指定（実装にモデル名を直書きしない）。失敗時は機械 summary へ成功 fallback するので、既定構成で API 課金は発生しない
- **compaction-first**: 要約には必ず `errors/raw.log:L{n}-L{m}` の行参照を残し、原ログを削除・書換えしない
- **足場撤去プロトコル**: 撤去判断の既定は人間。統計的有意性・最低サンプル数を撤去条件にしない。既定方針は「疑わしきは外す」（撤去後に問題が出たら git 履歴から復元する方が、効果不明な足場を保守し続けるより安い）
- **failures.md と breaker の関係**: ブレーカー / `loop-exclude` は失敗 run を止める隔離側、`failures.md` は失敗を知識化する学習側。学習側が安全装置を解除・迂回することはない

## レビューで潰した点

Claude レビューで `[P1]` を 3 回出し、codex が修正した。

1. **撤去 gate が実行不能だった** — 「各 arm 30 session・95% 信頼区間 ±5pp」＋「計測不能を撤去理由にしない」の組み合わせで、測れない＝永久に撤去できないロックになっていた。Manus の原則は「外す前提で足す」なので人間判断を既定に変更
2. **ユーザー設定が公開リポジトリに露出する経路があった** — settings の backup と marker を対象 repo 内に作りながら `.gitignore` は元ファイル 1 行しか追加しない設計だった。backup の中身は実際の権限リストと MCP 設定。XDG data 配下（`ARK_REPO_KEY` = repo 絶対パスの SHA-256、session ID 非依存）へ退避する形に変更
3. **cross-filesystem 対応で導入した repo 側一時 file に同じ穴が残っていた** — 復元経路の一時 file にはユーザーの元設定が入るのに、孤児検出は XDG 側しか見ておらず `.gitignore` にも載らない。固定名 `.claude/settings.local.json.ark-loop-tmp` にして孤児回収対象に追加し、`.gitignore` を 2 エントリに

## 検証

- 参照 13 節がすべて一意に解決
- placeholder（TBD / TODO / 未定）ゼロ
- spec が引用する行番号 4 箇所（`settings.json:52-70` / `:72-80`、`flow/SKILL.md:152-168`、`flow-loop/SKILL.md:67,107`）を実ファイルと照合
- 差分は Markdown 3 ファイルのみ。`server/` `client/` `shared/` `.claude/hooks/` `.claude/settings.json` に変更なし

## 備考

本 Issue 群は `.claude/` 配下のハーネス自改修にあたるため、全件 `loop-exclude` を付与している（`/flow-loop` が自分の hook を書き換えながら走るのを防ぐため）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * Arkのセッション内認知維持ループに関する実装仕様を追加しました。
  * セッション状態、タスク、エラー、引き継ぎ、知識共有などの扱いと責務を文書化しました。
  * 後続の実装作業に向けた計画、完了条件、検証方法を追加しました。
  * 関連する仕様書への参照を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->