### PR TITLE
fix(harness): DB スキーマ検出ガードの偽陰性を直し、パス drift を CI で検出する (#338)

### DIFF
--- a/.claude/lib/flow-safety-paths.sh
+++ b/.claude/lib/flow-safety-paths.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# flow / flow-x が共有する safety gate の監視 path と判定ロジック。
+
+FLOW_GUARD_DB_SCHEMA_PATHS=(
+  "packages/server/src/lib/database.ts"
+)
+
+FLOW_GUARD_SESSION_LIFECYCLE_PATHS=(
+  "packages/server/src/lib/session-orchestrator.ts"
+  "packages/server/src/lib/tmux-manager.ts"
+  "packages/server/src/lib/ttyd-manager.ts"
+)
+
+# DB schema の対象 path に schema 語句を含む diff がある場合だけ成功する。
+flow_guard_db_schema_changed() {
+  local diff_range="${1:-origin/main...HEAD}"
+  local changed_paths
+  changed_paths=$(git diff --name-only "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}") || return 1
+  [ -n "$changed_paths" ] || return 1
+
+  git diff "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}" \
+    | grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)'
+}
+
+# halt はオーケストレータへの指示なので、呼び出し側の SKILL.md が実行する。
+flow_guard_db_schema_halt_message() {
+  printf 'DB スキーマ変更検出 (%s、人間レビュー必須)\n' "${FLOW_GUARD_DB_SCHEMA_PATHS[*]}"
+}
+
+# session lifecycle の対象 path が diff に含まれる場合だけ成功する。
+flow_guard_session_lifecycle_changed() {
+  local diff_range="${1:-origin/main...HEAD}"
+  local changed_paths
+  changed_paths=$(git diff --name-only "$diff_range" -- "${FLOW_GUARD_SESSION_LIFECYCLE_PATHS[@]}") || return 1
+  [ -n "$changed_paths" ]
+}
+
+# 依存契約: 呼び出し側が先に .claude/lib/state-io.sh を source し、
+# flow_state_update を利用可能にしておくこと。
+flow_guard_warn_session_lifecycle_change() {
+  local scope_key="$1"
+  local diff_range="${2:-origin/main...HEAD}"
+  if flow_guard_session_lifecycle_changed "$diff_range"; then
+    flow_state_update progress \
+      '.warnings += ["tmux/ttyd セッションライフサイクル変更あり、再起動時の挙動を確認すること"]' \
+      "$scope_key"
+  fi
+}

--- a/.claude/lib/flow-safety-paths.sh
+++ b/.claude/lib/flow-safety-paths.sh
@@ -28,15 +28,16 @@ flow_guard_db_schema_changed() {
   fi
   [ -n "$changed_paths" ] || return 1
 
-  schema_diff=$(git diff "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}")
+  schema_diff=$(git diff --unified=0 "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}")
   git_status=$?
   if [ "$git_status" -ne 0 ]; then
     printf 'DB スキーマ変更の判定不能: git diff が失敗しました (range: %s)\n' "$diff_range" >&2
     return 2
   fi
 
-  grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)' \
-    <<< "$schema_diff"
+  grep -E '^[+-]' <<< "$schema_diff" \
+    | grep -vE '^(\+\+\+|---)' \
+    | grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)'
   grep_status=$?
   case "$grep_status" in
     0) return 0 ;;

--- a/.claude/lib/flow-safety-paths.sh
+++ b/.claude/lib/flow-safety-paths.sh
@@ -11,15 +11,41 @@ FLOW_GUARD_SESSION_LIFECYCLE_PATHS=(
   "packages/server/src/lib/ttyd-manager.ts"
 )
 
-# DB schema の対象 path に schema 語句を含む diff がある場合だけ成功する。
+# DB schema の対象 path に schema 語句を含む diff がある場合は 0、
+# 変更なしは 1、git diff などで評価できない場合は 2 を返す。
 flow_guard_db_schema_changed() {
   local diff_range="${1:-origin/main...HEAD}"
   local changed_paths
-  changed_paths=$(git diff --name-only "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}") || return 1
+  local git_status
+  local schema_diff
+  local grep_status
+
+  changed_paths=$(git diff --name-only "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}")
+  git_status=$?
+  if [ "$git_status" -ne 0 ]; then
+    printf 'DB スキーマ変更の判定不能: git diff が失敗しました (range: %s)\n' "$diff_range" >&2
+    return 2
+  fi
   [ -n "$changed_paths" ] || return 1
 
-  git diff "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}" \
-    | grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)'
+  schema_diff=$(git diff "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}")
+  git_status=$?
+  if [ "$git_status" -ne 0 ]; then
+    printf 'DB スキーマ変更の判定不能: git diff が失敗しました (range: %s)\n' "$diff_range" >&2
+    return 2
+  fi
+
+  grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)' \
+    <<< "$schema_diff"
+  grep_status=$?
+  case "$grep_status" in
+    0) return 0 ;;
+    1) return 1 ;;
+    *)
+      printf 'DB スキーマ変更の判定不能: schema 語句の検索に失敗しました\n' >&2
+      return 2
+      ;;
+  esac
 }
 
 # halt はオーケストレータへの指示なので、呼び出し側の SKILL.md が実行する。
@@ -27,11 +53,19 @@ flow_guard_db_schema_halt_message() {
   printf 'DB スキーマ変更検出 (%s、人間レビュー必須)\n' "${FLOW_GUARD_DB_SCHEMA_PATHS[*]}"
 }
 
-# session lifecycle の対象 path が diff に含まれる場合だけ成功する。
+# session lifecycle の対象 path が diff に含まれる場合は 0、
+# 変更なしは 1、git diff で評価できない場合は 2 を返す。
 flow_guard_session_lifecycle_changed() {
   local diff_range="${1:-origin/main...HEAD}"
   local changed_paths
-  changed_paths=$(git diff --name-only "$diff_range" -- "${FLOW_GUARD_SESSION_LIFECYCLE_PATHS[@]}") || return 1
+  local git_status
+
+  changed_paths=$(git diff --name-only "$diff_range" -- "${FLOW_GUARD_SESSION_LIFECYCLE_PATHS[@]}")
+  git_status=$?
+  if [ "$git_status" -ne 0 ]; then
+    printf 'セッションライフサイクル変更の判定不能: git diff が失敗しました (range: %s)\n' "$diff_range" >&2
+    return 2
+  fi
   [ -n "$changed_paths" ]
 }
 
@@ -40,9 +74,24 @@ flow_guard_session_lifecycle_changed() {
 flow_guard_warn_session_lifecycle_change() {
   local scope_key="$1"
   local diff_range="${2:-origin/main...HEAD}"
-  if flow_guard_session_lifecycle_changed "$diff_range"; then
-    flow_state_update progress \
-      '.warnings += ["tmux/ttyd セッションライフサイクル変更あり、再起動時の挙動を確認すること"]' \
-      "$scope_key"
-  fi
+  local guard_status
+
+  flow_guard_session_lifecycle_changed "$diff_range"
+  guard_status=$?
+  case "$guard_status" in
+    0)
+      flow_state_update progress \
+        '.warnings += ["tmux/ttyd セッションライフサイクル変更あり、再起動時の挙動を確認すること"]' \
+        "$scope_key"
+      ;;
+    1)
+      return 0
+      ;;
+    2)
+      flow_state_update progress \
+        '.warnings += ["tmux/ttyd セッションライフサイクル変更を判定不能 (git diff が失敗)、origin/main と diff range を確認すること"]' \
+        "$scope_key" || return 2
+      return 2
+      ;;
+  esac
 }

--- a/.claude/lib/tests/test-flow-safety-paths.sh
+++ b/.claude/lib/tests/test-flow-safety-paths.sh
@@ -117,6 +117,13 @@ db_schema_changed() {
   (cd "$TMP_REPO" && flow_guard_db_schema_changed 'origin/main...HEAD')
 }
 
+db_schema_invalid_range_status() {
+  local guard_status
+  (cd "$TMP_REPO" && flow_guard_db_schema_changed 'nonexistent/ref...HEAD')
+  guard_status=$?
+  printf '%s' "$guard_status"
+}
+
 echo ""
 echo "=== DB schema guard ==="
 printf '%s\n' 'ALTER TABLE sessions ADD COLUMN archived INTEGER;' \
@@ -140,6 +147,8 @@ printf '%s\n' '// no schema keyword here' \
 git -C "$TMP_REPO" add packages/server/src/lib/database.ts
 git -C "$TMP_REPO" commit -q -m 'database comment only'
 assert_failure "database.ts の schema 語句なし diff では検出しない" db_schema_changed
+assert_eq "不正な diff range の DB schema 判定は 2" "2" \
+  "$(db_schema_invalid_range_status)"
 
 FLOW_STATE_UPDATE_CALLS=0
 FLOW_STATE_UPDATE_TYPE=''
@@ -159,6 +168,24 @@ warn_session_lifecycle() {
   cd "$TMP_REPO" || return 1
   flow_guard_warn_session_lifecycle_change 'test-scope' 'origin/main...HEAD'
   cd "$original_dir" || return 1
+}
+
+session_lifecycle_invalid_range_status() {
+  local guard_status
+  (cd "$TMP_REPO" && flow_guard_session_lifecycle_changed 'nonexistent/ref...HEAD')
+  guard_status=$?
+  printf '%s' "$guard_status"
+}
+
+warn_session_lifecycle_invalid_range() {
+  local original_dir
+  local guard_status
+  original_dir=$(pwd)
+  cd "$TMP_REPO" || return 1
+  flow_guard_warn_session_lifecycle_change 'test-scope' 'nonexistent/ref...HEAD'
+  guard_status=$?
+  cd "$original_dir" || return 1
+  return "$guard_status"
 }
 
 echo ""
@@ -183,6 +210,14 @@ git -C "$TMP_REPO" commit -q -m 'unrelated change'
 assert_success "対象外 diff の warning 判定は正常終了する" warn_session_lifecycle
 assert_eq "対象外 diff では warning を追加しない" "1" "$FLOW_STATE_UPDATE_CALLS"
 
+assert_eq "不正な diff range の session lifecycle 判定は 2" "2" \
+  "$(session_lifecycle_invalid_range_status)"
+warn_session_lifecycle_invalid_range
+assert_eq "評価不能時は warning を 1 件追加する" "2" "$FLOW_STATE_UPDATE_CALLS"
+assert_eq "評価不能 warning は通常の変更 warning と区別できる" \
+  '.warnings += ["tmux/ttyd セッションライフサイクル変更を判定不能 (git diff が失敗)、origin/main と diff range を確認すること"]' \
+  "$FLOW_STATE_UPDATE_EXPR"
+
 count_literal() {
   local file="$1"
   local literal="$2"
@@ -204,6 +239,10 @@ for skill_path in \
     "$(count_literal "$skill_path" "flow_guard_warn_session_lifecycle_change \"\$SCOPE_KEY\" 'origin/main...HEAD'")"
   assert_eq "$skill_name の DB branch は halt 指示を維持する" "1" \
     "$(count_literal "$skill_path" 'halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)"')"
+  assert_eq "$skill_name の P3-2 は exit code 2 で halt する" "1" \
+    "$(count_literal "$skill_path" '2) halt "DB スキーマ変更の判定に失敗しました (git diff が失敗)。origin/main の存在と diff range を確認すること" ;;')"
+  assert_eq "$skill_name の P3-3 は exit code 2 を扱う" "1" \
+    "$(count_literal "$skill_path" "2) printf '%s\\n' 'warning: セッションライフサイクル変更を判定不能 (state に warning 記録済み)' >&2 ;;")"
   assert_eq "$skill_name の P3 に旧 DB pathspec がない" "0" \
     "$(count_literal "$skill_path" "'$LEGACY_SERVER_LIB/database.ts'")"
   assert_eq "$skill_name の P3 に旧 session pathspec がない" "0" \

