### PR TITLE
docs: correct loop hook contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,9 @@ test-results/
 .claude/push-completed.marker
 .claude/scheduled_tasks.lock
 .claude/stop_hook_active
+# Ark loop adapter: session-init/teardown never mutate .gitignore at runtime
+.claude/settings.local.json
+.claude/settings.local.json.ark-loop-tmp
 
 # Superpowers
 .superpowers/

--- a/docs/superpowers/plans/2026-08-18-issue-332.md
+++ b/docs/superpowers/plans/2026-08-18-issue-332.md
@@ -92,14 +92,14 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - [ ] `§5-2 loop-rules.md` のタスク管理3則を「task.md だけを正本にする」「tool step の前後で status／NOW を現実に合わせる」「Goal／Constraints を書き換えず逸脱時は停止」と固定する。
 - [ ] 同節のエラー3則を「失敗 action と原文を raw.log に残す」「再試行前に直前失敗と既知の禁止手を読む」「回復結果と再発性のある知見を inbox 候補にする」、外部化4則を「20行超の中間成果は artifact 化」「index に path＋1行要約を append」「本文再掲より path 参照を優先」「可逆 compaction 後にのみ不可逆 summary」と固定する。
 - [ ] review 用 `task-review.md.tmpl` は diff 全読、規約／artifact／握りつぶし／Goal 逸脱、再発指摘の inbox 候補化を観点に持ち、session ID から生成した順列で提示順だけを変える。観点集合は減らさず、同一 session 内では順序を安定させると書く。
-- [ ] `§5-3 Claude Code adapter` に、settings.local の退避／識別子付きArk entryだけの非破壊deep merge／復元、hook matcher、`additionalContext`、permission deny、agent 非依存 template との境界、前提となるignore entry不足またはunsafe settingsでは無変更でloopを無効化すること、将来 Codex adapter が native todo 同期を持ち込んではならないことを書く。
+- [ ] `§5-3 Claude Code adapter` に、settings.local の元ファイル有無の記録／識別子付きArk entryだけの非破壊deep merge／除去による復元、hook matcher、`additionalContext`、permission deny、agent 非依存 template との境界、前提となるignore entry不足またはunsafe settingsでは無変更でloopを無効化すること、将来 Codex adapter が native todo 同期を持ち込んではならないことを書く。
 
 ## Task 8: §6-1 に冪等 session-init 契約を書く
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → session ID 生成と per-repo owner 取得 → 消滅 owner の孤児 settings 復元 → session directory 作成 → config 読込と Ark への値返却 → template 展開 → knowledge copy →事前ignore設定・settings安全性・JSON schemaの検証 → Ark所有entryだけを非破壊注入、と固定する。別 session の owner が生存中または前提検証に失敗した場合は loop を無効化して続行する。
-- [ ] settings.local の退避／復元は `mv` ベースで冪等にし、teardown を通らない kill が通常系であること、2回連続 kill でも「元設定1個または注入設定＋backup1個」の解釈可能な状態から元設定へ収束すると書く。
+- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → session ID 生成と per-repo owner 取得 → 消滅 owner の孤児Ark entry回収 → session directory 作成 → config 読込と Ark への値返却 → template 展開 → knowledge copy →事前ignore設定・settings安全性・JSON schemaの検証 → Ark所有entryだけを非破壊注入、と固定する。別 session の owner が生存中または前提検証に失敗した場合は loop を無効化して続行する。
+- [ ] settings.local の元ファイル有無の記録、Ark所有entryの非破壊merge／除去、固定名一時fileからの原子的`mv`を冪等にし、teardownを通らないkillが通常系であること、2回連続killでも現在のsettingsと有無markerから状態を解釈し、session中の非Ark変更を保持して元の有無へ収束すると書く。
 - [ ] repo `.gitignore` に `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の2 entryを一回限りのversioned設定として重複なく明示し、グローバル ignore に依存しないこと、session-init / teardownが.gitignoreを変更しないこと、対象 repo にそれ以外の永続変更を残さないことを書く。
 - [ ] `--restart` は既存 session の `errors/summary.md` を `{{PREV_FAILURE_SUMMARY}}` に埋め、通常 init は空の定型文を入れる。`step_count` は新 session ごとに0から始め、同じ init の再実行では task 正本を上書きしないと書く。
 
@@ -107,10 +107,10 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§6-2 session-teardown.sh` の順序を、機械 summary 生成 → handoff 更新 → failures-inbox 追記 → owner の場合だけ settings.local 注入物の除去と original 復元 → transient flag と owner marker の cleanup とし、各段階を再実行可能にする。
+- [ ] `§6-2 session-teardown.sh` の順序を、機械 summary 生成 → handoff 更新 → failures-inbox 追記 → owner の場合だけ現在の settings.local から Ark所有entryを除去して非Ark変更を保持し、元設定なしmarkerかつ他entryなしの場合だけfile削除 → transient flag と owner marker の cleanup とし、各段階を再実行可能にする。
 - [ ] `handoff.md` の固定項目を Goal、完了／未完了 Plan、現在の `← NOW`、artifact path＋要約、直近 error summary path、次の最小 action、WORK_ID／session ID とする。artifact 本文や flow JSON の複製はしない。
 - [ ] `handoff.md` は次のモデルへ意味的文脈を渡す data plane、`/flow --resume` は `.claude/lib/state-io.sh` の phase／gate を復元する control plane と定義する。競合時は flow state が phase の正本、handoff は助言情報であり、自動マージも相互上書きもしない。
-- [ ] teardown 未実行なら次回 init が summary／handoff／settings 復元を同じ順序で補償し、最終的に teardown 実行済みと同じ repo 状態へ収束すると書く。
+- [ ] teardown 未実行なら次回 init が summary／handoff／現在のsettingsからのArk所有entry除去を同じ順序で補償し、session中の非Ark変更を保持してteardown実行済みと同じrepo状態へ収束すると書く。
 
 ## Task 10: §6-3 に compaction-first の error summary を書く
 

--- a/docs/superpowers/plans/2026-08-18-issue-332.md
+++ b/docs/superpowers/plans/2026-08-18-issue-332.md
@@ -52,7 +52,8 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - [ ] `§2-1 配布物` に `ark/loop/{templates,hooks,scripts,adapters/claude-code}` を定義し、`templates`・規約・file format は agent 非依存、settings 注入と hook JSON は Claude Code adapter に閉じ込め、将来の `adapters/codex/` は AGENTS.md 注入と wrapper だけで追加できる構造とする。
 - [ ] `§2-2 XDG runtime` に `${XDG_CONFIG_HOME:-$HOME/.config}/ark/loop/config.toml`、`${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/sessions/$ARK_SESSION_ID/`、`${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/knowledge/`、`${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/` を正規配置として記す。
 - [ ] session data の木を `task.md`、`artifacts/index.md`、`errors/raw.log`、`errors/summary.md`、`handoff.md`、one-shot stop flag、cache の `step_count`、knowledge の `failures.md` と `failures-inbox.md` まで具体化する。正しさに関わる状態を cache に置かない。
-- [ ] `§2-3 対象 repo への影響` に、実行時の一時変更は `.claude/settings.local.json` と固定名の repo 側一時 file だけ、ignore entry は versioned 設定または一回限りの install で事前導入し、session-init / teardown は `.gitignore` を変更しないこと、成果物本体は XDG data 配下とし、終了／次回 init で収束させると書く。
+- [ ] `§2-2 XDG runtime` に、書き込み前の `.claude`、`.claude/settings.local.json`、`.claude/settings.local.json.ark-loop-tmp` が期待する regular directory / file で symlink ではなく、owner・mode の許可条件を満たすことを検証し、失敗時は settings を変更せず loop を無効化すると書く。
+- [ ] `§2-3 対象 repo への影響` に、実行時の一時変更は `.claude/settings.local.json` と固定名の repo 側一時 file だけ、ignore entry は versioned 設定または一回限りの install で事前導入し、両 path が tracked でないことも有効化前に確認することを書く。いずれかが tracked なら ignore 対象でも settings を変更せず loop を無効化し、session-init / teardown は `.gitignore` を変更せず、成果物本体は XDG data 配下として終了／次回 init で収束させる。
 
 ## Task 4: §3 で config、file ownership、task の唯一正本を決める
 
@@ -71,7 +72,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
 - [ ] `§4 hook 共通契約` に、hook input は非信頼データ、全 script は環境変数未設定時に no-op、session cache 以外へカウンタを共有しない、エラーで本来の tool result を握りつぶさない、追加 hook の fast path 合計を100ms以内とする原則を置く。
-- [ ] 現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持し、Claude Codeの同一event hookと並列tool callが並行することを前提に、配列順・hook完了順を契約にしないこと、captureは PostToolUseFailure、reciteは PostToolBatch に登録すること、実機fixtureと計測値を #333/#335 の PR に残すことを書く。
+- [ ] 現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持し、Claude Codeの同一event hookと並列tool callが並行することを前提に、配列順・hook完了順を契約にしないこと、captureは PostToolUseFailure、reciteは PostToolBatch に登録すること、PostToolBatch entryには`matcher`を付けず生成settings fixtureで不在を検証すること、実機fixtureと計測値を #333/#335 の PR に残すことを書く。
 - [ ] `§4-1 recite-todo.sh` に、PostToolBatchごとにsession-local counterを増やし、既定10 batchごとに Goal 1行、`← NOW` 行、未完了件数だけを `additionalContext` へ出すと定義する。並列tool callがあっても復唱は最大1回とする。task 全文、timestamp、artifact 本文、native todo は注入せず、概念上は1回200 token以下、実装上の代理指標として UTF-8 で600 bytes以下を #333 で検証すると spec に明記する。
 - [ ] compaction 直後でも task 正本から同じ固定長形式を再構成し、prefix を変動させないこと、interval 変更と hook 無効化だけで recitation 足場を単独撤去できることを書く。
 
@@ -79,8 +80,8 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§4-2 capture-error.sh` に、PostToolUseFailureで通知された実行後失敗だけを `errors/raw.log` へ1物理行の JSONL（`at`, `tool`, `error_type`, `exit_code`, `message`）で append し、改行は JSON escape、message は上限付き、成功時は書き込まないと固定する。1 entry 1行により `L{n}-L{n}` 参照を安定させる。
-- [ ] capture は分類・要約・禁止手生成を行わず、原エラーを消さないこと、permission deny / validation rejectionはPostToolUseFailureでは取得しないためP3の記録対象外と明記すること、hook input の実 field 名は #335 で実ダンプを fixture 化して確定することを書く。
+- [ ] `§4-2 capture-error.sh` に、PostToolUseFailureで通知された実行後失敗だけを `errors/raw.log` へ固定key順の1物理行 JSONL（`at`, `tool`, `error_type`, `exit_code`, `is_interrupt`, `error`, `details`）で append する。`error` 原文と他の失敗fieldを失わず、`exit_code` は抽出時だけ数値、それ以外は `null` とする。成功時は書き込まず、1 entry 1行により `L{n}-L{n}` 参照を安定させる。
+- [ ] capture は分類・要約・禁止手生成を行わず、原エラーを消さないこと、permission deny / validation rejectionはPostToolUseFailureでは取得しないためP3の記録対象外と明記すること、#335 の実ダンプ fixture で Bash / PowerShell、MCP failure、process 起動失敗、interrupt に同じ変換規則を適用して失敗情報が残ることを確定する。
 - [ ] `§4-3 Stop` に、新規 Stop 登録ではなく `.claude/hooks/stop-gate.sh` の実体を `on-stop.sh` 相当へ置換する契約を書く。未完了 Plan がありstop_hook_activeがfalseならsession-local one-shot flagとadditionalContextで1回だけ継続を要求し、2回目またはstop_hook_active時は通して無限 Stop loop を防ぐ。
 - [ ] Stop 通過時は `handoff.md` を生成するが、teardown 完了を前提にしないこと、tmux kill／pm2 restart／process crash では次回 init が同じ収束処理を担うことを書く。
 
@@ -92,14 +93,15 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - [ ] `§5-2 loop-rules.md` のタスク管理3則を「task.md だけを正本にする」「tool step の前後で status／NOW を現実に合わせる」「Goal／Constraints を書き換えず逸脱時は停止」と固定する。
 - [ ] 同節のエラー3則を「失敗 action と原文を raw.log に残す」「再試行前に直前失敗と既知の禁止手を読む」「回復結果と再発性のある知見を inbox 候補にする」、外部化4則を「20行超の中間成果は artifact 化」「index に path＋1行要約を append」「本文再掲より path 参照を優先」「可逆 compaction 後にのみ不可逆 summary」と固定する。
 - [ ] review 用 `task-review.md.tmpl` は diff 全読、規約／artifact／握りつぶし／Goal 逸脱、再発指摘の inbox 候補化を観点に持ち、session ID から生成した順列で提示順だけを変える。観点集合は減らさず、同一 session 内では順序を安定させると書く。
-- [ ] `§5-3 Claude Code adapter` に、settings.local の元ファイル有無の記録／識別子付きArk entryだけの非破壊deep merge／除去による復元、hook matcher、`additionalContext`、permission deny、agent 非依存 template との境界、前提となるignore entry不足またはunsafe settingsでは無変更でloopを無効化すること、将来 Codex adapter が native todo 同期を持ち込んではならないことを書く。
+- [ ] `§5-3 Claude Code adapter` に、repo state directoryのownership manifestが注入前のsettings.local有無とArkが実際に追加したentryの配列／key path・canonical値だけを記録し、元ファイル有無markerを置き換えると書く。同一entryが既存なら追加も記録もせず、復元時は記録と同一内容のentryだけを除去し、変更済みentryは所有放棄を記録して残す。settings本体に`id`等を加えず、元設定なしで非Ark entryが残らない場合だけfileを削除する。
+- [ ] 同節に、hook matcher、`additionalContext`、permission deny、agent 非依存 template との境界、前提となるignore entry不足またはunsafe settingsの場合は、settingsを変更せずにloopを無効化すること、将来 Codex adapter が native todo 同期を持ち込んではならないことを書く。#333 は既存設定・注入・teardown・孤児回収のround-trip fixtureを完了条件とする。
 
 ## Task 8: §6-1 に冪等 session-init 契約を書く
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → session ID 生成と per-repo owner 取得 → 消滅 owner の孤児Ark entry回収 → session directory 作成 → config 読込と Ark への値返却 → template 展開 → knowledge copy →事前ignore設定・settings安全性・JSON schemaの検証 → Ark所有entryだけを非破壊注入、と固定する。別 session の owner が生存中または前提検証に失敗した場合は loop を無効化して続行する。
-- [ ] settings.local の元ファイル有無の記録、Ark所有entryの非破壊merge／除去、固定名一時fileからの原子的`mv`を冪等にし、teardownを通らないkillが通常系であること、2回連続killでも現在のsettingsと有無markerから状態を解釈し、session中の非Ark変更を保持して元の有無へ収束すると書く。
+- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → session ID 生成と per-repo owner 取得 → `.claude`・settings・固定名一時fileのsymlink／regular type／owner／modeと、両fileのignore／tracked状態をsettings書き込み前に検証 → manifestによる消滅ownerの孤児Ark entry回収 → session directory 作成 → config読込と値返却 → template展開 → knowledge copy → JSON schema検証 → manifestへ記録したArk所有entryだけを非破壊注入、と固定する。別 session の owner が生存中または前提検証に失敗した場合は settings を変更せず loop を無効化して続行する。
+- [ ] ownership manifestによるsettings.localの元ファイル有無とArkが実際に追加したentryの記録、同一entryだけの除去、固定名一時fileからの原子的`mv`を冪等にする。内容とmodeを保持し、teardownを通らないkillを通常系として、2回連続killでも現在のsettingsとmanifestから状態を解釈し、session中の非Ark変更を保持して元の有無へ収束させる。
 - [ ] repo `.gitignore` に `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の2 entryを一回限りのversioned設定として重複なく明示し、グローバル ignore に依存しないこと、session-init / teardownが.gitignoreを変更しないこと、対象 repo にそれ以外の永続変更を残さないことを書く。
 - [ ] `--restart` は既存 session の `errors/summary.md` を `{{PREV_FAILURE_SUMMARY}}` に埋め、通常 init は空の定型文を入れる。`step_count` は新 session ごとに0から始め、同じ init の再実行では task 正本を上書きしないと書く。
 