--- a/.claude/lib/tests/test-flow-safety-paths.sh
+++ b/.claude/lib/tests/test-flow-safety-paths.sh
@@ -98,6 +98,11 @@ for guard_path in "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}" "${FLOW_GUARD_SESSION_LIFEC
   mkdir -p "$TMP_REPO/$(dirname "$guard_path")"
   printf '%s\n' '// baseline' > "$TMP_REPO/$guard_path"
 done
+printf '%s\n' \
+  'CREATE TABLE sessions (id TEXT);' \
+  'logger.info("schema ready");' \
+  'DROP TABLE obsolete_sessions;' \
+  > "$TMP_REPO/packages/server/src/lib/database.ts"
 printf '%s\n' '# baseline' > "$TMP_REPO/README.md"
 git -C "$TMP_REPO" add .
 git -C "$TMP_REPO" commit -q -m baseline
@@ -117,6 +122,13 @@ db_schema_changed() {
   (cd "$TMP_REPO" && flow_guard_db_schema_changed 'origin/main...HEAD')
 }
 
+db_schema_changed_status() {
+  local guard_status
+  (cd "$TMP_REPO" && flow_guard_db_schema_changed 'origin/main...HEAD')
+  guard_status=$?
+  printf '%s' "$guard_status"
+}
+
 db_schema_invalid_range_status() {
   local guard_status
   (cd "$TMP_REPO" && flow_guard_db_schema_changed 'nonexistent/ref...HEAD')
@@ -134,6 +146,23 @@ assert_success "database.ts の schema diff を検出する" db_schema_changed
 assert_eq "DB schema halt message" \
   "DB スキーマ変更検出 (packages/server/src/lib/database.ts、人間レビュー必須)" \
   "$(flow_guard_db_schema_halt_message)"
+
+reset_to_baseline
+sed -i.bak 's/schema ready/schema ready (v2)/' \
+  "$TMP_REPO/packages/server/src/lib/database.ts"
+rm "$TMP_REPO/packages/server/src/lib/database.ts.bak"
+git -C "$TMP_REPO" add packages/server/src/lib/database.ts
+git -C "$TMP_REPO" commit -q -m 'database log change'
+assert_eq "schema 行の隣接行だけの変更は 1（非検出）" "1" \
+  "$(db_schema_changed_status)"
+
+reset_to_baseline
+sed -i.bak '/DROP TABLE obsolete_sessions;/d' \
+  "$TMP_REPO/packages/server/src/lib/database.ts"
+rm "$TMP_REPO/packages/server/src/lib/database.ts.bak"
+git -C "$TMP_REPO" add packages/server/src/lib/database.ts
+git -C "$TMP_REPO" commit -q -m 'remove drop table statement'
+assert_success "削除行の schema 語句を検出する" db_schema_changed
 
 reset_to_baseline
 printf '%s\n' 'CREATE TABLE ignored' >> "$TMP_REPO/README.md"

--- a/.claude/lib/tests/test-flow-safety-paths.sh
+++ b/.claude/lib/tests/test-flow-safety-paths.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# =============================================================================
+# flow / flow-x safety path contract regression test
+# =============================================================================
+set -uo pipefail
+
+TESTS=0
+PASSES=0
+FAILURES=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  TESTS=$((TESTS + 1))
+  if [ "$expected" = "$actual" ]; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+assert_success() {
+  local description="$1"
+  shift
+  TESTS=$((TESTS + 1))
+  if "$@"; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+  fi
+}
+
+assert_failure() {
+  local description="$1"
+  shift
+  TESTS=$((TESTS + 1))
+  if "$@"; then
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+  else
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SAFETY_PATHS_LIB="$SCRIPT_DIR/../flow-safety-paths.sh"
+
+if [ ! -f "$SAFETY_PATHS_LIB" ]; then
+  echo -e "${RED}FAIL${NC}: flow-safety-paths.sh が存在しない"
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$SAFETY_PATHS_LIB"
+
+echo "=== guard path contract ==="
+assert_eq "DB schema path は 1 件" "1" "${#FLOW_GUARD_DB_SCHEMA_PATHS[@]}"
+assert_eq "DB schema path" \
+  "packages/server/src/lib/database.ts" "${FLOW_GUARD_DB_SCHEMA_PATHS[0]}"
+assert_eq "session lifecycle path は 3 件" "3" "${#FLOW_GUARD_SESSION_LIFECYCLE_PATHS[@]}"
+assert_eq "session orchestrator path" \
+  "packages/server/src/lib/session-orchestrator.ts" "${FLOW_GUARD_SESSION_LIFECYCLE_PATHS[0]}"
+assert_eq "tmux manager path" \
+  "packages/server/src/lib/tmux-manager.ts" "${FLOW_GUARD_SESSION_LIFECYCLE_PATHS[1]}"
+assert_eq "ttyd manager path" \
+  "packages/server/src/lib/ttyd-manager.ts" "${FLOW_GUARD_SESSION_LIFECYCLE_PATHS[2]}"
+
+for guard_path in "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}" "${FLOW_GUARD_SESSION_LIFECYCLE_PATHS[@]}"; do
+  assert_success "guard path が実在する: $guard_path" test -f "$PROJECT_DIR/$guard_path"
+done
+
+TMP_REPO=$(mktemp -d "/tmp/test-flow-safety-paths.XXXXXX")
+trap 'rm -rf "$TMP_REPO"' EXIT
+
+git -C "$TMP_REPO" init -q
+git -C "$TMP_REPO" config user.email harness-test@example.invalid
+git -C "$TMP_REPO" config user.name 'harness test'
+
+for guard_path in "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}" "${FLOW_GUARD_SESSION_LIFECYCLE_PATHS[@]}"; do
+  mkdir -p "$TMP_REPO/$(dirname "$guard_path")"
+  printf '%s\n' '// baseline' > "$TMP_REPO/$guard_path"
+done
+printf '%s\n' '# baseline' > "$TMP_REPO/README.md"
+git -C "$TMP_REPO" add .
+git -C "$TMP_REPO" commit -q -m baseline
+BASELINE_SHA=$(git -C "$TMP_REPO" rev-parse HEAD)
+git -C "$TMP_REPO" update-ref refs/remotes/origin/main "$BASELINE_SHA"
+
+assert_eq "repository-local user.email" \
+  "harness-test@example.invalid" "$(git -C "$TMP_REPO" config --local user.email)"
+assert_eq "repository-local user.name" \
+  "harness test" "$(git -C "$TMP_REPO" config --local user.name)"
+
+reset_to_baseline() {
+  git -C "$TMP_REPO" reset -q --hard "$BASELINE_SHA"
+}
+
+db_schema_changed() {
+  (cd "$TMP_REPO" && flow_guard_db_schema_changed 'origin/main...HEAD')
+}
+
+echo ""
+echo "=== DB schema guard ==="
+printf '%s\n' 'ALTER TABLE sessions ADD COLUMN archived INTEGER;' \
+  >> "$TMP_REPO/packages/server/src/lib/database.ts"
+git -C "$TMP_REPO" add packages/server/src/lib/database.ts
+git -C "$TMP_REPO" commit -q -m 'database schema change'
+assert_success "database.ts の schema diff を検出する" db_schema_changed
+assert_eq "DB schema halt message" \
+  "DB スキーマ変更検出 (packages/server/src/lib/database.ts、人間レビュー必須)" \
+  "$(flow_guard_db_schema_halt_message)"
+
+reset_to_baseline
+printf '%s\n' 'CREATE TABLE ignored' >> "$TMP_REPO/README.md"
+git -C "$TMP_REPO" add README.md
+git -C "$TMP_REPO" commit -q -m 'unrelated schema words'
+assert_failure "対象外 path の schema 語句では検出しない" db_schema_changed
+
+reset_to_baseline
+printf '%s\n' '// no schema keyword here' \
+  >> "$TMP_REPO/packages/server/src/lib/database.ts"
+git -C "$TMP_REPO" add packages/server/src/lib/database.ts
+git -C "$TMP_REPO" commit -q -m 'database comment only'
+assert_failure "database.ts の schema 語句なし diff では検出しない" db_schema_changed
+
+FLOW_STATE_UPDATE_CALLS=0
+FLOW_STATE_UPDATE_TYPE=''
+FLOW_STATE_UPDATE_EXPR=''
+FLOW_STATE_UPDATE_SCOPE=''
+
+flow_state_update() {
+  FLOW_STATE_UPDATE_CALLS=$((FLOW_STATE_UPDATE_CALLS + 1))
+  FLOW_STATE_UPDATE_TYPE="$1"
+  FLOW_STATE_UPDATE_EXPR="$2"
+  FLOW_STATE_UPDATE_SCOPE="$3"
+}
+
+warn_session_lifecycle() {
+  local original_dir
+  original_dir=$(pwd)
+  cd "$TMP_REPO" || return 1
+  flow_guard_warn_session_lifecycle_change 'test-scope' 'origin/main...HEAD'
+  cd "$original_dir" || return 1
+}
+
+echo ""
+echo "=== session lifecycle guard ==="
+reset_to_baseline
+printf '%s\n' '// lifecycle change' \
+  >> "$TMP_REPO/packages/server/src/lib/tmux-manager.ts"
+git -C "$TMP_REPO" add packages/server/src/lib/tmux-manager.ts
+git -C "$TMP_REPO" commit -q -m 'tmux lifecycle change'
+assert_success "session lifecycle warning を発行する" warn_session_lifecycle
+assert_eq "flow_state_update call count" "1" "$FLOW_STATE_UPDATE_CALLS"
+assert_eq "flow_state_update type" "progress" "$FLOW_STATE_UPDATE_TYPE"
+assert_eq "flow_state_update expression" \
+  '.warnings += ["tmux/ttyd セッションライフサイクル変更あり、再起動時の挙動を確認すること"]' \
+  "$FLOW_STATE_UPDATE_EXPR"
+assert_eq "flow_state_update scope" "test-scope" "$FLOW_STATE_UPDATE_SCOPE"
+
+reset_to_baseline
+printf '%s\n' 'unrelated change' >> "$TMP_REPO/README.md"
+git -C "$TMP_REPO" add README.md
+git -C "$TMP_REPO" commit -q -m 'unrelated change'
+assert_success "対象外 diff の warning 判定は正常終了する" warn_session_lifecycle
+assert_eq "対象外 diff では warning を追加しない" "1" "$FLOW_STATE_UPDATE_CALLS"
+
+echo ""
+echo "========================================"
+echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"
+echo "========================================"
+[ "$FAILURES" -eq 0 ]

--- a/.claude/lib/tests/test-flow-safety-paths.sh
+++ b/.claude/lib/tests/test-flow-safety-paths.sh
@@ -82,6 +82,11 @@ for guard_path in "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}" "${FLOW_GUARD_SESSION_LIFEC
   assert_success "guard path が実在する: $guard_path" test -f "$PROJECT_DIR/$guard_path"
 done
 
+ZSH_DB_PATH=$(cd "$PROJECT_DIR" && zsh -c \
+  'source .claude/lib/flow-safety-paths.sh; print -r -- ${FLOW_GUARD_DB_SCHEMA_PATHS[1]}')
+assert_eq "zsh でも DB schema path を参照できる" \
+  "packages/server/src/lib/database.ts" "$ZSH_DB_PATH"
+
 TMP_REPO=$(mktemp -d "/tmp/test-flow-safety-paths.XXXXXX")
 trap 'rm -rf "$TMP_REPO"' EXIT
 

--- a/.claude/lib/tests/test-flow-safety-paths.sh
+++ b/.claude/lib/tests/test-flow-safety-paths.sh
@@ -183,6 +183,37 @@ git -C "$TMP_REPO" commit -q -m 'unrelated change'
 assert_success "対象外 diff の warning 判定は正常終了する" warn_session_lifecycle
 assert_eq "対象外 diff では warning を追加しない" "1" "$FLOW_STATE_UPDATE_CALLS"
 
+count_literal() {
+  local file="$1"
+  local literal="$2"
+  grep -F -c -- "$literal" "$file" || true
+}
+
+echo ""
+echo "=== flow / flow-x connection audit ==="
+LEGACY_SERVER_LIB="server""/lib"
+for skill_path in \
+  "$PROJECT_DIR/.claude/skills/flow/SKILL.md" \
+  "$PROJECT_DIR/.claude/skills/flow-x/SKILL.md"; do
+  skill_name=$(basename "$(dirname "$skill_path")")
+  assert_eq "$skill_name は共有 safety lib を 1 回 source する" "1" \
+    "$(count_literal "$skill_path" 'source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-safety-paths.sh"')"
+  assert_eq "$skill_name は DB schema 述語を 1 回呼ぶ" "1" \
+    "$(count_literal "$skill_path" "flow_guard_db_schema_changed 'origin/main...HEAD'")"
+  assert_eq "$skill_name は session warning を 1 回呼ぶ" "1" \
+    "$(count_literal "$skill_path" "flow_guard_warn_session_lifecycle_change \"\$SCOPE_KEY\" 'origin/main...HEAD'")"
+  assert_eq "$skill_name の DB branch は halt 指示を維持する" "1" \
+    "$(count_literal "$skill_path" 'halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)"')"
+  assert_eq "$skill_name の P3 に旧 DB pathspec がない" "0" \
+    "$(count_literal "$skill_path" "'$LEGACY_SERVER_LIB/database.ts'")"
+  assert_eq "$skill_name の P3 に旧 session pathspec がない" "0" \
+    "$(count_literal "$skill_path" "'$LEGACY_SERVER_LIB/session-orchestrator.ts'")"
+  assert_eq "$skill_name の P3 に旧 tmux pathspec がない" "0" \
+    "$(count_literal "$skill_path" "'$LEGACY_SERVER_LIB/tmux-manager.ts'")"
+  assert_eq "$skill_name の P3 に旧 ttyd pathspec がない" "0" \
+    "$(count_literal "$skill_path" "'$LEGACY_SERVER_LIB/ttyd-manager.ts'")"
+done
+
 echo ""
 echo "========================================"
 echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"

--- a/.claude/rules/backend-architecture.md
+++ b/.claude/rules/backend-architecture.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "server/**"
+  - "packages/server/**"
 ---
 
 # バックエンドアーキテクチャ実装パターン
@@ -8,7 +8,7 @@ paths:
 ## ディレクトリ構成
 
 ```
-server/
+packages/server/src/
 ├── index.ts                    # Express + Socket.IO サーバー（ハンドラー定義含む）
 └── lib/
     ├── session-orchestrator.ts # tmux + ttyd 統合管理（Orchestratorパターン）
@@ -38,7 +38,7 @@ server/
 
 - 下位マネージャーのイベントを `setupEventForwarding()` でリッスンし、上位イベントに変換して再emitする
 - サーバー起動時に `restoreExistingSessions()` で前回のtmuxセッションを復元し、対応するttydインスタンスも自動起動する
-- `ManagedSession` 型（`shared/types.ts`）を返すことで、クライアントに統一的な情報を提供する
+- `ManagedSession` 型（`packages/shared/src/types.ts`）を返すことで、クライアントに統一的な情報を提供する
 
 ### ttydのポート管理と重複起動防止
 
@@ -65,13 +65,13 @@ server/
 
 ## Socket.IOイベント設計
 
-`shared/types.ts` の `ServerToClientEvents` / `ClientToServerEvents` インターフェースで型安全に定義する。
+`packages/shared/src/types.ts` の `ServerToClientEvents` / `ClientToServerEvents` インターフェースで型安全に定義する。
 
 - サーバー → クライアント: `namespace:verb` 形式（例: `session:created`, `worktree:list`）
 - クライアント → サーバー: `namespace:verb` 形式（例: `session:start`, `repo:select`）
 - コールバック付きイベント: `session:copy` のように第2引数で `callback` を受け取るパターン
 
-イベントを追加・変更する場合は `shared/types.ts` の型定義を必ず更新すること。型定義とハンドラーの不一致はコンパイルエラーで検出される。
+イベントを追加・変更する場合は `packages/shared/src/types.ts` の型定義を必ず更新すること。型定義とハンドラーの不一致はコンパイルエラーで検出される。
 
 ## エラーハンドリング
 

--- a/.claude/rules/backend-migration.md
+++ b/.claude/rules/backend-migration.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "server/lib/database.ts"
+  - "packages/server/src/lib/database.ts"
   - "data/**"
 ---
 
@@ -9,7 +9,7 @@ paths:
 ## SQLite (better-sqlite3)
 
 - データベースファイル: `data/sessions.db`（自動生成、gitignore対象）
-- スキーマ定義: `server/lib/database.ts` 内で CREATE TABLE IF NOT EXISTS で管理
+- スキーマ定義: `packages/server/src/lib/database.ts` 内で CREATE TABLE IF NOT EXISTS で管理
 - マイグレーションツールは使用しない（スキーマ変更はコード内で直接実行）
 
 ## スキーマ変更時の注意

--- a/.claude/rules/backend-testing.md
+++ b/.claude/rules/backend-testing.md
@@ -1,7 +1,7 @@
 ---
 paths:
-  - "server/**"
-  - "shared/**"
+  - "packages/server/**"
+  - "packages/shared/**"
 ---
 
 # バックエンドテストルール
@@ -16,7 +16,7 @@ paths:
 
 ### ユニットテスト
 
-- `server/lib/` 配下の各マネージャーを個別にテスト
+- `packages/server/src/lib/` 配下の各マネージャーを個別にテスト
 - 外部プロセス（tmux, ttyd, cloudflared）の呼び出しはモック化
 - `child_process.execSync` / `spawnSync` を `vi.mock` でスタブ
 

--- a/.claude/rules/frontend-codegen.md
+++ b/.claude/rules/frontend-codegen.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "client/**"
+  - "packages/web/**"
 ---
 
 # フロントエンド開発ルール
@@ -14,10 +14,10 @@ paths:
 
 ## コンポーネント設計
 
-- UIコンポーネントは `client/src/components/` に配置
-- shadcn/uiベースのコンポーネントは `client/src/components/ui/` に配置
-- ページコンポーネントは `client/src/pages/` に配置
-- カスタムフックは `client/src/hooks/` に配置
+- UIコンポーネントは `packages/web/src/components/` に配置
+- shadcn/uiベースのコンポーネントは `packages/web/src/components/ui/` に配置
+- ページコンポーネントは `packages/web/src/pages/` に配置
+- カスタムフックは `packages/web/src/hooks/` に配置
 
 ## モバイル対応
 
@@ -29,8 +29,8 @@ paths:
 ## Socket.IO通信
 
 - 全Socket.IOイベントは `useSocket.ts` に集約
-- イベント型定義は `shared/types.ts` の `ServerToClientEvents` / `ClientToServerEvents` を参照
-- 新しいイベントを追加する場合は `shared/types.ts` の型定義も更新すること
+- イベント型定義は `packages/shared/src/types.ts` の `ServerToClientEvents` / `ClientToServerEvents` を参照
+- 新しいイベントを追加する場合は `packages/shared/src/types.ts` の型定義も更新すること
 
 ## 注意事項
 

--- a/.claude/scripts/garbage-collect.sh
+++ b/.claude/scripts/garbage-collect.sh
@@ -5,7 +5,7 @@
 PROJECT_ROOT="${1:-$(pwd)}"
 
 # プロジェクトルートのバリデーション
-if [ ! -d "$PROJECT_ROOT/server" ] && [ ! -d "$PROJECT_ROOT/client" ]; then
+if [ ! -d "$PROJECT_ROOT/packages/server/src" ] && [ ! -d "$PROJECT_ROOT/packages/web/src" ]; then
   echo "ERROR: $PROJECT_ROOT はプロジェクトルートではありません" >&2
   exit 1
 fi
@@ -16,19 +16,19 @@ echo "=== 孤立TypeScript/JavaScriptファイル検出 ==="
 echo "他ファイルからimportされていない.ts/.tsx/.js/.jsxファイルを検出"
 echo ""
 
-# server/lib/
-if [ -d "$PROJECT_ROOT/server/lib" ]; then
+# packages/server/src/lib/
+if [ -d "$PROJECT_ROOT/packages/server/src/lib" ]; then
   while IFS= read -r f; do
     basename=$(basename "$f" | sed 's/\.\(ts\|tsx\|js\|jsx\)$//')
     # index.ts はスキップ
     [[ "$basename" == "index" ]] && continue
     # このファイル以外から参照されているか
-    refs=$(grep -rlE "(from.*['\"].*/${basename}['\"]|import.*['\"].*/${basename})" "$PROJECT_ROOT/server" --include='*.ts' --include='*.tsx' --include='*.js' 2>/dev/null | grep -v "$f" | head -1)
+    refs=$(grep -rlE "(from.*['\"].*/${basename}['\"]|import.*['\"].*/${basename})" "$PROJECT_ROOT/packages/server/src" --include='*.ts' --include='*.tsx' --include='*.js' 2>/dev/null | grep -v "$f" | head -1)
     if [ -z "$refs" ]; then
       echo "  孤立候補 (server): $f"
       FOUND=$((FOUND + 1))
     fi
-  done < <(find "$PROJECT_ROOT/server/lib" \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
+  done < <(find "$PROJECT_ROOT/packages/server/src/lib" \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
     -not -name 'index.ts' -not -name 'index.js' \
     -not -path '*/tests/*' -not -path '*/test/*' -not -path '*/__tests__/*' \
     -not -path '*/node_modules/*' 2>/dev/null)
@@ -39,19 +39,19 @@ echo "=== 孤立フロントエンドコンポーネント検出 ==="
 echo "他ファイルからimportされていない.tsx/.tsファイルを検出"
 echo ""
 
-# client/src/
-if [ -d "$PROJECT_ROOT/client/src" ]; then
+# packages/web/src/
+if [ -d "$PROJECT_ROOT/packages/web/src" ]; then
   while IFS= read -r f; do
     basename=$(basename "$f" | sed 's/\.\(ts\|tsx\|js\|jsx\)$//')
     # エントリポイントはスキップ
     [[ "$basename" == "App" || "$basename" == "main" || "$basename" == "index" ]] && continue
     # このファイル以外から参照されているか
-    refs=$(grep -rlE "(from.*['\"].*/${basename}['\"]|import.*['\"].*/${basename})" "$PROJECT_ROOT/client/src" --include='*.tsx' --include='*.ts' --include='*.js' 2>/dev/null | grep -v "$f" | head -1)
+    refs=$(grep -rlE "(from.*['\"].*/${basename}['\"]|import.*['\"].*/${basename})" "$PROJECT_ROOT/packages/web/src" --include='*.tsx' --include='*.ts' --include='*.js' 2>/dev/null | grep -v "$f" | head -1)
     if [ -z "$refs" ]; then
-      echo "  孤立候補 (client): $f"
+      echo "  孤立候補 (web): $f"
       FOUND=$((FOUND + 1))
     fi
-  done < <(find "$PROJECT_ROOT/client/src" \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
+  done < <(find "$PROJECT_ROOT/packages/web/src" \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) \
     -not -name 'App.tsx' -not -name 'main.tsx' -not -name 'index.tsx' -not -name 'index.ts' \
     -not -path '*/node_modules/*' 2>/dev/null)
 fi
@@ -64,10 +64,10 @@ echo ""
 DUPES=0
 
 # server
-if [ -d "$PROJECT_ROOT/server/lib" ]; then
+if [ -d "$PROJECT_ROOT/packages/server/src/lib" ]; then
   echo "--- server ---"
   JSCPD_SERVER_TMPDIR=$(mktemp -d)
-  npx jscpd "$PROJECT_ROOT/server/lib" --min-lines 10 --min-tokens 70 \
+  npx jscpd "$PROJECT_ROOT/packages/server/src/lib" --min-lines 10 --min-tokens 70 \
     --ignore "**/tests/**,**/*test*,**/*spec*" --reporters json --output "$JSCPD_SERVER_TMPDIR" >/dev/null 2>&1 || true
   if [ -f "$JSCPD_SERVER_TMPDIR/jscpd-report.json" ]; then
     SERVER_DUPES=$(jq '.statistics.total.clones // 0' "$JSCPD_SERVER_TMPDIR/jscpd-report.json")
@@ -85,25 +85,25 @@ if [ -d "$PROJECT_ROOT/server/lib" ]; then
   echo ""
 fi
 
-# client
-if [ -d "$PROJECT_ROOT/client/src" ]; then
-  echo "--- client ---"
-  JSCPD_CLIENT_TMPDIR=$(mktemp -d)
-  npx jscpd "$PROJECT_ROOT/client/src" --min-lines 10 --min-tokens 70 \
-    --ignore "**/*.test.*,**/*.spec.*" --reporters json --output "$JSCPD_CLIENT_TMPDIR" >/dev/null 2>&1 || true
-  if [ -f "$JSCPD_CLIENT_TMPDIR/jscpd-report.json" ]; then
-    CLIENT_DUPES=$(jq '.statistics.total.clones // 0' "$JSCPD_CLIENT_TMPDIR/jscpd-report.json")
-    CLIENT_DUP_LINES=$(jq '.statistics.total.duplicatedLines // 0' "$JSCPD_CLIENT_TMPDIR/jscpd-report.json")
-    CLIENT_TOTAL_LINES=$(jq '.statistics.total.lines // 1' "$JSCPD_CLIENT_TMPDIR/jscpd-report.json")
-    CLIENT_RATE=$(awk -v dup="$CLIENT_DUP_LINES" -v total="$CLIENT_TOTAL_LINES" 'BEGIN {printf "%.2f%%", dup * 100 / total}')
+# web
+if [ -d "$PROJECT_ROOT/packages/web/src" ]; then
+  echo "--- web ---"
+  JSCPD_WEB_TMPDIR=$(mktemp -d)
+  npx jscpd "$PROJECT_ROOT/packages/web/src" --min-lines 10 --min-tokens 70 \
+    --ignore "**/*.test.*,**/*.spec.*" --reporters json --output "$JSCPD_WEB_TMPDIR" >/dev/null 2>&1 || true
+  if [ -f "$JSCPD_WEB_TMPDIR/jscpd-report.json" ]; then
+    WEB_DUPES=$(jq '.statistics.total.clones // 0' "$JSCPD_WEB_TMPDIR/jscpd-report.json")
+    WEB_DUP_LINES=$(jq '.statistics.total.duplicatedLines // 0' "$JSCPD_WEB_TMPDIR/jscpd-report.json")
+    WEB_TOTAL_LINES=$(jq '.statistics.total.lines // 1' "$JSCPD_WEB_TMPDIR/jscpd-report.json")
+    WEB_RATE=$(awk -v dup="$WEB_DUP_LINES" -v total="$WEB_TOTAL_LINES" 'BEGIN {printf "%.2f%%", dup * 100 / total}')
   else
-    CLIENT_DUPES=0
-    CLIENT_RATE="0%"
+    WEB_DUPES=0
+    WEB_RATE="0%"
     echo "  WARNING: jscpd実行失敗またはレポート未生成" >&2
   fi
-  rm -rf "$JSCPD_CLIENT_TMPDIR"
-  echo "  クローン: ${CLIENT_DUPES}件, 重複率: ${CLIENT_RATE}"
-  DUPES=$((DUPES + CLIENT_DUPES))
+  rm -rf "$JSCPD_WEB_TMPDIR"
+  echo "  クローン: ${WEB_DUPES}件, 重複率: ${WEB_RATE}"
+  DUPES=$((DUPES + WEB_DUPES))
   echo ""
 fi
 

--- a/.claude/scripts/garbage-collect.sh
+++ b/.claude/scripts/garbage-collect.sh
@@ -23,7 +23,7 @@ if [ -d "$PROJECT_ROOT/packages/server/src/lib" ]; then
     # index.ts はスキップ
     [[ "$basename" == "index" ]] && continue
     # このファイル以外から参照されているか
-    refs=$(grep -rlE "(from.*['\"].*/${basename}['\"]|import.*['\"].*/${basename})" "$PROJECT_ROOT/packages/server/src" --include='*.ts' --include='*.tsx' --include='*.js' 2>/dev/null | grep -v "$f" | head -1)
+    refs=$(grep -rlE "(from.*['\"].*/${basename}['\"]|import.*['\"].*/${basename})" "$PROJECT_ROOT/packages/server/src" --include='*.ts' --include='*.tsx' --include='*.js' --include='*.jsx' 2>/dev/null | grep -v "$f" | head -1)
     if [ -z "$refs" ]; then
       echo "  孤立候補 (server): $f"
       FOUND=$((FOUND + 1))
@@ -46,7 +46,7 @@ if [ -d "$PROJECT_ROOT/packages/web/src" ]; then
     # エントリポイントはスキップ
     [[ "$basename" == "App" || "$basename" == "main" || "$basename" == "index" ]] && continue
     # このファイル以外から参照されているか
-    refs=$(grep -rlE "(from.*['\"].*/${basename}['\"]|import.*['\"].*/${basename})" "$PROJECT_ROOT/packages/web/src" --include='*.tsx' --include='*.ts' --include='*.js' 2>/dev/null | grep -v "$f" | head -1)
+    refs=$(grep -rlE "(from.*['\"].*/${basename}['\"]|import.*['\"].*/${basename})" "$PROJECT_ROOT/packages/web/src" --include='*.tsx' --include='*.ts' --include='*.js' --include='*.jsx' 2>/dev/null | grep -v "$f" | head -1)
     if [ -z "$refs" ]; then
       echo "  孤立候補 (web): $f"
       FOUND=$((FOUND + 1))

--- a/.claude/skills/db-connect/SKILL.md
+++ b/.claude/skills/db-connect/SKILL.md
@@ -26,6 +26,6 @@ sqlite3 data/sessions.db "SELECT * FROM sessions;"
 
 ## 注意事項
 
-- サーバー起動時にテーブルが自動作成される（`server/lib/database.ts` 参照）
+- サーバー起動時にテーブルが自動作成される（`packages/server/src/lib/database.ts` 参照）
 - SQLiteファイルはgitignoreに含まれている
 - サーバー稼働中にSQLite CLIで書き込むとロック競合の可能性がある

--- a/.claude/skills/flow-loop/SKILL.md
+++ b/.claude/skills/flow-loop/SKILL.md
@@ -66,7 +66,7 @@ slug 運用 (Issue 紐付けなし) の run は pick クエリに乗らないた
 
 ### `loop-exclude` ラベル (キュー衛生)
 
-loop で処理**できない / させたくない** Issue には GitHub ラベル `loop-exclude` を付けて pick 対象から外す (人間が付け外しする運用マーカー)。対象の典型: 外部提供・デザイン確定待ち / DB スキーマ変更 (`server/lib/database.ts`) が主作業の Issue (flow-x P3 で必ず halt するため loop に乗せる意味がない) / `.claude/` 配下のハーネス自改修 (ループ稼働中の自己書き換えは挙動が予測しにくい。人間同席の単発 `/flow-x` か直接作業を推奨)。
+loop で処理**できない / させたくない** Issue には GitHub ラベル `loop-exclude` を付けて pick 対象から外す (人間が付け外しする運用マーカー)。対象の典型: 外部提供・デザイン確定待ち / DB スキーマ変更 (`packages/server/src/lib/database.ts`) が主作業の Issue (flow-x P3 で必ず halt するため loop に乗せる意味がない) / `.claude/` 配下のハーネス自改修 (ループ稼働中の自己書き換えは挙動が予測しにくい。人間同席の単発 `/flow-x` か直接作業を推奨)。
 
 - **目的はブレーカー保護**: 処理不能 Issue を pick → 即 halt が続くと連続 halt 3 でブレーカーが落ち、処理可能な Issue まで止まる。ラベルで入口を絞る方が安い。
 - ブロッカーが解消したら**ラベルを外すだけ**で次 tick から自然に候補へ戻る。state もフラグも不要。

--- a/.claude/skills/flow-x/SKILL.md
+++ b/.claude/skills/flow-x/SKILL.md
@@ -574,14 +574,19 @@ flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 ### 3-2. DB スキーマ変更検出 (flow と同一)
 ark の SQLite スキーマは `packages/server/src/lib/database.ts` の `CREATE TABLE` 群で定義される。
 ```bash
-if flow_guard_db_schema_changed 'origin/main...HEAD'; then
-  halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)"
-fi
+flow_guard_db_schema_changed 'origin/main...HEAD'
+case $? in
+  0) halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)" ;;
+  2) halt "DB スキーマ変更の判定に失敗しました (git diff が失敗)。origin/main の存在と diff range を確認すること" ;;
+esac
 ```
 
 ### 3-3. tmux/ttyd セッションライフサイクル変更検出 (flow と同一)
 ```bash
 flow_guard_warn_session_lifecycle_change "$SCOPE_KEY" 'origin/main...HEAD'