@@ -107,7 +109,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§6-2 session-teardown.sh` の順序を、機械 summary 生成 → handoff 更新 → failures-inbox 追記 → owner の場合だけ現在の settings.local から Ark所有entryを除去して非Ark変更を保持し、元設定なしmarkerかつ他entryなしの場合だけfile削除 → transient flag と owner marker の cleanup とし、各段階を再実行可能にする。
+- [ ] `§6-2 session-teardown.sh` の順序を、機械 summary 生成 → handoff 更新 → failures-inbox 追記 → owner の場合だけmanifest記録と現在のsettings.localが同一のArk所有entryを除去し、変更済みentryは所有放棄を記録して残し、元設定なしを示すmanifestかつ非Ark entryなしの場合だけfile削除 → transient flag と owner marker の cleanup とし、各段階を再実行可能にする。
 - [ ] `handoff.md` の固定項目を Goal、完了／未完了 Plan、現在の `← NOW`、artifact path＋要約、直近 error summary path、次の最小 action、WORK_ID／session ID とする。artifact 本文や flow JSON の複製はしない。
 - [ ] `handoff.md` は次のモデルへ意味的文脈を渡す data plane、`/flow --resume` は `.claude/lib/state-io.sh` の phase／gate を復元する control plane と定義する。競合時は flow state が phase の正本、handoff は助言情報であり、自動マージも相互上書きもしない。
 - [ ] teardown 未実行なら次回 init が summary／handoff／現在のsettingsからのArk所有entry除去を同じ順序で補償し、session中の非Ark変更を保持してteardown実行済みと同じrepo状態へ収束すると書く。
@@ -138,6 +140,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - [ ] `rg -n '^## §[1-7]|^### §(4-[123]|5-[123]|6-[123])' docs/superpowers/specs/ark-loop-implementation-spec.md` で §1〜§7 と全参照枝番が一意に存在することを確認する。
 - [ ] `rg -n '§1, §2, §3, §4-1, §5-1, §5-3, §6-1|§5-2|§4-2, §6-3|§4-3, §6-2, §7|\{\{PREV_FAILURE_SUMMARY\}\}' docs/superpowers/specs/ark-loop-implementation-spec.md` で #333〜#336 の参照 map と placeholder 名を確認する。
 - [ ] `rg -n '機械的|opt-in|task.md.*唯一|TodoWrite|artifacts/|flow-progress-|handoff.md|--resume|failures.md|breaker|loop-exclude|撤去|疑わしきは外す|git 履歴' docs/superpowers/specs/ark-loop-implementation-spec.md` で5追補と撤去 gate が欠落していないことを確認する。
+- [ ] #333 の復元fixtureでsettingsの内容とmodeを注入前と比較し、`test ! -e .claude/settings.local.json.ark-loop-tmp` と `git status --short --ignored` でignored fileを含むrepo側残留がないことを確認する。
 - [ ] `git diff --name-only` が `docs/superpowers/specs/ark-loop-implementation-spec.md`、`.claude/skills/flow-loop/SKILL.md`、versionedなadapter前提を置く`.gitignore`（および事前承認済み plan）のみを示し、`server/`・`client/`・`shared/`・`.claude/hooks/`・`.claude/settings.json` に差分がないことを確認する。
 - [ ] `gh issue view 332 --json labels` と #333〜#336 の同じ読み取りで `loop-engineering`、`P0`〜`P4`、`loop-exclude` の存在を再確認し、ラベル API の write は行わない。
 
@@ -148,5 +151,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - `docs/superpowers/specs/ark-loop-implementation-spec.md` が存在し、#333〜#336 の全節参照と `{{PREV_FAILURE_SUMMARY}}` 契約が解決している。
 - `.claude/skills/flow-loop/SKILL.md` から spec への相互参照が1行だけ追加されている。
 - `task.md` が唯一の正本であり、P1 の recite と P2 の loop-rules に派生制約が明記されている。
+- #333 の fixture で既存設定・注入・teardown・孤児回収のround-trip、復元後の内容とmode、`PostToolBatch` entryの`matcher`不在、ignored fileを含むrepo側残留なしが検証されている。
+- #335 の fixture で`error`原文と全失敗情報を保持し、抽出不能な`exit_code`を`null`とする変換規則が検証されている。
 - 1セッション内認知維持層と複数セッション運転層の所有権、課金原則、知識化と隔離の関係、人間判断を既定として定量計測を補強材料に留める足場撤去 gate が固定されている。
 - 実装対象 2ファイル（spec と `flow-loop` の `SKILL.md`）およびversionedなadapter前提を置く`.gitignore`に加えて、この plan を成果物としてコミットし、Task 12 の検証対象4 path 以外の Ark アプリ本体および hook/settings 実装には変更がない。

--- a/docs/superpowers/plans/2026-08-18-issue-332.md
+++ b/docs/superpowers/plans/2026-08-18-issue-332.md
@@ -52,7 +52,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - [ ] `§2-1 配布物` に `ark/loop/{templates,hooks,scripts,adapters/claude-code}` を定義し、`templates`・規約・file format は agent 非依存、settings 注入と hook JSON は Claude Code adapter に閉じ込め、将来の `adapters/codex/` は AGENTS.md 注入と wrapper だけで追加できる構造とする。
 - [ ] `§2-2 XDG runtime` に `${XDG_CONFIG_HOME:-$HOME/.config}/ark/loop/config.toml`、`${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/sessions/$ARK_SESSION_ID/`、`${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/knowledge/`、`${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/` を正規配置として記す。
 - [ ] session data の木を `task.md`、`artifacts/index.md`、`errors/raw.log`、`errors/summary.md`、`handoff.md`、one-shot stop flag、cache の `step_count`、knowledge の `failures.md` と `failures-inbox.md` まで具体化する。正しさに関わる状態を cache に置かない。
-- [ ] `§2-3 対象 repo への影響` に、実行時の一時変更は `.claude/settings.local.json` と repo `.gitignore` の明示エントリだけ、成果物本体は XDG data 配下とし、終了／次回 init で収束させると書く。
+- [ ] `§2-3 対象 repo への影響` に、実行時の一時変更は `.claude/settings.local.json` と固定名の repo 側一時 file だけ、ignore entry は versioned 設定または一回限りの install で事前導入し、session-init / teardown は `.gitignore` を変更しないこと、成果物本体は XDG data 配下とし、終了／次回 init で収束させると書く。
 
 ## Task 4: §3 で config、file ownership、task の唯一正本を決める
 
@@ -63,7 +63,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - [ ] `§3-3 native todo との関係` で選択肢 (a) を採用し、loop 有効セッションでは `task.md` を唯一の正本にして `TodoWrite`／native Task todo state に作業項目を複製しないと決める。根拠を、native schema が Goal／Constraints／`← NOW` と更新不変条件を構造化できないこと、正本化すると §2-1 の agent 非依存な adapter 境界を壊すこと、native の保存形式は変更されうる内部実装で公開契約ではないこと、の3点で示す。
 - [ ] native task state も JSON file と `.lock` により永続化・排他され、hook／別 process から読めて再起動後も残る事実を明記する。native state 単体の排他と選択肢 (c) の双方向同期の整合性を区別し、native task session ID と会話 transcript session ID の対応付けは可能だが自明でないと補足する。
 - [ ] 選択肢 (a) には Claude Code の native todo が提供するユーザー可視の進捗表示を失うコストがあること、それでも recitation schema と adapter 境界を満たす安定した単一正本を優先するため採用することを同節に1〜2行で残す。
-- [ ] 同節から導かれる拘束を明記する。P1 の `recite-todo.sh` は `task.md` だけを読み native todo を参照・更新しない。P2 の `loop-rules.md` は native todo の使用禁止、Plan status と `← NOW` の更新、Goal／Constraints の不変条件を含む。native todo が必要な作業は loop を無効化するか、task.md へ移してから続ける。
+- [ ] 同節から導かれる拘束を明記する。P1 の `recite-todo.sh` は `task.md` だけを読み native todo を参照・更新しない。loop 有効sessionでは Task / Todo toolをpermission denyまたは同等のallowlistで利用不能にする。P2 の `loop-rules.md` は native todo の使用禁止、Plan status と `← NOW` の更新、Goal／Constraints の不変条件を含む。native todo が必要な作業は loop を無効化するか、task.md へ移してから続ける。
 - [ ] `§3-4 flow state との所有権表` に、`flow-progress-*.json` は phase／gate／safety／warning 等の制御面、`artifacts/` は内容面と分離し、相互コピー・双方向同期・flow state schema 追加をしないと書く。接続は WORK_ID／session path の参照だけに留める。
 
 ## Task 5: §4-1 に固定長 recitation と既存 hook 共存を書く
@@ -71,17 +71,17 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
 - [ ] `§4 hook 共通契約` に、hook input は非信頼データ、全 script は環境変数未設定時に no-op、session cache 以外へカウンタを共有しない、エラーで本来の tool result を握りつぶさない、追加 hook の fast path 合計を100ms以内とする原則を置く。
-- [ ] 現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持し、後続では論理順を `capture-error` → 既存の該当 hook（Bash は post-push-monitor、Write/Edit は post-edit-lint）→ `recite-todo` とすること、実 Claude Code の直列実行契約を #333/#335 で実機確認し計測値を PR に残すことを書く。
-- [ ] `§4-1 recite-todo.sh` に、成功した tool step ごとに session-local counter を増やし、既定10 step ごとに Goal 1行、`← NOW` 行、未完了件数だけを `additionalContext` へ出すと定義する。task 全文、timestamp、artifact 本文、native todo は注入せず、概念上は1回200 token以下、実装上の代理指標として UTF-8 で600 bytes以下を #333 で検証すると spec に明記する。
+- [ ] 現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持し、Claude Codeの同一event hookと並列tool callが並行することを前提に、配列順・hook完了順を契約にしないこと、captureは PostToolUseFailure、reciteは PostToolBatch に登録すること、実機fixtureと計測値を #333/#335 の PR に残すことを書く。
+- [ ] `§4-1 recite-todo.sh` に、PostToolBatchごとにsession-local counterを増やし、既定10 batchごとに Goal 1行、`← NOW` 行、未完了件数だけを `additionalContext` へ出すと定義する。並列tool callがあっても復唱は最大1回とする。task 全文、timestamp、artifact 本文、native todo は注入せず、概念上は1回200 token以下、実装上の代理指標として UTF-8 で600 bytes以下を #333 で検証すると spec に明記する。
 - [ ] compaction 直後でも task 正本から同じ固定長形式を再構成し、prefix を変動させないこと、interval 変更と hook 無効化だけで recitation 足場を単独撤去できることを書く。
 
 ## Task 6: §4-2 と §4-3 に失敗捕捉と Stop 契約を書く
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§4-2 capture-error.sh` に、PostToolUse の失敗だけを `errors/raw.log` へ1物理行の JSONL（`at`, `tool`, `error_type`, `exit_code`, `message`）で append し、改行は JSON escape、message は上限付き、成功時は書き込まないと固定する。1 entry 1行により `L{n}-L{n}` 参照を安定させる。
-- [ ] capture は分類・要約・禁止手生成を行わず、原エラーを消さないこと、同一 tool event の capture が recite より先に完了すること、hook input の実 field 名は #335 で実ダンプを fixture 化して確定することを書く。
-- [ ] `§4-3 Stop` に、新規 Stop 登録ではなく `.claude/hooks/stop-gate.sh` の実体を `on-stop.sh` 相当へ置換する契約を書く。未完了 Plan があれば session-local one-shot flag で1回だけ継続を要求し、2回目は通して無限 Stop loop を防ぐ。
+- [ ] `§4-2 capture-error.sh` に、PostToolUseFailureで通知された実行後失敗だけを `errors/raw.log` へ1物理行の JSONL（`at`, `tool`, `error_type`, `exit_code`, `message`）で append し、改行は JSON escape、message は上限付き、成功時は書き込まないと固定する。1 entry 1行により `L{n}-L{n}` 参照を安定させる。
+- [ ] capture は分類・要約・禁止手生成を行わず、原エラーを消さないこと、permission deny / validation rejectionはPostToolUseFailureでは取得しないためP3の記録対象外と明記すること、hook input の実 field 名は #335 で実ダンプを fixture 化して確定することを書く。
+- [ ] `§4-3 Stop` に、新規 Stop 登録ではなく `.claude/hooks/stop-gate.sh` の実体を `on-stop.sh` 相当へ置換する契約を書く。未完了 Plan がありstop_hook_activeがfalseならsession-local one-shot flagとadditionalContextで1回だけ継続を要求し、2回目またはstop_hook_active時は通して無限 Stop loop を防ぐ。
 - [ ] Stop 通過時は `handoff.md` を生成するが、teardown 完了を前提にしないこと、tmux kill／pm2 restart／process crash では次回 init が同じ収束処理を担うことを書く。
 
 ## Task 7: §5 に task template、10規約、review rotation、adapter を書く
@@ -92,15 +92,15 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - [ ] `§5-2 loop-rules.md` のタスク管理3則を「task.md だけを正本にする」「tool step の前後で status／NOW を現実に合わせる」「Goal／Constraints を書き換えず逸脱時は停止」と固定する。
 - [ ] 同節のエラー3則を「失敗 action と原文を raw.log に残す」「再試行前に直前失敗と既知の禁止手を読む」「回復結果と再発性のある知見を inbox 候補にする」、外部化4則を「20行超の中間成果は artifact 化」「index に path＋1行要約を append」「本文再掲より path 参照を優先」「可逆 compaction 後にのみ不可逆 summary」と固定する。
 - [ ] review 用 `task-review.md.tmpl` は diff 全読、規約／artifact／握りつぶし／Goal 逸脱、再発指摘の inbox 候補化を観点に持ち、session ID から生成した順列で提示順だけを変える。観点集合は減らさず、同一 session 内では順序を安定させると書く。
-- [ ] `§5-3 Claude Code adapter` に、settings.local の退避／注入、hook matcher、`additionalContext`、agent 非依存 template との境界、将来 Codex adapter が native todo 同期を持ち込んではならないことを書く。
+- [ ] `§5-3 Claude Code adapter` に、settings.local の退避／識別子付きArk entryだけの非破壊deep merge／復元、hook matcher、`additionalContext`、permission deny、agent 非依存 template との境界、前提となるignore entry不足またはunsafe settingsでは無変更でloopを無効化すること、将来 Codex adapter が native todo 同期を持ち込んではならないことを書く。
 
 ## Task 8: §6-1 に冪等 session-init 契約を書く
 
 **Files:** `docs/superpowers/specs/ark-loop-implementation-spec.md`
 
-- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → session ID 生成と per-repo owner 取得 → 消滅 owner の孤児 settings 復元 → session directory 作成 → config 読込と Ark への値返却 → template 展開 → knowledge copy → settings.local 再退避・注入、と固定する。別 session の owner が生存中なら loop を無効化して続行する。
+- [ ] `§6-1 session-init.sh` の順序を、XDG path 解決 → session ID 生成と per-repo owner 取得 → 消滅 owner の孤児 settings 復元 → session directory 作成 → config 読込と Ark への値返却 → template 展開 → knowledge copy →事前ignore設定・settings安全性・JSON schemaの検証 → Ark所有entryだけを非破壊注入、と固定する。別 session の owner が生存中または前提検証に失敗した場合は loop を無効化して続行する。
 - [ ] settings.local の退避／復元は `mv` ベースで冪等にし、teardown を通らない kill が通常系であること、2回連続 kill でも「元設定1個または注入設定＋backup1個」の解釈可能な状態から元設定へ収束すると書く。
-- [ ] repo `.gitignore` に `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の2 entry を重複なく明示し、グローバル ignore に依存しないこと、対象 repo にそれ以外の永続変更を残さないことを書く。
+- [ ] repo `.gitignore` に `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の2 entryを一回限りのversioned設定として重複なく明示し、グローバル ignore に依存しないこと、session-init / teardownが.gitignoreを変更しないこと、対象 repo にそれ以外の永続変更を残さないことを書く。
 - [ ] `--restart` は既存 session の `errors/summary.md` を `{{PREV_FAILURE_SUMMARY}}` に埋め、通常 init は空の定型文を入れる。`step_count` は新 session ごとに0から始め、同じ init の再実行では task 正本を上書きしないと書く。
 
 ## Task 9: §6-2 に teardown、handoff、resume 境界を書く
@@ -138,7 +138,7 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - [ ] `rg -n '^## §[1-7]|^### §(4-[123]|5-[123]|6-[123])' docs/superpowers/specs/ark-loop-implementation-spec.md` で §1〜§7 と全参照枝番が一意に存在することを確認する。
 - [ ] `rg -n '§1, §2, §3, §4-1, §5-1, §5-3, §6-1|§5-2|§4-2, §6-3|§4-3, §6-2, §7|\{\{PREV_FAILURE_SUMMARY\}\}' docs/superpowers/specs/ark-loop-implementation-spec.md` で #333〜#336 の参照 map と placeholder 名を確認する。
 - [ ] `rg -n '機械的|opt-in|task.md.*唯一|TodoWrite|artifacts/|flow-progress-|handoff.md|--resume|failures.md|breaker|loop-exclude|撤去|疑わしきは外す|git 履歴' docs/superpowers/specs/ark-loop-implementation-spec.md` で5追補と撤去 gate が欠落していないことを確認する。
-- [ ] `git diff --name-only` が `docs/superpowers/specs/ark-loop-implementation-spec.md` と `.claude/skills/flow-loop/SKILL.md`（および事前承認済み plan）のみを示し、`server/`・`client/`・`shared/`・`.claude/hooks/`・`.claude/settings.json` に差分がないことを確認する。
+- [ ] `git diff --name-only` が `docs/superpowers/specs/ark-loop-implementation-spec.md`、`.claude/skills/flow-loop/SKILL.md`、versionedなadapter前提を置く`.gitignore`（および事前承認済み plan）のみを示し、`server/`・`client/`・`shared/`・`.claude/hooks/`・`.claude/settings.json` に差分がないことを確認する。
 - [ ] `gh issue view 332 --json labels` と #333〜#336 の同じ読み取りで `loop-engineering`、`P0`〜`P4`、`loop-exclude` の存在を再確認し、ラベル API の write は行わない。
 
 ---
@@ -149,4 +149,4 @@ Task 1〜11 で作成する各節は、契約（何を守るか）を簡潔に�
 - `.claude/skills/flow-loop/SKILL.md` から spec への相互参照が1行だけ追加されている。
 - `task.md` が唯一の正本であり、P1 の recite と P2 の loop-rules に派生制約が明記されている。
 - 1セッション内認知維持層と複数セッション運転層の所有権、課金原則、知識化と隔離の関係、人間判断を既定として定量計測を補強材料に留める足場撤去 gate が固定されている。
-- 実装対象 2ファイル（spec と `flow-loop` の `SKILL.md`）に加えて、この plan を成果物としてコミットし、Task 12 の検証対象3 path 以外の Ark アプリ本体および hook/settings 実装には変更がない。
+- 実装対象 2ファイル（spec と `flow-loop` の `SKILL.md`）およびversionedなadapter前提を置く`.gitignore`に加えて、この plan を成果物としてコミットし、Task 12 の検証対象4 path 以外の Ark アプリ本体および hook/settings 実装には変更がない。

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -103,8 +103,7 @@ ${XDG_DATA_HOME:-$HOME/.local/share}/ark/loop/
 │   └── failures-inbox.md
 └── repos/$ARK_REPO_KEY/
     ├── owner
-    ├── settings.local.json.ark-loop-original
-    └── settings.local.json.ark-loop-no-original
+    └── settings-ownership.json
 
 ${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/
 └── step_count
@@ -112,13 +111,13 @@ ${XDG_CACHE_HOME:-$HOME/.cache}/ark/loop/$ARK_SESSION_ID/
 
 session data、knowledge、repo state は永続 data であり、cache は消失しても再生成できる `step_count` だけを持つ。cache に正しさに関わる状態を置かず、永続 data と相互に代用しない。`ARK_REPO_KEY` は対象 repo の canonical な絶対パスの UTF-8 bytes に対する SHA-256 lowercase hex とし、session ID に依存させない。
 
-XDG 配下の session data、repo state、cache の各 directory は mode `0700`、その file は mode `0600` とする。使用前に各 path が期待する regular directory / regular file であり symlink でないことと、owner・mode を検証する。repo 内の `.claude/settings.local.json` も読み取り前に symlink でないことを検証する。検証は既存 `.claude/lib/flow-state-dir.sh` の secure default 規則に準拠し、不一致時は使用しない。
+XDG 配下の session data、repo state、cache の各 directory は mode `0700`、その file は mode `0600` とする。使用前に各 path が期待する regular directory / regular file であり symlink でないことと、owner・mode を検証する。repo 内は `.claude`、`.claude/settings.local.json`、`.claude/settings.local.json.ark-loop-tmp` の3 pathを読み書きの直前に検証し、`.claude` は symlink でない regular directory、後二者は存在する場合に symlink でない regular file で、いずれも owner・mode が許可条件を満たさなければならない。後二者の不存在だけは許容する。検証は既存 `.claude/lib/flow-state-dir.sh` の secure default 規則に準拠し、不一致時は settings を変更せず loop を無効化する。
 
 ### §2-3 対象 repo への影響
 
-実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と固定名の `.claude/settings.local.json.ark-loop-tmp` だけとする。`.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の ignore entry は、adapter の有効化前に versioned な repo 設定または明示的な一回限りの install で導入する前提とし、`session-init.sh` と `session-teardown.sh` は repo `.gitignore` を変更してはならない。entry がない対象 repo では、adapter は settings を変更せず loop を無効化して理由を返す。認知維持の成果物本体と settings の元ファイル有無 marker は XDG data 配下に置き、対象 repo 内に marker を作らない。
+実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と固定名の `.claude/settings.local.json.ark-loop-tmp` だけとする。両 path の ignore entry は、adapter の有効化前に versioned な repo 設定または明示的な一回限りの install で導入し、両 path が tracked でないことも確認する。entry 不足またはいずれかが tracked の対象 repo では、ignore 対象でも versioned file を変更せず、adapter は settings を変更せず loop を無効化して理由を返す。`session-init.sh` と `session-teardown.sh` は repo `.gitignore` を変更してはならない。認知維持の成果物本体と settings ownership manifest は XDG data 配下に置き、対象 repo 内に marker を作らない。
 
-正常終了は settings 注入物と repo 側の一時 file を除去し、異常終了は次回 init が同じ回収を行う。どちらも session 中の非 Ark 変更を保持して Ark 所有 entry のない repo 設定へ収束し、実行だけで versioned file を dirty にしない。#333 の完了条件は、対象 repo に versioned な事前設定以外の変更が入らず、repo 側の一時 file が残存しないこととする。
+正常終了は settings 注入物と repo 側の一時 file を除去し、異常終了は次回 init が同じ回収を行う。どちらも session 中の非 Ark 変更を保持して Ark 所有 entry のない repo 設定へ収束し、実行だけで versioned file を dirty にしない。#333 では既存設定から注入、teardown、孤児回収までの round-trip fixture により内容と mode の復元を検証し、`test ! -e .claude/settings.local.json.ark-loop-tmp` と `git status --short --ignored` により ignored file を含む残留がないことを完了条件とする。
 
 ## §3 設定・状態・正本
 
@@ -190,7 +189,7 @@ hook input は非信頼データとして parse し、path、文字列、数値�
 
 現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持する。Claude Code は同一eventに一致する hook を並列実行し、並列 tool call では PostToolUse も呼出しごとに並行するため、adapter は settings 配列の記載順または hook 間の完了順を契約にしてはならない。
 
-`capture-error` は実行開始後に失敗した tool だけを対象とする `PostToolUseFailure` に登録する。`recite-todo` は一連の tool call が完了して次のモデル呼出し前に一度だけ走る `PostToolBatch` に登録し、既存 PostToolUse hook・error captureの完了順へ依存しない。既存 hook の保持、各hookの個別100ms fast path、event種別と追加contextの実機fixtureを #333 / #335 の PR に記録する。
+`capture-error` は実行開始後に失敗した tool だけを対象とする `PostToolUseFailure` に登録する。`recite-todo` は一連の tool call が完了して次のモデル呼出し前に一度だけ走る `PostToolBatch` に登録し、既存 PostToolUse hook・error captureの完了順へ依存しない。`PostToolBatch` の hook entry には非対応の `matcher` を付けず、生成 settings fixture でも不在を検証する。既存 hook の保持、各hookの個別100ms fast path、event種別と追加contextの実機fixtureを #333 / #335 の PR に記録する。
 
 ### §4-1 recite-todo.sh
 
@@ -211,10 +210,10 @@ compaction 直後も `task.md` 正本から同じ key、同じ順序、同じ行
 `PostToolUseFailure` で通知される、実行を開始した後に失敗した tool event だけを `errors/raw.log` へ、次の field を持つ1物理行の JSONL として append する。
 
 ```json
-{"at":"RFC3339","tool":"tool name","error_type":"input field or tool_error","exit_code":1,"message":"escaped message"}
+{"at":"RFC3339","tool":"tool name","error_type":"input field or tool_error","exit_code":null,"is_interrupt":false,"error":"original error text","details":{}}
 ```
 
-`at`、`tool`、`error_type`、`exit_code`、`message` は常に同じ key 順で出力する。message の改行は JSON escape し、UTF-8 で4096 bytesを上限として code point 境界で切る。成功 event は書き込まない。1 entry を必ず1行に収め、`L{n}-L{n}` の参照を安定させる。
+top-level key は例の順で固定し、`details` 内の key は bytewise 昇順とする。`error` は原文を欠落なく保存して改行だけを JSON escape する。`exit_code` は `error` から抽出できた場合だけ数値、それ以外は `null` とし、`is_interrupt` は入力値を保ち、不在時は `null` とする。`details` はこれら以外の失敗 field を元の型と値のまま保持する。成功 event は書き込まず、1 entry を必ず1物理行に収めて `L{n}-L{n}` の参照を安定させる。#335 の fixture は Bash / PowerShell、MCP failure、process 起動失敗、interrupt に同じ変換規則を適用し、原文と失敗情報が失われないことを検証する。
 
 capture は入力にある型の正規化以外の分類、要約、「禁止手」の生成を行わず、原 tool error の表示・終了状態を変更しない。permission deny と tool input のschema / tool固有validation拒否は `PostToolUseFailure` の対象外であるため、P3では raw.log に記録しない。これらを将来の学習対象にする場合は `PermissionDenied`等の別eventを使う独立した契約を追加する。hook input の実 field 名と成功・失敗判定は #335 で実機ダンプを fixture 化して確定し、fixture にない field を推測して補わない。
 
@@ -282,7 +281,9 @@ Plan には checkbox を使い、`← NOW` は常にちょうど1個だけ置く
 
 Claude Code adapter だけが、既存 `.claude/settings.local.json` の有無の記録・非破壊な loop settings 注入・復元、hook matcher、hook input JSON、`additionalContext` output、Claude Code の `allowed-tools` / permission deny を扱う。agent 非依存の template、規約、session file format に Claude Code 固有 key を入れない。
 
-注入前に既存settingsをJSONとして構文・型検証し、Arkが所有する識別子付きhookとpermission ruleだけを深く追加する。既存のMCP、permission、hook、その他のkeyを削除・置換・並べ替えてはならず、teardownはArk所有entryだけを除去して元の意味を復元する。解析不能、symlink、安全でないownership・mode、または§2-3の事前ignore設定がない場合は、元settingsを変更せずloopを無効化する。
+repo state directory の `settings-ownership.json` は、注入前の settings file の有無と、Ark が実際に追加した entry ごとの配列／key pathおよび canonical な permission 文字列または hook objectだけを記録し、従来の元ファイル有無 markerを置き換える。追加候補と同一の entry が既にあれば追加も記録もせず、存在しない場合だけ非破壊に追加して manifest に記録する。settings schema に所有判定用の `id` 等を加えてはならない。
+
+復元は manifest に記録された entry のうち現在も注入時と同一内容のものだけを除去する。変更された entry は所有を放棄して残し、manifest の該当 entry に `abandoned` と記録する。manifest が元ファイルなしを示し、除去後に Ark 以外の entry が1つも残らない場合だけ settings file を削除する。既存の MCP、permission、hook、その他の key を削除・置換・並べ替えてはならない。解析不能、§2-2 の path・ownership・mode 検証失敗、または§2-3の事前ignore・tracked検証失敗の場合は、settingsを変更せずloopを無効化する。#333 は既存設定・注入・teardown・孤児回収を通す round-trip fixture と、`PostToolBatch` entry に `matcher` がない fixture を完了条件とする。
 
 adapter は §3-3 の単一正本を変えてはならない。将来の Codex adapter も AGENTS.md と wrapper の接続に留め、native todo 同期や別の進捗正本を持ち込んではならない。
 
@@ -294,21 +295,21 @@ init の順序を次で固定する。
 
 1. XDG path と対象 repo の canonical な絶対パスを解決し、§2-2 の `ARK_REPO_KEY` と repo state directory を導出する。
 2. session ID を生成または再取得し、session ID と Ark が管理する owner process の PID を持つ repo state directory の `owner` marker を検査する。別 session の owner が生存中なら孤児回収と settings 注入を行わず、loop を無効化して起動を続ける。
-3. owner が存在しないか消滅している場合は ownership を原子的に取得し、同じ session が owner の場合は保持する。owner だけが現在の settings から Ark 所有 entry を除去し、元ファイル有無 marker が示す有無へ収束させ、孤児化した repo 側の `.claude/settings.local.json.ark-loop-tmp` を無条件に削除してから、session directory と cache directory を作る。
+3. owner が存在しないか消滅している場合は ownership を原子的に取得し、同じ session が owner の場合は保持する。owner は settings に触れる前に `.claude`、settings file、一時 file の§2-2の安全性と、両 file の§2-3のignore・tracked状態を検証する。失敗時は settings を変更せず loop を無効化する。成功時だけ manifest に従って孤児 Ark entry を回収し、安全性を確認済みの regular な一時 file を除去してから、session directory と cache directory を作る。
 4. config を読み、§3-1 の値を Ark へ返す。
 5. 新規 session に限って template を展開する。
 6. host の `failures.md` を session へ read-only copy する。
-7. §2-3の事前ignore設定と既存settingsの安全性・JSON schemaを検証してから、Ark所有entryだけを非破壊に追加する。前提を満たさない場合は settings を変更せず loop を無効化する。
+7. 既存settingsのJSON schemaを検証してから、manifestへ記録するArk所有entryだけを非破壊に追加する。前提を満たさない場合は settings を変更せず loop を無効化する。
 
-`owner` marker の取得・生存確認・消滅 owner からの引継ぎは per-repo で排他的に行う。同じ session の再実行だけは既存 ownership を継続できる。repo state directory の `settings.local.json.ark-loop-original` と `settings.local.json.ark-loop-no-original` は注入前の settings file の有無だけを記録する marker とし、内容の復元元にはせず、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。Ark 所有 entry は §5-3 の識別子で判定できることを注入と復元の前提とする。
+`owner` marker の取得・生存確認・消滅 owner からの引継ぎは per-repo で排他的に行う。同じ session の再実行だけは既存 ownership を継続できる。repo state directory と file は owner のみ読み書き可能にする。`settings-ownership.json` は§5-3の契約に従い、注入前の有無とArkが実際に追加したentryだけを所有の根拠とする。
 
-注入時は現在の `.claude/settings.local.json` を読み、§5-3 の構文・型を検証し、その有無を対応する marker へ原子的に記録してから Ark 所有 entry だけを deep merge する。結果は repo 側の固定名 `.claude/settings.local.json.ark-loop-tmp` に書き、同 filesystem 上の `mv` で原子的に確定する。`mktemp` 等による可変名を使わない。
+注入時は現在の `.claude/settings.local.json` を読み、§5-3 の構文・型を検証する。同一 entry がない候補だけを追加対象としてmanifestへ原子的に記録し、deep mergeする。結果は repo 側の固定名 `.claude/settings.local.json.ark-loop-tmp` に書き、既存 file の mode を保持し、新規 file は mode `0600` として、同 filesystem 上の `mv` で原子的に確定する。`mktemp` 等による可変名を使わない。
 
-復元時は現在の `.claude/settings.local.json` を読み、Ark 所有 entry だけを除去し、その他の key・値・順序を保持する。元設定なし marker があり、除去後に Ark 以外の entry が残らない場合に限り settings file を削除し、それ以外は固定名一時 file を経由した同 filesystem 上の `mv` で原子的に書き戻す。成功後に元ファイル有無 marker を除去する。session 中に Claude Code やユーザーが settings.local を更新しうるため、backup による置換はそれらを失う。repo と XDG data が異なる filesystem でも rename に依存せず、孤児化した repo 側の一時 file は中間状態として無条件に削除する。
+復元時は現在の `.claude/settings.local.json` を読み、manifest に記録された entry と同一内容のものだけを除去し、その他の key・値・順序を保持する。変更された entry は残して manifest に `abandoned` と記録する。manifest が元設定なしを示し、除去後に Ark 以外の entry が残らない場合に限り settings file を削除し、それ以外は内容と mode を保持して固定名一時 file 経由の同 filesystem 上の `mv` で原子的に書き戻す。session 中に Claude Code やユーザーが settings.local を更新しうるため、backup による置換はそれらを失う。repo と XDG data が異なる filesystem でも rename に依存せず、安全性を確認できた孤児一時 fileだけを中間状態として除去する。
 
-teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、現在の settings、元ファイル有無 marker、Ark 所有 entry、破棄可能な一時 file から状態を解釈でき、次回 init の手順3で session 中の非 Ark 変更を保持したまま元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても孤児 marker を発見して Ark 所有 entry を回収できる。
+teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、現在の settings、ownership manifest、破棄可能な一時 file から状態を解釈でき、次回 init の手順3で session 中の非 Ark 変更を保持したまま元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても manifest を発見して孤児 Ark entry を回収できる。
 
-repo `.gitignore` の `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の完全一致2行は、adapterを有効化する前にversionedな設定または明示的な一回限りのinstallで導入する。`session-init.sh`と`session-teardown.sh`は `.gitignore` を変更しない。対象 repo にそれ以外の永続変更を残さず、前提entryがない場合は settings に触れず loop を無効化する。
+repo `.gitignore` の `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の完全一致2行は、adapterを有効化する前にversionedな設定または明示的な一回限りのinstallで導入する。両 path が tracked でないことも確認し、ignore entry があってもいずれかが tracked なら settings に触れず loop を無効化する。`session-init.sh`と`session-teardown.sh`は `.gitignore` を変更せず、対象 repo にそれ以外の永続変更を残さない。
 
 `--restart <session-id>` は指定 session の `errors/summary.md` から UTF-8 で最大2000 bytesの抜粋と `errors/raw.log` の path を `{{PREV_FAILURE_SUMMARY}}` に埋める。通常 init は固定文 `なし（通常起動）` を埋める。`step_count` は新 session ごとに0から始めるが、同じ init の再実行では既存 `task.md` と進捗を上書きしない。
 
@@ -319,14 +320,14 @@ teardown の順序を次で固定し、各段階を単独で再実行可能に�
 1. 機械的 error summary を生成する。
 2. `handoff.md` を更新する。
 3. 再発性のある候補を host の `failures-inbox.md` へ重複なく追記する。
-4. 自分の session ID が repo state directory の `owner` marker と一致する場合に限り、現在の settings.local から Ark 所有 entry だけを除去し、非 Ark 変更を保持して §6-1 の原子的手順で書き戻す。元設定なし marker があり、Ark 以外の entry が残らない場合に限り file を削除し、成功後に元ファイル有無 marker を除去する。
+4. 自分の session ID が repo state directory の `owner` marker と一致する場合に限り、manifest 記録と現在の settings.local が同一の Ark 所有 entry だけを除去し、非 Ark 変更を保持して §6-1 の原子的手順で内容と mode を書き戻す。変更済み entry は所有を放棄して残し、その結果をmanifestへ記録する。manifest が元設定なしを示し、Ark 以外の entry が残らない場合に限り file を削除する。
 5. `stop_once` 等の transient flag を cleanup し、手順4の書き戻しまたは削除が成功した自分が owner の場合に限って `owner` marker を除去する。
 
 `handoff.md` の固定項目は Goal、完了 Plan、未完了 Plan、現在の `← NOW`、artifact path と1行要約、直近の error summary path、次の最小 action、WORK_ID、session ID とする。artifact 本文と flow JSON は複製しない。
 
 `handoff.md` は次のモデルへ意味的文脈を渡す data plane である。`/flow --resume` は現行 `.claude/skills/flow/SKILL.md:152-168` と `.claude/lib/state-io.sh` に従って phase / gate を復元する control plane である。競合時は flow state を phase の正本とし、handoff は助言情報として扱う。自動マージも相互上書きもしない。
 
-teardown が未実行なら、次回 init は summary、handoff、現在の settings からの Ark 所有 entry 除去をこの順で補償してから新しい注入へ進む。session 中の非 Ark 変更を保持し、最終的な repo 状態は teardown 実行済みの場合と同じでなければならない。
+teardown が未実行なら、次回 init は summary、handoff、ownership manifest と現在の settings が一致する Ark 所有 entry の除去をこの順で補償してから新しい注入へ進む。session 中の非 Ark 変更を保持し、最終的な repo 状態は teardown 実行済みの場合と同じでなければならない。
 
 ### §6-3 summarize-errors.sh
 

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -116,9 +116,9 @@ XDG 配下の session data、repo state、cache の各 directory は mode `0700`
 
 ### §2-3 対象 repo への影響
 
-実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json`、固定名の `.claude/settings.local.json.ark-loop-tmp`、repo `.gitignore` の `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の明示 entry だけとする。認知維持の成果物本体と settings の backup / marker は XDG data 配下に置き、対象 repo 内に backup / marker を作らない。
+実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と固定名の `.claude/settings.local.json.ark-loop-tmp` だけとする。`.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の ignore entry は、adapter の有効化前に versioned な repo 設定または明示的な一回限りの install で導入する前提とし、`session-init.sh` と `session-teardown.sh` は repo `.gitignore` を変更してはならない。entry がない対象 repo では、adapter は settings を変更せず loop を無効化して理由を返す。認知維持の成果物本体と settings の backup / marker は XDG data 配下に置き、対象 repo 内に backup / marker を作らない。
 
-正常終了は settings 注入物と repo 側の一時 file を除去し、異常終了は次回 init が同じ復元と除去を行う。どちらも元の repo 設定へ収束し、それ以外の永続変更を残さない。#333 の完了条件は、対象 repo に `.claude/settings.local.json` と repo `.gitignore` への上記2 entry の追記以外の変更が入らず、repo 側の一時 file が残存しないこととする。
+正常終了は settings 注入物と repo 側の一時 file を除去し、異常終了は次回 init が同じ復元と除去を行う。どちらも元の repo 設定へ収束し、実行だけで versioned file を dirty にしない。#333 の完了条件は、対象 repo に versioned な事前設定以外の変更が入らず、repo 側の一時 file が残存しないこととする。
 
 ## §3 設定・状態・正本
 
@@ -171,6 +171,7 @@ native 側の `.lock` は native state 単体の排他を提供するが、選�
 - P2 の `loop-rules.md` は native todo の使用禁止、Plan status と `← NOW` の現実に合わせた更新、Goal / Constraints の不変条件を含む。
 - native todo が必要な作業は loop を無効化するか、項目を `task.md` へ移してから loop を継続する。
 - 将来 adapter も native todo との同期を追加してはならない。
+- Claude Code adapter は loop 有効 session で `TodoWrite`、`TaskCreate`、`TaskGet`、`TaskList`、`TaskUpdate` を permission deny または同等の tool allowlist により利用不能にし、指示だけで二重正本を防ごうとしてはならない。対象 Claude Code version に tool が存在しない場合も設定エラーにせず、この制約を no-op として扱う。
 
 ### §3-4 flow state との所有権表
 
@@ -187,17 +188,13 @@ native 側の `.lock` は native state 単体の排他を提供するが、選�
 
 hook input は非信頼データとして parse し、path、文字列、数値を検証する。全 script は loop 用環境変数が未設定なら no-op で成功し、counter を session cache 以外で共有せず、自身の失敗で本来の tool result を握りつぶさない。追加 hook の counter 更新などの fast path は合計100ms以内とする。
 
-現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持する。後続実装での論理順は、同一 tool event ごとに次とする。
+現行 `.claude/settings.json:52-70` の PostToolUse 2件を保持する。Claude Code は同一eventに一致する hook を並列実行し、並列 tool call では PostToolUse も呼出しごとに並行するため、adapter は settings 配列の記載順または hook 間の完了順を契約にしてはならない。
 
-1. `capture-error`
-2. 既存の該当 hook（Bash は `post-push-monitor.sh`、Write / Edit は `post-edit-lint.sh`）
-3. `recite-todo`
-
-Claude Code が配列内の command hook を実際に直列実行するかは #333 と #335 で実機確認し、既存分を含む計測値を両 PR に残す。直列性が成立しなければ、この論理順を保証する単一 dispatcher に adapter 内で束ねる。
+`capture-error` は実行開始後に失敗した tool だけを対象とする `PostToolUseFailure` に登録する。`recite-todo` は一連の tool call が完了して次のモデル呼出し前に一度だけ走る `PostToolBatch` に登録し、既存 PostToolUse hook・error captureの完了順へ依存しない。既存 hook の保持、各hookの個別100ms fast path、event種別と追加contextの実機fixtureを #333 / #335 の PR に記録する。
 
 ### §4-1 recite-todo.sh
 
-成功した tool step ごとに `ARK_CACHE_DIR/step_count` を排他的に1増加させ、`ARK_RECITE_INTERVAL`（既定10）step ごとに次の固定形式だけを `additionalContext` へ出す。
+`PostToolBatch` ごとに `ARK_CACHE_DIR/step_count` を排他的に1増加させ、`ARK_RECITE_INTERVAL`（既定10）batch ごとに次の固定形式だけを `additionalContext` へ出す。ここで batch は Claude Code が次のモデル呼出し前に完了させた tool call 群を指し、並列 tool call があっても復唱は最大1回とする。
 
 ```text
 Goal: <1行>
@@ -211,7 +208,7 @@ compaction 直後も `task.md` 正本から同じ key、同じ順序、同じ行
 
 ### §4-2 capture-error.sh
 
-PostToolUse の失敗 event だけを `errors/raw.log` へ、次の field を持つ1物理行の JSONL として append する。
+`PostToolUseFailure` で通知される、実行を開始した後に失敗した tool event だけを `errors/raw.log` へ、次の field を持つ1物理行の JSONL として append する。
 
 ```json
 {"at":"RFC3339","tool":"tool name","error_type":"input field or tool_error","exit_code":1,"message":"escaped message"}
@@ -219,13 +216,13 @@ PostToolUse の失敗 event だけを `errors/raw.log` へ、次の field を持
 
 `at`、`tool`、`error_type`、`exit_code`、`message` は常に同じ key 順で出力する。message の改行は JSON escape し、UTF-8 で4096 bytesを上限として code point 境界で切る。成功 event は書き込まない。1 entry を必ず1行に収め、`L{n}-L{n}` の参照を安定させる。
 
-capture は入力にある型の正規化以外の分類、要約、「禁止手」の生成を行わず、原 tool error の表示・終了状態を変更しない。同一 tool event の capture は recite より先に完了させる。hook input の実 field 名と成功・失敗判定は #335 で実機ダンプを fixture 化して確定し、fixture にない field を推測して補わない。
+capture は入力にある型の正規化以外の分類、要約、「禁止手」の生成を行わず、原 tool error の表示・終了状態を変更しない。permission deny と tool input のschema / tool固有validation拒否は `PostToolUseFailure` の対象外であるため、P3では raw.log に記録しない。これらを将来の学習対象にする場合は `PermissionDenied`等の別eventを使う独立した契約を追加する。hook input の実 field 名と成功・失敗判定は #335 で実機ダンプを fixture 化して確定し、fixture にない field を推測して補わない。
 
 ### §4-3 Stop
 
 新しい Stop hook は登録しない。現行 `.claude/settings.json:72-80` の登録先を保ち、現在 no-op の `.claude/hooks/stop-gate.sh:1-8` の実体を `on-stop.sh` 相当へ置換する。
 
-未完了 Plan があり、`ARK_SESSION_DIR/stop_once` がなければ flag を原子的に作成して1回だけ継続を要求する。同じ session の2回目以降は未完了でも Stop を通し、flag は teardown まで保持して無限 Stop loop を防ぐ。
+未完了 Plan があり、`ARK_SESSION_DIR/stop_once` がなく、Stop input の `stop_hook_active` が false なら、flag を原子的に作成して `additionalContext` により1回だけ継続を要求する。同じ session の2回目以降、または `stop_hook_active` が true の場合は未完了でも Stop を通し、flag は teardown まで保持して無限 Stop loop を防ぐ。handoff生成またはflag操作に失敗しても、Stopを永久にblockしてはならない。
 
 Stop 通過時は `handoff.md` を生成するが、Stop hook は teardown 完了を保証しない。tmux kill、pm2 restart、process crash を含め、teardown を通らない終了では次回 init が同じ収束処理を担う。
 
@@ -283,7 +280,9 @@ Plan には checkbox を使い、`← NOW` は常にちょうど1個だけ置く
 
 ### §5-3 Claude Code adapter
 
-Claude Code adapter だけが、既存 `.claude/settings.local.json` の退避・loop settings の注入・復元、hook matcher、hook input JSON、`additionalContext` output、Claude Code の `allowed-tools` を扱う。agent 非依存の template、規約、session file format に Claude Code 固有 key を入れない。
+Claude Code adapter だけが、既存 `.claude/settings.local.json` の退避・非破壊な loop settings 注入・復元、hook matcher、hook input JSON、`additionalContext` output、Claude Code の `allowed-tools` / permission deny を扱う。agent 非依存の template、規約、session file format に Claude Code 固有 key を入れない。
+
+注入前に既存settingsをJSONとして構文・型検証し、Arkが所有する識別子付きhookとpermission ruleだけを深く追加する。既存のMCP、permission、hook、その他のkeyを削除・置換・並べ替えてはならず、teardownはArk所有entryだけを除去して元の意味を復元する。解析不能、symlink、安全でないownership・mode、または§2-3の事前ignore設定がない場合は、元settingsを変更せずloopを無効化する。
 
 adapter は §3-3 の単一正本を変えてはならない。将来の Codex adapter も AGENTS.md と wrapper の接続に留め、native todo 同期や別の進捗正本を持ち込んではならない。
 
@@ -299,13 +298,13 @@ init の順序を次で固定する。
 4. config を読み、§3-1 の値を Ark へ返す。
 5. 新規 session に限って template を展開する。
 6. host の `failures.md` を session へ read-only copy する。
-7. 現在の settings.local を再退避し、loop settings を注入する。
+7. §2-3の事前ignore設定と既存settingsの安全性・JSON schemaを検証してから、Ark所有entryだけを非破壊に追加する。前提を満たさない場合は settings を変更せず loop を無効化する。
 
 `owner` marker の取得・生存確認・消滅 owner からの引継ぎは per-repo で排他的に行う。同じ session の再実行だけは既存 ownership を継続できる。backup は repo state directory の `settings.local.json.ark-loop-original`、元設定なし marker は同 directory の `settings.local.json.ark-loop-no-original` とし、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。repo 側の一時 file は `.claude/settings.local.json.ark-loop-tmp` の固定名とし、`mktemp` 等による可変名を使わない。元設定がある場合は XDG 側の一時 file へ copy してから同 filesystem 上の `mv` で backup を確定し、元設定がない場合は XDG 側で marker を原子的に確定した後、repo 側の一時 file から loop settings を `.claude/settings.local.json` へ `mv` する。復元時は backup を repo 側の一時 file へ copy してから同 filesystem 上の `mv` で settings.local を置換し、置換成功後だけ backup を除去する。marker の場合は注入 file の除去成功後だけ marker を除去する。復元中に残った repo 側の一時 file は中間状態でしかないため、孤児回収では backup / marker が示す正本の状態へ収束させたうえで無条件に削除する。各境界で存在確認し、repo と XDG data が異なる filesystem でも rename に依存しない。
 
 teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、backup があればそれを元設定の正本、marker があれば元設定なしの正本として解釈し、次回 init の手順3で元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても孤児 backup / marker を発見して復元できる。
 
-repo `.gitignore` には `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` を完全一致の2行としてそれぞれ重複なく追加し、グローバル ignore に依存しない。対象 repo にそれ以外の永続変更を残さない。
+repo `.gitignore` の `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の完全一致2行は、adapterを有効化する前にversionedな設定または明示的な一回限りのinstallで導入する。`session-init.sh`と`session-teardown.sh`は `.gitignore` を変更しない。対象 repo にそれ以外の永続変更を残さず、前提entryがない場合は settings に触れず loop を無効化する。
 
 `--restart <session-id>` は指定 session の `errors/summary.md` から UTF-8 で最大2000 bytesの抜粋と `errors/raw.log` の path を `{{PREV_FAILURE_SUMMARY}}` に埋める。通常 init は固定文 `なし（通常起動）` を埋める。`step_count` は新 session ごとに0から始めるが、同じ init の再実行では既存 `task.md` と進捗を上書きしない。
 

--- a/docs/superpowers/specs/ark-loop-implementation-spec.md
+++ b/docs/superpowers/specs/ark-loop-implementation-spec.md
@@ -116,9 +116,9 @@ XDG 配下の session data、repo state、cache の各 directory は mode `0700`
 
 ### §2-3 対象 repo への影響
 
-実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と固定名の `.claude/settings.local.json.ark-loop-tmp` だけとする。`.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の ignore entry は、adapter の有効化前に versioned な repo 設定または明示的な一回限りの install で導入する前提とし、`session-init.sh` と `session-teardown.sh` は repo `.gitignore` を変更してはならない。entry がない対象 repo では、adapter は settings を変更せず loop を無効化して理由を返す。認知維持の成果物本体と settings の backup / marker は XDG data 配下に置き、対象 repo 内に backup / marker を作らない。
+実行時に対象 repo へ加えてよい一時変更は、注入中の `.claude/settings.local.json` と固定名の `.claude/settings.local.json.ark-loop-tmp` だけとする。`.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の ignore entry は、adapter の有効化前に versioned な repo 設定または明示的な一回限りの install で導入する前提とし、`session-init.sh` と `session-teardown.sh` は repo `.gitignore` を変更してはならない。entry がない対象 repo では、adapter は settings を変更せず loop を無効化して理由を返す。認知維持の成果物本体と settings の元ファイル有無 marker は XDG data 配下に置き、対象 repo 内に marker を作らない。
 
-正常終了は settings 注入物と repo 側の一時 file を除去し、異常終了は次回 init が同じ復元と除去を行う。どちらも元の repo 設定へ収束し、実行だけで versioned file を dirty にしない。#333 の完了条件は、対象 repo に versioned な事前設定以外の変更が入らず、repo 側の一時 file が残存しないこととする。
+正常終了は settings 注入物と repo 側の一時 file を除去し、異常終了は次回 init が同じ回収を行う。どちらも session 中の非 Ark 変更を保持して Ark 所有 entry のない repo 設定へ収束し、実行だけで versioned file を dirty にしない。#333 の完了条件は、対象 repo に versioned な事前設定以外の変更が入らず、repo 側の一時 file が残存しないこととする。
 
 ## §3 設定・状態・正本
 
@@ -280,7 +280,7 @@ Plan には checkbox を使い、`← NOW` は常にちょうど1個だけ置く
 
 ### §5-3 Claude Code adapter
 
-Claude Code adapter だけが、既存 `.claude/settings.local.json` の退避・非破壊な loop settings 注入・復元、hook matcher、hook input JSON、`additionalContext` output、Claude Code の `allowed-tools` / permission deny を扱う。agent 非依存の template、規約、session file format に Claude Code 固有 key を入れない。
+Claude Code adapter だけが、既存 `.claude/settings.local.json` の有無の記録・非破壊な loop settings 注入・復元、hook matcher、hook input JSON、`additionalContext` output、Claude Code の `allowed-tools` / permission deny を扱う。agent 非依存の template、規約、session file format に Claude Code 固有 key を入れない。
 
 注入前に既存settingsをJSONとして構文・型検証し、Arkが所有する識別子付きhookとpermission ruleだけを深く追加する。既存のMCP、permission、hook、その他のkeyを削除・置換・並べ替えてはならず、teardownはArk所有entryだけを除去して元の意味を復元する。解析不能、symlink、安全でないownership・mode、または§2-3の事前ignore設定がない場合は、元settingsを変更せずloopを無効化する。
 
@@ -294,15 +294,19 @@ init の順序を次で固定する。
 
 1. XDG path と対象 repo の canonical な絶対パスを解決し、§2-2 の `ARK_REPO_KEY` と repo state directory を導出する。
 2. session ID を生成または再取得し、session ID と Ark が管理する owner process の PID を持つ repo state directory の `owner` marker を検査する。別 session の owner が生存中なら孤児回収と settings 注入を行わず、loop を無効化して起動を続ける。
-3. owner が存在しないか消滅している場合は ownership を原子的に取得し、同じ session が owner の場合は保持する。owner だけが孤児 backup / 元設定なし marker と repo 側の `.claude/settings.local.json.ark-loop-tmp` を元の有無へ復元・回収してから、session directory と cache directory を作る。
+3. owner が存在しないか消滅している場合は ownership を原子的に取得し、同じ session が owner の場合は保持する。owner だけが現在の settings から Ark 所有 entry を除去し、元ファイル有無 marker が示す有無へ収束させ、孤児化した repo 側の `.claude/settings.local.json.ark-loop-tmp` を無条件に削除してから、session directory と cache directory を作る。
 4. config を読み、§3-1 の値を Ark へ返す。
 5. 新規 session に限って template を展開する。
 6. host の `failures.md` を session へ read-only copy する。
 7. §2-3の事前ignore設定と既存settingsの安全性・JSON schemaを検証してから、Ark所有entryだけを非破壊に追加する。前提を満たさない場合は settings を変更せず loop を無効化する。
 
-`owner` marker の取得・生存確認・消滅 owner からの引継ぎは per-repo で排他的に行う。同じ session の再実行だけは既存 ownership を継続できる。backup は repo state directory の `settings.local.json.ark-loop-original`、元設定なし marker は同 directory の `settings.local.json.ark-loop-no-original` とし、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。repo 側の一時 file は `.claude/settings.local.json.ark-loop-tmp` の固定名とし、`mktemp` 等による可変名を使わない。元設定がある場合は XDG 側の一時 file へ copy してから同 filesystem 上の `mv` で backup を確定し、元設定がない場合は XDG 側で marker を原子的に確定した後、repo 側の一時 file から loop settings を `.claude/settings.local.json` へ `mv` する。復元時は backup を repo 側の一時 file へ copy してから同 filesystem 上の `mv` で settings.local を置換し、置換成功後だけ backup を除去する。marker の場合は注入 file の除去成功後だけ marker を除去する。復元中に残った repo 側の一時 file は中間状態でしかないため、孤児回収では backup / marker が示す正本の状態へ収束させたうえで無条件に削除する。各境界で存在確認し、repo と XDG data が異なる filesystem でも rename に依存しない。
+`owner` marker の取得・生存確認・消滅 owner からの引継ぎは per-repo で排他的に行う。同じ session の再実行だけは既存 ownership を継続できる。repo state directory の `settings.local.json.ark-loop-original` と `settings.local.json.ark-loop-no-original` は注入前の settings file の有無だけを記録する marker とし、内容の復元元にはせず、同時に存在させない。repo state directory と file は owner のみ読み書き可能にする。Ark 所有 entry は §5-3 の識別子で判定できることを注入と復元の前提とする。
 
-teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、backup があればそれを元設定の正本、marker があれば元設定なしの正本として解釈し、次回 init の手順3で元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても孤児 backup / marker を発見して復元できる。
+注入時は現在の `.claude/settings.local.json` を読み、§5-3 の構文・型を検証し、その有無を対応する marker へ原子的に記録してから Ark 所有 entry だけを deep merge する。結果は repo 側の固定名 `.claude/settings.local.json.ark-loop-tmp` に書き、同 filesystem 上の `mv` で原子的に確定する。`mktemp` 等による可変名を使わない。
+
+復元時は現在の `.claude/settings.local.json` を読み、Ark 所有 entry だけを除去し、その他の key・値・順序を保持する。元設定なし marker があり、除去後に Ark 以外の entry が残らない場合に限り settings file を削除し、それ以外は固定名一時 file を経由した同 filesystem 上の `mv` で原子的に書き戻す。成功後に元ファイル有無 marker を除去する。session 中に Claude Code やユーザーが settings.local を更新しうるため、backup による置換はそれらを失う。repo と XDG data が異なる filesystem でも rename に依存せず、孤児化した repo 側の一時 file は中間状態として無条件に削除する。
+
+teardown を通らない kill を通常系として扱う。連続する2回の kill 後も、現在の settings、元ファイル有無 marker、Ark 所有 entry、破棄可能な一時 file から状態を解釈でき、次回 init の手順3で session 中の非 Ark 変更を保持したまま元の有無へ収束させる。repo state は session directory の外にあり `ARK_REPO_KEY` が session ID に依存しないため、次回 init が前回の session ID を知らなくても孤児 marker を発見して Ark 所有 entry を回収できる。
 
 repo `.gitignore` の `.claude/settings.local.json` と `.claude/settings.local.json.ark-loop-tmp` の完全一致2行は、adapterを有効化する前にversionedな設定または明示的な一回限りのinstallで導入する。`session-init.sh`と`session-teardown.sh`は `.gitignore` を変更しない。対象 repo にそれ以外の永続変更を残さず、前提entryがない場合は settings に触れず loop を無効化する。
 
@@ -315,14 +319,14 @@ teardown の順序を次で固定し、各段階を単独で再実行可能に�
 1. 機械的 error summary を生成する。
 2. `handoff.md` を更新する。
 3. 再発性のある候補を host の `failures-inbox.md` へ重複なく追記する。
-4. 自分の session ID が repo state directory の `owner` marker と一致する場合に限り、settings.local の loop 注入物を除去し、backup から §6-1 の原子的手順で original を復元する。元設定なし marker の場合は注入 file を除去し、成功後に marker を除去する。
-5. `stop_once` 等の transient flag を cleanup し、手順4の復元・除去が成功した自分が owner の場合に限って `owner` marker を除去する。
+4. 自分の session ID が repo state directory の `owner` marker と一致する場合に限り、現在の settings.local から Ark 所有 entry だけを除去し、非 Ark 変更を保持して §6-1 の原子的手順で書き戻す。元設定なし marker があり、Ark 以外の entry が残らない場合に限り file を削除し、成功後に元ファイル有無 marker を除去する。
+5. `stop_once` 等の transient flag を cleanup し、手順4の書き戻しまたは削除が成功した自分が owner の場合に限って `owner` marker を除去する。
 
 `handoff.md` の固定項目は Goal、完了 Plan、未完了 Plan、現在の `← NOW`、artifact path と1行要約、直近の error summary path、次の最小 action、WORK_ID、session ID とする。artifact 本文と flow JSON は複製しない。
 
 `handoff.md` は次のモデルへ意味的文脈を渡す data plane である。`/flow --resume` は現行 `.claude/skills/flow/SKILL.md:152-168` と `.claude/lib/state-io.sh` に従って phase / gate を復元する control plane である。競合時は flow state を phase の正本とし、handoff は助言情報として扱う。自動マージも相互上書きもしない。
 
-teardown が未実行なら、次回 init は summary、handoff、settings 復元をこの順で補償してから新しい注入へ進む。最終的な repo 状態は teardown 実行済みの場合と同じでなければならない。
+teardown が未実行なら、次回 init は summary、handoff、現在の settings からの Ark 所有 entry 除去をこの順で補償してから新しい注入へ進む。session 中の非 Ark 変更を保持し、最終的な repo 状態は teardown 実行済みの場合と同じでなければならない。
 
 ### §6-3 summarize-errors.sh
 


### PR DESCRIPTION
## 概要

PR #337で導入した認知維持ループspecを、Claude Codeの実際のhook契約へ補正します。新機能やruntime実装は含めず、後続の #333 / #335 が誤ったイベントまたは実行順前提で着手しないようにします。

## 変更内容

| 領域 | 補正内容 |
| --- | --- |
| hook event | error captureを`PostToolUseFailure`へ、固定長recitationを`PostToolBatch`へ移し、hook配列の順序・完了順への依存を削除。 |
| failure scope | permission denyとschema / validation rejectionはP3のraw log対象外と明示し、将来の別event対応へ分離。 |
| settings注入 | Ark所有entryのみの非破壊deep merge、事前ignore設定・JSON・path安全性の検証、失敗時の無変更disableを契約化。 |
| repo clean | `.gitignore`の必要entryをversionedな一回限りの設定へ移し、session-init / teardownがversioned fileを変更しないようにした。 |
| 単一正本とStop | native Task / Todo toolを実効的に利用不能にすること、`stop_hook_active`を考慮するone-shot Stopを明記。 |

## 連携Issue

- #333と#335の本文・受入条件を、この補正specと同時に更新済みです。
- #333はPostToolBatch、並列batch、非破壊settings注入、native task denyを実装対象にします。
- #335はPostToolUseFailure、対象外event、実機fixtureを実装対象にします。

## 検証

- `git diff --check`
- §1〜§7の見出し数および既存参照表を検査
- `PostToolBatch`、`PostToolUseFailure`、permission deny対象外、runtimeで`.gitignore`を変更しない契約をgrepで確認
- `pnpm lint`は実行を試行したが、worktreeに`node_modules`がなく`biome: not found`で実行不能。今回の変更はMarkdownと`.gitignore`のみで、コード静的検査は未実施です。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 一時設定ファイルがバージョン管理対象外となり、不要な変更が記録されにくくなりました。
  * 並列実行時の処理や失敗時の継続動作が安定し、予期しない設定変更を抑制します。
  * 安全性の検証を強化し、条件を満たさない環境では自動処理を無効化するようになりました。

* **ドキュメント**
  * 一時変更、エラー処理、設定の復元に関する仕様を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->