+case $? in
+  2) printf '%s\n' 'warning: セッションライフサイクル変更を判定不能 (state に warning 記録済み)' >&2 ;;
+esac
 ```
 
 ### 3-4. Claude による実装レビュー (中間ゲート)

--- a/.claude/skills/flow-x/SKILL.md
+++ b/.claude/skills/flow-x/SKILL.md
@@ -194,6 +194,7 @@ flow_state_update progress '.gate = "codex-impl"' "$SCOPE_KEY"
 
 ```bash
 source "$CLAUDE_PROJECT_DIR/.claude/lib/state-io.sh"
+source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-safety-paths.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/check-cr-threads.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/cleanup.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/ticket-source.sh"
@@ -443,7 +444,7 @@ cd "$WORKTREE_PATH"
 #### 1-4b. 既存 flow worktree から起動 (`IN_FLOW_WORKTREE=1`)
 ```bash
 # 既に flow worktree 内なので create_worktree は呼ばない。
-# サブディレクトリ (server/, client/ 等) から起動された場合に備えて worktree root に必ず cd する。
+# サブディレクトリ (packages/server/, packages/web/ 等) から起動された場合に備えて worktree root に必ず cd する。
 WORKTREE_PATH="$CURRENT_WORKTREE"
 cd "$WORKTREE_PATH"
 echo "P1: 既存 worktree から起動: $WORKTREE_PATH ($BRANCH)" >&2
@@ -551,8 +552,8 @@ plan は**成果物としてコミットし、作業の PR に含める** (CLAUD
 - codex への指示に必ず明示:
   - **plan (`$PLAN_PATH`) を読んで Task 順に TDD 実装**
   - **TDD (Red → Green → Refactor) 必須**、Red を先に書く
-  - **プロジェクト規約厳守**: `CLAUDE.md`, `.claude/rules/*.md`。サーバ側 (`server/`) の変更は vitest テスト優先 (`server/lib/*.test.ts` パターン)、フロントエンド (`client/`) は新規 vitest 不要 (必要なら e2e)。**Socket.IO イベント追加は `shared/types.ts` + `server/index.ts` + `client/src/hooks/useSocket.ts` の 3 点セットで更新**
-  - **DB スキーマ変更 (`server/lib/database.ts` のテーブル定義変更) は禁止** — 必要なら停止して報告 (人間レビュー必須スコープ)
+  - **プロジェクト規約厳守**: `CLAUDE.md`, `.claude/rules/*.md`。サーバ側 (`packages/server/`) の変更は vitest テスト優先 (`packages/server/src/lib/*.test.ts` パターン)、フロントエンド (`packages/web/`) は新規 vitest 不要 (必要なら e2e)。**Socket.IO イベント追加は `packages/shared/src/types.ts` + `packages/server/src/index.ts` + `packages/web/src/hooks/useSocket.ts` の 3 点セットで更新**
+  - **DB スキーマ変更 (`packages/server/src/lib/database.ts` のテーブル定義変更) は禁止** — 必要なら停止して報告 (人間レビュー必須スコープ)
   - 検証コマンド (`pnpm check` / `pnpm exec vitest run`) を自分で走らせて green を確認してからコミット
   - 小さくコミット、メッセージは日本語で `<内容>` 形式、Co-Authored-By なし
   - ❌ git push / PR 作成はしない (P6 以降で flow-x がコントロール)
@@ -571,21 +572,16 @@ flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 > **検証の分担**: sandbox 無効で起動するため codex はテストも自分で走らせられるが、**フル検証は P4 (Claude 実行) で必ず再走する**（codex が `-o` 完了前に異常終了する事例があり、その場合 `pnpm check` が通れば Claude が検証を引き継ぐ。前節 3 参照）。codex には「コンパイル + 可能な範囲のテストまで確認してコミット」を求める。
 
 ### 3-2. DB スキーマ変更検出 (flow と同一)
-ark の SQLite スキーマは `server/lib/database.ts` の `CREATE TABLE` 群で定義される。
+ark の SQLite スキーマは `packages/server/src/lib/database.ts` の `CREATE TABLE` 群で定義される。
 ```bash
-if git diff --name-only origin/main...HEAD -- 'server/lib/database.ts' | grep -q . \
-  && git diff origin/main...HEAD -- 'server/lib/database.ts' | grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)'; then
-  halt "DB スキーマ変更検出 (server/lib/database.ts、人間レビュー必須)"
+if flow_guard_db_schema_changed 'origin/main...HEAD'; then
+  halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)"
 fi
 ```
 
 ### 3-3. tmux/ttyd セッションライフサイクル変更検出 (flow と同一)
 ```bash
-if git diff --name-only origin/main...HEAD \
-  -- 'server/lib/session-orchestrator.ts' 'server/lib/tmux-manager.ts' 'server/lib/ttyd-manager.ts' \
-  | grep -q .; then
-  flow_state_update progress '.warnings += ["tmux/ttyd セッションライフサイクル変更あり、再起動時の挙動を確認すること"]' "$SCOPE_KEY"
-fi
+flow_guard_warn_session_lifecycle_change "$SCOPE_KEY" 'origin/main...HEAD'
 ```
 
 ### 3-4. Claude による実装レビュー (中間ゲート)
@@ -593,7 +589,7 @@ fi
 P5 (push 前) で本格レビューするが、**P3 完了時点でも Claude が diff をざっと確認**し、明らかな規約違反・plan 逸脱・TDD 不履行 (テストなし実装) があれば codex に差し戻す:
 1. `git diff --stat origin/main...HEAD` で変更範囲を把握、plan のスコープと一致するか
 2. テストが追加されているか (TDD 履行。server 変更なら vitest)
-3. 規約違反の明白なもの (Socket.IO 3 点セット漏れ、shared/types.ts 未更新等)
+3. 規約違反の明白なもの (Socket.IO 3 点セット漏れ、packages/shared/src/types.ts 未更新等)
 4. 問題があれば codex exec で修正依頼、なければ P4 へ
 
 ### 3-5. 遷移
@@ -609,8 +605,8 @@ flow_state_update progress '.phase = "P4"' "$SCOPE_KEY"
 
 | 変更対象 | コマンド (作業ディレクトリ: `$WORKTREE_PATH`) |
 |---|---|
-| `server/`, `client/`, `shared/` の `.ts` / `.tsx` | `pnpm check`  (= `biome check . && tsc --noEmit`) |
-| `server/lib/*.test.ts` 追加・変更時 | `pnpm exec vitest run` |
+| `packages/{server,shared,web,desktop}/` の `.ts` / `.tsx` | `pnpm check`  (= `biome check . && tsc --noEmit`) |
+| `packages/server/src/lib/*.test.ts` 追加・変更時 | `pnpm exec vitest run` |
 | `e2e/*.spec.ts` 追加・変更時 | `pnpm test:e2e` (実機が必要なため、CI で十分なら warn でスキップ可) |
 | `package.json` / `pnpm-lock.yaml` | `pnpm install --frozen-lockfile` で整合性確認 |
 
@@ -833,7 +829,7 @@ ark の本番デプロイは `pnpm install --frozen-lockfile && pnpm build && pk
 
 | 条件 | 動作 |
 |---|---|
-| merge commit が `server/`, `client/`, `shared/`, `package.json` 等を含まない | **no-target finalize** (deploy 不要) |
+| merge commit が `packages/server/`, `packages/web/`, `packages/shared/`, `packages/desktop/`, `package.json`, `packages/server/ecosystem.config.cjs`, `packages/web/vite.config.ts` 等を含まない | **no-target finalize** (deploy 不要) |
 | `pm2 jlist` で `claude-code-ark` が `online` でない | **no-target finalize** (`pnpm dev` 想定、デプロイ不要) |
 | 上記以外 | **deploy 実行 + health 監視** (30 秒 × 5 = 最大 2.5 分) |
 

--- a/.claude/skills/flow-x/references/subagent-plan-prompt.md
+++ b/.claude/skills/flow-x/references/subagent-plan-prompt.md
@@ -42,10 +42,10 @@
 3. 関連ファイル・既存実装をコードベースから探索する。**必ず以下を確認**:
    - プロジェクト直下の `CLAUDE.md`
    - `.claude/rules/` 配下の関連ルール (backend-architecture / backend-testing / frontend-codegen / backend-migration)
-   - `shared/types.ts` (Socket.IO イベント型・共通型)
-   - `server/index.ts` (Express + Socket.IO ハンドラー)
-   - `server/lib/` の既存マネージャー (session-orchestrator / tmux-manager / ttyd-manager / database 等)
-   - frontend 変更時は `client/src/components/` `client/src/hooks/` の既存パターン
+   - `packages/shared/src/types.ts` (Socket.IO イベント型・共通型)
+   - `packages/server/src/index.ts` (Express + Socket.IO ハンドラー)
+   - `packages/server/src/lib/` の既存マネージャー (session-orchestrator / tmux-manager / ttyd-manager / database 等)
+   - frontend 変更時は `packages/web/src/components/` `packages/web/src/hooks/` の既存パターン
 4. superpowers:writing-plans 規約に従い、以下のヘッダー形式で plan を作成する:
 
    ```markdown
@@ -80,11 +80,11 @@
 
 ### ark 固有制約
 
-- **DB スキーマ変更**: `server/lib/database.ts` の SQLite テーブル定義を変更する場合は plan で明示。マイグレーションは `database.ts` の起動時 `CREATE TABLE IF NOT EXISTS` で対応するのが既存パターン
-- **Socket.IO イベント追加**: 必ず `shared/types.ts` の型と `server/index.ts` のハンドラー、`client/src/hooks/useSocket.ts` の購読を 3 点セットで更新する旨を plan に書く
+- **DB スキーマ変更**: `packages/server/src/lib/database.ts` の SQLite テーブル定義を変更する場合は plan で明示。マイグレーションは `database.ts` の起動時 `CREATE TABLE IF NOT EXISTS` で対応するのが既存パターン
+- **Socket.IO イベント追加**: 必ず `packages/shared/src/types.ts` の型と `packages/server/src/index.ts` のハンドラー、`packages/web/src/hooks/useSocket.ts` の購読を 3 点セットで更新する旨を plan に書く
 - **tmux/ttyd 関連**: セッションライフサイクル (start / stop / restart / restore) を変える場合、`SessionOrchestrator` への影響と再起動時の挙動を plan で言及
 - **モバイル対応**: 新しい UI を追加する場合、`MobileLayout` / `MobileSessionView` への対応有無を plan に記載
-- **テスト**: 既存の vitest テスト (`server/lib/*.test.ts`) と Playwright e2e (`e2e/`) のどちらでカバーするか plan に明示
+- **テスト**: 既存の vitest テスト (`packages/server/src/lib/*.test.ts`) と Playwright e2e (`e2e/`) のどちらでカバーするか plan に明示
 
 ### 制約
 

--- a/.claude/skills/flow/SKILL.md
+++ b/.claude/skills/flow/SKILL.md
@@ -279,15 +279,20 @@ flow_state_update progress '.phase = "P3"' "$SCOPE_KEY"
 ark の SQLite スキーマは `packages/server/src/lib/database.ts` の `CREATE TABLE` 群で定義される。
 スキーマ変更 (テーブル追加・カラム追加・rename・削除) は人間レビュー必須。
 ```bash
-if flow_guard_db_schema_changed 'origin/main...HEAD'; then
-  halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)"
-fi
+flow_guard_db_schema_changed 'origin/main...HEAD'
+case $? in
+  0) halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)" ;;
+  2) halt "DB スキーマ変更の判定に失敗しました (git diff が失敗)。origin/main の存在と diff range を確認すること" ;;
+esac
 ```
 
 ### 3-3. tmux/ttyd セッションライフサイクル変更検出
 セッション周りは安全装置の塊。SessionOrchestrator / TmuxManager / TtydManager のいずれかが変わったら warn:
 ```bash
 flow_guard_warn_session_lifecycle_change "$SCOPE_KEY" 'origin/main...HEAD'
+case $? in
+  2) printf '%s\n' 'warning: セッションライフサイクル変更を判定不能 (state に warning 記録済み)' >&2 ;;
+esac
 ```
 
 ### 3-4. 遷移

--- a/.claude/skills/flow/SKILL.md
+++ b/.claude/skills/flow/SKILL.md
@@ -58,6 +58,7 @@ argument-hint: [#<issue> | <slug>] [--resume | --from PHASE | --dry-run | --plan
 
 ```bash
 source "$CLAUDE_PROJECT_DIR/.claude/lib/state-io.sh"
+source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-safety-paths.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/codex-gate.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/check-cr-threads.sh"
 source "$CLAUDE_PROJECT_DIR/.claude/lib/cleanup.sh"
@@ -270,28 +271,23 @@ flow_state_update progress '.phase = "P3"' "$SCOPE_KEY"
 - `Agent` ツール (subagent_type: `general-purpose` or `Explore`) を必要に応じて spawn
 - subagent への指示文に必ず以下を明示:
   - **TDD (Red → Green → Refactor) 必須**
-  - サーバ側 (`server/`) の変更は vitest テストを優先 (`server/lib/*.test.ts` パターン)
-  - フロントエンド (`client/`) の変更は新規 vitest テストの追加は不要、必要なら e2e (Playwright) を追加
-  - 共通型 (`shared/types.ts`) と Socket.IO ハンドラー (`server/index.ts`) は同時に更新する
+  - サーバ側 (`packages/server/`) の変更は vitest テストを優先 (`packages/server/src/lib/*.test.ts` パターン)
+  - フロントエンド (`packages/web/`) の変更は新規 vitest テストの追加は不要、必要なら e2e (Playwright) を追加
+  - 共通型 (`packages/shared/src/types.ts`) と Socket.IO ハンドラー (`packages/server/src/index.ts`) は同時に更新する
 
 ### 3-2. DB スキーマ変更検出
-ark の SQLite スキーマは `server/lib/database.ts` の `CREATE TABLE` 群で定義される。
+ark の SQLite スキーマは `packages/server/src/lib/database.ts` の `CREATE TABLE` 群で定義される。
 スキーマ変更 (テーブル追加・カラム追加・rename・削除) は人間レビュー必須。
 ```bash
-if git diff --name-only origin/main...HEAD -- 'server/lib/database.ts' | grep -q . \
-  && git diff origin/main...HEAD -- 'server/lib/database.ts' | grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)'; then
-  halt "DB スキーマ変更検出 (server/lib/database.ts、人間レビュー必須)"
+if flow_guard_db_schema_changed 'origin/main...HEAD'; then
+  halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)"
 fi
 ```
 
 ### 3-3. tmux/ttyd セッションライフサイクル変更検出
 セッション周りは安全装置の塊。SessionOrchestrator / TmuxManager / TtydManager のいずれかが変わったら warn:
 ```bash
-if git diff --name-only origin/main...HEAD \
-  -- 'server/lib/session-orchestrator.ts' 'server/lib/tmux-manager.ts' 'server/lib/ttyd-manager.ts' \
-  | grep -q .; then
-  flow_state_update progress '.warnings += ["tmux/ttyd セッションライフサイクル変更あり、再起動時の挙動を確認すること"]' "$SCOPE_KEY"
-fi
+flow_guard_warn_session_lifecycle_change "$SCOPE_KEY" 'origin/main...HEAD'
 ```
 
 ### 3-4. 遷移
@@ -307,8 +303,8 @@ flow_state_update progress '.phase = "P4"' "$SCOPE_KEY"
 
 | 変更対象 | コマンド (作業ディレクトリ: `$WORKTREE_PATH`) |
 |---|---|
-| `server/`, `client/`, `shared/` の `.ts` / `.tsx` | `pnpm check`  (= `biome check . && tsc --noEmit`) |
-| `server/lib/*.test.ts` 追加・変更時 | `pnpm exec vitest run` |
+| `packages/{server,shared,web,desktop}/` の `.ts` / `.tsx` | `pnpm check`  (= `biome check . && tsc --noEmit`) |
+| `packages/server/src/lib/*.test.ts` 追加・変更時 | `pnpm exec vitest run` |
 | `e2e/*.spec.ts` 追加・変更時 | `pnpm test:e2e` (実機が必要なため、CI で十分なら warn でスキップ可) |
 | `package.json` / `pnpm-lock.yaml` | `pnpm install --frozen-lockfile` で整合性確認 |
 
@@ -523,7 +519,7 @@ P12 では以下の判定で動作を分ける:
 
 | 条件 | 動作 |
 |---|---|
-| merge commit が `server/`, `client/`, `shared/`, `package.json`, `ecosystem.config.cjs`, `vite.config.ts` 等を含まない | **no-target finalize** (deploy 不要) |
+| merge commit が `packages/server/`, `packages/web/`, `packages/shared/`, `packages/desktop/`, `package.json`, `packages/server/ecosystem.config.cjs`, `packages/web/vite.config.ts` 等を含まない | **no-target finalize** (deploy 不要) |
 | `pm2 jlist` で `claude-code-ark` が `online` でない | **no-target finalize** (`pnpm dev` 想定、デプロイ不要) |
 | 上記以外 | **deploy 実行 + health 監視** (30 秒 × 5 = 最大 2.5 分) |
 

--- a/.claude/skills/flow/references/subagent-plan-prompt.md
+++ b/.claude/skills/flow/references/subagent-plan-prompt.md
@@ -38,10 +38,10 @@
 3. 関連ファイル・既存実装をコードベースから探索する。**必ず以下を確認**:
    - プロジェクト直下の `CLAUDE.md`
    - `.claude/rules/` 配下の関連ルール (backend-architecture / backend-testing / frontend-codegen / backend-migration)
-   - `shared/types.ts` (Socket.IO イベント型・共通型)
-   - `server/index.ts` (Express + Socket.IO ハンドラー)
-   - `server/lib/` の既存マネージャー (session-orchestrator / tmux-manager / ttyd-manager / database 等)
-   - frontend 変更時は `client/src/components/` `client/src/hooks/` の既存パターン
+   - `packages/shared/src/types.ts` (Socket.IO イベント型・共通型)
+   - `packages/server/src/index.ts` (Express + Socket.IO ハンドラー)
+   - `packages/server/src/lib/` の既存マネージャー (session-orchestrator / tmux-manager / ttyd-manager / database 等)
+   - frontend 変更時は `packages/web/src/components/` `packages/web/src/hooks/` の既存パターン
 4. superpowers:writing-plans 規約に従い、以下のヘッダー形式で plan を作成する:
 
    ```markdown
@@ -76,11 +76,11 @@
 
 ### ark 固有制約
 
-- **DB スキーマ変更**: `server/lib/database.ts` の SQLite テーブル定義を変更する場合は plan で明示。マイグレーションは `database.ts` の起動時 `CREATE TABLE IF NOT EXISTS` で対応するのが既存パターン
-- **Socket.IO イベント追加**: 必ず `shared/types.ts` の型と `server/index.ts` のハンドラー、`client/src/hooks/useSocket.ts` の購読を 3 点セットで更新する旨を plan に書く
+- **DB スキーマ変更**: `packages/server/src/lib/database.ts` の SQLite テーブル定義を変更する場合は plan で明示。マイグレーションは `database.ts` の起動時 `CREATE TABLE IF NOT EXISTS` で対応するのが既存パターン
+- **Socket.IO イベント追加**: 必ず `packages/shared/src/types.ts` の型と `packages/server/src/index.ts` のハンドラー、`packages/web/src/hooks/useSocket.ts` の購読を 3 点セットで更新する旨を plan に書く
 - **tmux/ttyd 関連**: セッションライフサイクル (start / stop / restart / restore) を変える場合、`SessionOrchestrator` への影響と再起動時の挙動を plan で言及
 - **モバイル対応**: 新しい UI を追加する場合、`MobileLayout` / `MobileSessionView` への対応有無を plan に記載
-- **テスト**: 既存の vitest テスト (`server/lib/*.test.ts`) と Playwright e2e (`e2e/`) のどちらでカバーするか plan に明示
+- **テスト**: 既存の vitest テスト (`packages/server/src/lib/*.test.ts`) と Playwright e2e (`e2e/`) のどちらでカバーするか plan に明示
 
 ### 制約
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ brew install cloudflared
 ### 関連ファイル
 
 ```
-server/lib/
+packages/server/src/lib/
 ├── tunnel.ts   # Cloudflare Tunnel管理（Quick / Named）
 ├── auth.ts     # トークン認証（Quick Tunnel用）
 └── qrcode.ts   # QRコード生成
@@ -262,53 +262,36 @@ server/lib/
 
 ```
 claude-code-ark/
-├── client/
-│   └── src/
-│       ├── components/
-│       │   ├── TerminalPane.tsx        # ttyd iframe + 入力バー（PC用）
-│       │   ├── MultiPaneLayout.tsx     # PC向けグリッドレイアウト
-│       │   ├── MobileLayout.tsx        # モバイル用ルートコンポーネント
-│       │   ├── MobileSessionList.tsx   # モバイル用セッション一覧
-│       │   ├── MobileSessionView.tsx   # モバイル用セッション詳細
-│       │   ├── SessionDashboard.tsx    # セッション管理ダッシュボード
-│       │   ├── RepoSelectDialog.tsx    # リポジトリ選択ダイアログ
-│       │   ├── CreateWorktreeDialog.tsx # Worktree作成ダイアログ
-│       │   ├── WorktreeContextMenu.tsx # Worktreeコンテキストメニュー
-│       │   ├── ProfileManagerDialog.tsx # プロファイル管理ダイアログ（Linux限定）
-│       │   ├── RepoProfileMenu.tsx     # リポジトリのプロファイル切替サブメニュー
-│       │   ├── ErrorBoundary.tsx       # エラーバウンダリ
-│       │   └── ui/                     # shadcn/ui コンポーネント群
-│       ├── hooks/
-│       │   ├── useSocket.ts            # Socket.IO通信（全イベント管理）
-│       │   ├── useVisualViewport.ts    # モバイルキーボード対応
-│       │   ├── useComposition.ts       # IME入力対応
-│       │   ├── useMobile.tsx           # モバイル判定
-│       │   └── usePersistFn.ts         # コールバック安定化
-│       └── pages/
-│           ├── Dashboard.tsx           # メインページ
-│           └── NotFound.tsx            # 404ページ
-├── server/
-│   ├── index.ts                        # Expressサーバー + Socket.IOハンドラー
-│   └── lib/
-│       ├── session-orchestrator.ts     # tmux + ttyd 統合管理
-│       ├── tmux-manager.ts             # tmuxセッション管理
-│       ├── ttyd-manager.ts             # ttyd Webターミナル管理
-│       ├── system.ts                   # 実行環境の機能判定（multiProfileSupported等）
-│       ├── database.ts                 # SQLite永続化
-│       ├── git.ts                      # Git worktree操作
-│       ├── tunnel.ts                   # Cloudflare Tunnel管理
-│       ├── auth.ts                     # トークン認証
-│       ├── qrcode.ts                   # QRコード生成
-│       ├── port-scanner.ts             # ポートスキャン
-│       ├── file-manager.ts             # ファイル管理
-│       ├── file-upload-manager.ts      # ファイルアップロード管理
-│       ├── constants.ts                # 定数定義
-│       └── errors.ts                   # エラーユーティリティ
-├── shared/
-│   └── types.ts                        # クライアント/サーバー共通型定義
+├── packages/
+│   ├── server/
+│   │   ├── src/
+│   │   │   ├── cli.ts
+│   │   │   ├── index.ts
+│   │   │   └── lib/
+│   │   │       ├── session-orchestrator.ts
+│   │   │       ├── tmux-manager.ts
+│   │   │       ├── ttyd-manager.ts
+│   │   │       └── database.ts
+│   │   ├── build.mjs
+│   │   └── ecosystem.config.cjs
+│   ├── shared/
+│   │   └── src/
+│   │       ├── types.ts
+│   │       └── file-paths.ts
+│   ├── web/
+│   │   └── src/
+│   │       ├── components/
+│   │       ├── hooks/
+│   │       └── pages/
+│   └── desktop/
+│       ├── src/
+│       │   ├── main.ts
+│       │   └── preload.ts
+│       └── electron-builder.yml
 ├── data/
-│   └── sessions.db                     # SQLiteデータベース（自動生成）
-└── package.json
+│   └── sessions.db
+├── package.json
+└── pnpm-workspace.yaml
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ packages/server/src/lib/
 ```
 claude-code-ark/
 ├── packages/
-│   ├── ./server/
+│   ├── server/
 │   │   ├── src/
 │   │   │   ├── cli.ts
 │   │   │   ├── index.ts
@@ -274,7 +274,7 @@ claude-code-ark/
 │   │   │       └── database.ts
 │   │   ├── build.mjs
 │   │   └── ecosystem.config.cjs
-│   ├── ./shared/
+│   ├── shared/
 │   │   └── src/
 │   │       ├── types.ts
 │   │       └── file-paths.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,7 @@ packages/server/src/lib/
 ```
 claude-code-ark/
 ├── packages/
-│   ├── server/
+│   ├── ./server/
 │   │   ├── src/
 │   │   │   ├── cli.ts
 │   │   │   ├── index.ts
@@ -274,7 +274,7 @@ claude-code-ark/
 │   │   │       └── database.ts
 │   │   ├── build.mjs
 │   │   └── ecosystem.config.cjs
-│   ├── shared/
+│   ├── ./shared/
 │   │   └── src/
 │   │       ├── types.ts
 │   │       └── file-paths.ts

--- a/docs/superpowers/plans/2026-08-19-issue-338.md
+++ b/docs/superpowers/plans/2026-08-19-issue-338.md
@@ -1,0 +1,187 @@
+# issue-338: ハーネスのパス参照を monorepo 構成へ追随させる Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** monorepo 移行後の実在パスを flow / flow-x の安全ガードと開発規約へ反映し、将来パスが移動しても CI とダミー diff テストが偽陰性を検出する状態にする。
+
+**Issue:** 338 (GitHub Issue 紐付けあり)
+
+**Architecture:** DB スキーマと tmux/ttyd ライフサイクルの監視対象を `.claude/lib/flow-safety-paths.sh` の配列へ一元化する。共有 lib は副作用のない DB 変更述語と halt メッセージ生成、および実在する `flow_state_update` を使う session warning に責務を限定する。flow / flow-x は同じ lib を source し、DB 述語が真の場合のオーケストレータ向け `halt` は SKILL.md 側で実行する。実在パスの assert、スキーマ変更を含む一時 Git リポジトリによる halt 条件、negative case、セッションファイル変更時の warn を bash テストで固定し、ルートの `pnpm test` から実行して CI で drift を fail させる。P3 の phase 構造・遷移・halt/warn 条件は変えず、`.claude/hooks/`、settings ファイル、`packages/` 配下は変更しない。
+
+**Tech Stack:** bash lib / bash test / Markdown 規約ファイル
+
+---
+
+## Task 1: 安全ガードの回帰テストを Red で追加する（4分）
+
+**Files:**
+- Create: `.claude/lib/tests/test-flow-safety-paths.sh`
+- Reference: `.claude/lib/tests/test-flow-state-dir.sh:1-78,208-237`
+- Reference: `.claude/lib/deploy-watch.sh:43-63`
+
+- [ ] `.claude/lib/tests/test-flow-safety-paths.sh` を、既存テストと同じ `set -uo pipefail`、`TESTS` / `PASSES` / `FAILURES`、`assert_eq` / `assert_success`、終了時サマリーの形式で作る。`SCRIPT_DIR` から `PROJECT_DIR=$(cd "$SCRIPT_DIR/../../.." && pwd)` を解決し、対象 lib が未作成なら `FAIL: flow-safety-paths.sh が存在しない` と終了する。
+- [ ] lib を source 後、`FLOW_GUARD_DB_SCHEMA_PATHS` が `packages/server/src/lib/database.ts` の 1 件、`FLOW_GUARD_SESSION_LIFECYCLE_PATHS` が次の 3 件であることを配列の件数と値の両方で assert する。
+
+```text
+packages/server/src/lib/session-orchestrator.ts
+packages/server/src/lib/tmux-manager.ts
+packages/server/src/lib/ttyd-manager.ts
+```
+
+- [ ] 2 配列の全要素について `[ -f "$PROJECT_DIR/$guard_path" ]` を assert し、monorepo の移動・削除時にテストが必ず失敗する契約を作る。
+- [ ] `mktemp -d` と `trap` で一時 Git リポジトリを作り、上記 4 ファイルと無関係な `README.md` を baseline commit に含める。一時リポジトリの作成直後に `git -C "$tmp" config user.email harness-test@example.invalid` と `git -C "$tmp" config user.name 'harness test'` を設定し、baseline と各ケースの全 commit が global / system の Git identity に依存しないようにする。baseline SHA を `refs/remotes/origin/main` に設定し、テスト終了時に一時ディレクトリを削除する。
+- [ ] baseline から `packages/server/src/lib/database.ts` に `ALTER TABLE sessions ADD COLUMN archived INTEGER;` を加えた commit を作る。`flow_guard_db_schema_changed 'origin/main...HEAD'` が 0 を返すことと、`flow_guard_db_schema_halt_message` が `DB スキーマ変更検出 (packages/server/src/lib/database.ts、人間レビュー必須)` を stdout に出すことを assert する。実在しないシェル関数を検証する `halt()` stub や exit code 97 は使わない。
+- [ ] baseline から分岐した別ケースで、(1) `README.md` に `CREATE TABLE ignored` を書いた diff、(2) `database.ts` に SQL キーワードを含まないコメントだけを書いた diff、の双方で `flow_guard_db_schema_changed` が非 0 を返すことを assert する。これにより「対象パス」と「スキーマ語句」の AND 条件、および SKILL.md 側で halt しない条件を固定する。
+- [ ] baseline から `packages/server/src/lib/tmux-manager.ts` だけを変更した commit を作り、stub の `flow_state_update` が `progress`、`.warnings += ["tmux/ttyd セッションライフサイクル変更あり、再起動時の挙動を確認すること"]`、テスト用 scope key の 3 引数で 1 回呼ばれることを assert する。無関係なファイルだけの diff では呼ばれないことも assert する。
+- [ ] `bash .claude/lib/tests/test-flow-safety-paths.sh` を実行し、lib 未作成による Red（非 0 終了と上記 missing メッセージ）を確認する。この時点ではテストを弱めたり skip したりしない。
+- [ ] Task 1 の完了条件として、一時リポジトリ内の全 commit に repository-local の test identity が設定され、CI 実行者の global / system `user.email`・`user.name` が未設定でも同じテストが成立することを確認する。
+
+## Task 2: 監視パスと既存 gate ロジックを共有 lib へ切り出す（5分）
+
+**Files:**
+- Create: `.claude/lib/flow-safety-paths.sh`
+- Test: `.claude/lib/tests/test-flow-safety-paths.sh`
+- Reference: `.claude/lib/state-io.sh`
+
+- [ ] `.claude/lib/flow-safety-paths.sh` に次の公開配列を定義する。glob ではなく、Git pathspec と実在チェックの双方で使える repository-relative な完全パスを保持する。
+
+```bash
+FLOW_GUARD_DB_SCHEMA_PATHS=(
+  "packages/server/src/lib/database.ts"
+)
+
+FLOW_GUARD_SESSION_LIFECYCLE_PATHS=(
+  "packages/server/src/lib/session-orchestrator.ts"
+  "packages/server/src/lib/tmux-manager.ts"
+  "packages/server/src/lib/ttyd-manager.ts"
+)
+```
+
+- [ ] `flow_guard_db_schema_changed <diff-range>` を追加し、既存 P3-2 と同じく、対象配列に `git diff --name-only` の結果があり、かつ同じ diff が `(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)` に一致する場合だけ 0 を返す。既定 range は `origin/main...HEAD` とする。
+- [ ] `flow_guard_db_schema_halt_message` を追加し、`DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)` という文字列を stdout に出すだけにする。共有 lib は述語とメッセージ生成に徹し、シェル関数として実在しない `halt` を呼ぶ `flow_guard_check_db_schema_change` のようなラッパーは作らない。
+- [ ] `flow_guard_session_lifecycle_changed <diff-range>` を追加し、対象 3 パスのいずれかが `git diff --name-only` に現れた場合だけ 0 を返す。`flow_guard_warn_session_lifecycle_change <scope-key> <diff-range>` は真の場合だけ既存の warning JSON を `flow_state_update progress ... "$scope_key"` へ渡す。`flow_state_update` は `.claude/lib/state-io.sh` に実在する関数であり、この warning ラッパーは呼び出し側が先に `state-io.sh` を source することへ依存する、と依存契約をコメントで明記する。
+- [ ] 配列展開、`local` 変数名、source 時のパス解決を bash 3.2 / zsh 共通の記法に限定する。`BASH_SOURCE` による self-location、zsh 特殊変数 `path` / `status`、未引用の配列展開に加え、bash 4 以降専用の `mapfile` / `readarray`、`declare -A`、`${var^^}` / `${var,,}`、`&>>` は使わない。通常の indexed 配列、`${#arr[@]}`、`${arr[@]}`、`$(...)` の範囲で実装する。
+- [ ] `/bin/bash .claude/lib/tests/test-flow-safety-paths.sh` を再実行し、実在パス、dummy schema diff で述語が 0、halt メッセージ、negative case で述語が非 0、session warn がすべて Green になることを確認する。macOS CI の `/bin/bash` 3.2 で解釈・実行できることを完了条件とする。
+- [ ] `zsh -c 'source .claude/lib/flow-safety-paths.sh; print -r -- ${FLOW_GUARD_DB_SCHEMA_PATHS[1]}'` をテストにも追加し、出力が `packages/server/src/lib/database.ts` になることを確認する。
+- [ ] Task 2 の完了条件として、同じ lib と test が bash 3.2 と zsh の両方で動作し、DB 関数は `halt` コマンドや状態更新を一切実行しないことを確認する。
+
+## Task 3: flow / flow-x を共有安全ガードへ接続する（5分）
+
+**Files:**
+- Modify: `.claude/skills/flow/SKILL.md:60-64,273-291,310-311,526`
+- Modify: `.claude/skills/flow-x/SKILL.md:196-200,446,554-585,596,612-613,836`
+- Modify: `.claude/lib/tests/test-flow-safety-paths.sh`
+
+- [ ] flow の STEP 0 source 群（60-64 行）と flow-x の STEP 0 source 群（196-200 行）に `source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-safety-paths.sh"` を追加する。既存 source、`flow_state_dir_init`、phase 初期化の順序は維持する。
+- [ ] flow の P3-2（277-284 行）と flow-x の P3-2（573-579 行）の説明を `packages/server/src/lib/database.ts` に直し、inline の `git diff` 条件を次の形へ置き換える。`halt` はシェル関数ではなくオーケストレータへの停止指示なので SKILL.md 側に残し、判定条件と人間レビュー必須という扱いは変えない。
+
+```bash
+if flow_guard_db_schema_changed 'origin/main...HEAD'; then
+  halt "DB スキーマ変更検出 (${FLOW_GUARD_DB_SCHEMA_PATHS[*]}、人間レビュー必須)"
+fi
+```
+
+- [ ] flow の P3-3（287-294 行）と flow-x の P3-3（582-588 行）の inline pathspec を `flow_guard_warn_session_lifecycle_change "$SCOPE_KEY" 'origin/main...HEAD'` へ置き換える。warning の文言、追記先、P4 への遷移は変えない。
+- [ ] 同じ 2 ファイル内の説明用旧パスも現構成へ直す。flow は 273-275 行を `packages/server/src/lib/*.test.ts`、`packages/web/`、`packages/shared/src/types.ts`、`packages/server/src/index.ts` に、310-311 行を `packages/{server,shared,web,desktop}/` と server test の実パスに、526 行の deploy 対象例を `packages/server/`、`packages/web/`、`packages/shared/`、`packages/desktop/`、`packages/server/ecosystem.config.cjs`、`packages/web/vite.config.ts` にする。flow-x は 446、554-555、596、612-613、836 行を同じ正解パスへ直す。
+- [ ] 回帰テストへ、flow と flow-x の両方が共有 lib を source し、DB 述語と session warn の各関数を 1 回ずつ呼ぶこと、および DB 述語が真の branch に上記 `halt` メッセージがあることの静的 assert を追加する。また両 SKILL の P3-2 / P3-3 に `server/lib/database.ts` や `server/lib/{session-orchestrator,tmux-manager,ttyd-manager}.ts` の inline pathspec が残っていないことを assert する。
+- [ ] `bash .claude/lib/tests/test-flow-safety-paths.sh` を実行し、共有 lib の動的テストと両 SKILL の接続監査が Green になることを確認する。P3 の見出し番号、P3-4 以降の手順、phase 更新には差分がないことを `git diff -- .claude/skills/flow/SKILL.md .claude/skills/flow-x/SKILL.md` で確認する。
+
+## Task 4: `.claude/rules` の適用 paths と本文を monorepo 化する（4分）
+
+**Files:**
+- Modify: `.claude/rules/backend-architecture.md:3,11-23,41,68,74`
+- Modify: `.claude/rules/backend-migration.md:3,12`
+- Modify: `.claude/rules/backend-testing.md:3-4,19`
+- Modify: `.claude/rules/frontend-codegen.md:3,17-20,32-33`
+
+- [ ] `backend-architecture.md` の frontmatter を `paths: ["packages/server/**"]` 相当に直し、ディレクトリ図の root を `packages/server/src/`、entrypoint を `index.ts`、manager 群を `lib/` 配下として記載する。`ManagedSession` と Socket.IO 型の 41、68、74 行はすべて `packages/shared/src/types.ts` に直す。
+- [ ] `backend-migration.md` の対象を `packages/server/src/lib/database.ts` と `data/**` にし、12 行のスキーマ定義説明も同じ完全パスへ直す。
+- [ ] `backend-testing.md` の frontmatter を `packages/server/**` と `packages/shared/**` にし、19 行の unit test 配置を `packages/server/src/lib/` に直す。
+- [ ] `frontend-codegen.md` の frontmatter を `packages/web/**` にし、17-20 行を `packages/web/src/components/`、`packages/web/src/components/ui/`、`packages/web/src/pages/`、`packages/web/src/hooks/` に直す。32-33 行の共通型は `packages/shared/src/types.ts` にする。
+- [ ] `sed -n '1,25p'` で 4 ファイルの frontmatter と本文先頭を再読し、実在する package へ規約が紐付いたことを確認する。
+
+## Task 5: grep で発見した補助ハーネスの旧パスを解消する（5分）
+
+**Files:**
+- Modify: `.claude/skills/flow/references/subagent-plan-prompt.md:41-44,79-80,83`
+- Modify: `.claude/skills/flow-x/references/subagent-plan-prompt.md:45-48,83-84,87`
+- Modify: `.claude/skills/db-connect/SKILL.md:29`
+- Modify: `.claude/skills/flow-loop/SKILL.md:69`
+- Modify: `.claude/scripts/garbage-collect.sh:8,19-31,42-54,66-70,88-92`
+
+- [ ] flow と flow-x の plan prompt で、共通型を `packages/shared/src/types.ts`、サーバ entrypoint を `packages/server/src/index.ts`、manager/test を `packages/server/src/lib/`、frontend を `packages/web/src/{components,hooks}/` に直す。DB / Socket.IO の制約記述も同じ完全パスへ揃える。
+- [ ] `db-connect/SKILL.md` 29 行と `flow-loop/SKILL.md` 69 行の DB 参照を `packages/server/src/lib/database.ts` に直す。flow-loop の `loop-exclude` 運用説明そのものは変更せず、この実装から GitHub ラベル操作は行わない。
+- [ ] `garbage-collect.sh` の project-root 判定を `packages/server/src` と `packages/web/src` の存在確認に変える。server の探索・参照検索・jscpd 対象を `packages/server/src/lib` / `packages/server/src`、frontend の探索・参照検索・jscpd 対象を `packages/web/src` に変え、表示ラベルも `client` ではなく `web` に揃える。
+- [ ] `bash -n .claude/scripts/garbage-collect.sh` と `zsh -n .claude/scripts/garbage-collect.sh` を実行し、パス修正で shell 構文を壊していないことを確認する。実ファイルの削除判定や削除処理は実行しない。
+
+## Task 6: `CLAUDE.md` の構造説明を現行 packages に合わせる（4分）
+
+**Files:**
+- Modify: `CLAUDE.md:237-240,261-312`
+
+- [ ] リモートアクセスの関連ファイル（237-240 行）を `packages/server/src/lib/` 配下の `tunnel.ts`、`auth.ts`、`qrcode.ts` として記載する。
+- [ ] ディレクトリ構造節（261-312 行）を次の骨格へ置き換える。列挙するファイルは実在確認済みのものに限定し、旧 `client/`、`server/`、`shared/` を top-level として記載しない。
+
+```text
+claude-code-ark/
+├── packages/
+│   ├── server/
+│   │   ├── src/
+│   │   │   ├── cli.ts
+│   │   │   ├── index.ts
+│   │   │   └── lib/
+│   │   │       ├── session-orchestrator.ts
+│   │   │       ├── tmux-manager.ts
+│   │   │       ├── ttyd-manager.ts
+│   │   │       └── database.ts
+│   │   ├── build.mjs
+│   │   └── ecosystem.config.cjs
+│   ├── shared/
+│   │   └── src/
+│   │       ├── types.ts
+│   │       └── file-paths.ts
+│   ├── web/
+│   │   └── src/
+│   │       ├── components/
+│   │       ├── hooks/
+│   │       └── pages/
+│   └── desktop/
+│       ├── src/
+│       │   ├── main.ts
+│       │   └── preload.ts
+│       └── electron-builder.yml
+├── data/
+│   └── sessions.db
+├── package.json
+└── pnpm-workspace.yaml
+```
+
+- [ ] `find packages -maxdepth 3 -type f` の結果と更新後の図を照合し、図に存在しないパスや旧 top-level package が残っていないことを確認する。
+
+## Task 7: 回帰テストを CI に接続し、全スコープを検証する（5分）
+
+**Files:**
+- Modify: `package.json:24`
+- Test: `.claude/lib/tests/test-flow-safety-paths.sh`
+- Verify: `.github/workflows/ci.yml:25-29`
+
+- [ ] root `package.json` の scripts に `"test:harness": "/bin/bash .claude/lib/tests/test-flow-safety-paths.sh"` を追加し、既存 `test` を `"test": "vitest run && pnpm test:harness"` にする。既存 CI は macOS runner の 29 行で `pnpm test` を実行済みなので workflow 自体は変更せず、新しい path-existence / dummy-diff テストを PR ごとに `/bin/bash` で必ず通す。
+- [ ] `pnpm test:harness` を実行し、実在する 4 パス、DB schema dummy diff での述語 0 と halt メッセージ、2 つの negative case での述語非 0、session lifecycle warn、flow / flow-x の共有 lib 接続と halt branch、zsh source の全 assert が pass することを確認する。テストと lib に bash 4 以降専用記法がなく、macOS CI の bash 3.2 と zsh の両方で動くことを完了条件に含める。
+- [ ] `pnpm test` を実行し、既存 Vitest と harness test が連続して成功することを確認する。続けて `pnpm check` を実行し、root scripts と Markdown / shell 変更を含むリポジトリ検証が成功することを確認する。
+- [ ] root `package.json` は `.claude/lib/deploy-watch.sh` の `_DEPLOY_WATCH_PATHS` に含まれるため、この PR のマージ後は P12 で実際の pm2 deploy が走ることを実装時の注意と完了条件に明記する。ハーネスのみの意図でも P12 の no-target は期待しない。
+- [ ] 指定された網羅監査を実行し、出力が 0 件であることを確認する。該当が出た場合は、生成物や履歴ではなく `.claude/` / `CLAUDE.md` の実参照なら本 Issue 内で正しい `packages/...` へ直す。
+
+```bash
+if grep -rn -E '(^|[^/a-zA-Z._-])(server|client|shared)/' .claude/ CLAUDE.md; then
+  echo "旧 top-level path が残っています" >&2
+  exit 1
+fi
+```
+
+- [ ] `git diff --check` を実行する。次に `git diff --name-only origin/main...HEAD` を確認し、変更がこの plan、`.claude/lib/flow-safety-paths.sh`、その test、列挙済み Markdown / script、`CLAUDE.md`、root `package.json` に限定されていることを確認する。
+- [ ] 次の禁止スコープ監査が無出力になることを確認する。`.claude/hooks/`、settings、`packages/` のいずれかが出た場合は実装完了にせず、その差分を本 Issue の成果物から除外する。
+
+```bash
+git diff --name-only origin/main...HEAD \
+  | grep -E '^(\.claude/hooks/|\.claude/settings\.json$|\.claude/settings\.local\.json$|packages/)' || true
+```

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "preview": "pnpm --filter @ark/web preview",
     "test:e2e": "playwright test",
     "check": "biome check . && tsc -b",
-    "test": "vitest run",
+    "test": "vitest run && pnpm test:harness",
+    "test:harness": "/bin/bash .claude/lib/tests/test-flow-safety-paths.sh",
     "format": "biome check --write .",
     "lint": "biome lint ."
   },


### PR DESCRIPTION
monorepo 移行（`packages/{server,web,shared,desktop}`）にハーネスのパス参照が追随しておらず、**flow / flow-x の DB スキーマ変更検出ガードが常に偽陰性**になっていた。ガードを「読まれる文書」から「落ちるテスト」に変え、再発を CI で検出できるようにする。

Closes #338

## 何が壊れていたか

`.claude/skills/flow-x/SKILL.md` の P3-2 は `server/lib/database.ts` を見ていたが、実体は `packages/server/src/lib/database.ts`。存在しないパスなので `git diff --name-only` は常に空を返し、**「DB スキーマ変更なし」と判定され続けていた**。

DB スキーマ変更は SKILL.md 上「人間レビュー必須スコープ」で halt 対象。その安全弁が無言で外れていた。PR #337 の run でもこのチェックは偽陰性で通過している。

同じ drift が `.claude/rules/*.md` の `paths:` にもあり、4 本すべてが現構成に一致しないため**規約が実質的に適用されていなかった**。

## 変更内容

### 1. ガード対象パスを共有 lib へ切り出す

`.claude/lib/flow-safety-paths.sh`（新規）に配列と判定ロジックを一元化し、flow / flow-x は source して使う。`.claude/lib/deploy-watch.sh` の `_DEPLOY_WATCH_PATHS`（移行済み）と同じ形。

述語は **3 値**を返す。

| rc | 意味 | flow / flow-x の動作 |
| --- | --- | --- |
| 0 | 変更を検出 | halt（人間レビュー必須） |
| 1 | 変更なし | 継続 |
| 2 | **評価不能**（`git diff` 失敗） | halt（判定に失敗した旨） |

`halt` はシェル関数ではなくオーケストレータへの停止指示なので、lib は述語とメッセージ生成に徹し、`halt` の記述は SKILL.md 側に残している。

### 2. 再発を CI で検出する

`.claude/lib/tests/test-flow-safety-paths.sh`（新規、48 assert）を `pnpm test` 経由で CI に接続した。

- **ガード対象 4 パスの実在を assert** — パスが移動・削除された瞬間に PR が赤くなる
- 一時 Git リポジトリでダミーのスキーマ変更 diff を作り、実際に検出されることを検証
- negative case 2 種（無関係ファイルに `CREATE TABLE` の文字列 / `database.ts` にコメントのみ）で「対象パス AND スキーマ語句」の条件を固定
- 評価不能ケースで rc=2 になることを検証
- 両 SKILL.md に旧 pathspec が残っていないこと、exit 2 の分岐があることを静的 assert

### 3. 旧パス参照の一掃

`.claude/rules/*.md`（4 本）、`flow` / `flow-x` の SKILL.md と plan prompt、`db-connect`、`flow-loop`、`garbage-collect.sh`、`CLAUDE.md` のディレクトリ構造。網羅監査 `grep -rE '(^|[^/a-zA-Z._-])(server|client|shared)/' .claude/ CLAUDE.md` が **0 件**になることを完了条件にした。

## 検証

一時リポジトリを作って実際の挙動を確認した。

| ケース | rc | 判定 |
| --- | --- | --- |
| `database.ts` に `ALTER TABLE` | 0 | 検出 → halt |
| 無関係な `README.md` に `CREATE TABLE` | 1 | 非検出 |
| 不正な diff range | 2 | 評価不能 → halt |
| 変更なし | 1 | 非検出 |

**修正前は 1 番目のケースが常に「変更なし」だった。**

- `pnpm test:harness` 48/48 pass（`/bin/bash` と zsh の両方）
- `pnpm test` exit 0（vitest 1097 + harness 48）
- `pnpm check` exit 0。warning 47 件・info 1 件は **main と同数**で既存分
- 旧 top-level path の残存 0 件
- `.claude/hooks/` / settings / `packages/` への変更なし

## 設計上の判断

**fail-closed にした。** レビュー中、`git diff` が失敗したときに `|| return 1`（= 変更なし）で素通りする実装になっていたため 3 値化した。原因が「存在しないパス」でも「git の失敗」でも、結果が「安全弁が黙って外れる」なら同じ欠陥だと判断した。

**CI は macOS。** `runs-on: macos-latest` で `/bin/bash` は 3.2 なので、`mapfile` / `declare -A` / `${var^^}` 等の bash 4 以降専用記法は使っていない。テストの一時リポジトリには repository-local の git identity を設定しており、CI に global identity が無くても動く。

## 備考

`package.json` を変更しているため（`test` に `test:harness` を連結）、**マージ後の P12 で実際に pm2 deploy が走る**。`.claude/lib/deploy-watch.sh` の `_DEPLOY_WATCH_PATHS` に `package.json` が含まれるため。ハーネスのみの変更だが no-target にはならない。

`.claude/` 配下のハーネス自改修にあたるため `loop-exclude` を付与している。ハーネスの別種の不具合（codex stdin ハング、`mise trust`、ガードの誤検知、push マーカー未検出）は #340 で扱う。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - データベーススキーマ変更とセッションライフサイクル変更を検出する安全チェックを追加しました。
  - 重要な変更の検出時に警告・停止メッセージを表示し、判定不能な場合も安全側に処理します。

- **改善**
  - モノレポ構成に合わせ、開発ルールや各種参照先を更新しました。
  - テスト実行時に安全チェックの回帰テストも自動実行されるようになりました。

- **ドキュメント**
  - プロジェクト構成、データベース、フロントエンド、テストに関する案内を現行構成へ更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->