### PR TITLE
fix(harness): flow-x の正規手順を止めるガード誤検知と codex 起動の摩擦を解消する (#340)

### DIFF
--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -330,7 +330,8 @@ elif ! $IS_PR_COMMENT && [[ "$COMMAND" =~ /replies.sh ]]; then
   IS_PR_COMMENT=true
 fi
 if $IS_PR_COMMENT; then
-  # push完了マーカーの確認（60秒以内に作成されたものが必要）
+  # push完了マーカーの repository + HEAD identity を確認する。
+  # 時刻ではなく、現在の project worktree 群に属する同一 commit かで判定する。
   PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
   HOOK_INPUT_CWD=$(echo "$STDIN_INPUT" | jq -r '.cwd // ""' 2>/dev/null) || HOOK_INPUT_CWD=""
   HOOK_CWD=$(pwd -P)
@@ -341,23 +342,14 @@ if $IS_PR_COMMENT; then
     echo "  FIX: 先にgit pushを実行してください" >&2
     exit 2
   fi
-  # GNU stat (-c) と BSD stat (-f) の両方に対応。両方失敗時は明示的にブロック
-  MARKER_MTIME=$(stat -c %Y "$MARKER" 2>/dev/null || stat -f %m "$MARKER" 2>/dev/null) || {
-    echo "BLOCKED: pushマーカーの読み取りに失敗しました" >&2
-    echo "  WHY: マーカーファイルが削除された可能性がある" >&2
-    echo "  FIX: git pushを再実行してください" >&2
-    exit 2
-  }
-  MARKER_AGE=$(( $(date +%s) - MARKER_MTIME ))
-  if [ "$MARKER_AGE" -gt 60 ]; then
-    echo "BLOCKED: pushマーカーが古くなっています（${MARKER_AGE}秒前、有効期限60秒）" >&2
-    echo "  WHY: 古いpushの後に新しい変更がある可能性がある" >&2
-    echo "  FIX: 最新の変更をgit pushしてから返信してください" >&2
-    exit 2
-  fi
-  # push時のcommit SHAと現在のHEADが一致するか検証（バックグラウンドpush対策）
   MARKER_HEAD=$(head -1 "$MARKER" 2>/dev/null) || MARKER_HEAD=""
   MARKER_REPO_DIR=$(sed -n '2p' "$MARKER" 2>/dev/null) || MARKER_REPO_DIR=""
+  if [ -z "$MARKER_HEAD" ]; then
+    echo "BLOCKED: pushマーカーのcommit SHAが空です" >&2
+    echo "  WHY: push完了を示すcommit identityを確認できない" >&2
+    echo "  FIX: 対象リポジトリでgit pushを再実行してください" >&2
+    exit 2
+  fi
   if [ -n "$MARKER_REPO_DIR" ]; then
     TARGET_REPO_DIR="$MARKER_REPO_DIR"
   else
@@ -368,6 +360,19 @@ if $IS_PR_COMMENT; then
     echo "BLOCKED: pushしたリポジトリのHEADを確認できません" >&2
     echo "  WHY: 照合対象のディレクトリが存在しないか、Gitリポジトリではない" >&2
     echo "  FIX: 対象リポジトリでgit pushを再実行してください" >&2
+    exit 2
+  fi
+  if ! TARGET_COMMON_DIR=$(git -C "$TARGET_REPO_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || \
+     ! PROJECT_COMMON_DIR=$(git -C "$PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+    echo "BLOCKED: pushしたリポジトリのgit common dirを確認できません" >&2
+    echo "  WHY: marker または現在のprojectが有効なGitリポジトリではない" >&2
+    echo "  FIX: 現在のprojectのworktreeでgit pushを再実行してください" >&2
+    exit 2
+  fi
+  if [ "$TARGET_COMMON_DIR" != "$PROJECT_COMMON_DIR" ]; then
+    echo "BLOCKED: pushマーカーが別のリポジトリを指しています" >&2
+    echo "  WHY: markerのrepositoryが現在のprojectのworktreeツリーに属していない" >&2
+    echo "  FIX: 現在のprojectの対象worktreeでgit pushを再実行してください" >&2
     exit 2
   fi
   if [ "$MARKER_HEAD" != "$CURRENT_HEAD" ]; then

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -7,6 +7,21 @@ set -eo pipefail
 # stdinからツール入力JSONを読み取り、コマンドを抽出（パース失敗時はスキップ）
 STDIN_INPUT=$(cat)
 COMMAND=$(echo "$STDIN_INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null) || exit 0
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=./push-marker-utils.sh
+source "$SCRIPT_DIR/push-marker-utils.sh"
+
+# --- actual git commit / push の hook bypass だけを拒否する ---
+if push_marker_detect_hook_bypass "$COMMAND"; then
+  if [ "$PUSH_MARKER_BYPASS_FLAG" = "-n" ]; then
+    echo "BLOCKED: -n（--no-verify短縮形）によるgit hookのバイパスは禁止されています" >&2
+  else
+    echo "BLOCKED: --no-verify によるgit hookのバイパスは禁止されています" >&2
+  fi
+  echo "  WHY: pre-bash-guard の品質ゲート、または flow P4/P5 のローカル検証がスキップされ、CI で失敗するコードが送信される" >&2
+  echo "  FIX: 失敗の根本原因を修正してから commit / push してください" >&2
+  exit 2
+fi
 
 # --- git commit / git tag はメッセージ内容を検査しない（誤検出防止） ---
 if [[ "$COMMAND" =~ ^[[:space:]]*git[[:space:]]+(commit|tag)[[:space:]] ]]; then
@@ -96,28 +111,6 @@ if [[ "$COMMAND" =~ git[[:space:]]+(.+[[:space:]]+)?push[[:space:]]+.*--force ]]
     echo "BLOCKED: git push --force は危険なコマンドです" >&2
     echo "  WHY: リモートの他の人のコミットを上書きし、チームの作業が失われる" >&2
     echo "  FIX: --force-with-lease を使用（リモートが変更されていない場合のみ上書き）" >&2
-    exit 2
-  fi
-fi
-
-# --no-verify: git hooksのバイパスを禁止（エージェントが品質チェックをスキップするのを防ぐ）
-# git push --no-verify もpre-pushフックをバイパスするためブロック対象
-if [[ "$COMMAND" =~ git[[:space:]]+.+--no-verify ]]; then
-  echo "BLOCKED: --no-verify によるgit hookのバイパスは禁止されています" >&2
-  echo "  WHY: pre-bash-guard の biome check / tsc --noEmit ゲート、または flow P4/P5 のローカル検証がスキップされ、CI で失敗するコードが push される" >&2
-  echo "  FIX: 失敗の根本原因 (型エラー / lint 違反 / テスト失敗) を修正してから push" >&2
-  exit 2
-fi
-
-# -n フラグ: git commit -n は --no-verify の短縮形なのでブロック
-# ただし git push -n はdry-runなので許可
-if [[ "$COMMAND" =~ git[[:space:]]+.+-n([[:space:]]|$) ]]; then
-  if [[ "$COMMAND" =~ git[[:space:]]+push ]] || [[ "$COMMAND" =~ git[[:space:]]+.*push ]]; then
-    : # git push -n はdry-run、許可
-  else
-    echo "BLOCKED: -n（--no-verify短縮形）によるgit hookのバイパスは禁止されています" >&2
-    echo "  WHY: pre-bash-guard の biome check / tsc --noEmit ゲート、または flow P4/P5 のローカル検証がスキップされ、CI で失敗するコードが push される" >&2
-    echo "  FIX: 失敗の根本原因 (型エラー / lint 違反 / テスト失敗) を修正してからコミット" >&2
     exit 2
   fi
 fi
@@ -269,9 +262,6 @@ if $IS_PR_COMMENT; then
   PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
   HOOK_INPUT_CWD=$(echo "$STDIN_INPUT" | jq -r '.cwd // ""' 2>/dev/null) || HOOK_INPUT_CWD=""
   HOOK_CWD=$(pwd -P)
-  SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-  # shellcheck source=./push-marker-utils.sh
-  source "$SCRIPT_DIR/push-marker-utils.sh"
   MARKER="$PROJECT_DIR/.claude/push-completed.marker"
   if [ ! -f "$MARKER" ]; then
     echo "BLOCKED: push完了前にCodeRabbit返信はできません" >&2

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -31,26 +31,98 @@ fi
 
 
 # --- pre-push-reviewフラグファイル作成のガード ---
-# コマンド文字列にフラグ名が含まれていれば検査
-# スキルの正規パターンのみ許可、それ以外は全てブロック
-if [[ "$COMMAND" =~ claude-pre-push-review-done ]]; then
-  # スキルの厳密なパターン: touch "$(git rev-parse --git-dir)/claude-pre-push-review-done"
-  # 5条件全て満たす場合のみ許可:
-  # (1) touchで始まる (2) git rev-parseを含む (3) コマンド連結(;|&)なし
-  # (4) コメント(#)なし (5) リダイレクト(>)なし (6) 改行なし
-  if [[ "$COMMAND" =~ ^[[:space:]]*touch[[:space:]] ]] && \
-     [[ "$COMMAND" =~ git[[:space:]]+rev-parse[[:space:]]+--git-dir ]] && \
-     ! [[ "$COMMAND" =~ [\;\|\&] ]] && \
-     ! [[ "$COMMAND" =~ \# ]] && \
-     ! [[ "$COMMAND" =~ \> ]] && \
-     ! [[ "$COMMAND" =~ $'\n' ]]; then
-    exit 0
+_review_flag_token_is_target() {
+  case "$1" in
+    claude-pre-push-review-done|*/claude-pre-push-review-done) return 0 ;;
+  esac
+  return 1
+}
+
+_review_flag_is_canonical_touch_segment() {
+  local segment target inner subcommand_index
+
+  segment="$(_push_marker_trim "$1")"
+  _push_marker_tokenize_segment "$segment" || return 1
+  [ "${#PUSH_MARKER_TOKENS[@]}" -eq 2 ] || return 1
+  [ "${PUSH_MARKER_TOKENS[0]}" = "touch" ] || return 1
+  target="${PUSH_MARKER_TOKENS[1]}"
+  case "$target" in
+    \$\(*\)/claude-pre-push-review-done) ;;
+    *) return 1 ;;
+  esac
+
+  inner="${target#\$(}"
+  inner="${inner%)/claude-pre-push-review-done}"
+  _push_marker_tokenize_segment "$inner" || return 1
+  subcommand_index=$(_push_marker_git_subcommand_index) || return 1
+  [ "${PUSH_MARKER_TOKENS[$subcommand_index]}" = "rev-parse" ] || return 1
+  [ $((subcommand_index + 2)) -eq "${#PUSH_MARKER_TOKENS[@]}" ] || return 1
+  case "${PUSH_MARKER_TOKENS[$((subcommand_index + 1))]}" in
+    --git-dir|--absolute-git-dir) return 0 ;;
+  esac
+  return 1
+}
+
+_review_flag_segment_creates_flag() {
+  local segment token command_token redirection_target
+  local command_position=true
+  local i j
+
+  segment="$(_push_marker_trim "$1")"
+  _push_marker_tokenize_segment "$segment" || return 1
+
+  for ((i = 0; i < ${#PUSH_MARKER_TOKENS[@]}; i++)); do
+    token="${PUSH_MARKER_TOKENS[$i]}"
+
+    case "$token" in
+      *\>*)
+        redirection_target="${token#*>}"
+        if [ -z "$redirection_target" ] && [ $((i + 1)) -lt "${#PUSH_MARKER_TOKENS[@]}" ]; then
+          redirection_target="${PUSH_MARKER_TOKENS[$((i + 1))]}"
+        fi
+        _review_flag_token_is_target "$redirection_target" && return 0
+        ;;
+    esac
+
+    if $command_position; then
+      command_token="$token"
+      command_position=false
+      case "$command_token" in
+        touch|install|cp|mv|ln|tee|truncate)
+          j=$((i + 1))
+          while [ "$j" -lt "${#PUSH_MARKER_TOKENS[@]}" ] && [ "${PUSH_MARKER_TOKENS[$j]}" != "|" ]; do
+            _review_flag_token_is_target "${PUSH_MARKER_TOKENS[$j]}" && return 0
+            j=$((j + 1))
+          done
+          ;;
+        dd)
+          j=$((i + 1))
+          while [ "$j" -lt "${#PUSH_MARKER_TOKENS[@]}" ] && [ "${PUSH_MARKER_TOKENS[$j]}" != "|" ]; do
+            case "${PUSH_MARKER_TOKENS[$j]}" in
+              of=*)
+                _review_flag_token_is_target "${PUSH_MARKER_TOKENS[$j]#of=}" && return 0
+                ;;
+            esac
+            j=$((j + 1))
+          done
+          ;;
+      esac
+    fi
+    [ "$token" = "|" ] && command_position=true
+  done
+  return 1
+}
+
+_push_marker_split_shell_command "$COMMAND"
+for REVIEW_FLAG_SEGMENT in "${PUSH_MARKER_SEGMENTS[@]}"; do
+  if _review_flag_segment_creates_flag "$REVIEW_FLAG_SEGMENT" && \
+     ! _review_flag_is_canonical_touch_segment "$REVIEW_FLAG_SEGMENT"; then
+    echo "BLOCKED: pre-push-reviewフラグファイルの手動作成は禁止されています" >&2
+    echo "  WHY: /flow の P5 (push 前 codex ゲート) を経ずに PR 作成ガードをバイパスするのを防止" >&2
+    echo "  FIX: /flow を実行してください。P5 PASS 時にフラグを自動作成します" >&2
+    exit 2
   fi
-  echo "BLOCKED: pre-push-reviewフラグファイルの手動作成は禁止されています" >&2
-  echo "  WHY: /flow の P5 (push 前 codex ゲート) を経ずに PR 作成ガードをバイパスするのを防止" >&2
-  echo "  FIX: /flow を実行してください。P5 PASS 時にフラグを自動作成します" >&2
-  exit 2
-fi
+done
 
 
 # --- 破壊的コマンドガード ---

--- a/.claude/hooks/pre-bash-guard.sh
+++ b/.claude/hooks/pre-bash-guard.sh
@@ -66,21 +66,41 @@ _review_flag_is_canonical_touch_segment() {
 _review_flag_segment_creates_flag() {
   local segment token command_token redirection_target
   local command_position=true
+  local skip_redirection_target=false
   local i j
 
   segment="$(_push_marker_trim "$1")"
-  _push_marker_tokenize_segment "$segment" || return 1
+  _push_marker_tokenize_segment "$segment" true || return 1
 
   for ((i = 0; i < ${#PUSH_MARKER_TOKENS[@]}; i++)); do
     token="${PUSH_MARKER_TOKENS[$i]}"
 
+    if $skip_redirection_target; then
+      skip_redirection_target=false
+      continue
+    fi
+
     case "$token" in
+      '|')
+        command_position=true
+        continue
+        ;;
       *\>*)
-        redirection_target="${token#*>}"
+        redirection_target="${token##*>}"
+        redirection_target="${redirection_target#|}"
+        redirection_target="${redirection_target#&}"
         if [ -z "$redirection_target" ] && [ $((i + 1)) -lt "${#PUSH_MARKER_TOKENS[@]}" ]; then
           redirection_target="${PUSH_MARKER_TOKENS[$((i + 1))]}"
         fi
         _review_flag_token_is_target "$redirection_target" && return 0
+        skip_redirection_target=true
+        continue
+        ;;
+      *\<*)
+        # 入力リダイレクトも command より前に置けるため、対象 word を飛ばして
+        # command_position を維持する。<> の作成先は上の > branch で検査済み。
+        skip_redirection_target=true
+        continue
         ;;
     esac
 
@@ -108,7 +128,6 @@ _review_flag_segment_creates_flag() {
           ;;
       esac
     fi
-    [ "$token" = "|" ] && command_position=true
   done
   return 1
 }

--- a/.claude/hooks/push-marker-utils.sh
+++ b/.claude/hooks/push-marker-utils.sh
@@ -22,7 +22,7 @@ _push_marker_split_shell_command() {
   PUSH_MARKER_SEPARATORS=()
 
   for ((i = 0; i < ${#command}; i++)); do
-    char="${command:i:1}"
+    char="${command:$((i)):1}"
 
     if $escaped; then
       current+="$char"
@@ -61,7 +61,7 @@ _push_marker_split_shell_command() {
         current=""
         ;;
       '&'|'|')
-        next="${command:i+1:1}"
+        next="${command:$((i + 1)):1}"
         if [ "$next" = "$char" ]; then
           PUSH_MARKER_SEGMENTS+=("$current")
           PUSH_MARKER_SEPARATORS+=("${char}${char}")
@@ -92,7 +92,7 @@ _push_marker_tokenize_segment() {
   PUSH_MARKER_TOKENS=()
 
   for ((i = 0; i < ${#input}; i++)); do
-    char="${input:i:1}"
+    char="${input:$((i)):1}"
 
     if $escaped; then
       token+="$char"
@@ -199,7 +199,7 @@ _push_marker_commit_short_has_no_verify() {
   local i
 
   for ((i = 0; i < ${#token}; i++)); do
-    char="${token:i:1}"
+    char="${token:$((i)):1}"
     case "$char" in
       n) return 0 ;;
       # 以降は同じ token 内の option value なので、その中の n は flag ではない。
@@ -214,6 +214,10 @@ push_marker_detect_hook_bypass() {
   local command="$1"
   local segment subcommand subcommand_index token
   local i
+
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    setopt localoptions ksharrays
+  fi
 
   PUSH_MARKER_BYPASS_FLAG=""
   _push_marker_split_shell_command "$command"
@@ -272,6 +276,10 @@ push_marker_detect_git_push() {
   local command="$1"
   local segment
 
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    setopt localoptions ksharrays
+  fi
+
   # shellcheck disable=SC2034 # 呼び出し元へ返す出力変数
   PUSH_MARKER_IS_GIT_PUSH=false
   # shellcheck disable=SC2034 # 呼び出し元へ返す出力変数
@@ -319,7 +327,7 @@ _push_marker_parse_cd_argument() {
   fi
 
   for ((i = 0; i < ${#rest}; i++)); do
-    char="${rest:i:1}"
+    char="${rest:$((i)):1}"
 
     if $trailing; then
       [[ "$char" =~ [[:space:]] ]] || return 1
@@ -406,6 +414,49 @@ _push_marker_resolve_cd_dir() {
   (cd "$candidate" && pwd -P)
 }
 
+_push_marker_resolve_git_cwd() {
+  local base_dir="$1"
+  local subcommand_index="$2"
+  local effective_dir="$base_dir"
+  local token cd_arg candidate
+  local i=1
+
+  while [ "$i" -lt "$subcommand_index" ]; do
+    token="${PUSH_MARKER_TOKENS[$i]}"
+    case "$token" in
+      -C)
+        [ $((i + 1)) -lt "$subcommand_index" ] || return 1
+        cd_arg="${PUSH_MARKER_TOKENS[$((i + 1))]}"
+        i=$((i + 2))
+        ;;
+      -C?*)
+        cd_arg="${token#-C}"
+        i=$((i + 1))
+        ;;
+      -c|--git-dir|--work-tree|--exec-path|--namespace|--super-prefix|--config-env)
+        i=$((i + 2))
+        continue
+        ;;
+      *)
+        i=$((i + 1))
+        continue
+        ;;
+    esac
+
+    if [[ "$cd_arg" = /* ]]; then
+      candidate="$cd_arg"
+    else
+      [ -n "$effective_dir" ] || return 1
+      candidate="$effective_dir/$cd_arg"
+    fi
+    [ -d "$candidate" ] || return 1
+    effective_dir=$(cd "$candidate" && pwd -P) || return 1
+  done
+
+  [ -n "$effective_dir" ] || return 1
+  printf '%s' "$effective_dir"
+}
+
 push_marker_resolve_repo_dir() {
   local input_cwd="$1"
   local command="$2"
@@ -413,8 +464,12 @@ push_marker_resolve_repo_dir() {
   local input_dir=""
   local fallback_dir=""
   local current_dir=""
-  local segment resolved_dir
+  local segment resolved_dir subcommand_index
   local found_cd=false
+
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    setopt localoptions ksharrays
+  fi
 
   if [ -d "$input_cwd" ]; then
     input_dir=$(cd "$input_cwd" && pwd -P)
@@ -433,11 +488,10 @@ push_marker_resolve_repo_dir() {
       found_cd=true
     fi
     if _push_marker_is_git_push_segment "$segment"; then
-      if [ -n "$current_dir" ]; then
-        printf '%s' "$current_dir"
-        return 0
-      fi
-      return 1
+      subcommand_index=$(_push_marker_git_subcommand_index) || return 1
+      resolved_dir=$(_push_marker_resolve_git_cwd "$current_dir" "$subcommand_index") || return 1
+      printf '%s' "$resolved_dir"
+      return 0
     fi
   done
 

--- a/.claude/hooks/push-marker-utils.sh
+++ b/.claude/hooks/push-marker-utils.sh
@@ -149,12 +149,11 @@ _push_marker_tokenize_segment() {
   return 0
 }
 
-_push_marker_is_git_push_segment() {
-  local segment token
+# tokenized git segment から global option を飛ばし、actual subcommand index を返す。
+_push_marker_git_subcommand_index() {
+  local token
   local i=1
 
-  segment="$(_push_marker_trim "$1")"
-  _push_marker_tokenize_segment "$segment" || return 1
   [ "${#PUSH_MARKER_TOKENS[@]}" -gt 1 ] || return 1
   [ "${PUSH_MARKER_TOKENS[0]}" = "git" ] || return 1
 
@@ -162,6 +161,7 @@ _push_marker_is_git_push_segment() {
     token="${PUSH_MARKER_TOKENS[$i]}"
     case "$token" in
       -C|-c|--git-dir|--work-tree|--exec-path|--namespace|--super-prefix|--config-env)
+        [ $((i + 1)) -lt "${#PUSH_MARKER_TOKENS[@]}" ] || return 1
         i=$((i + 2))
         ;;
       --git-dir=*|--work-tree=*|--exec-path=*|--namespace=*|--super-prefix=*|--config-env=*)
@@ -181,7 +181,91 @@ _push_marker_is_git_push_segment() {
   done
 
   [ "$i" -lt "${#PUSH_MARKER_TOKENS[@]}" ] || return 1
-  [ "${PUSH_MARKER_TOKENS[$i]}" = "push" ]
+  printf '%s' "$i"
+}
+
+_push_marker_is_git_push_segment() {
+  local segment subcommand_index
+
+  segment="$(_push_marker_trim "$1")"
+  _push_marker_tokenize_segment "$segment" || return 1
+  subcommand_index=$(_push_marker_git_subcommand_index) || return 1
+  [ "${PUSH_MARKER_TOKENS[$subcommand_index]}" = "push" ]
+}
+
+_push_marker_commit_short_has_no_verify() {
+  local token="${1#-}"
+  local char
+  local i
+
+  for ((i = 0; i < ${#token}; i++)); do
+    char="${token:i:1}"
+    case "$char" in
+      n) return 0 ;;
+      # 以降は同じ token 内の option value なので、その中の n は flag ではない。
+      m|F|C|c) return 1 ;;
+    esac
+  done
+  return 1
+}
+
+# actual git commit / push の hook bypass flag だけを検出する。
+push_marker_detect_hook_bypass() {
+  local command="$1"
+  local segment subcommand subcommand_index token
+  local i
+
+  PUSH_MARKER_BYPASS_FLAG=""
+  _push_marker_split_shell_command "$command"
+
+  for segment in "${PUSH_MARKER_SEGMENTS[@]}"; do
+    segment="$(_push_marker_trim "$segment")"
+    _push_marker_tokenize_segment "$segment" || continue
+    subcommand_index=$(_push_marker_git_subcommand_index) || continue
+    subcommand="${PUSH_MARKER_TOKENS[$subcommand_index]}"
+
+    case "$subcommand" in
+      commit)
+        i=$((subcommand_index + 1))
+        while [ "$i" -lt "${#PUSH_MARKER_TOKENS[@]}" ]; do
+          token="${PUSH_MARKER_TOKENS[$i]}"
+          [ "$token" = "--" ] && break
+          case "$token" in
+            --no-verify)
+              PUSH_MARKER_BYPASS_FLAG="--no-verify"
+              return 0
+              ;;
+            -m|-F|-C|-c|--message|--file|--reuse-message|--reedit-message|--fixup|--squash|--author|--date|--cleanup|--trailer|--pathspec-from-file)
+              i=$((i + 2))
+              continue
+              ;;
+            --message=*|--file=*|--reuse-message=*|--reedit-message=*|--fixup=*|--squash=*|--author=*|--date=*|--cleanup=*|--trailer=*|--pathspec-from-file=*)
+              ;;
+            -?*)
+              if _push_marker_commit_short_has_no_verify "$token"; then
+                PUSH_MARKER_BYPASS_FLAG="-n"
+                return 0
+              fi
+              ;;
+          esac
+          i=$((i + 1))
+        done
+        ;;
+      push)
+        i=$((subcommand_index + 1))
+        while [ "$i" -lt "${#PUSH_MARKER_TOKENS[@]}" ]; do
+          token="${PUSH_MARKER_TOKENS[$i]}"
+          [ "$token" = "--" ] && break
+          if [ "$token" = "--no-verify" ]; then
+            PUSH_MARKER_BYPASS_FLAG="--no-verify"
+            return 0
+          fi
+          i=$((i + 1))
+        done
+        ;;
+    esac
+  done
+  return 1
 }
 
 push_marker_detect_git_push() {

--- a/.claude/hooks/push-marker-utils.sh
+++ b/.claude/hooks/push-marker-utils.sh
@@ -82,11 +82,12 @@ _push_marker_split_shell_command() {
 
 _push_marker_tokenize_segment() {
   local input="$1"
+  local split_operators="${2:-false}"
   local token=""
   local quote=""
   local escaped=false
   local started=false
-  local char
+  local char next operand operator_prefix redirection_operator
   local i
 
   PUSH_MARKER_TOKENS=()
@@ -135,6 +136,67 @@ _push_marker_tokenize_segment() {
           PUSH_MARKER_TOKENS+=("$token")
           token=""
           started=false
+        fi
+        ;;
+      '<'|'>')
+        if $split_operators; then
+          operator_prefix=""
+          case "$token" in
+            "")
+              ;;
+            *[!0-9])
+              case "${char}:${token}" in
+                '>:'*'&')
+                  operand="${token%&}"
+                  [ -n "$operand" ] && PUSH_MARKER_TOKENS+=("$operand")
+                  operator_prefix="&"
+                  ;;
+                *)
+                  PUSH_MARKER_TOKENS+=("$token")
+                  ;;
+              esac
+              ;;
+            *)
+              # file descriptor 番号はリダイレクト演算子の一部として保持する。
+              operator_prefix="$token"
+              ;;
+          esac
+
+          redirection_operator="${operator_prefix}${char}"
+          next="${input:$((i + 1)):1}"
+          case "${char}${next}" in
+            '>>'|'>&'|'>|'|'<<'|'<>'|'<&')
+              redirection_operator+="$next"
+              i=$((i + 1))
+              if [ "$redirection_operator" = "<<" ] && \
+                 [ "${input:$((i + 1)):1}" = "<" ]; then
+                redirection_operator+="<"
+                i=$((i + 1))
+              fi
+              ;;
+          esac
+          PUSH_MARKER_TOKENS+=("$redirection_operator")
+          token=""
+          started=false
+        else
+          token+="$char"
+          started=true
+        fi
+        ;;
+      '|')
+        if $split_operators; then
+          if $started; then
+            PUSH_MARKER_TOKENS+=("$token")
+          fi
+          PUSH_MARKER_TOKENS+=("|")
+          token=""
+          started=false
+          # |& も command 境界として扱う。
+          next="${input:$((i + 1)):1}"
+          [ "$next" = "&" ] && i=$((i + 1))
+        else
+          token+="$char"
+          started=true
         fi
         ;;
       *)
@@ -198,12 +260,17 @@ _push_marker_commit_short_has_no_verify() {
   local char
   local i
 
+  # caller が、cluster 末尾 option の値である次 token を再解析しないための出力値。
+  PUSH_MARKER_COMMIT_SHORT_TAKES_NEXT=false
   for ((i = 0; i < ${#token}; i++)); do
     char="${token:$((i)):1}"
     case "$char" in
       n) return 0 ;;
       # 以降は同じ token 内の option value なので、その中の n は flag ではない。
-      m|F|C|c) return 1 ;;
+      m|F|C|c|t)
+        [ $((i + 1)) -eq "${#token}" ] && PUSH_MARKER_COMMIT_SHORT_TAKES_NEXT=true
+        return 1
+        ;;
     esac
   done
   return 1
@@ -249,6 +316,10 @@ push_marker_detect_hook_bypass() {
               if _push_marker_commit_short_has_no_verify "$token"; then
                 PUSH_MARKER_BYPASS_FLAG="-n"
                 return 0
+              fi
+              if $PUSH_MARKER_COMMIT_SHORT_TAKES_NEXT; then
+                i=$((i + 2))
+                continue
               fi
               ;;
           esac

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -171,7 +171,33 @@ assert_marker_absent "値が結合したグローバルオプション後の sub
 
 run_post "git -C '$REPO_WORKTREE' push"
 assert_eq "グローバルオプション後の git push は検出する" \
-  "$MAIN_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+assert_eq "git -C の指定先をマーカー2行目に記録する" \
+  "$REPO_WORKTREE" "$(sed -n '2p' "$MARKER" 2>/dev/null)"
+
+run_post "git -c key=value -C '$REPO_WORKTREE' --no-pager push"
+assert_eq "mixed global options の git -C は指定先 HEAD を記録する" \
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+assert_eq "mixed global options の git -C は指定先 path を記録する" \
+  "$REPO_WORKTREE" "$(sed -n '2p' "$MARKER" 2>/dev/null)"
+
+run_post "git -C '../work tree' push" "$REPO_MAIN"
+assert_eq "relative git -C は input cwd 基準の HEAD を記録する" \
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+assert_eq "relative git -C は canonical path を記録する" \
+  "$REPO_WORKTREE" "$(sed -n '2p' "$MARKER" 2>/dev/null)"
+
+run_post "git -C '$TMP_TEST_DIR' -C 'work tree' push" "$REPO_MAIN"
+assert_eq "repeated git -C は直前の指定先基準の HEAD を記録する" \
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+assert_eq "repeated git -C は最終 canonical path を記録する" \
+  "$REPO_WORKTREE" "$(sed -n '2p' "$MARKER" 2>/dev/null)"
+
+run_post "git -C '$TMP_TEST_DIR/missing-repo' push" "$REPO_MAIN"
+assert_marker_absent "存在しない git -C は hook cwd へ fallback しない"
+
+run_post "git -C '$REPO_WORKTREE' push -n" "$REPO_MAIN"
+assert_marker_absent "git -C <dir> push -n はマーカーを書かない"
 
 run_post "git push --dry-run" "$REPO_MAIN"
 assert_marker_absent "git push --dry-run はマーカーを書かない"

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -51,19 +51,20 @@ fi
 TMP_TEST_DIR=$(mktemp -d "/tmp/test-push-marker.XXXXXX")
 trap 'rm -rf "$TMP_TEST_DIR"' EXIT
 
-HOOK_PROJECT="$TMP_TEST_DIR/hook-project"
 REPO_MAIN="$TMP_TEST_DIR/main-repo"
 REPO_WORKTREE="$TMP_TEST_DIR/work tree"
 REPO_WITHOUT_HEAD="$TMP_TEST_DIR/repo-without-head"
 NON_GIT_DIR="$TMP_TEST_DIR/non-git-dir"
 TEST_HOME="$TMP_TEST_DIR/home"
 REPO_TILDE="$TEST_HOME/tilde-repo"
+OTHER_REPO="$TMP_TEST_DIR/other-repo"
+HOOK_PROJECT="$REPO_MAIN"
 MARKER="$HOOK_PROJECT/.claude/push-completed.marker"
 POST_STDERR="$TMP_TEST_DIR/post.stderr"
 PRE_STDERR="$TMP_TEST_DIR/pre.stderr"
 
-mkdir -p "$HOOK_PROJECT/.claude/hooks" "$REPO_MAIN" "$REPO_WORKTREE" \
-  "$REPO_WITHOUT_HEAD" "$NON_GIT_DIR" "$REPO_TILDE"
+mkdir -p "$REPO_MAIN" "$REPO_WITHOUT_HEAD" "$NON_GIT_DIR" "$REPO_TILDE" \
+  "$OTHER_REPO" "$HOOK_PROJECT/.claude/hooks"
 
 # post hook のマーカー書き込み後の処理だけを無害な fixture に差し替える。
 printf '%s\n' \
@@ -88,13 +89,18 @@ init_repo() {
 }
 
 init_repo "$REPO_MAIN" "main"
-init_repo "$REPO_WORKTREE" "worktree"
+git -C "$REPO_MAIN" worktree add -q -b worktree-test "$REPO_WORKTREE"
+printf '%s\n' "worktree" > "$REPO_WORKTREE/fixture.txt"
+git -C "$REPO_WORKTREE" add fixture.txt
+git -C "$REPO_WORKTREE" commit -qm "worktree fixture"
 init_repo "$REPO_TILDE" "tilde"
+init_repo "$OTHER_REPO" "other"
 git -C "$REPO_WITHOUT_HEAD" init -q
 
 MAIN_HEAD=$(git -C "$REPO_MAIN" rev-parse HEAD)
 WORKTREE_HEAD=$(git -C "$REPO_WORKTREE" rev-parse HEAD)
 TILDE_HEAD=$(git -C "$REPO_TILDE" rev-parse HEAD)
+OTHER_HEAD=$(git -C "$OTHER_REPO" rev-parse HEAD)
 
 run_post() {
   local command="$1"
@@ -407,6 +413,45 @@ set +e
 HEAD_FAILURE_STATUS=$?
 set -e
 assert_eq "照合先で git rev-parse が失敗したらブロックする" "2" "$HEAD_FAILURE_STATUS"
+
+echo ""
+echo "=== pre-bash-guard: marker identity and age ==="
+
+printf '%s\n%s\n' "$WORKTREE_HEAD" "$REPO_WORKTREE" > "$MARKER"
+touch -t 202001010000 "$MARKER"
+run_pre "cd '$REPO_WORKTREE' && gh pr comment 1 --body ok"
+assert_eq "old matching marker allows PR comment" "0" "$PRE_STATUS"
+
+run_pre "gh issue comment 340 --body ok" "$REPO_MAIN"
+assert_eq "old matching marker allows Issue comment" "0" "$PRE_STATUS"
+
+rm -f "$MARKER"
+run_pre "gh issue comment 340 --body ok" "$REPO_MAIN"
+assert_eq "missing marker blocks comment" "2" "$PRE_STATUS"
+
+printf '\n%s\n' "$REPO_WORKTREE" > "$MARKER"
+run_pre "gh issue comment 340 --body ok" "$REPO_MAIN"
+assert_eq "empty marker SHA blocks comment" "2" "$PRE_STATUS"
+
+printf '%s\n%s\n' "$WORKTREE_HEAD" "$TMP_TEST_DIR/missing-repo" > "$MARKER"
+run_pre "gh issue comment 340 --body ok" "$REPO_MAIN"
+assert_eq "missing marker repository blocks comment" "2" "$PRE_STATUS"
+
+printf '%s\n%s\n' "$MAIN_HEAD" "$REPO_WORKTREE" > "$MARKER"
+touch -t 202001010000 "$MARKER"
+run_pre "gh issue comment 340 --body ok" "$REPO_MAIN"
+assert_eq "mismatched marker HEAD blocks comment regardless of age" "2" "$PRE_STATUS"
+
+printf '%s\n%s\n' "$WORKTREE_HEAD" "$REPO_WORKTREE" > "$MARKER"
+printf '%s\n' "after push" >> "$REPO_WORKTREE/fixture.txt"
+git -C "$REPO_WORKTREE" add fixture.txt
+git -C "$REPO_WORKTREE" commit -qm "after push"
+run_pre "gh issue comment 340 --body ok" "$REPO_MAIN"
+assert_eq "new commit after marker blocks comment" "2" "$PRE_STATUS"
+
+printf '%s\n%s\n' "$OTHER_HEAD" "$OTHER_REPO" > "$MARKER"
+run_pre "gh issue comment 340 --body ok" "$REPO_MAIN"
+assert_eq "self-consistent marker from another repository is blocked" "2" "$PRE_STATUS"
 
 echo ""
 echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -49,6 +49,7 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 TMP_TEST_DIR=$(mktemp -d "/tmp/test-push-marker.XXXXXX")
+TMP_TEST_DIR=$(cd "$TMP_TEST_DIR" && pwd -P)
 trap 'rm -rf "$TMP_TEST_DIR"' EXIT
 
 REPO_MAIN="$TMP_TEST_DIR/main-repo"
@@ -290,6 +291,12 @@ assert_eq "actual git commit -n is blocked" "2" "$PRE_STATUS"
 run_pre "git commit -an -m x"
 assert_eq "actual git commit short option cluster containing n is blocked" "2" "$PRE_STATUS"
 
+run_pre "git commit -am '-n'"
+assert_eq "short option cluster value is not reparsed as no-verify" "0" "$PRE_STATUS"
+
+run_pre "git commit -at '-n'"
+assert_eq "template option cluster value is not reparsed as no-verify" "0" "$PRE_STATUS"
+
 run_pre "git commit --no-verify -m x"
 assert_eq "actual git commit --no-verify is blocked" "2" "$PRE_STATUS"
 
@@ -341,6 +348,30 @@ assert_eq "manual touch of review flag is blocked" "2" "$PRE_STATUS"
 run_pre "printf x > '$TMP_TEST_DIR/claude-pre-push-review-done'"
 assert_eq "redirection creation of review flag is blocked" "2" "$PRE_STATUS"
 
+run_pre "echo x >> '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "spaced append redirection creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "echo x >>'$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "joined append redirection creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "echo x >| '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "noclobber override redirection creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "echo x &> '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "combined output redirection creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "echo x &>> '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "combined append redirection creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "echo x >& '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "legacy combined output redirection creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "echo x 1>> '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "file descriptor append redirection creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "touch '$TMP_TEST_DIR/claude-pre-push-review-done'>/dev/null"
+assert_eq "redirection joined after touch target is blocked" "2" "$PRE_STATUS"
+
 run_pre "install /dev/null '$TMP_TEST_DIR/claude-pre-push-review-done'"
 assert_eq "install creation of review flag is blocked" "2" "$PRE_STATUS"
 
@@ -356,11 +387,38 @@ assert_eq "ln creation of review flag is blocked" "2" "$PRE_STATUS"
 run_pre "printf x | tee '$TMP_TEST_DIR/claude-pre-push-review-done'"
 assert_eq "tee creation of review flag is blocked" "2" "$PRE_STATUS"
 
+run_pre "printf x|tee '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "joined pipe tee creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "printf x |tee '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "pipe joined to tee creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "printf x|  tee '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "joined pipe with extra spacing tee creation is blocked" "2" "$PRE_STATUS"
+
+run_pre "printf x|&tee '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "stderr pipe tee creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "tee '$TMP_TEST_DIR/claude-pre-push-review-done'</dev/null"
+assert_eq "input redirection joined after tee target is blocked" "2" "$PRE_STATUS"
+
+run_pre "2>/dev/null tee '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "leading joined redirection before tee is blocked" "2" "$PRE_STATUS"
+
+run_pre "2> /dev/null tee '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "leading spaced redirection before tee is blocked" "2" "$PRE_STATUS"
+
 run_pre "truncate -s 0 '$TMP_TEST_DIR/claude-pre-push-review-done'"
 assert_eq "truncate creation of review flag is blocked" "2" "$PRE_STATUS"
 
 run_pre "dd if=/dev/null of='$TMP_TEST_DIR/claude-pre-push-review-done'"
 assert_eq "dd creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "printf x|dd of='$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "joined pipe dd creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "dd of='$TMP_TEST_DIR/claude-pre-push-review-done'</dev/null"
+assert_eq "input redirection joined after dd target is blocked" "2" "$PRE_STATUS"
 
 run_pre "touch \"\$(git rev-parse --absolute-git-dir)/claude-pre-push-review-done\" && touch '$TMP_TEST_DIR/claude-pre-push-review-done'"
 assert_eq "canonical touch cannot hide another creation" "2" "$PRE_STATUS"

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -265,6 +265,85 @@ run_pre "echo ok && git commit -n -m x"
 assert_eq "linked actual git commit -n is blocked" "2" "$PRE_STATUS"
 
 echo ""
+echo "=== pre-bash-guard: review flag creation ==="
+
+run_pre "grep -r claude-pre-push-review-done '$TMP_TEST_DIR'"
+assert_eq "grep mention of review flag is allowed" "0" "$PRE_STATUS"
+
+run_pre "cat '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "cat mention of review flag is allowed" "0" "$PRE_STATUS"
+
+run_pre "ls '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "ls mention of review flag is allowed" "0" "$PRE_STATUS"
+
+run_pre "find '$TMP_TEST_DIR' -name claude-pre-push-review-done"
+assert_eq "find mention of review flag is allowed" "0" "$PRE_STATUS"
+
+run_pre "gh issue create --body 'claude-pre-push-review-done is documented'"
+assert_eq "issue body mention of review flag is allowed" "0" "$PRE_STATUS"
+
+run_pre "echo 'claude-pre-push-review-done' > '$TMP_TEST_DIR/note.txt'"
+assert_eq "review flag text redirected to another basename is allowed" "0" "$PRE_STATUS"
+
+run_pre 'touch "$(git rev-parse --git-dir)/claude-pre-push-review-done"'
+assert_eq "canonical git-dir touch is allowed" "0" "$PRE_STATUS"
+
+run_pre 'touch "$(git rev-parse --absolute-git-dir)/claude-pre-push-review-done"'
+assert_eq "canonical absolute-git-dir touch is allowed" "0" "$PRE_STATUS"
+
+run_pre "cd '$REPO_WORKTREE' && touch \"\$(git rev-parse --absolute-git-dir)/claude-pre-push-review-done\""
+assert_eq "canonical touch after cd is allowed" "0" "$PRE_STATUS"
+
+run_pre "touch \"\$(git -C '$REPO_WORKTREE' rev-parse --absolute-git-dir)/claude-pre-push-review-done\""
+assert_eq "canonical git -C touch is allowed" "0" "$PRE_STATUS"
+
+run_pre "touch '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "manual touch of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "printf x > '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "redirection creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "install /dev/null '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "install creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "cp /dev/null '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "cp creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "mv '$TMP_TEST_DIR/note.txt' '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "mv creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "ln '$TMP_TEST_DIR/note.txt' '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "ln creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "printf x | tee '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "tee creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "truncate -s 0 '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "truncate creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "dd if=/dev/null of='$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "dd creation of review flag is blocked" "2" "$PRE_STATUS"
+
+run_pre "touch \"\$(git rev-parse --absolute-git-dir)/claude-pre-push-review-done\" && touch '$TMP_TEST_DIR/claude-pre-push-review-done'"
+assert_eq "canonical touch cannot hide another creation" "2" "$PRE_STATUS"
+
+REVIEW_FLAG="$(git -C "$REPO_MAIN" rev-parse --absolute-git-dir)/claude-pre-push-review-done"
+rm -f "$REVIEW_FLAG"
+run_pre "gh pr create --title test --body test"
+assert_eq "PR create without review flag is blocked" "2" "$PRE_STATUS"
+
+touch "$REVIEW_FLAG"
+run_pre "gh pr create --title test --body test"
+assert_eq "PR create with recent review flag is allowed" "0" "$PRE_STATUS"
+assert_eq "recent review flag is consumed" "0" "$([ -e "$REVIEW_FLAG" ] && echo 1 || echo 0)"
+
+touch "$REVIEW_FLAG"
+touch -t 202001010000 "$REVIEW_FLAG"
+run_pre "gh pr create --title test --body test"
+assert_eq "PR create with stale review flag is blocked" "2" "$PRE_STATUS"
+rm -f "$REVIEW_FLAG"
+
+echo ""
 echo "=== pre-bash-guard: マーカー SHA 照合 ==="
 
 printf '%s\n' "$WORKTREE_HEAD" > "$MARKER"

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -60,6 +60,7 @@ TEST_HOME="$TMP_TEST_DIR/home"
 REPO_TILDE="$TEST_HOME/tilde-repo"
 MARKER="$HOOK_PROJECT/.claude/push-completed.marker"
 POST_STDERR="$TMP_TEST_DIR/post.stderr"
+PRE_STDERR="$TMP_TEST_DIR/pre.stderr"
 
 mkdir -p "$HOOK_PROJECT/.claude/hooks" "$REPO_MAIN" "$REPO_WORKTREE" \
   "$REPO_WITHOUT_HEAD" "$NON_GIT_DIR" "$REPO_TILDE"
@@ -114,6 +115,21 @@ run_post() {
     POST_STATUS=0
   else
     POST_STATUS=$?
+  fi
+}
+
+run_pre() {
+  local command="$1"
+  local input_cwd="${2:-$REPO_MAIN}"
+  local input
+
+  input=$(jq -n --arg command "$command" --arg cwd "$input_cwd" \
+    '{cwd: $cwd, tool_input: {command: $command}}')
+  if PRE_OUTPUT=$(cd "$input_cwd" && printf '%s\n' "$input" | \
+    CLAUDE_PROJECT_DIR="$HOOK_PROJECT" bash "$PRE_HOOK" 2>"$PRE_STDERR"); then
+    PRE_STATUS=0
+  else
+    PRE_STATUS=$?
   fi
 }
 
@@ -196,6 +212,57 @@ run_post "git push" "$NON_GIT_DIR"
 assert_marker_absent "非 Git ディレクトリが cwd の場合はマーカーを書かない"
 assert_eq "非 Git ディレクトリが cwd でも監視の起動 JSON を出力する" \
   "PostToolUse" "$(printf '%s\n' "$POST_OUTPUT" | jq -r '.hookSpecificOutput.hookEventName // ""' 2>/dev/null)"
+
+echo ""
+echo "=== pre-bash-guard: git hook bypass ==="
+
+run_pre "printf 'git docs' | grep -n docs.md"
+assert_eq "unrelated grep -n is allowed" "0" "$PRE_STATUS"
+
+run_pre "git status && sed -n '1,3p' file"
+assert_eq "unrelated sed -n after git status is allowed" "0" "$PRE_STATUS"
+
+run_pre "git commit -m 'document --no-verify and -n'"
+assert_eq "bypass strings in commit message are allowed" "0" "$PRE_STATUS"
+
+run_pre "git commit -m '-n'"
+assert_eq "short bypass string as commit message is allowed" "0" "$PRE_STATUS"
+
+run_pre "git tag -n"
+assert_eq "git tag -n is allowed" "0" "$PRE_STATUS"
+
+run_pre "git push -n"
+assert_eq "git push -n dry-run is allowed" "0" "$PRE_STATUS"
+
+run_pre "git commit -m '破壊的削除コマンドの扱いを修正'"
+assert_eq "destructive-command wording in commit message is allowed" "0" "$PRE_STATUS"
+
+run_pre "git commit -m '過剰な権限付与のガードを追加'"
+assert_eq "permission wording in commit message is allowed" "0" "$PRE_STATUS"
+
+run_pre "git commit -m '自動 resolve ガードの誤検知を直す'"
+assert_eq "resolve wording in commit message is allowed" "0" "$PRE_STATUS"
+
+run_pre "git commit -m 'claude-pre-push-review-done の誤検知を修正'"
+assert_eq "review flag basename in commit message is allowed" "0" "$PRE_STATUS"
+
+run_pre "git commit -n -m x"
+assert_eq "actual git commit -n is blocked" "2" "$PRE_STATUS"
+
+run_pre "git commit -an -m x"
+assert_eq "actual git commit short option cluster containing n is blocked" "2" "$PRE_STATUS"
+
+run_pre "git commit --no-verify -m x"
+assert_eq "actual git commit --no-verify is blocked" "2" "$PRE_STATUS"
+
+run_pre "git -C '$REPO_WORKTREE' commit --no-verify -m x"
+assert_eq "git global options do not hide commit --no-verify" "2" "$PRE_STATUS"
+
+run_pre "git push --no-verify"
+assert_eq "actual git push --no-verify is blocked" "2" "$PRE_STATUS"
+
+run_pre "echo ok && git commit -n -m x"
+assert_eq "linked actual git commit -n is blocked" "2" "$PRE_STATUS"
 
 echo ""
 echo "=== pre-bash-guard: マーカー SHA 照合 ==="

--- a/.claude/hooks/tests/test-push-marker.sh
+++ b/.claude/hooks/tests/test-push-marker.sh
@@ -181,6 +181,12 @@ assert_eq "mixed global options の git -C は指定先 HEAD を記録する" \
 assert_eq "mixed global options の git -C は指定先 path を記録する" \
   "$REPO_WORKTREE" "$(sed -n '2p' "$MARKER" 2>/dev/null)"
 
+run_post "git -C'$REPO_WORKTREE' push"
+assert_eq "value-joined git -C は指定先 HEAD を記録する" \
+  "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"
+assert_eq "value-joined git -C は指定先 path を記録する" \
+  "$REPO_WORKTREE" "$(sed -n '2p' "$MARKER" 2>/dev/null)"
+
 run_post "git -C '../work tree' push" "$REPO_MAIN"
 assert_eq "relative git -C は input cwd 基準の HEAD を記録する" \
   "$WORKTREE_HEAD" "$(head -1 "$MARKER" 2>/dev/null)"

--- a/.claude/lib/cleanup.sh
+++ b/.claude/lib/cleanup.sh
@@ -193,7 +193,8 @@ cleanup_flow_state_files() {
       fi
       local _lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
       local _lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
-      trap 'flow_lock_release "$lock_file" "$_lock_backend" "$_lock_owner_pid" || true' EXIT
+      local _lock_owner_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+      trap 'flow_lock_release "$lock_file" "$_lock_backend" "$_lock_owner_pid" "$_lock_owner_token" || true' EXIT
       $_action
     )
   }
@@ -232,7 +233,8 @@ cleanup_flow_state_files() {
       fi
       local _history_lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
       local _history_lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
-      trap 'flow_lock_release "$hist_lock" "$_history_lock_backend" "$_history_lock_owner_pid" || true' EXIT
+      local _history_lock_owner_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+      trap 'flow_lock_release "$hist_lock" "$_history_lock_backend" "$_history_lock_owner_pid" "$_history_lock_owner_token" || true' EXIT
       jq -c . "$base/flow-kpi-${scope_key}.json" >> "$base/flow-kpi-history.jsonl"
     )
   }

--- a/.claude/lib/cleanup.sh
+++ b/.claude/lib/cleanup.sh
@@ -19,7 +19,7 @@ if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
   return 1
 fi
 # shellcheck source=/dev/null
-source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"
+source "$CLAUDE_PROJECT_DIR/.claude/lib/state-io.sh"
 
 # === 公開関数 ===
 
@@ -134,7 +134,7 @@ EOF
 #     . 空白 等を全て拒否)。ark の SCOPE_KEY (work_id) は元から whitelist 内
 #   - .lock ファイルは削除しない (state-io.sh の inode 差し替え invariant のため)。
 #     terminal 後の lock は永続化させて並行 reader との race を未然に防ぐ
-#   - final mode の state 削除は state-io と同じ flock を取得して atomic に行う
+#   - final mode の state 削除は state-io と同じ排他 lock を取得して atomic に行う
 #     (並行 writer (--resume / cron callback) が `mv` で recreate するレースを防ぐ)。
 #     lock 取得失敗時は削除をスキップ (best-effort)
 #   - codex-gate ログと .new.* (atomic write 中間) は両モードで削除 (履歴のみ)
@@ -167,7 +167,7 @@ cleanup_flow_state_files() {
     base="$FLOW_STATE_DIR"
   fi
   # 削除対象 (state-io.sh / codex-gate.sh の出力に対応):
-  #   final mode のみ削除 (flock 取得して atomic):
+  #   final mode のみ削除 (state-io 共通 lock を取得して atomic):
   #     flow-progress-<scope>.json
   #     flow-kpi-<scope>.json (削除前に flow-kpi-history.jsonl に append)
   #     flow-context-<scope>.json
@@ -181,23 +181,21 @@ cleanup_flow_state_files() {
   : > "$lock_file" 2>/dev/null || true
 
   # 内部ヘルパー: scope-specific lock を取って関数を実行する。
-  # bash/zsh ともに動く。flock 無し環境では裸実行。lock 取得失敗時は warning + return 0
-  # (cleanup は best-effort)。state-io の writer / reader と race しないことを保証する。
+  # state-io の共通 helper により flock / mkdir fallback のどちらでも writer と race
+  # しない。lock 取得失敗時は warning + return 0 (cleanup は best-effort)。
   _cleanup_with_scope_lock() {
     local _action="$1"
-    if command -v flock >/dev/null 2>&1; then
-      (
-        exec 9<"$lock_file"
-        if ! flock -x -w 30 9; then
-          echo "WARNING: cleanup_flow_state_files ($mode): flock 30 秒待機 timeout、$_action をスキップ" >&2
-          exit 0
-        fi
-        $_action
-      )
-    else
-      # flock 無し環境: state-io の writer も flock を取れないので race は元から制御外
+    (
+      exec 9>"$lock_file"
+      if ! flow_lock_acquire "$lock_file" 9 30 30 auto; then
+        echo "WARNING: cleanup_flow_state_files ($mode): state lock 30 秒待機 timeout、$_action をスキップ" >&2
+        exit 0
+      fi
+      local _lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
+      local _lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
+      trap 'flow_lock_release "$lock_file" "$_lock_backend" "$_lock_owner_pid" || true' EXIT
       $_action
-    fi
+    )
   }
 
   # 内部ヘルパー: .new.* (writer の atomic-write 中間ファイル) を削除する。
@@ -225,15 +223,16 @@ cleanup_flow_state_files() {
     local hist_lock="$base/flow-kpi-history.lock"
     : > "$hist_lock" 2>/dev/null || true
     (
-      if command -v flock >/dev/null 2>&1; then
-        exec 8<"$hist_lock"
-        # scope lock と同じ -w 30 で timeout を統一。操作は jq -c の 1 行 append で
-        # 短時間だが、stuck 時に無限待機する事態を避ける。
-        if ! flock -x -w 30 8; then
-          echo "WARNING: _cleanup_archive_kpi_to_history: history lock 30 秒待機 timeout" >&2
-          exit 1
-        fi
+      exec 8>"$hist_lock"
+      # scope lock と同じ 30 秒 timeout。操作は jq -c の 1 行 append で短時間だが、
+      # stuck 時に無限待機する事態を避ける。
+      if ! flow_lock_acquire "$hist_lock" 8 30 30 auto; then
+        echo "WARNING: _cleanup_archive_kpi_to_history: history lock 30 秒待機 timeout" >&2
+        exit 1
       fi
+      local _history_lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
+      local _history_lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
+      trap 'flow_lock_release "$hist_lock" "$_history_lock_backend" "$_history_lock_owner_pid" || true' EXIT
       jq -c . "$base/flow-kpi-${scope_key}.json" >> "$base/flow-kpi-history.jsonl"
     )
   }

--- a/.claude/lib/state-io.sh
+++ b/.claude/lib/state-io.sh
@@ -49,11 +49,22 @@ _flow_lock_file() {
   printf '%s/flow-%s.lock\n' "$FLOW_STATE_DIR" "$key"
 }
 
-# 現在の shell process の pid を返す。bash の subshell では $$ が親 shell の pid の
-# ままなので、子 /bin/sh の PPID を使って実際に lock を保持する process を記録する。
-# bash 3.2 / zsh のどちらにも依存しない方法にしている。
-_flow_lock_current_pid() {
-  /bin/sh -c 'printf "%s\n" "$PPID"'
+# lock ownership / reclaim directory 用の一意 token を生成する。
+_flow_lock_generate_token() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  else
+    od -An -tx1 -N16 /dev/urandom | tr -d ' \n'
+  fi
+}
+
+# 現在の shell process の pid を lock directory へ直接書く。command substitution
+# 内で子 shell の PPID を読むと、macOS bash 3.2 では短命な command-substitution
+# process を指す。子 /bin/sh を直接起動すれば、その PPID は lock を保持する実 shell
+# になる。bash 3.2 / zsh 固有の BASHPID / sysparams には依存しない。
+_flow_lock_write_owner_pid() {
+  local pid_file="$1"
+  /bin/sh -c 'printf "%s\n" "$PPID" > "$1"' flow-lock-owner "$pid_file"
 }
 
 _flow_lock_dir() {
@@ -74,31 +85,30 @@ _flow_lock_mtime() {
 
 _flow_lock_discard_dir() {
   local lock_dir="$1"
-  rm -f "$lock_dir/pid" 2>/dev/null || true
+  rm -f "$lock_dir/pid" "$lock_dir/token" 2>/dev/null || true
   rmdir "$lock_dir" 2>/dev/null || true
 }
 
 # mkdir lock が stale なら atomic rename で隔離する。
-# owner pid が記録済みなら死亡時に即回収し、pid 未記録なら mkdir と pid 書き込みの
-# 短い race を避けるため mtime が stale_seconds を超えた場合だけ回収する。
+# pid の有無にかかわらず mtime が stale_seconds 以上で、かつ owner pid が死亡済み
+# (または未記録) の場合だけ回収する。pid 再利用時は生存扱いとして fail closed にする。
 _flow_lock_reclaim_stale() {
   local lock_dir="$1"
   local stale_seconds="$2"
-  local current_pid="$3"
-  local observed_owner now lock_mtime reclaim_dir moved_owner
+  local reclaim_token="$3"
+  local observed_owner observed_token now lock_mtime reclaim_dir
+  local moved_owner moved_token
 
   observed_owner=$(cat "$lock_dir/pid" 2>/dev/null || true)
   case "$observed_owner" in ''|*[!0-9]*) observed_owner="" ;; esac
-  if [ -n "$observed_owner" ]; then
-    kill -0 "$observed_owner" 2>/dev/null && return 1
-  else
-    now=$(date +%s)
-    lock_mtime=$(_flow_lock_mtime "$lock_dir" 2>/dev/null || printf '%s\n' "$now")
-    case "$lock_mtime" in ''|*[!0-9]*) lock_mtime="$now" ;; esac
-    [ $((now - lock_mtime)) -ge "$stale_seconds" ] || return 1
-  fi
+  observed_token=$(cat "$lock_dir/token" 2>/dev/null || true)
+  now=$(date +%s)
+  lock_mtime=$(_flow_lock_mtime "$lock_dir" 2>/dev/null || printf '%s\n' "$now")
+  case "$lock_mtime" in ''|*[!0-9]*) lock_mtime="$now" ;; esac
+  [ $((now - lock_mtime)) -ge "$stale_seconds" ] || return 1
+  [ -z "$observed_owner" ] || ! kill -0 "$observed_owner" 2>/dev/null || return 1
 
-  reclaim_dir="${lock_dir}.reclaim.${current_pid}"
+  reclaim_dir="${lock_dir}.reclaim.${reclaim_token}"
   if [ -e "$reclaim_dir" ]; then
     _flow_lock_discard_dir "$reclaim_dir"
     [ ! -e "$reclaim_dir" ] || return 1
@@ -106,10 +116,12 @@ _flow_lock_reclaim_stale() {
   command mv "$lock_dir" "$reclaim_dir" 2>/dev/null || return 1
 
   # stale 判定後に別 process が lock を作り直していた場合は奪わない。観測した pid と
-  # rename した directory の pid が一致するときだけ旧 lock として破棄する。
+  # token の両方が rename した directory と一致するときだけ旧 lock として破棄する。
   moved_owner=$(cat "$reclaim_dir/pid" 2>/dev/null || true)
   case "$moved_owner" in ''|*[!0-9]*) moved_owner="" ;; esac
+  moved_token=$(cat "$reclaim_dir/token" 2>/dev/null || true)
   if [ "$moved_owner" != "$observed_owner" ] \
+    || [ "$moved_token" != "$observed_token" ] \
     || { [ -n "$moved_owner" ] && kill -0 "$moved_owner" 2>/dev/null; }; then
     if [ ! -e "$lock_dir" ]; then
       command mv "$reclaim_dir" "$lock_dir" 2>/dev/null || true
@@ -123,18 +135,19 @@ _flow_lock_reclaim_stale() {
 
 # 排他 lock を取得する共通 API。
 # 引数: $1 lock_file, $2 flock fd, $3 wait 秒 (-1=無期限, 0=non-blocking),
-#       $4 pid 未記録 directory の stale 秒, $5 backend (auto|mkdir|mkdir-direct)
+#       $4 stale とみなす最小経過秒, $5 backend (auto|mkdir|mkdir-direct)
 # auto は flock があれば従来の fd lock、なければ <lock_file>.d の mkdir lock を使う。
 # mkdir-direct は flow-loop の既存 flow-loop.lock directory path を維持するための指定。
-# 成功時の実 backend / owner pid は FLOW_LOCK_ACQUIRED_BACKEND / FLOW_LOCK_ACQUIRED_PID
-# に設定する。EXIT trap では pid 再計算時の subshell が異なるため、後者を release に渡す。
+# 成功時の実 backend / owner pid / token は FLOW_LOCK_ACQUIRED_BACKEND /
+# FLOW_LOCK_ACQUIRED_PID / FLOW_LOCK_ACQUIRED_TOKEN に設定する。release は token が
+# 一致する lock だけを削除する。
 flow_lock_acquire() {
   local lock_file="${1:-}"
   local lock_fd="${2:-9}"
   local wait_seconds="${3:--1}"
   local stale_seconds="${4:-30}"
   local requested_backend="${5:-auto}"
-  local lock_backend lock_dir current_pid deadline now
+  local lock_backend lock_dir current_pid owner_token deadline now
   [ -n "$lock_file" ] || return 1
 
   lock_backend="$requested_backend"
@@ -154,28 +167,36 @@ flow_lock_acquire() {
     esac
     FLOW_LOCK_ACQUIRED_BACKEND="flock"
     FLOW_LOCK_ACQUIRED_PID=""
+    FLOW_LOCK_ACQUIRED_TOKEN=""
     return 0
   fi
   case "$lock_backend" in mkdir|mkdir-direct) ;; *) return 1 ;; esac
 
   lock_dir=$(_flow_lock_dir "$lock_file" "$lock_backend")
-  current_pid=$(_flow_lock_current_pid) || return 1
+  owner_token=$(_flow_lock_generate_token) || return 1
+  [ -n "$owner_token" ] || return 1
   now=$(date +%s)
   deadline=$((now + wait_seconds))
   while :; do
     if mkdir "$lock_dir" 2>/dev/null; then
-      if ! printf '%s\n' "$current_pid" > "$lock_dir/pid" 2>/dev/null; then
+      if ! printf '%s\n' "$owner_token" > "$lock_dir/token" 2>/dev/null \
+        || ! _flow_lock_write_owner_pid "$lock_dir/pid"; then
         _flow_lock_discard_dir "$lock_dir"
         return 1
       fi
-      [ "$(cat "$lock_dir/pid" 2>/dev/null || true)" = "$current_pid" ] || return 1
+      current_pid=$(cat "$lock_dir/pid" 2>/dev/null || true)
+      case "$current_pid" in ''|*[!0-9]*) _flow_lock_discard_dir "$lock_dir"; return 1 ;; esac
+      if [ "$(cat "$lock_dir/token" 2>/dev/null || true)" != "$owner_token" ]; then
+        return 1
+      fi
       FLOW_LOCK_ACQUIRED_BACKEND="$lock_backend"
       FLOW_LOCK_ACQUIRED_PID="$current_pid"
+      FLOW_LOCK_ACQUIRED_TOKEN="$owner_token"
       return 0
     fi
     # stale lock を回収できた場合は non-blocking 指定でも直ちに mkdir を再試行する。
     # ここで先に timeout 判定すると、回収だけして取得失敗を返してしまう。
-    if _flow_lock_reclaim_stale "$lock_dir" "$stale_seconds" "$current_pid"; then
+    if _flow_lock_reclaim_stale "$lock_dir" "$stale_seconds" "$owner_token"; then
       continue
     fi
     if [ "$wait_seconds" -eq 0 ]; then
@@ -190,36 +211,29 @@ flow_lock_acquire() {
 }
 
 # flow_lock_acquire で得た lock を解放する。flock は fd close に任せる。
-# 引数: $1 lock_file, $2 backend, $3 acquire 時の owner pid (省略時は現在 pid),
-#       $4 stale_seconds (指定時は死亡 owner も回収)
-# stale_seconds を指定した場合は、自分以外の既に死亡した owner も回収する
-# (flow-loop の別 shell invocation からの unlock 用)。
+# 引数: $1 lock_file, $2 backend, $3 acquire 時の owner pid,
+#       $4 acquire 時の owner token
 flow_lock_release() {
   local lock_file="${1:-}"
   local lock_backend="${2:-}"
   local acquired_pid="${3:-}"
-  local stale_seconds="${4:-}"
-  local lock_dir current_pid owner_pid
+  local acquired_token="${4:-}"
+  local lock_dir owner_pid owner_token
   [ -n "$lock_file" ] || return 1
   [ "$lock_backend" != "flock" ] || return 0
   case "$lock_backend" in mkdir|mkdir-direct) ;; *) return 1 ;; esac
 
   lock_dir=$(_flow_lock_dir "$lock_file" "$lock_backend")
   [ -d "$lock_dir" ] || return 0
-  if [ -n "$acquired_pid" ]; then
-    current_pid="$acquired_pid"
-  else
-    current_pid=$(_flow_lock_current_pid) || return 1
-  fi
   owner_pid=$(cat "$lock_dir/pid" 2>/dev/null || true)
   case "$owner_pid" in ''|*[!0-9]*) owner_pid="" ;; esac
-  if [ "$owner_pid" = "$current_pid" ]; then
+  owner_token=$(cat "$lock_dir/token" 2>/dev/null || true)
+  if [ -n "$acquired_token" ] && [ "$owner_token" = "$acquired_token" ] \
+    && { [ -z "$acquired_pid" ] || [ "$owner_pid" = "$acquired_pid" ]; }; then
     _flow_lock_discard_dir "$lock_dir"
     return 0
   fi
-  if [ -n "$stale_seconds" ]; then
-    _flow_lock_reclaim_stale "$lock_dir" "$stale_seconds" "$current_pid" || true
-  fi
+  return 1
 }
 
 _flow_gen_run_id() {
@@ -261,7 +275,8 @@ flow_state_init() {
       || { echo "ERROR: state lock 取得失敗 (重複起動?): $scope_key" >&2; return 1; }
     local lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
     local lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
-    trap 'flow_lock_release "$lock_file" "$lock_backend" "$lock_owner_pid" || true' EXIT
+    local lock_owner_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+    trap 'flow_lock_release "$lock_file" "$lock_backend" "$lock_owner_pid" "$lock_owner_token" || true' EXIT
 
     if [ -e "$progress_file" ] || [ -e "$kpi_file" ] || [ -e "$context_file" ]; then
       echo "ERROR: state already exists for $scope_key (cleanup_stale を先に呼んでください)" >&2
@@ -395,7 +410,8 @@ flow_state_update() {
     flow_lock_acquire "$lock" 9 -1 30 auto || return 1
     local lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
     local lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
-    trap 'flow_lock_release "$lock" "$lock_backend" "$lock_owner_pid" || true' EXIT
+    local lock_owner_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+    trap 'flow_lock_release "$lock" "$lock_backend" "$lock_owner_pid" "$lock_owner_token" || true' EXIT
     local tmp="${file}.new.$$"
     jq "$expr | .updated_at = $now | .owner_pid = $$" "$file" > "$tmp" || {
       rm -f "$tmp"
@@ -452,7 +468,8 @@ flow_state_cleanup_stale() {
     flow_lock_acquire "$lock" 9 -1 30 auto || return 1
     local lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
     local lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
-    trap 'flow_lock_release "$lock" "$lock_backend" "$lock_owner_pid" || true' EXIT
+    local lock_owner_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+    trap 'flow_lock_release "$lock" "$lock_backend" "$lock_owner_pid" "$lock_owner_token" || true' EXIT
     # 排他ロック保持中に flow_state_is_stale を呼ぶと、process substitution 内の
     # `flock -s "$lock"` が同じパスを別 fd で再ロックしようとしてデッドロックする
     # (codex review [P2] 指摘)。ロック取得済みなので、ファイルを直接読んで判定する。

--- a/.claude/lib/state-io.sh
+++ b/.claude/lib/state-io.sh
@@ -10,7 +10,7 @@
 #
 # 設計判断:
 #   - 状態を 3 ファイルに分離: progress / kpi / context
-#   - flock + atomic rename で並行アクセスを保護
+#   - flock (利用不可なら atomic mkdir lock) + atomic rename で並行アクセスを保護
 #   - SCOPE_KEY は <work_id>-<merge-base[:12]> で固定
 #     work_id は Issue 紐付け時 `issue-<N>`、無い時はブランチの sanitized slug
 #   - run_id (uuid) で同一作業の複数実行を識別
@@ -49,6 +49,179 @@ _flow_lock_file() {
   printf '%s/flow-%s.lock\n' "$FLOW_STATE_DIR" "$key"
 }
 
+# 現在の shell process の pid を返す。bash の subshell では $$ が親 shell の pid の
+# ままなので、子 /bin/sh の PPID を使って実際に lock を保持する process を記録する。
+# bash 3.2 / zsh のどちらにも依存しない方法にしている。
+_flow_lock_current_pid() {
+  /bin/sh -c 'printf "%s\n" "$PPID"'
+}
+
+_flow_lock_dir() {
+  local lock_file="$1"
+  local backend="$2"
+  if [ "$backend" = "mkdir-direct" ]; then
+    printf '%s\n' "$lock_file"
+  else
+    printf '%s.d\n' "$lock_file"
+  fi
+}
+
+_flow_lock_mtime() {
+  local lock_dir="$1"
+  stat -c %Y "$lock_dir" 2>/dev/null \
+    || stat -f %m "$lock_dir" 2>/dev/null
+}
+
+_flow_lock_discard_dir() {
+  local lock_dir="$1"
+  rm -f "$lock_dir/pid" 2>/dev/null || true
+  rmdir "$lock_dir" 2>/dev/null || true
+}
+
+# mkdir lock が stale なら atomic rename で隔離する。
+# owner pid が記録済みなら死亡時に即回収し、pid 未記録なら mkdir と pid 書き込みの
+# 短い race を避けるため mtime が stale_seconds を超えた場合だけ回収する。
+_flow_lock_reclaim_stale() {
+  local lock_dir="$1"
+  local stale_seconds="$2"
+  local current_pid="$3"
+  local observed_owner now lock_mtime reclaim_dir moved_owner
+
+  observed_owner=$(cat "$lock_dir/pid" 2>/dev/null || true)
+  case "$observed_owner" in ''|*[!0-9]*) observed_owner="" ;; esac
+  if [ -n "$observed_owner" ]; then
+    kill -0 "$observed_owner" 2>/dev/null && return 1
+  else
+    now=$(date +%s)
+    lock_mtime=$(_flow_lock_mtime "$lock_dir" 2>/dev/null || printf '%s\n' "$now")
+    case "$lock_mtime" in ''|*[!0-9]*) lock_mtime="$now" ;; esac
+    [ $((now - lock_mtime)) -ge "$stale_seconds" ] || return 1
+  fi
+
+  reclaim_dir="${lock_dir}.reclaim.${current_pid}"
+  if [ -e "$reclaim_dir" ]; then
+    _flow_lock_discard_dir "$reclaim_dir"
+    [ ! -e "$reclaim_dir" ] || return 1
+  fi
+  command mv "$lock_dir" "$reclaim_dir" 2>/dev/null || return 1
+
+  # stale 判定後に別 process が lock を作り直していた場合は奪わない。観測した pid と
+  # rename した directory の pid が一致するときだけ旧 lock として破棄する。
+  moved_owner=$(cat "$reclaim_dir/pid" 2>/dev/null || true)
+  case "$moved_owner" in ''|*[!0-9]*) moved_owner="" ;; esac
+  if [ "$moved_owner" != "$observed_owner" ] \
+    || { [ -n "$moved_owner" ] && kill -0 "$moved_owner" 2>/dev/null; }; then
+    if [ ! -e "$lock_dir" ]; then
+      command mv "$reclaim_dir" "$lock_dir" 2>/dev/null || true
+    fi
+    [ ! -e "$reclaim_dir" ] || _flow_lock_discard_dir "$reclaim_dir"
+    return 1
+  fi
+  _flow_lock_discard_dir "$reclaim_dir"
+  return 0
+}
+
+# 排他 lock を取得する共通 API。
+# 引数: $1 lock_file, $2 flock fd, $3 wait 秒 (-1=無期限, 0=non-blocking),
+#       $4 pid 未記録 directory の stale 秒, $5 backend (auto|mkdir|mkdir-direct)
+# auto は flock があれば従来の fd lock、なければ <lock_file>.d の mkdir lock を使う。
+# mkdir-direct は flow-loop の既存 flow-loop.lock directory path を維持するための指定。
+# 成功時の実 backend / owner pid は FLOW_LOCK_ACQUIRED_BACKEND / FLOW_LOCK_ACQUIRED_PID
+# に設定する。EXIT trap では pid 再計算時の subshell が異なるため、後者を release に渡す。
+flow_lock_acquire() {
+  local lock_file="${1:-}"
+  local lock_fd="${2:-9}"
+  local wait_seconds="${3:--1}"
+  local stale_seconds="${4:-30}"
+  local requested_backend="${5:-auto}"
+  local lock_backend lock_dir current_pid deadline now
+  [ -n "$lock_file" ] || return 1
+
+  lock_backend="$requested_backend"
+  if [ "$lock_backend" = "auto" ]; then
+    if command -v flock >/dev/null 2>&1; then
+      lock_backend="flock"
+    else
+      lock_backend="mkdir"
+    fi
+  fi
+
+  if [ "$lock_backend" = "flock" ]; then
+    case "$wait_seconds" in
+      0) command flock -xn "$lock_fd" || return 1 ;;
+      -1) command flock -x "$lock_fd" || return 1 ;;
+      *) command flock -x -w "$wait_seconds" "$lock_fd" || return 1 ;;
+    esac
+    FLOW_LOCK_ACQUIRED_BACKEND="flock"
+    FLOW_LOCK_ACQUIRED_PID=""
+    return 0
+  fi
+  case "$lock_backend" in mkdir|mkdir-direct) ;; *) return 1 ;; esac
+
+  lock_dir=$(_flow_lock_dir "$lock_file" "$lock_backend")
+  current_pid=$(_flow_lock_current_pid) || return 1
+  now=$(date +%s)
+  deadline=$((now + wait_seconds))
+  while :; do
+    if mkdir "$lock_dir" 2>/dev/null; then
+      if ! printf '%s\n' "$current_pid" > "$lock_dir/pid" 2>/dev/null; then
+        _flow_lock_discard_dir "$lock_dir"
+        return 1
+      fi
+      [ "$(cat "$lock_dir/pid" 2>/dev/null || true)" = "$current_pid" ] || return 1
+      FLOW_LOCK_ACQUIRED_BACKEND="$lock_backend"
+      FLOW_LOCK_ACQUIRED_PID="$current_pid"
+      return 0
+    fi
+    # stale lock を回収できた場合は non-blocking 指定でも直ちに mkdir を再試行する。
+    # ここで先に timeout 判定すると、回収だけして取得失敗を返してしまう。
+    if _flow_lock_reclaim_stale "$lock_dir" "$stale_seconds" "$current_pid"; then
+      continue
+    fi
+    if [ "$wait_seconds" -eq 0 ]; then
+      return 1
+    fi
+    now=$(date +%s)
+    if [ "$wait_seconds" -gt 0 ] && [ "$now" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+# flow_lock_acquire で得た lock を解放する。flock は fd close に任せる。
+# 引数: $1 lock_file, $2 backend, $3 acquire 時の owner pid (省略時は現在 pid),
+#       $4 stale_seconds (指定時は死亡 owner も回収)
+# stale_seconds を指定した場合は、自分以外の既に死亡した owner も回収する
+# (flow-loop の別 shell invocation からの unlock 用)。
+flow_lock_release() {
+  local lock_file="${1:-}"
+  local lock_backend="${2:-}"
+  local acquired_pid="${3:-}"
+  local stale_seconds="${4:-}"
+  local lock_dir current_pid owner_pid
+  [ -n "$lock_file" ] || return 1
+  [ "$lock_backend" != "flock" ] || return 0
+  case "$lock_backend" in mkdir|mkdir-direct) ;; *) return 1 ;; esac
+
+  lock_dir=$(_flow_lock_dir "$lock_file" "$lock_backend")
+  [ -d "$lock_dir" ] || return 0
+  if [ -n "$acquired_pid" ]; then
+    current_pid="$acquired_pid"
+  else
+    current_pid=$(_flow_lock_current_pid) || return 1
+  fi
+  owner_pid=$(cat "$lock_dir/pid" 2>/dev/null || true)
+  case "$owner_pid" in ''|*[!0-9]*) owner_pid="" ;; esac
+  if [ "$owner_pid" = "$current_pid" ]; then
+    _flow_lock_discard_dir "$lock_dir"
+    return 0
+  fi
+  if [ -n "$stale_seconds" ]; then
+    _flow_lock_reclaim_stale "$lock_dir" "$stale_seconds" "$current_pid" || true
+  fi
+}
+
 _flow_gen_run_id() {
   if command -v uuidgen >/dev/null 2>&1; then
     uuidgen | tr '[:upper:]' '[:lower:]'
@@ -84,7 +257,11 @@ flow_state_init() {
 
   : > "$lock_file"
   (
-    flock -xn 9 || { echo "ERROR: state lock 取得失敗 (重複起動?): $scope_key" >&2; return 1; }
+    flow_lock_acquire "$lock_file" 9 0 30 auto \
+      || { echo "ERROR: state lock 取得失敗 (重複起動?): $scope_key" >&2; return 1; }
+    local lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
+    local lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
+    trap 'flow_lock_release "$lock_file" "$lock_backend" "$lock_owner_pid" || true' EXIT
 
     if [ -e "$progress_file" ] || [ -e "$kpi_file" ] || [ -e "$context_file" ]; then
       echo "ERROR: state already exists for $scope_key (cleanup_stale を先に呼んでください)" >&2
@@ -188,10 +365,17 @@ flow_state_read() {
   file=$(_flow_state_file "$type" "$key")
   lock=$(_flow_lock_file "$key")
   [ -f "$file" ] || { echo "ERROR: state file not found: $file" >&2; return 1; }
-  (
-    flock -s 9
+  if command -v flock >/dev/null 2>&1; then
+    (
+      command flock -s 9
+      jq -r "$filter" "$file"
+    ) 9>"$lock"
+  else
+    # mkdir lock では共有 lock を表現できない。read を排他 lock に格上げすると、長い
+    # reader が writer を不必要に直列化する。writer は同一 filesystem 上の atomic
+    # rename で完成済み JSON だけを公開するため、fallback の read は lock を取らない。
     jq -r "$filter" "$file"
-  ) 9>"$lock"
+  fi
 }
 
 # state JSON のフィールドを atomic rename で update する。
@@ -208,7 +392,10 @@ flow_state_update() {
   now=$(date +%s)
 
   (
-    flock -x 9
+    flow_lock_acquire "$lock" 9 -1 30 auto || return 1
+    local lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
+    local lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
+    trap 'flow_lock_release "$lock" "$lock_backend" "$lock_owner_pid" || true' EXIT
     local tmp="${file}.new.$$"
     jq "$expr | .updated_at = $now | .owner_pid = $$" "$file" > "$tmp" || {
       rm -f "$tmp"
@@ -231,8 +418,15 @@ flow_state_is_stale() {
 
   : > "$lock"
   local updated_at owner_pid now
-  if ! { read -r updated_at; read -r owner_pid; } < <(
-    flock -s "$lock" jq -r '.updated_at, .owner_pid' "$file"
+  if command -v flock >/dev/null 2>&1; then
+    if ! { read -r updated_at; read -r owner_pid; } < <(
+      command flock -s "$lock" jq -r '.updated_at, .owner_pid' "$file"
+    ); then
+      return 0
+    fi
+  elif ! { read -r updated_at; read -r owner_pid; } < <(
+    # flow_state_read と同じく、atomic rename で公開済みの完全な JSON を lockless に読む。
+    jq -r '.updated_at, .owner_pid' "$file"
   ); then
     return 0
   fi
@@ -255,7 +449,10 @@ flow_state_cleanup_stale() {
   progress_file=$(_flow_state_file progress "$key")
   : > "$lock"
   (
-    flock -x 9
+    flow_lock_acquire "$lock" 9 -1 30 auto || return 1
+    local lock_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
+    local lock_owner_pid="$FLOW_LOCK_ACQUIRED_PID"
+    trap 'flow_lock_release "$lock" "$lock_backend" "$lock_owner_pid" || true' EXIT
     # 排他ロック保持中に flow_state_is_stale を呼ぶと、process substitution 内の
     # `flock -s "$lock"` が同じパスを別 fd で再ロックしようとしてデッドロックする
     # (codex review [P2] 指摘)。ロック取得済みなので、ファイルを直接読んで判定する。

--- a/.claude/lib/tests/test-codex-stdin.sh
+++ b/.claude/lib/tests/test-codex-stdin.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# =============================================================================
+# flow / flow-x codex stdin contract regression test
+# =============================================================================
+set -uo pipefail
+
+TESTS=0
+PASSES=0
+FAILURES=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  TESTS=$((TESTS + 1))
+  if [ "$expected" = "$actual" ]; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+FLOW_SKILL="$PROJECT_DIR/.claude/skills/flow/SKILL.md"
+FLOW_X_SKILL="$PROJECT_DIR/.claude/skills/flow-x/SKILL.md"
+CODEX_GATE="$PROJECT_DIR/.claude/lib/codex-gate.sh"
+
+for required_file in "$FLOW_SKILL" "$FLOW_X_SKILL" "$CODEX_GATE"; do
+  TESTS=$((TESTS + 1))
+  if [ -f "$required_file" ]; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: required file exists: $required_file"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: required file missing: $required_file"
+  fi
+done
+
+FLOW_X_COMMANDS=$(awk '
+  /^nohup codex exec / { command=$0; collecting=1; next }
+  collecting { command=command " " $0 }
+  collecting && /&[[:space:]]*$/ { print command; command=""; collecting=0 }
+' "$FLOW_X_SKILL")
+
+FLOW_X_INVOCATIONS=$(printf '%s\n' "$FLOW_X_COMMANDS" | grep -c '^nohup codex exec ' || true)
+FLOW_X_CLOSED_STDIN=$(printf '%s\n' "$FLOW_X_COMMANDS" | grep -c ' < /dev/null ' || true)
+FLOW_X_EXPECTED_LOGS=$(printf '%s\n' "$FLOW_X_COMMANDS" \
+  | grep -Ec 'codex-(<phase>|p2|p3)-\$\{SCOPE_KEY\}-run\.log' || true)
+
+echo "=== flow-x detached codex stdin ==="
+assert_eq "detached codex invocation count" "4" "$FLOW_X_INVOCATIONS"
+assert_eq "all detached codex invocations close stdin" "4" "$FLOW_X_CLOSED_STDIN"
+assert_eq "all detached codex invocations keep scoped run logs" "4" "$FLOW_X_EXPECTED_LOGS"
+assert_eq "P8 reuses the documented codex invocation" "1" \
+  "$(grep -c 'codex exec.*前節参照.*各 auto-fixable' "$FLOW_X_SKILL" || true)"
+
+GATE_EXEC_COUNT=$(grep -c '_run_codex exec ' "$CODEX_GATE" || true)
+GATE_DIFF_STDIN=$(awk '
+  /git diff --no-ext-diff origin\/main\.\.\.HEAD/ { seen_diff=1 }
+  seen_diff && /\| _run_codex exec / { found=1 }
+  END { print found + 0 }
+' "$CODEX_GATE")
+GATE_PLAN_STDIN=$(awk '
+  /_run_codex exec / { in_exec=1 }
+  in_exec && /< "\$plan_path"/ { found=1; in_exec=0 }
+  END { print found + 0 }
+' "$CODEX_GATE")
+
+echo ""
+echo "=== normal flow supplied stdin ==="
+assert_eq "codex-gate has two codex exec invocations" "2" "$GATE_EXEC_COUNT"
+assert_eq "diff review supplies git diff on stdin" "1" "$GATE_DIFF_STDIN"
+assert_eq "plan review supplies plan file on stdin" "1" "$GATE_PLAN_STDIN"
+assert_eq "flow sources codex-gate.sh" "1" \
+  "$(grep -c 'source .*\.claude/lib/codex-gate\.sh' "$FLOW_SKILL" || true)"
+assert_eq "flow calls codex review gates" "1" \
+  "$(grep -c 'codex_gate_review_plan ' "$FLOW_SKILL" | awk '{ print ($1 > 0) ? 1 : 0 }')"
+
+echo ""
+echo "========================================"
+echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"
+if [ "$FAILURES" -gt 0 ]; then
+  echo -e "${RED}FAILED${NC}"
+  exit 1
+fi
+echo -e "${GREEN}ALL PASSED${NC}"

--- a/.claude/lib/tests/test-codex-stdin.sh
+++ b/.claude/lib/tests/test-codex-stdin.sh
@@ -61,7 +61,7 @@ assert_eq "detached codex invocation count" "4" "$FLOW_X_INVOCATIONS"
 assert_eq "all detached codex invocations close stdin" "4" "$FLOW_X_CLOSED_STDIN"
 assert_eq "all detached codex invocations keep scoped run logs" "4" "$FLOW_X_EXPECTED_LOGS"
 assert_eq "P8 reuses the documented codex invocation" "1" \
-  "$(grep -c 'codex exec.*前節参照.*各 auto-fixable' "$FLOW_X_SKILL" || true)"
+  "$(grep -c 'codex exec.*前節.*invocation.*各 auto-fixable' "$FLOW_X_SKILL" || true)"
 
 GATE_EXEC_COUNT=$(grep -c '_run_codex exec ' "$CODEX_GATE" || true)
 GATE_DIFF_STDIN=$(awk '

--- a/.claude/lib/tests/test-codex-stdin.sh
+++ b/.claude/lib/tests/test-codex-stdin.sh
@@ -52,14 +52,19 @@ FLOW_X_COMMANDS=$(awk '
 ' "$FLOW_X_SKILL")
 
 FLOW_X_INVOCATIONS=$(printf '%s\n' "$FLOW_X_COMMANDS" | grep -c '^nohup codex exec ' || true)
-FLOW_X_CLOSED_STDIN=$(printf '%s\n' "$FLOW_X_COMMANDS" | grep -c ' < /dev/null ' || true)
-FLOW_X_EXPECTED_LOGS=$(printf '%s\n' "$FLOW_X_COMMANDS" \
-  | grep -Ec 'codex-(<phase>|p2|p3)-\$\{SCOPE_KEY\}-run\.log' || true)
+FLOW_X_OPEN_STDIN=$(printf '%s\n' "$FLOW_X_COMMANDS" | awk '
+  /^nohup codex exec / && index($0, " < /dev/null ") == 0 { missing++ }
+  END { print missing + 0 }
+')
+FLOW_X_UNSCOPED_LOGS=$(printf '%s\n' "$FLOW_X_COMMANDS" | awk '
+  /^nohup codex exec / && $0 !~ /codex-(<phase>|p2|p3)-\$\{SCOPE_KEY\}-run\.log/ { missing++ }
+  END { print missing + 0 }
+')
 
 echo "=== flow-x detached codex stdin ==="
 assert_eq "detached codex invocation count" "4" "$FLOW_X_INVOCATIONS"
-assert_eq "all detached codex invocations close stdin" "4" "$FLOW_X_CLOSED_STDIN"
-assert_eq "all detached codex invocations keep scoped run logs" "4" "$FLOW_X_EXPECTED_LOGS"
+assert_eq "detached codex invocation missing closed stdin" "0" "$FLOW_X_OPEN_STDIN"
+assert_eq "detached codex invocation missing scoped run log" "0" "$FLOW_X_UNSCOPED_LOGS"
 assert_eq "P8 reuses the documented codex invocation" "1" \
   "$(grep -c 'codex exec.*前節.*invocation.*各 auto-fixable' "$FLOW_X_SKILL" || true)"
 

--- a/.claude/lib/tests/test-setup-worktree.sh
+++ b/.claude/lib/tests/test-setup-worktree.sh
@@ -71,6 +71,7 @@ if [ ! -f "$SETUP_WORKTREE" ]; then
 fi
 
 TMP_TEST_DIR=$(mktemp -d "/tmp/test-setup-worktree.XXXXXX")
+TMP_TEST_DIR=$(cd "$TMP_TEST_DIR" && pwd -P)
 trap 'rm -rf "$TMP_TEST_DIR"' EXIT
 
 ORIGIN_REPO="$TMP_TEST_DIR/origin.git"

--- a/.claude/lib/tests/test-setup-worktree.sh
+++ b/.claude/lib/tests/test-setup-worktree.sh
@@ -74,11 +74,17 @@ TMP_TEST_DIR=$(mktemp -d "/tmp/test-setup-worktree.XXXXXX")
 trap 'rm -rf "$TMP_TEST_DIR"' EXIT
 
 ORIGIN_REPO="$TMP_TEST_DIR/origin.git"
-MAIN_REPO="$TMP_TEST_DIR/main"
+REAL_ROOT="$TMP_TEST_DIR/real"
+LINK_ROOT="$TMP_TEST_DIR/link"
+MAIN_REPO="$REAL_ROOT/main"
+LINK_MAIN_REPO="$LINK_ROOT/main"
 FAKE_BIN="$TMP_TEST_DIR/bin"
 MISE_LOG="$TMP_TEST_DIR/mise.log"
+GIT_WORKTREE_ADD_LOG="$TMP_TEST_DIR/git-worktree-add.log"
 
 git init -q --bare "$ORIGIN_REPO"
+mkdir -p "$REAL_ROOT"
+ln -s "$REAL_ROOT" "$LINK_ROOT"
 git init -q "$MAIN_REPO"
 git -C "$MAIN_REPO" config user.email harness-test@example.invalid
 git -C "$MAIN_REPO" config user.name 'harness test'
@@ -91,17 +97,29 @@ git -C "$MAIN_REPO" push -q -u origin main
 git -C "$ORIGIN_REPO" symbolic-ref HEAD refs/heads/main
 
 mkdir -p "$FAKE_BIN"
+REAL_GIT_BIN=$(command -v git)
 printf '%s\n' \
   '#!/usr/bin/env bash' \
   'printf "%s\n" "$*" >> "$MISE_TEST_LOG"' \
   'exit "${MISE_TEST_STATUS:-0}"' \
   > "$FAKE_BIN/mise"
 chmod 700 "$FAKE_BIN/mise"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'if [ "${1:-}" = "-C" ] && [ "${3:-}" = "worktree" ] && [ "${4:-}" = "add" ]; then' \
+  '  printf "%s\n" "$*" >> "$GIT_WORKTREE_ADD_TEST_LOG"' \
+  'fi' \
+  'exec "$REAL_GIT_TEST_BIN" "$@"' \
+  > "$FAKE_BIN/git"
+chmod 700 "$FAKE_BIN/git"
 : > "$MISE_LOG"
+: > "$GIT_WORKTREE_ADD_LOG"
 
 export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
 export MISE_TEST_LOG="$MISE_LOG"
 export MISE_TEST_STATUS=0
+export REAL_GIT_TEST_BIN="$REAL_GIT_BIN"
+export GIT_WORKTREE_ADD_TEST_LOG="$GIT_WORKTREE_ADD_LOG"
 export PATH="$FAKE_BIN:$PATH"
 # shellcheck disable=SC1090
 source "$SETUP_WORKTREE"
@@ -112,6 +130,14 @@ mise_call_count() {
     return
   fi
   wc -l < "$MISE_LOG" | tr -d ' '
+}
+
+git_worktree_add_count() {
+  if [ ! -s "$GIT_WORKTREE_ADD_LOG" ]; then
+    printf '0\n'
+    return
+  fi
+  wc -l < "$GIT_WORKTREE_ADD_LOG" | tr -d ' '
 }
 
 worktree_path() {
@@ -165,12 +191,25 @@ assert_success "mise command 不在でも作成できる" \
 assert_eq "mise command 不在は trust しない" "3" "$(mise_call_count)"
 
 echo ""
+echo "=== symlink path reuse ==="
+SYMLINK_BRANCH='fix/issue-340/symlink-path-reuse'
+: > "$GIT_WORKTREE_ADD_LOG"
+assert_success "symlink 経由で worktree を作成できる" \
+  create_worktree "$LINK_MAIN_REPO" "$SYMLINK_BRANCH"
+assert_success "symlink 経由でも existing worktree を再利用できる" \
+  create_worktree "$LINK_MAIN_REPO" "$SYMLINK_BRANCH"
+assert_eq "symlink 経由の reuse では worktree add を再実行しない" \
+  "1" "$(git_worktree_add_count)"
+assert_eq "symlink 経由の reuse でも trust check を 1 回行う" \
+  "5" "$(mise_call_count)"
+
+echo ""
 echo "=== trust failure is fail-fast ==="
 export MISE_TEST_STATUS=23
 FAIL_BRANCH='fix/issue-340/mise-failure'
 assert_failure_reason "mise trust failure で create_worktree が失敗する" \
   "mise trust に失敗" create_worktree "$MAIN_REPO" "$FAIL_BRANCH"
-assert_eq "failure case でも trust は 1 回だけ" "4" "$(mise_call_count)"
+assert_eq "failure case でも trust は 1 回だけ" "6" "$(mise_call_count)"
 
 echo ""
 echo "========================================"

--- a/.claude/lib/tests/test-setup-worktree.sh
+++ b/.claude/lib/tests/test-setup-worktree.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# =============================================================================
+# setup-worktree mise trust contract regression test
+# =============================================================================
+set -uo pipefail
+
+TESTS=0
+PASSES=0
+FAILURES=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  TESTS=$((TESTS + 1))
+  if [ "$expected" = "$actual" ]; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+assert_success() {
+  local description="$1"
+  shift
+  TESTS=$((TESTS + 1))
+  if "$@"; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+  fi
+}
+
+assert_failure_reason() {
+  local description="$1"
+  local expected_reason="$2"
+  shift 2
+  local output status
+  output=$("$@" 2>&1)
+  status=$?
+  TESTS=$((TESTS + 1))
+  if [ "$status" -ne 0 ] && printf '%s\n' "$output" | grep -q "$expected_reason"; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+    echo "  expected non-zero and diagnostic containing: $expected_reason"
+    echo "  status: $status"
+    echo "  output: $output"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+SETUP_WORKTREE="$PROJECT_DIR/.claude/lib/worktree/setup-worktree.sh"
+
+if [ ! -f "$SETUP_WORKTREE" ]; then
+  echo -e "${RED}FAIL${NC}: setup-worktree.sh が存在しない"
+  exit 1
+fi
+
+TMP_TEST_DIR=$(mktemp -d "/tmp/test-setup-worktree.XXXXXX")
+trap 'rm -rf "$TMP_TEST_DIR"' EXIT
+
+ORIGIN_REPO="$TMP_TEST_DIR/origin.git"
+MAIN_REPO="$TMP_TEST_DIR/main"
+FAKE_BIN="$TMP_TEST_DIR/bin"
+MISE_LOG="$TMP_TEST_DIR/mise.log"
+
+git init -q --bare "$ORIGIN_REPO"
+git init -q "$MAIN_REPO"
+git -C "$MAIN_REPO" config user.email harness-test@example.invalid
+git -C "$MAIN_REPO" config user.name 'harness test'
+printf '%s\n' '[tools]' 'node = "22"' > "$MAIN_REPO/.mise.toml"
+git -C "$MAIN_REPO" add .mise.toml
+git -C "$MAIN_REPO" commit -q -m baseline
+git -C "$MAIN_REPO" branch -M main
+git -C "$MAIN_REPO" remote add origin "$ORIGIN_REPO"
+git -C "$MAIN_REPO" push -q -u origin main
+git -C "$ORIGIN_REPO" symbolic-ref HEAD refs/heads/main
+
+mkdir -p "$FAKE_BIN"
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  'printf "%s\n" "$*" >> "$MISE_TEST_LOG"' \
+  'exit "${MISE_TEST_STATUS:-0}"' \
+  > "$FAKE_BIN/mise"
+chmod 700 "$FAKE_BIN/mise"
+: > "$MISE_LOG"
+
+export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
+export MISE_TEST_LOG="$MISE_LOG"
+export MISE_TEST_STATUS=0
+export PATH="$FAKE_BIN:$PATH"
+# shellcheck disable=SC1090
+source "$SETUP_WORKTREE"
+
+mise_call_count() {
+  if [ ! -s "$MISE_LOG" ]; then
+    printf '0\n'
+    return
+  fi
+  wc -l < "$MISE_LOG" | tr -d ' '
+}
+
+worktree_path() {
+  compute_worktree_path "$MAIN_REPO" "$1"
+}
+
+echo "=== matching config ==="
+MATCH_BRANCH='fix/issue-340/mise-match'
+MATCH_WORKTREE=$(worktree_path "$MATCH_BRANCH")
+assert_success "matching config worktree を作成できる" \
+  create_worktree "$MAIN_REPO" "$MATCH_BRANCH"
+assert_eq "matching config は mise trust を 1 回呼ぶ" "1" "$(mise_call_count)"
+assert_eq "matching config の trust 引数" \
+  "trust --yes $MATCH_WORKTREE/.mise.toml" "$(tail -n 1 "$MISE_LOG")"
+
+assert_success "existing worktree を再利用できる" \
+  create_worktree "$MAIN_REPO" "$MATCH_BRANCH"
+assert_eq "reuse でも trust check を 1 回行う" "2" "$(mise_call_count)"
+
+echo ""
+echo "=== untrusted config is skipped ==="
+printf '%s\n' '[tools]' 'node = "99"' > "$MATCH_WORKTREE/.mise.toml"
+assert_success "mismatched config の worktree を再利用できる" \
+  create_worktree "$MAIN_REPO" "$MATCH_BRANCH"
+assert_eq "mismatched config は trust しない" "2" "$(mise_call_count)"
+git -C "$MATCH_WORKTREE" checkout -q -- .mise.toml
+
+NO_MAIN_BRANCH='fix/issue-340/no-main-config'
+NO_MAIN_WORKTREE=$(worktree_path "$NO_MAIN_BRANCH")
+mv "$MAIN_REPO/.mise.toml" "$MAIN_REPO/.mise.toml.saved"
+assert_success "main config 不在でも作成できる" \
+  create_worktree "$MAIN_REPO" "$NO_MAIN_BRANCH"
+assert_eq "main config 不在は trust しない" "2" "$(mise_call_count)"
+mv "$MAIN_REPO/.mise.toml.saved" "$MAIN_REPO/.mise.toml"
+
+NO_WORKTREE_BRANCH='fix/issue-340/no-worktree-config'
+NO_WORKTREE_WORKTREE=$(worktree_path "$NO_WORKTREE_BRANCH")
+assert_success "worktree config fixture を作成できる" \
+  create_worktree "$MAIN_REPO" "$NO_WORKTREE_BRANCH"
+assert_eq "fixture 作成時は trust する" "3" "$(mise_call_count)"
+rm "$NO_WORKTREE_WORKTREE/.mise.toml"
+assert_success "worktree config 不在でも再利用できる" \
+  create_worktree "$MAIN_REPO" "$NO_WORKTREE_BRANCH"
+assert_eq "worktree config 不在は trust しない" "3" "$(mise_call_count)"
+
+NO_MISE_BRANCH='fix/issue-340/no-mise-command'
+assert_success "mise command 不在でも作成できる" \
+  env PATH="/usr/bin:/bin" bash -c \
+    'source "$CLAUDE_PROJECT_DIR/.claude/lib/worktree/setup-worktree.sh"; create_worktree "$1" "$2"' \
+    bash "$MAIN_REPO" "$NO_MISE_BRANCH"
+assert_eq "mise command 不在は trust しない" "3" "$(mise_call_count)"
+
+echo ""
+echo "=== trust failure is fail-fast ==="
+export MISE_TEST_STATUS=23
+FAIL_BRANCH='fix/issue-340/mise-failure'
+assert_failure_reason "mise trust failure で create_worktree が失敗する" \
+  "mise trust に失敗" create_worktree "$MAIN_REPO" "$FAIL_BRANCH"
+assert_eq "failure case でも trust は 1 回だけ" "4" "$(mise_call_count)"
+
+echo ""
+echo "========================================"
+echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"
+if [ "$FAILURES" -gt 0 ]; then
+  echo -e "${RED}FAILED${NC}"
+  exit 1
+fi
+echo -e "${GREEN}ALL PASSED${NC}"

--- a/.claude/lib/tests/test-state-lock.sh
+++ b/.claude/lib/tests/test-state-lock.sh
@@ -1,0 +1,195 @@
+#!/bin/bash
+# =============================================================================
+# state-io 共通 lock の flock / mkdir fallback 回帰テスト
+# =============================================================================
+set -uo pipefail
+
+TESTS=0
+PASSES=0
+FAILURES=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+assert_eq() {
+  local description="$1"
+  local expected="$2"
+  local actual="$3"
+  TESTS=$((TESTS + 1))
+  if [ "$expected" = "$actual" ]; then
+    PASSES=$((PASSES + 1))
+    echo -e "${GREEN}PASS${NC}: $description"
+  else
+    FAILURES=$((FAILURES + 1))
+    echo -e "${RED}FAIL${NC}: $description"
+    echo "  expected: $expected"
+    echo "  actual:   $actual"
+  fi
+}
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+STATE_IO="$PROJECT_DIR/.claude/lib/state-io.sh"
+CLEANUP_LIB="$PROJECT_DIR/.claude/lib/cleanup.sh"
+TMP_TEST_DIR=$(mktemp -d "/tmp/test-state-lock.XXXXXX")
+NO_FLOCK_BIN="$TMP_TEST_DIR/bin-no-flock"
+HOLDER_PID=""
+
+cleanup_test() {
+  if [ -n "$HOLDER_PID" ] && kill -0 "$HOLDER_PID" 2>/dev/null; then
+    kill -9 "$HOLDER_PID" 2>/dev/null || true
+    wait "$HOLDER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_TEST_DIR"
+}
+trap cleanup_test EXIT
+
+mkdir -p "$NO_FLOCK_BIN" "$TMP_TEST_DIR/state-no-flock" \
+  "$TMP_TEST_DIR/state-no-flock-zsh" "$TMP_TEST_DIR/state-no-flock-cleanup" \
+  "$TMP_TEST_DIR/state-normal"
+chmod 700 "$TMP_TEST_DIR/state-no-flock" "$TMP_TEST_DIR/state-no-flock-zsh" \
+  "$TMP_TEST_DIR/state-no-flock-cleanup" "$TMP_TEST_DIR/state-normal"
+
+# PATH 全体を test bin に限定し、state-io が使うコマンドだけを symlink する。
+# 単に PATH の先頭へ空 directory を足すだけでは後段の /usr/bin/flock が見えるため、
+# この構成で command -v flock が確実に失敗する状態を作る。
+for tool_name in cat chmod date find id jq mkdir mv od rm rmdir sleep stat tr uuidgen; do
+  tool_target=$(command -v "$tool_name" 2>/dev/null || true)
+  case "$tool_target" in
+    /*) ln -s "$tool_target" "$NO_FLOCK_BIN/$tool_name" ;;
+  esac
+done
+
+echo "=== state lock: flock fallback ==="
+
+NO_FLOCK_SCOPE="no-flock-state-$$"
+no_flock_state_output=$(env PATH="$NO_FLOCK_BIN" \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" FLOW_STATE_DIR="$TMP_TEST_DIR/state-no-flock" \
+  /bin/bash -c '
+    source "$1"
+    scope=$(flow_state_init "$2" "feature/$2" /tmp/no-flock-worktree) || exit 1
+    flow_state_update progress '\''.phase = "P2"'\'' "$scope" || exit 2
+    phase=$(flow_state_read progress '\''.phase'\'' "$scope") || exit 3
+    [ ! -d "$FLOW_STATE_DIR/flow-$scope.lock.d" ] || exit 4
+    printf "%s|%s\n" "$scope" "$phase"
+  ' bash "$STATE_IO" "$NO_FLOCK_SCOPE" 2>&1)
+assert_eq "flock 不在でも init → update → read が成功する" \
+  "$NO_FLOCK_SCOPE|P2" "$no_flock_state_output"
+
+ZSH_BIN=$(command -v zsh) || { echo "ERROR: zsh が必要です" >&2; exit 1; }
+NO_FLOCK_ZSH_SCOPE="no-flock-zsh-state-$$"
+no_flock_zsh_output=$(env PATH="$NO_FLOCK_BIN" \
+  CLAUDE_PROJECT_DIR="$PROJECT_DIR" FLOW_STATE_DIR="$TMP_TEST_DIR/state-no-flock-zsh" \
+  "$ZSH_BIN" -c '
+    source "$1"
+    scope=$(flow_state_init "$2" "feature/$2" /tmp/no-flock-zsh-worktree) || exit 1
+    flow_state_update progress '\''.phase = "P2"'\'' "$scope" || exit 2
+    phase=$(flow_state_read progress '\''.phase'\'' "$scope") || exit 3
+    [ ! -d "$FLOW_STATE_DIR/flow-$scope.lock.d" ] || exit 4
+    printf "%s|%s\n" "$scope" "$phase"
+  ' zsh "$STATE_IO" "$NO_FLOCK_ZSH_SCOPE" 2>&1)
+assert_eq "zsh でも flock 不在時の init → update → read が成功する" \
+  "$NO_FLOCK_ZSH_SCOPE|P2" "$no_flock_zsh_output"
+
+LOCK_FILE="$TMP_TEST_DIR/state-no-flock/contention.lock"
+READY_FILE="$TMP_TEST_DIR/holder-ready"
+env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  /bin/bash -c '
+    source "$1"
+    exec 9>"$2"
+    flow_lock_acquire "$2" 9 0 30 auto || exit 1
+    [ "$FLOW_LOCK_ACQUIRED_BACKEND" = "mkdir" ] || exit 2
+    : > "$3"
+    sleep 30
+  ' bash "$STATE_IO" "$LOCK_FILE" "$READY_FILE" &
+HOLDER_PID=$!
+
+ready_attempts=0
+while [ ! -f "$READY_FILE" ] && kill -0 "$HOLDER_PID" 2>/dev/null \
+  && [ "$ready_attempts" -lt 50 ]; do
+  sleep 0.1
+  ready_attempts=$((ready_attempts + 1))
+done
+
+contention_result="holder-failed"
+if [ -f "$READY_FILE" ]; then
+  if env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+    /bin/bash -c '
+      source "$1"
+      exec 9>"$2"
+      flow_lock_acquire "$2" 9 0 30 auto
+    ' bash "$STATE_IO" "$LOCK_FILE" >/dev/null 2>&1; then
+    contention_result="acquired"
+  else
+    contention_result="blocked"
+  fi
+fi
+assert_eq "mkdir lock 保持中は別 process の non-blocking 取得が失敗する" \
+  "blocked" "$contention_result"
+
+# SIGKILL では release trap を実行できない。directory に残った holder pid が死亡済みと
+# 判定され、次の process が stale lock を奪取できることを検証する。
+kill -9 "$HOLDER_PID" 2>/dev/null || true
+wait "$HOLDER_PID" 2>/dev/null || true
+HOLDER_PID=""
+stale_result=$(env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  /bin/bash -c '
+    source "$1"
+    exec 9>"$2"
+    flow_lock_acquire "$2" 9 0 30 auto || exit 1
+    backend="$FLOW_LOCK_ACQUIRED_BACKEND"
+    flow_lock_release "$2" "$backend"
+    printf "%s" "$backend"
+  ' bash "$STATE_IO" "$LOCK_FILE" 2>&1)
+assert_eq "異常終了した process の pid lock は stale として奪取できる" \
+  "mkdir" "$stale_result"
+
+NO_FLOCK_CLEANUP_SCOPE="no-flock-cleanup-$$"
+cleanup_result=$(env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  CLEANUP_FLOW_STATE_DIR="$TMP_TEST_DIR/state-no-flock-cleanup" \
+  __CLEANUP_LIB_SOURCED_FOR_TEST__=1 /bin/bash -c '
+    source "$1"
+    base="$CLEANUP_FLOW_STATE_DIR"
+    printf '\''{"branch":"feature/%s"}'\'' "$2" > "$base/flow-progress-$2.json"
+    printf '\''{"scope_key":"%s"}'\'' "$2" > "$base/flow-kpi-$2.json"
+    printf '\''{}'\'' > "$base/flow-context-$2.json"
+    cleanup_flow_state_files "$2" final || exit 1
+    [ ! -e "$base/flow-progress-$2.json" ] || exit 2
+    [ ! -e "$base/flow-kpi-$2.json" ] || exit 3
+    [ ! -e "$base/flow-context-$2.json" ] || exit 4
+    [ -f "$base/flow-done-$2.json" ] || exit 5
+    [ -f "$base/flow-kpi-history.jsonl" ] || exit 6
+    [ ! -d "$base/flow-$2.lock.d" ] || exit 7
+    printf cleaned
+  ' bash "$CLEANUP_LIB" "$NO_FLOCK_CLEANUP_SCOPE" 2>&1)
+cleanup_rc=$?
+assert_eq "cleanup も flock 不在時に共通 mkdir lock で state を安全に削除する" \
+  "0|cleaned" "$cleanup_rc|$cleanup_result"
+
+NORMAL_SCOPE="normal-state-$$"
+if command -v flock >/dev/null 2>&1; then
+  expected_normal_backend="flock"
+else
+  expected_normal_backend="mkdir"
+fi
+normal_output=$(CLAUDE_PROJECT_DIR="$PROJECT_DIR" FLOW_STATE_DIR="$TMP_TEST_DIR/state-normal" \
+  /bin/bash -c '
+    source "$1"
+    exec 9>"$2/backend.lock"
+    flow_lock_acquire "$2/backend.lock" 9 0 30 auto || exit 1
+    selected_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
+    flow_lock_release "$2/backend.lock" "$selected_backend"
+    scope=$(flow_state_init "$3" "feature/$3" /tmp/normal-worktree) || exit 2
+    flow_state_update progress '\''.phase = "P3"'\'' "$scope" || exit 3
+    printf "%s|" "$selected_backend"
+    flow_state_read progress '\''.phase'\'' "$scope"
+  ' bash "$STATE_IO" "$TMP_TEST_DIR/state-normal" "$NORMAL_SCOPE" 2>&1)
+assert_eq "通常 PATH では利用可能な backend で従来の state 経路が動く" \
+  "$expected_normal_backend|P3" "$normal_output"
+
+echo ""
+echo "========================================"
+echo "Tests: $TESTS, Passed: $PASSES, Failed: $FAILURES"
+echo "========================================"
+[ "$FAILURES" -eq 0 ]

--- a/.claude/lib/tests/test-state-lock.sh
+++ b/.claude/lib/tests/test-state-lock.sh
@@ -148,7 +148,7 @@ env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
   /bin/bash -c '
     source "$1"
     exec 9>"$2"
-    flow_lock_acquire "$2" 9 0 30 auto || exit 1
+    flow_lock_acquire "$2" 9 0 1 auto || exit 1
     [ "$FLOW_LOCK_ACQUIRED_BACKEND" = "mkdir" ] || exit 2
     printf "holder \$\$: %s\nholder BASHPID: %s\nrecorded owner pid: %s\n" \
       "$$" "${BASHPID-<unavailable>}" "$FLOW_LOCK_ACQUIRED_PID" > "$4"
@@ -179,7 +179,7 @@ if [ -f "$READY_FILE" ]; then
       printf "contender \$\$: %s\ncontender BASHPID: %s\nobserved owner pid: %s\nobserved owner kill -0: %s\n" \
         "$$" "${BASHPID-<unavailable>}" "$observed_owner" \
         "$observed_owner_liveness" > "$3"
-      flow_lock_acquire "$2" 9 0 30 auto
+      flow_lock_acquire "$2" 9 0 1 auto
     ' bash "$STATE_IO" "$LOCK_FILE" "$CONTENDER_DIAGNOSTICS" >/dev/null 2>&1; then
     contention_result="acquired"
   else
@@ -197,17 +197,60 @@ fi
 kill -9 "$HOLDER_PID" 2>/dev/null || true
 wait "$HOLDER_PID" 2>/dev/null || true
 HOLDER_PID=""
+sleep 1
 stale_result=$(env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
   /bin/bash -c '
     source "$1"
     exec 9>"$2"
-    flow_lock_acquire "$2" 9 0 30 auto || exit 1
+    flow_lock_acquire "$2" 9 0 1 auto || exit 1
     backend="$FLOW_LOCK_ACQUIRED_BACKEND"
-    flow_lock_release "$2" "$backend"
+    owner_pid="$FLOW_LOCK_ACQUIRED_PID"
+    owner_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+    flow_lock_release "$2" "$backend" "$owner_pid" "$owner_token"
     printf "%s" "$backend"
   ' bash "$STATE_IO" "$LOCK_FILE" 2>&1)
 assert_eq "異常終了した process の pid lock は stale として奪取できる" \
   "mkdir" "$stale_result"
+
+REUSED_PID_LOCK="$TMP_TEST_DIR/state-no-flock/reused-pid.lock"
+mkdir "$REUSED_PID_LOCK.d"
+printf '%s\n' "$$" > "$REUSED_PID_LOCK.d/pid"
+printf '%s\n' "simulated-reused-pid" > "$REUSED_PID_LOCK.d/token"
+if env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  /bin/bash -c '
+    source "$1"
+    exec 9>"$2"
+    flow_lock_acquire "$2" 9 0 0 auto
+  ' bash "$STATE_IO" "$REUSED_PID_LOCK" >/dev/null 2>&1; then
+  reused_pid_result="acquired"
+else
+  reused_pid_result="blocked"
+fi
+assert_eq "pid が別の生存 process に再利用された場合は stale lock を奪取しない" \
+  "blocked" "$reused_pid_result"
+rm -f "$REUSED_PID_LOCK.d/pid" "$REUSED_PID_LOCK.d/token"
+rmdir "$REUSED_PID_LOCK.d"
+
+OWNERSHIP_LOCK="$TMP_TEST_DIR/state-no-flock/ownership.lock"
+ownership_result=$(env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
+  /bin/bash -c '
+    source "$1"
+    exec 9>"$2"
+    flow_lock_acquire "$2" 9 0 1 auto || exit 1
+    old_pid="$FLOW_LOCK_ACQUIRED_PID"
+    old_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+    flow_lock_release "$2" mkdir "$old_pid" "$old_token" || exit 2
+    flow_lock_acquire "$2" 9 0 1 auto || exit 3
+    new_pid="$FLOW_LOCK_ACQUIRED_PID"
+    new_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+    flow_lock_release "$2" mkdir "$old_pid" "$old_token" 2>/dev/null && exit 4
+    [ -d "$2.d" ] || exit 5
+    [ "$(cat "$2.d/token")" = "$new_token" ] || exit 6
+    flow_lock_release "$2" mkdir "$new_pid" "$new_token" || exit 7
+    printf protected
+  ' bash "$STATE_IO" "$OWNERSHIP_LOCK" 2>&1)
+assert_eq "release は取得時 token が一致する自分の lock だけを解放する" \
+  "protected" "$ownership_result"
 
 NO_FLOCK_CLEANUP_SCOPE="no-flock-cleanup-$$"
 cleanup_result=$(env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
@@ -243,7 +286,10 @@ normal_output=$(CLAUDE_PROJECT_DIR="$PROJECT_DIR" FLOW_STATE_DIR="$TMP_TEST_DIR/
     exec 9>"$2/backend.lock"
     flow_lock_acquire "$2/backend.lock" 9 0 30 auto || exit 1
     selected_backend="$FLOW_LOCK_ACQUIRED_BACKEND"
-    flow_lock_release "$2/backend.lock" "$selected_backend"
+    selected_pid="$FLOW_LOCK_ACQUIRED_PID"
+    selected_token="$FLOW_LOCK_ACQUIRED_TOKEN"
+    flow_lock_release "$2/backend.lock" "$selected_backend" \
+      "$selected_pid" "$selected_token"
     scope=$(flow_state_init "$3" "feature/$3" /tmp/normal-worktree) || exit 2
     flow_state_update progress '\''.phase = "P3"'\'' "$scope" || exit 3
     printf "%s|" "$selected_backend"

--- a/.claude/lib/tests/test-state-lock.sh
+++ b/.claude/lib/tests/test-state-lock.sh
@@ -35,6 +35,53 @@ CLEANUP_LIB="$PROJECT_DIR/.claude/lib/cleanup.sh"
 TMP_TEST_DIR=$(mktemp -d "/tmp/test-state-lock.XXXXXX")
 NO_FLOCK_BIN="$TMP_TEST_DIR/bin-no-flock"
 HOLDER_PID=""
+HOLDER_DIAGNOSTICS="$TMP_TEST_DIR/holder-diagnostics"
+CONTENDER_DIAGNOSTICS="$TMP_TEST_DIR/contender-diagnostics"
+
+print_lock_failure_diagnostics() {
+  local lock_dir="${LOCK_FILE}.d"
+
+  echo "  --- lock contention environment:"
+  echo "  uname -s: $(uname -s 2>&1)"
+  echo "  bash --version: $(/bin/bash --version 2>&1 | sed -n '1p')"
+  echo "  test shell \$\$: $$"
+  echo "  test shell BASHPID: ${BASHPID-<unavailable>}"
+  echo "  holder process pid (\$!): $HOLDER_PID"
+  if kill -0 "$HOLDER_PID" 2>/dev/null; then
+    echo "  holder process kill -0: alive"
+  else
+    echo "  holder process kill -0: dead"
+  fi
+  echo "  --- holder observations:"
+  if [ -s "$HOLDER_DIAGNOSTICS" ]; then
+    sed 's/^/  /' "$HOLDER_DIAGNOSTICS"
+  else
+    echo "  (unavailable)"
+  fi
+  echo "  --- contender observations before acquire:"
+  if [ -s "$CONTENDER_DIAGNOSTICS" ]; then
+    sed 's/^/  /' "$CONTENDER_DIAGNOSTICS"
+  else
+    echo "  (unavailable)"
+  fi
+  echo "  --- zsh pid observations:"
+  "$ZSH_BIN" -c '
+    zmodload zsh/system 2>/dev/null || true
+    print -r -- "zsh \$\$: $$"
+    print -r -- "zsh sysparams[pid]: ${sysparams[pid]-<unavailable>}"
+  ' 2>&1 | sed 's/^/  /'
+  echo "  --- lock directory after contender: $lock_dir"
+  if [ -d "$lock_dir" ]; then
+    ls -la "$lock_dir" 2>&1 | sed 's/^/  /'
+    for lock_entry in "$lock_dir"/*; do
+      [ -f "$lock_entry" ] || continue
+      echo "  file ${lock_entry##*/}:"
+      sed 's/^/    /' "$lock_entry" 2>&1
+    done
+  else
+    echo "  (missing)"
+  fi
+}
 
 cleanup_test() {
   if [ -n "$HOLDER_PID" ] && kill -0 "$HOLDER_PID" 2>/dev/null; then
@@ -103,9 +150,11 @@ env PATH="$NO_FLOCK_BIN" CLAUDE_PROJECT_DIR="$PROJECT_DIR" \
     exec 9>"$2"
     flow_lock_acquire "$2" 9 0 30 auto || exit 1
     [ "$FLOW_LOCK_ACQUIRED_BACKEND" = "mkdir" ] || exit 2
+    printf "holder \$\$: %s\nholder BASHPID: %s\nrecorded owner pid: %s\n" \
+      "$$" "${BASHPID-<unavailable>}" "$FLOW_LOCK_ACQUIRED_PID" > "$4"
     : > "$3"
     sleep 30
-  ' bash "$STATE_IO" "$LOCK_FILE" "$READY_FILE" &
+  ' bash "$STATE_IO" "$LOCK_FILE" "$READY_FILE" "$HOLDER_DIAGNOSTICS" &
 HOLDER_PID=$!
 
 ready_attempts=0
@@ -121,8 +170,17 @@ if [ -f "$READY_FILE" ]; then
     /bin/bash -c '
       source "$1"
       exec 9>"$2"
+      observed_owner=$(cat "$2.d/pid" 2>/dev/null || true)
+      if [ -n "$observed_owner" ] && kill -0 "$observed_owner" 2>/dev/null; then
+        observed_owner_liveness=alive
+      else
+        observed_owner_liveness=dead
+      fi
+      printf "contender \$\$: %s\ncontender BASHPID: %s\nobserved owner pid: %s\nobserved owner kill -0: %s\n" \
+        "$$" "${BASHPID-<unavailable>}" "$observed_owner" \
+        "$observed_owner_liveness" > "$3"
       flow_lock_acquire "$2" 9 0 30 auto
-    ' bash "$STATE_IO" "$LOCK_FILE" >/dev/null 2>&1; then
+    ' bash "$STATE_IO" "$LOCK_FILE" "$CONTENDER_DIAGNOSTICS" >/dev/null 2>&1; then
     contention_result="acquired"
   else
     contention_result="blocked"
@@ -130,6 +188,9 @@ if [ -f "$READY_FILE" ]; then
 fi
 assert_eq "mkdir lock 保持中は別 process の non-blocking 取得が失敗する" \
   "blocked" "$contention_result"
+if [ "$contention_result" != "blocked" ]; then
+  print_lock_failure_diagnostics
+fi
 
 # SIGKILL では release trap を実行できない。directory に残った holder pid が死亡済みと
 # 判定され、次の process が stale lock を奪取できることを検証する。

--- a/.claude/lib/tests/test-state-lock.sh
+++ b/.claude/lib/tests/test-state-lock.sh
@@ -77,6 +77,9 @@ no_flock_state_output=$(env PATH="$NO_FLOCK_BIN" \
 assert_eq "flock 不在でも init → update → read が成功する" \
   "$NO_FLOCK_SCOPE|P2" "$no_flock_state_output"
 
+# zsh 経路も lock の backend 切り替えと一体で検証するため、この専用テストに置く。
+# test-zsh-compat.sh は汎用の zsh 互換検証に専念でき、かつ本テストの単独実行でも
+# mkdir fallback が zsh から利用できる保証を失わない。
 ZSH_BIN=$(command -v zsh) || { echo "ERROR: zsh が必要です" >&2; exit 1; }
 NO_FLOCK_ZSH_SCOPE="no-flock-zsh-state-$$"
 no_flock_zsh_output=$(env PATH="$NO_FLOCK_BIN" \

--- a/.claude/lib/tests/test-zsh-compat.sh
+++ b/.claude/lib/tests/test-zsh-compat.sh
@@ -13,6 +13,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 LIB_DIR="$REPO_ROOT/.claude/lib"
+HOOK_UTILS="$REPO_ROOT/.claude/hooks/push-marker-utils.sh"
 
 TESTS=0
 PASSES=0
@@ -116,7 +117,41 @@ unset_rc=$(zsh -c "
 assert_eq "worktree: CLAUDE_PROJECT_DIR 未設定時は source が fail loud" "failed" "$unset_rc"
 
 # -----------------------------------------------------------------------------
-# Test 3: 静的ガード — zsh 特殊変数を local に使う / 素の mv を使う退行を防ぐ
+# Test 3: push marker utils が zsh source でも bash と同じ判定を返す
+# -----------------------------------------------------------------------------
+zsh_push_detect=$(zsh -c '
+  source "$1" || exit 7
+  push_marker_detect_git_push "git -C /tmp push"
+  print -r -- "$PUSH_MARKER_IS_GIT_PUSH:$PUSH_MARKER_IS_DRY_RUN"
+' zsh "$HOOK_UTILS" 2>&1)
+assert_eq "push marker: zsh でも git -C push を検出する" \
+  "true:false" "$zsh_push_detect"
+
+zsh_stash_detect=$(zsh -c '
+  source "$1" || exit 7
+  push_marker_detect_git_push "git -C /tmp stash push"
+  print -r -- "$PUSH_MARKER_IS_GIT_PUSH:$PUSH_MARKER_IS_DRY_RUN"
+' zsh "$HOOK_UTILS" 2>&1)
+assert_eq "push marker: zsh でも stash push を除外する" \
+  "false:false" "$zsh_stash_detect"
+
+zsh_dry_run_detect=$(zsh -c '
+  source "$1" || exit 7
+  push_marker_detect_git_push "git push -n"
+  print -r -- "$PUSH_MARKER_IS_GIT_PUSH:$PUSH_MARKER_IS_DRY_RUN"
+' zsh "$HOOK_UTILS" 2>&1)
+assert_eq "push marker: zsh でも push -n を dry-run 判定する" \
+  "true:true" "$zsh_dry_run_detect"
+
+zsh_repo_dir=$(zsh -c '
+  source "$1" || exit 7
+  push_marker_resolve_repo_dir "" "git -C \"$2\" push" /tmp
+' zsh "$HOOK_UTILS" "$TMP_STATE" 2>&1)
+assert_eq "push marker: zsh でも git -C の effective cwd を解決する" \
+  "$TMP_STATE" "$zsh_repo_dir"
+
+# -----------------------------------------------------------------------------
+# Test 4: 静的ガード — zsh 特殊変数を local に使う / 素の mv を使う退行を防ぐ
 #   awk スクリプト内の path= は対象外（シェル変数ではない）なので `local` 行に限定。
 #   lib 配下の全シェルスクリプトを対象にし、将来の新規追加でも zsh 特殊変数
 #   （PATH を破壊する path / read-only な status 等）の混入を検出する。

--- a/.claude/lib/tests/test-zsh-compat.sh
+++ b/.claude/lib/tests/test-zsh-compat.sh
@@ -48,6 +48,7 @@ require_zsh
 # 進行中の場合にその state をテストが破壊するため。pid で衝突を避ける)
 SK="zshcompat-test-$$"
 TMP_STATE=$(mktemp -d "/tmp/test-zsh-flow-state.XXXXXX")
+TMP_STATE=$(cd "$TMP_STATE" && pwd -P)
 cleanup_state() {
   rm -f "$TMP_STATE"/flow-progress-"$SK".json "$TMP_STATE"/flow-kpi-"$SK".json \
     "$TMP_STATE"/flow-context-"$SK".json "$TMP_STATE"/flow-"$SK".lock \

--- a/.claude/lib/tests/test-zsh-compat.sh
+++ b/.claude/lib/tests/test-zsh-compat.sh
@@ -24,12 +24,19 @@ NC='\033[0m'
 
 assert_eq() {
   local description="$1" expected="$2" actual="$3"
+  local zsh_exit_code="${4-}" zsh_stderr_file="${5-}" diagnostics="${6-}"
   TESTS=$((TESTS + 1))
   if [ "$expected" = "$actual" ]; then
     PASSES=$((PASSES + 1)); echo -e "${GREEN}PASS${NC}: $description"
   else
     FAILURES=$((FAILURES + 1)); echo -e "${RED}FAIL${NC}: $description"
     echo "  expected: $expected"; echo "  actual:   $actual"
+    if [ -n "$zsh_exit_code" ]; then
+      print_zsh_failure_diagnostics "$zsh_exit_code" "$zsh_stderr_file"
+    fi
+    if [ "$diagnostics" = "state" ]; then
+      print_state_environment_diagnostics
+    fi
   fi
 }
 
@@ -49,6 +56,71 @@ require_zsh
 SK="zshcompat-test-$$"
 TMP_STATE=$(mktemp -d "/tmp/test-zsh-flow-state.XXXXXX")
 TMP_STATE=$(cd "$TMP_STATE" && pwd -P)
+TMP_DIAGNOSTICS=$(mktemp -d "/tmp/test-zsh-compat-diagnostics.XXXXXX")
+STATE_DIAGNOSTICS_PRINTED=0
+
+print_indented_file() {
+  local file="$1"
+  if [ -s "$file" ]; then
+    sed 's/^/  /' "$file"
+  else
+    echo "  (empty)"
+  fi
+}
+
+print_zsh_failure_diagnostics() {
+  local exit_code="$1" stderr_file="$2"
+  echo "  --- zsh subshell exit code: $exit_code"
+  echo "  --- zsh subshell stderr:"
+  print_indented_file "$stderr_file"
+}
+
+print_state_environment_diagnostics() {
+  [ "$STATE_DIAGNOSTICS_PRINTED" -eq 0 ] || return 0
+  STATE_DIAGNOSTICS_PRINTED=1
+
+  local stat_result flow_dir_init_rc
+  local flow_dir_init_stderr="$TMP_DIAGNOSTICS/flow-state-dir-init.stderr"
+
+  echo "  --- state environment:"
+  echo "  uname -s: $(uname -s 2>&1)"
+  echo "  zsh --version: $(zsh --version 2>&1)"
+  echo "  TMP_STATE: $TMP_STATE"
+  if [ -e "$TMP_STATE" ]; then
+    echo "  TMP_STATE exists: yes"
+    if stat_result=$(stat -c 'owner=%U(%u) mode=%a' "$TMP_STATE" 2>/dev/null); then
+      :
+    elif stat_result=$(stat -f 'owner=%Su(%u) mode=%Lp' "$TMP_STATE" 2>/dev/null); then
+      :
+    else
+      stat_result="stat failed"
+    fi
+    echo "  TMP_STATE stat: $stat_result"
+  else
+    echo "  TMP_STATE exists: no"
+    echo "  TMP_STATE stat: unavailable"
+  fi
+  echo "  FLOW_STATE_DIR: $TMP_STATE (zsh subshell override)"
+  echo "  FLOW_STATE_DIR_INITIALIZED: ${FLOW_STATE_DIR_INITIALIZED-<unset>}"
+  echo "  FLOW_STATE_DIR_SECURE_DEFAULT: ${FLOW_STATE_DIR_SECURE_DEFAULT-<unset>}"
+  echo "  XDG_RUNTIME_DIR: ${XDG_RUNTIME_DIR-<unset>}"
+
+  zsh -c '
+    export CLAUDE_PROJECT_DIR="$1"
+    export FLOW_STATE_DIR="$2"
+    source "$1/.claude/lib/flow-state-dir.sh"
+    flow_state_dir_init
+  ' zsh "$REPO_ROOT" "$TMP_STATE" >/dev/null 2>"$flow_dir_init_stderr"
+  flow_dir_init_rc=$?
+  echo "  --- standalone flow_state_dir_init exit code: $flow_dir_init_rc"
+  echo "  --- standalone flow_state_dir_init stderr:"
+  print_indented_file "$flow_dir_init_stderr"
+  echo "  --- ls -la TMP_STATE:"
+  # 診断要件として ls -la の出力をそのまま記録する。
+  # shellcheck disable=SC2012
+  ls -la "$TMP_STATE" 2>&1 | sed 's/^/  /'
+}
+
 cleanup_state() {
   rm -f "$TMP_STATE"/flow-progress-"$SK".json "$TMP_STATE"/flow-kpi-"$SK".json \
     "$TMP_STATE"/flow-context-"$SK".json "$TMP_STATE"/flow-"$SK".lock \
@@ -57,32 +129,41 @@ cleanup_state() {
     /tmp/flow-context-"$SK".json /tmp/flow-"$SK".lock \
     /tmp/flow-progress-"$SK".json.new.* 2>/dev/null
 }
-trap 'cleanup_state; rm -rf "$TMP_STATE"' EXIT
+trap 'cleanup_state; rm -rf "$TMP_STATE" "$TMP_DIAGNOSTICS"' EXIT
 cleanup_state
+phase_stderr="$TMP_DIAGNOSTICS/phase-update.stderr"
 phase_after_update=$(zsh -c "
-  setopt aliases 2>/dev/null
+  setopt aliases
   alias mv='mv -i'
   export CLAUDE_PROJECT_DIR='$REPO_ROOT'
   export FLOW_STATE_DIR='$TMP_STATE'
   source '$LIB_DIR/state-io.sh'
-  sk=\$(flow_state_init '$SK' 'feature/$SK' /tmp/zshcompat-wt 2>/dev/null) || exit 7
-  flow_state_update progress '.phase = \"P2\"' \"\$sk\" </dev/null 2>/dev/null
+  sk=\$(flow_state_init '$SK' 'feature/$SK' /tmp/zshcompat-wt) || exit 7
+  flow_state_update progress '.phase = \"P2\"' \"\$sk\" </dev/null
   flow_state_read progress '.phase' \"\$sk\"
-" 2>/dev/null)
-assert_eq "state-io: zsh の mv -i エイリアス下でも phase 更新が反映される" "P2" "$phase_after_update"
+" 2>"$phase_stderr")
+phase_rc=$?
+assert_eq "state-io: zsh の mv -i エイリアス下でも phase 更新が反映される" \
+  "P2" "$phase_after_update" "$phase_rc" "$phase_stderr" state
 assert_eq "state-io: progress は FLOW_STATE_DIR 配下に作られる" \
-  "yes" "$([ -f "$TMP_STATE/flow-progress-$SK.json" ] && echo yes || echo no)"
+  "yes" "$([ -f "$TMP_STATE/flow-progress-$SK.json" ] && echo yes || echo no)" \
+  "$phase_rc" "$phase_stderr" state
 assert_eq "state-io: kpi は FLOW_STATE_DIR 配下に作られる" \
-  "yes" "$([ -f "$TMP_STATE/flow-kpi-$SK.json" ] && echo yes || echo no)"
+  "yes" "$([ -f "$TMP_STATE/flow-kpi-$SK.json" ] && echo yes || echo no)" \
+  "$phase_rc" "$phase_stderr" state
 assert_eq "state-io: context は FLOW_STATE_DIR 配下に作られる" \
-  "yes" "$([ -f "$TMP_STATE/flow-context-$SK.json" ] && echo yes || echo no)"
+  "yes" "$([ -f "$TMP_STATE/flow-context-$SK.json" ] && echo yes || echo no)" \
+  "$phase_rc" "$phase_stderr" state
 assert_eq "state-io: scope lock は FLOW_STATE_DIR 配下に作られる" \
-  "yes" "$([ -f "$TMP_STATE/flow-$SK.lock" ] && echo yes || echo no)"
+  "yes" "$([ -f "$TMP_STATE/flow-$SK.lock" ] && echo yes || echo no)" \
+  "$phase_rc" "$phase_stderr" state
 assert_eq "state-io: atomic update の中間 file が残らない" \
-  "0" "$(find "$TMP_STATE" -maxdepth 1 -name '*.new.*' -type f | wc -l | tr -d ' ')"
+  "0" "$(find "$TMP_STATE" -maxdepth 1 -name '*.new.*' -type f | wc -l | tr -d ' ')" \
+  "$phase_rc" "$phase_stderr" state
 
 # deploy-watch は外部状態判定を stub し、context update の配置だけを integration 確認する。
 deploy_merge_sha="0123456789abcdef"
+deploy_stderr="$TMP_DIAGNOSTICS/deploy-watch.stderr"
 deploy_context=$(zsh -c "
   export CLAUDE_PROJECT_DIR='$REPO_ROOT'
   export FLOW_STATE_DIR='$TMP_STATE'
@@ -92,9 +173,10 @@ deploy_context=$(zsh -c "
   _deploy_watch_pm2_online() { return 1; }
   deploy_watch_init '$SK' '$deploy_merge_sha'
   flow_state_read context '.deploy_watch.merge_sha' '$SK'
-" 2>/dev/null)
+" 2>"$deploy_stderr")
+deploy_rc=$?
 assert_eq "deploy-watch: context update は FLOW_STATE_DIR 配下の state を更新する" \
-  "$deploy_merge_sha" "$deploy_context"
+  "$deploy_merge_sha" "$deploy_context" "$deploy_rc" "$deploy_stderr" state
 cleanup_state
 
 # -----------------------------------------------------------------------------
@@ -102,54 +184,67 @@ cleanup_state
 #   zsh で source すると BASH_SOURCE は未定義のため、self-locate に依存すると
 #   sibling lib の source が壊れる。CLAUDE_PROJECT_DIR 経由の絶対パス解決を検証。
 # -----------------------------------------------------------------------------
+compute_stderr="$TMP_DIAGNOSTICS/compute-worktree-path.stderr"
 zsh_compute=$(zsh -c "
   export CLAUDE_PROJECT_DIR='$REPO_ROOT'
   source '$LIB_DIR/worktree/compute-worktree-path.sh' || exit 7
   compute_worktree_path /home/user/dev/myrepo feature/issue-1/foo
-" 2>/dev/null)
+" 2>"$compute_stderr")
+compute_rc=$?
 assert_eq "worktree: zsh でも sibling source + compute_worktree_path が動く" \
-  "/home/user/dev/ark-feature-issue-1-foo" "$zsh_compute"
+  "/home/user/dev/ark-feature-issue-1-foo" "$zsh_compute" "$compute_rc" "$compute_stderr"
 
 # CLAUDE_PROJECT_DIR 未設定なら fail loud（誤 path 推測で続行しない）
+unset_stderr="$TMP_DIAGNOSTICS/compute-worktree-path-unset.stderr"
 unset_rc=$(zsh -c "
   unset CLAUDE_PROJECT_DIR
-  source '$LIB_DIR/worktree/compute-worktree-path.sh' 2>/dev/null && echo sourced || echo failed
-" 2>/dev/null)
-assert_eq "worktree: CLAUDE_PROJECT_DIR 未設定時は source が fail loud" "failed" "$unset_rc"
+  source '$LIB_DIR/worktree/compute-worktree-path.sh' && echo sourced || echo failed
+" 2>"$unset_stderr")
+unset_exit_code=$?
+assert_eq "worktree: CLAUDE_PROJECT_DIR 未設定時は source が fail loud" \
+  "failed" "$unset_rc" "$unset_exit_code" "$unset_stderr"
 
 # -----------------------------------------------------------------------------
 # Test 3: push marker utils が zsh source でも bash と同じ判定を返す
 # -----------------------------------------------------------------------------
+push_detect_stderr="$TMP_DIAGNOSTICS/push-detect.stderr"
 zsh_push_detect=$(zsh -c '
   source "$1" || exit 7
   push_marker_detect_git_push "git -C /tmp push"
   print -r -- "$PUSH_MARKER_IS_GIT_PUSH:$PUSH_MARKER_IS_DRY_RUN"
-' zsh "$HOOK_UTILS" 2>&1)
+' zsh "$HOOK_UTILS" 2>"$push_detect_stderr")
+push_detect_rc=$?
 assert_eq "push marker: zsh でも git -C push を検出する" \
-  "true:false" "$zsh_push_detect"
+  "true:false" "$zsh_push_detect" "$push_detect_rc" "$push_detect_stderr"
 
+stash_detect_stderr="$TMP_DIAGNOSTICS/stash-detect.stderr"
 zsh_stash_detect=$(zsh -c '
   source "$1" || exit 7
   push_marker_detect_git_push "git -C /tmp stash push"
   print -r -- "$PUSH_MARKER_IS_GIT_PUSH:$PUSH_MARKER_IS_DRY_RUN"
-' zsh "$HOOK_UTILS" 2>&1)
+' zsh "$HOOK_UTILS" 2>"$stash_detect_stderr")
+stash_detect_rc=$?
 assert_eq "push marker: zsh でも stash push を除外する" \
-  "false:false" "$zsh_stash_detect"
+  "false:false" "$zsh_stash_detect" "$stash_detect_rc" "$stash_detect_stderr"
 
+dry_run_detect_stderr="$TMP_DIAGNOSTICS/dry-run-detect.stderr"
 zsh_dry_run_detect=$(zsh -c '
   source "$1" || exit 7
   push_marker_detect_git_push "git push -n"
   print -r -- "$PUSH_MARKER_IS_GIT_PUSH:$PUSH_MARKER_IS_DRY_RUN"
-' zsh "$HOOK_UTILS" 2>&1)
+' zsh "$HOOK_UTILS" 2>"$dry_run_detect_stderr")
+dry_run_detect_rc=$?
 assert_eq "push marker: zsh でも push -n を dry-run 判定する" \
-  "true:true" "$zsh_dry_run_detect"
+  "true:true" "$zsh_dry_run_detect" "$dry_run_detect_rc" "$dry_run_detect_stderr"
 
+repo_dir_stderr="$TMP_DIAGNOSTICS/repo-dir.stderr"
 zsh_repo_dir=$(zsh -c '
   source "$1" || exit 7
   push_marker_resolve_repo_dir "" "git -C \"$2\" push" /tmp
-' zsh "$HOOK_UTILS" "$TMP_STATE" 2>&1)
+' zsh "$HOOK_UTILS" "$TMP_STATE" 2>"$repo_dir_stderr")
+repo_dir_rc=$?
 assert_eq "push marker: zsh でも git -C の effective cwd を解決する" \
-  "$TMP_STATE" "$zsh_repo_dir"
+  "$TMP_STATE" "$zsh_repo_dir" "$repo_dir_rc" "$repo_dir_stderr"
 
 # -----------------------------------------------------------------------------
 # Test 4: 静的ガード — zsh 特殊変数を local に使う / 素の mv を使う退行を防ぐ

--- a/.claude/lib/tests/test-zsh-compat.sh
+++ b/.claude/lib/tests/test-zsh-compat.sh
@@ -45,9 +45,6 @@ require_zsh() {
 }
 require_zsh
 
-# pnpm test:harness の既存経路から、flock 有無を切り替える共通 lock 回帰テストも実行する。
-/bin/bash "$SCRIPT_DIR/test-state-lock.sh" || exit 1
-
 # -----------------------------------------------------------------------------
 # Test 1: state-io の atomic 書き込みが zsh の `mv -i` エイリアス下でも成功する
 #   state-io.sh が素の `mv` を使うと、ユーザの `alias mv='mv -i'` が効いた zsh で

--- a/.claude/lib/tests/test-zsh-compat.sh
+++ b/.claude/lib/tests/test-zsh-compat.sh
@@ -45,6 +45,9 @@ require_zsh() {
 }
 require_zsh
 
+# pnpm test:harness の既存経路から、flock 有無を切り替える共通 lock 回帰テストも実行する。
+/bin/bash "$SCRIPT_DIR/test-state-lock.sh" || exit 1
+
 # -----------------------------------------------------------------------------
 # Test 1: state-io の atomic 書き込みが zsh の `mv -i` エイリアス下でも成功する
 #   state-io.sh が素の `mv` を使うと、ユーザの `alias mv='mv -i'` が効いた zsh で

--- a/.claude/lib/worktree/setup-worktree.sh
+++ b/.claude/lib/worktree/setup-worktree.sh
@@ -17,6 +17,65 @@ fi
 # shellcheck source=./compute-worktree-path.sh
 source "$CLAUDE_PROJECT_DIR/.claude/lib/worktree/compute-worktree-path.sh"
 
+# パス比較専用に symlink を解決する。対象が未作成なら、存在する親だけを
+# 解決して basename を戻す。解決できない場合は元の文字列へフォールバックする。
+_normalize_path_for_comparison() {
+  local input_path="$1"
+  local normalized parent basename normalized_parent
+
+  if [ -d "$input_path" ]; then
+    if normalized=$(cd "$input_path" 2>/dev/null && pwd -P); then
+      printf '%s\n' "$normalized"
+      return 0
+    fi
+  else
+    parent="${input_path%/*}"
+    basename="${input_path##*/}"
+    if [ "$parent" = "$input_path" ]; then
+      parent='.'
+    elif [ -z "$parent" ]; then
+      parent='/'
+    fi
+    if normalized_parent=$(cd "$parent" 2>/dev/null && pwd -P); then
+      if [ "$normalized_parent" = '/' ]; then
+        printf '/%s\n' "$basename"
+      else
+        printf '%s/%s\n' "$normalized_parent" "$basename"
+      fi
+      return 0
+    fi
+  fi
+
+  printf '%s\n' "$input_path"
+}
+
+_worktree_path_is_registered() {
+  local main_root="$1"
+  local expected_path="$2"
+  local expected_normalized worktree_output line registered_path registered_normalized
+
+  expected_normalized=$(_normalize_path_for_comparison "$expected_path")
+  if ! worktree_output=$(git -C "$main_root" worktree list --porcelain 2>/dev/null); then
+    return 1
+  fi
+
+  while IFS= read -r line; do
+    case "$line" in
+      worktree\ *)
+        registered_path="${line#worktree }"
+        registered_normalized=$(_normalize_path_for_comparison "$registered_path")
+        if [ "$registered_normalized" = "$expected_normalized" ]; then
+          return 0
+        fi
+        ;;
+    esac
+  done <<EOF
+$worktree_output
+EOF
+
+  return 1
+}
+
 # main worktree と同一内容の .mise.toml だけを自動 trust する。
 _trust_worktree_mise_config() {
   local main_root="$1"
@@ -64,18 +123,15 @@ create_worktree() {
     echo "ERROR: $main_root は git repo として認識できません" >&2
     return 1
   }
-  if command -v realpath >/dev/null 2>&1; then
-    realmain=$(realpath "$main_root/.git" 2>/dev/null) || realmain="$main_root/.git"
-  else
-    realmain="$main_root/.git"
-  fi
+  common_dir=$(_normalize_path_for_comparison "$common_dir")
+  realmain=$(_normalize_path_for_comparison "$main_root/.git")
   if [ "$common_dir" != "$realmain" ]; then
     echo "ERROR: $main_root は main worktree ではありません（追加 worktree からの flow 起動は禁止）" >&2
     echo "  main worktree に cd してから再実行してください" >&2
     return 1
   fi
 
-  if git -C "$main_root" worktree list --porcelain 2>/dev/null | grep -q "^worktree $wt_path$"; then
+  if _worktree_path_is_registered "$main_root" "$wt_path"; then
     echo "既存 worktree を再利用: $wt_path" >&2
     _trust_worktree_mise_config "$main_root" "$wt_path"
     return $?

--- a/.claude/lib/worktree/setup-worktree.sh
+++ b/.claude/lib/worktree/setup-worktree.sh
@@ -17,6 +17,26 @@ fi
 # shellcheck source=./compute-worktree-path.sh
 source "$CLAUDE_PROJECT_DIR/.claude/lib/worktree/compute-worktree-path.sh"
 
+# main worktree と同一内容の .mise.toml だけを自動 trust する。
+_trust_worktree_mise_config() {
+  local main_root="$1"
+  local wt_path="$2"
+
+  command -v mise >/dev/null 2>&1 || return 0
+  [ -f "$main_root/.mise.toml" ] || return 0
+  [ -f "$wt_path/.mise.toml" ] || return 0
+
+  if ! cmp -s "$main_root/.mise.toml" "$wt_path/.mise.toml"; then
+    echo "mise trust をスキップ: worktree の .mise.toml は main と内容が異なります" >&2
+    return 0
+  fi
+
+  if ! mise trust --yes "$wt_path/.mise.toml"; then
+    echo "ERROR: mise trust に失敗: $wt_path/.mise.toml" >&2
+    return 1
+  fi
+}
+
 # 引数:
 #   $1 main_root   main worktree の絶対パス
 #   $2 branch      ブランチ名 (feature/issue-NNN/<slug> or feature/<slug>)
@@ -57,7 +77,8 @@ create_worktree() {
 
   if git -C "$main_root" worktree list --porcelain 2>/dev/null | grep -q "^worktree $wt_path$"; then
     echo "既存 worktree を再利用: $wt_path" >&2
-    return 0
+    _trust_worktree_mise_config "$main_root" "$wt_path"
+    return $?
   fi
 
   if ! git -C "$main_root" fetch origin --quiet 2>/dev/null; then
@@ -71,7 +92,8 @@ create_worktree() {
       echo "ERROR: worktree 作成に失敗 (既存 branch $branch)" >&2
       return 1
     }
-    return 0
+    _trust_worktree_mise_config "$main_root" "$wt_path"
+    return $?
   fi
 
   # ローカルに無いがリモートに既存 branch があれば、それをベースに track する
@@ -80,11 +102,13 @@ create_worktree() {
       echo "ERROR: worktree 作成に失敗 (remote branch origin/$branch)" >&2
       return 1
     }
-    return 0
+    _trust_worktree_mise_config "$main_root" "$wt_path"
+    return $?
   fi
 
   git -C "$main_root" worktree add "$wt_path" -b "$branch" origin/main >/dev/null 2>&1 || {
     echo "ERROR: worktree 作成に失敗 (新規 branch $branch from origin/main)" >&2
     return 1
   }
+  _trust_worktree_mise_config "$main_root" "$wt_path"
 }

--- a/.claude/skills/flow-loop/SKILL.md
+++ b/.claude/skills/flow-loop/SKILL.md
@@ -75,12 +75,12 @@ loop で処理**できない / させたくない** Issue には GitHub ラベ�
 ## tick の手順
 
 **STEP 0 前提**: `flow_loop_stopped` が真 → 「停止中。`/flow-loop start` で再開」と報告して終了。`flow_loop_within_active_hours` が偽 (かつ `--force` なし) → 「稼働時間外 (active_hours)」と報告して終了。
-**STEP 1 排他**: `flow_loop_lock` 失敗 → 「別 tick 実行中 (stale なら 1h で自動回収)」と報告して終了。**以降どの経路で終わる場合も必ず `flow_loop_unlock` する** (halt 提示で中断する場合も含む)。
+**STEP 1 排他**: `flow_loop_lock` 失敗 → 「別 tick 実行中 (owner pid が死亡し、かつ lock が 1h 超なら自動回収)」と報告して終了。取得した shell の `FLOW_LOOP_LOCK_PID` / `FLOW_LOOP_LOCK_TOKEN` を tick 中保持する。**以降どの経路で終わる場合も、取得時の値を `flow_loop_unlock "$FLOW_LOOP_LOCK_PID" "$FLOW_LOOP_LOCK_TOKEN"` に渡して必ず解錠する** (別 Bash invocation からの解錠、halt 提示で中断する場合も含む)。取得 token が異なる他 tick の lock は解錠しない。
 **STEP 2 ブレーカー**: `flow_loop_init` 後、`flow_loop_breaker_tripped` が真 → unlock して「ブレーカー作動中 (連続 halt ≥ 3)。原因を確認し `/flow-loop start` でリセット」と報告・終了。
 **STEP 3 run 走査**: `flow_loop_active_scope_keys` で全 run を列挙し、各 state (`flow_state_read progress '.phase / .gate / .gate_mode / .safety_level / .work_id / .branch'` と `context '.worktree_path / .pr_number / .codex_pid'`) を読み、下の**シグナル判定表**に従って前進できるものから処理する。1 つの run が halt しても tick 全体は止めず、記録して次の run へ。**cwd 規律**: セッションの cwd は main worktree から動かさない。run の worktree 内の操作はサブシェル `(cd "$WT" && ...)` または `git -C "$WT"` で行う (flow-x 共通ルールと同じ。cwd を worktree に置き去りにすると以後の run 処理を壊す)。
 **STEP 4 pick**: アクティブ run 数 (`flow_loop_active_count`) < `wip_limit` **かつ** `flow_loop_pick_budget_left` > 0 なら `pick_query` で候補を検索し (`gh issue list --search "$(flow_loop_read '.pick_query')" --json number,title,body,labels --limit 20`)、除外 (同 Issue の進行中 state 既存 / body 空 = DoR 未達) を除いた先頭 1 件を新規着手する。**依存検出**: 採用前に候補 Issue 本文の「連携/依存」と open PR (`gh pr list` → `gh pr diff <n> --name-only`) の変更ファイル群を照合し、作業対象が重なるものは「依存待ち」として skip (ダイジェストに列挙。ブロッカー PR のマージ後に自然に候補へ戻る)。着手は `$CLAUDE_PROJECT_DIR/.claude/skills/flow-x/SKILL.md` を Read し、`--async-gates` 相当 (`GATE_MODE="async"`) で STEP 0 から実行、**P2.5 の設計承認 park (plan コミット済み draft PR) まで**進める。着手したら `flow_loop_record_pick` で予算を消費し、metrics に `pick` を記録。**1 tick の新規着手は 1 件まで** (時間予算・暴走防止)。
 **STEP 5 集計と計測**: この tick のイベントを `flow_loop_metrics_append` で記録する — pick (`pick`) / 新規 park (`park`・gate 付き) / 設計承認 (`plan-approved`) / 差し戻し検知 (`fix`) / マージ (`merged`) / 新規 halt (`halt`・理由付き) / P12 terminal (`done`・deploy_status 付き)。`flow_loop_update '.last_tick_at = '"$(date +%s)"` で更新。この tick で**新たに halt が発生**したら `.consecutive_halts += 1`、**前進があれば** (フェーズ遷移・マージ・pick 成功のいずれか) `.consecutive_halts = 0`。
-**STEP 6 解錠**: `flow_loop_unlock`。
+**STEP 6 解錠**: `flow_loop_unlock "$FLOW_LOOP_LOCK_PID" "$FLOW_LOOP_LOCK_TOKEN"`。
 **STEP 7 ダイジェスト報告と通知**: 表で報告 — 前進した run / 設計承認待ち (PR URL) / マージ承認待ち (PR URL) / halt 中 (理由) / 実装中 (detached codex) / CI・CodeRabbit 監視中 / deploy 監視中 / pick・skip (DoR 未達・依存待ち・予算到達含む)。最後に「人間が次にやること」を 1〜2 行で明示する。
 **通知 (イベント駆動・スパム防止)**: この tick で**新規 park (plan-review / merge-review)・新規 halt・ブレーカー発動**が起きた場合のみ `PushNotification` を送る (本文例: 「設計承認待ち 1 件: PR #90」)。イベントの無い tick では通知しない。
 

--- a/.claude/skills/flow-loop/lib/loop.sh
+++ b/.claude/skills/flow-loop/lib/loop.sh
@@ -16,7 +16,8 @@
 #     PR で変える。runtime directory の loop.json 直接編集は一時的な調整用。
 #   - パス解決に BASH_SOURCE を使わない。Claude の Bash ツールは実体が zsh のことがあり、
 #     zsh で source すると BASH_SOURCE が空になるため CLAUDE_PROJECT_DIR を使う。
-#   - tick 排他は mkdir の atomic 性を使う (flock ファイルと違い stale 回収を mtime で判定できる)。
+#   - tick 排他は state-io.sh の共通 mkdir lock を使う。呼び出し間で fd を保持できないため
+#     flock backend は選ばず、既存どおり pid / mtime による 1h stale 回収を行う。
 #   - pick は GitHub Issue のみ対応。pick_query は gh issue list --search 用の
 #     GitHub 検索構文で持つ。
 
@@ -27,7 +28,7 @@ if [ -z "${CLAUDE_PROJECT_DIR:-}" ]; then
   return 1
 fi
 # shellcheck source=/dev/null
-source "$CLAUDE_PROJECT_DIR/.claude/lib/flow-state-dir.sh"
+source "$CLAUDE_PROJECT_DIR/.claude/lib/state-io.sh"
 
 # 限定 override が無い用途だけ共通 directory を解決する。
 if [ -z "${FLOW_LOOP_STATE_DIR:-}" ] || [ -z "${FLOW_LOOP_RUNS_DIR:-}" ]; then
@@ -90,81 +91,17 @@ flow_loop_breaker_tripped() {
   [ -n "$n" ] && [ "$n" -eq "$n" ] 2>/dev/null && [ "$n" -ge "$FLOW_LOOP_BREAKER_THRESHOLD" ]
 }
 
-# tick 排他。mkdir の atomic 性で取得し、lock dir 内に所有者 pid を記録する。
-# 回収条件: 所有 pid が死んでいる、または pid 不明かつ mtime が閾値超 (stale)。
-# 所有 pid が生存している限り mtime に関わらず回収しない (1h を超える正当な長時間 tick を
-# 横取りして二重実行になる事故を防ぐ)。
-#
-# 設計制約: tick は Claude が複数の Bash 呼び出しにまたがって実行するため、fd を保持し
-# 続ける flock は使えない (呼び出し間で fd が生きない)。mkdir + pid 記録 + 取得後検証で
-# 近似する。取得後検証 (pid read-back) により、reclaim レースで他プロセスに lock を
-# 奪われた側は取得失敗を自覚して撤退する。pid 書き込み直前の極小窓は残るが、tick 間隔
-# (分単位) に対して十分小さく、シングルユーザー運用では実害がない。
-
-# 取得後検証: lock の pid が自分であること (reclaim レースの敗者検出)
-_flow_loop_lock_owned_by_self() {
-  [ "$(cat "$FLOW_LOOP_LOCK/pid" 2>/dev/null || echo "")" = "$$" ]
-}
-
+# tick は複数の Bash 呼び出しにまたがり得るため flock fd を保持できない。
+# 共通 helper の mkdir-direct backend で既存の flow-loop.lock directory path を維持する。
 flow_loop_lock() {
   mkdir -p "$FLOW_LOOP_STATE_DIR"
-  if mkdir "$FLOW_LOOP_LOCK" 2>/dev/null; then
-    printf '%s' "$$" > "$FLOW_LOOP_LOCK/pid" 2>/dev/null || true
-    _flow_loop_lock_owned_by_self && return 0
-    return 1
-  fi
-  local owner
-  owner="$(cat "$FLOW_LOOP_LOCK/pid" 2>/dev/null || echo "")"
-  case "$owner" in *[!0-9]*) owner="" ;; esac
-  # 所有者が生きている → 正当な実行中。回収しない
-  if [ -n "$owner" ] && kill -0 "$owner" 2>/dev/null; then
-    return 1
-  fi
-  local now mtime
-  now="$(date +%s)"
-  # GNU (stat -c %Y) を先に試す。BSD 先行 (stat -f %m) にすると GNU stat では
-  # -f がファイルシステムモードになり %m が「マウントポイント文字列」で成功してしまう
-  # (mtime に mount path が入り算術式が爆発、stale 回収も永久に効かない) ため順序が重要。
-  mtime="$(stat -c %Y "$FLOW_LOOP_LOCK" 2>/dev/null || stat -f %m "$FLOW_LOOP_LOCK" 2>/dev/null || echo "$now")"
-  case "$mtime" in ''|*[!0-9]*) mtime="$now" ;; esac
-  if { [ -n "$owner" ] && ! kill -0 "$owner" 2>/dev/null; } \
-     || [ $((now - mtime)) -ge "$FLOW_LOOP_LOCK_STALE_SECONDS" ]; then
-    # 回収は rename (atomic) で勝者を 1 人に絞る。素の削除だと、2 つの tick が
-    # 同時に stale を観測したとき、一方が取得し直した新 lock をもう一方が削除して
-    # 両者とも取得成功する二重実行レースがある。mv は同一パスに対して 1 プロセスしか
-    # 成功しないため、敗者はそのまま通常の mkdir 競争 (どちらか一方だけ成功) に戻る。
-    local reclaim="$FLOW_LOOP_LOCK.reclaim.$$"
-    if command mv "$FLOW_LOOP_LOCK" "$reclaim" 2>/dev/null; then
-      # mv した dir が本当に自分が stale 判定した旧 lock か検証してから捨てる。
-      # 別プロセスが先に reclaim → 新 lock を作った直後だと、その新 lock を
-      # 掴んでしまう可能性があるため、生存所有者の lock なら黙って返却する
-      local stolen_owner
-      stolen_owner="$(cat "$reclaim/pid" 2>/dev/null || echo "")"
-      case "$stolen_owner" in *[!0-9]*) stolen_owner="" ;; esac
-      if [ -n "$stolen_owner" ] && [ "$stolen_owner" != "$$" ] && kill -0 "$stolen_owner" 2>/dev/null; then
-        command mv "$reclaim" "$FLOW_LOOP_LOCK" 2>/dev/null || rm -rf "$reclaim"
-        return 1
-      fi
-      rm -rf "$reclaim"
-    fi
-    if mkdir "$FLOW_LOOP_LOCK" 2>/dev/null; then
-      printf '%s' "$$" > "$FLOW_LOOP_LOCK/pid" 2>/dev/null || true
-      _flow_loop_lock_owned_by_self && return 0
-    fi
-  fi
-  return 1
+  flow_lock_acquire "$FLOW_LOOP_LOCK" 9 0 "$FLOW_LOOP_LOCK_STALE_SECONDS" mkdir-direct
 }
 
-# 解錠は自分が所有する lock のみ。他プロセスが生存所有している lock は触らない
-# (旧所有者の遅延 unlock が新所有者の lock を消して二重実行になる事故を防ぐ)。
+# 自分の lock を解放する。別 invocation から呼ばれた場合も、owner が既に死亡して
+# いれば共通 stale 回収を使い、生存中の別 owner の lock は触らない。
 flow_loop_unlock() {
-  local owner
-  owner="$(cat "$FLOW_LOOP_LOCK/pid" 2>/dev/null || echo "")"
-  case "$owner" in *[!0-9]*) owner="" ;; esac
-  if [ -n "$owner" ] && [ "$owner" != "$$" ] && kill -0 "$owner" 2>/dev/null; then
-    return 0
-  fi
-  rm -rf "$FLOW_LOOP_LOCK" 2>/dev/null || true
+  flow_lock_release "$FLOW_LOOP_LOCK" mkdir-direct "" 0
 }
 
 # 現在のプロジェクト (repo) の git-common-dir。run の所属判定に使う。

--- a/.claude/skills/flow-loop/lib/loop.sh
+++ b/.claude/skills/flow-loop/lib/loop.sh
@@ -17,7 +17,7 @@
 #   - パス解決に BASH_SOURCE を使わない。Claude の Bash ツールは実体が zsh のことがあり、
 #     zsh で source すると BASH_SOURCE が空になるため CLAUDE_PROJECT_DIR を使う。
 #   - tick 排他は state-io.sh の共通 mkdir lock を使う。呼び出し間で fd を保持できないため
-#     flock backend は選ばず、既存どおり pid / mtime による 1h stale 回収を行う。
+#     flock backend は選ばず、pid 死亡 + mtime 1h 超の AND で stale 回収を行う。
 #   - pick は GitHub Issue のみ対応。pick_query は gh issue list --search 用の
 #     GitHub 検索構文で持つ。
 
@@ -95,13 +95,20 @@ flow_loop_breaker_tripped() {
 # 共通 helper の mkdir-direct backend で既存の flow-loop.lock directory path を維持する。
 flow_loop_lock() {
   mkdir -p "$FLOW_LOOP_STATE_DIR"
-  flow_lock_acquire "$FLOW_LOOP_LOCK" 9 0 "$FLOW_LOOP_LOCK_STALE_SECONDS" mkdir-direct
+  flow_lock_acquire "$FLOW_LOOP_LOCK" 9 0 "$FLOW_LOOP_LOCK_STALE_SECONDS" mkdir-direct \
+    || return 1
+  FLOW_LOOP_LOCK_PID="$FLOW_LOCK_ACQUIRED_PID"
+  FLOW_LOOP_LOCK_TOKEN="$FLOW_LOCK_ACQUIRED_TOKEN"
+  export FLOW_LOOP_LOCK_PID FLOW_LOOP_LOCK_TOKEN
 }
 
-# 自分の lock を解放する。別 invocation から呼ばれた場合も、owner が既に死亡して
-# いれば共通 stale 回収を使い、生存中の別 owner の lock は触らない。
+# 自分の token と一致する lock だけを解放する。別 invocation から呼ぶ場合は、取得時の
+# FLOW_LOOP_LOCK_PID / FLOW_LOOP_LOCK_TOKEN を引数で明示的に受け渡す。
 flow_loop_unlock() {
-  flow_lock_release "$FLOW_LOOP_LOCK" mkdir-direct "" 0
+  local owner_pid="${1:-${FLOW_LOOP_LOCK_PID:-}}"
+  local owner_token="${2:-${FLOW_LOOP_LOCK_TOKEN:-}}"
+  [ -n "$owner_token" ] || return 1
+  flow_lock_release "$FLOW_LOOP_LOCK" mkdir-direct "$owner_pid" "$owner_token"
 }
 
 # 現在のプロジェクト (repo) の git-common-dir。run の所属判定に使う。

--- a/.claude/skills/flow-loop/tests/test-loop.sh
+++ b/.claude/skills/flow-loop/tests/test-loop.sh
@@ -169,15 +169,28 @@ else
   echo "WARN: touch -t 不可 → stale lock テストを skip"
   rm -rf "$FLOW_LOOP_LOCK"
 fi
-# 所有者 pid ベースの回収判定
+# 所有者 pid と経過時間の AND による回収判定
 mkdir -p "$FLOW_LOOP_LOCK"; printf '%s' "999999" > "$FLOW_LOOP_LOCK/pid"
-assert_rc "所有 pid が死んでいる lock は mtime に関わらず即回収できる" 0 'flow_loop_lock'
-flow_loop_unlock
-mkdir -p "$FLOW_LOOP_LOCK"; printf '%s' "$$" > "$FLOW_LOOP_LOCK/pid"
+assert_rc "所有 pid が死んでいても fresh lock は回収しない" 1 'flow_loop_lock'
 if touch -t "$(date -v-2H +%Y%m%d%H%M 2>/dev/null || date -d '2 hours ago' +%Y%m%d%H%M)" "$FLOW_LOOP_LOCK" 2>/dev/null; then
-  assert_rc "所有 pid が生存中なら mtime が stale でも横取りしない" 1 'flow_loop_lock'
+  assert_rc "所有 pid が死亡かつ 1h 超の lock は回収できる" 0 'flow_loop_lock'
+  flow_loop_unlock
+else
+  echo "WARN: touch -t 不可 → dead owner stale lock テストを skip"
+  rm -f "$FLOW_LOOP_LOCK/pid"
+  rmdir "$FLOW_LOOP_LOCK"
 fi
-# 所有者が自分 (生存) の lock は unlock で消える (後始末を兼ねる)
+mkdir -p "$FLOW_LOOP_LOCK"
+printf '%s' "$$" > "$FLOW_LOOP_LOCK/pid"
+printf '%s' "simulated-reused-pid" > "$FLOW_LOOP_LOCK/token"
+if touch -t "$(date -v-2H +%Y%m%d%H%M 2>/dev/null || date -d '2 hours ago' +%Y%m%d%H%M)" "$FLOW_LOOP_LOCK" 2>/dev/null; then
+  assert_rc "pid が生存中なら別 process への再利用を想定して横取りしない" 1 'flow_loop_lock'
+fi
+assert_rc "取得 token が異なる lock は unlock で消さない" 1 'flow_loop_unlock'
+rm -f "$FLOW_LOOP_LOCK/pid" "$FLOW_LOOP_LOCK/token"
+rmdir "$FLOW_LOOP_LOCK"
+# 自分が取得した lock は token 一致で unlock できる。
+flow_loop_lock
 flow_loop_unlock
 assert_rc "自分所有の lock は unlock で消える" 1 '[ -d "$FLOW_LOOP_LOCK" ]'
 

--- a/.claude/skills/flow-x/SKILL.md
+++ b/.claude/skills/flow-x/SKILL.md
@@ -648,7 +648,7 @@ flow_state_update progress '.iter += 1' "$SCOPE_KEY"
 
 PASS 後、`.git/claude-pre-push-review-done` flag を作成 (`pre-bash-guard.sh` の push ゲート用):
 ```bash
-touch "$(git rev-parse --git-dir)/claude-pre-push-review-done"
+touch "$(git -C "$WORKTREE_PATH" rev-parse --absolute-git-dir)/claude-pre-push-review-done"
 flow_state_update progress '.phase = "P6" | .iter = 0' "$SCOPE_KEY"
 ```
 

--- a/.claude/skills/flow-x/SKILL.md
+++ b/.claude/skills/flow-x/SKILL.md
@@ -79,7 +79,7 @@ issue 形式の判定とブランチ規約の共通化は `.claude/lib/ticket-so
 
 ## codex 実行の運用知見（実運用で検証済み）
 
-flow-x を実運用で回して判明した、codex exec の安定運用に必須の知見。**全 codex 起動はこの形に従う**。
+flow-x を実運用で回して判明した、codex exec の安定運用に必須の知見。**全 codex 起動はこの形に従う**。detached 起動は prompt を argv で渡し、stdin は `/dev/null` で閉じる。
 
 ### 1. 起動は `--dangerously-bypass-approvals-and-sandbox` を使う（`--full-auto` は使わない）
 
@@ -89,7 +89,7 @@ flow-x を実運用で回して判明した、codex exec の安定運用に必�
 # 完了判定・ログが混線するのを防ぐ)。起動 pid は必ず記録する (停止は pid 指名で行う)
 nohup codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
   -o "$FLOW_STATE_DIR/codex-<phase>-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
-  "$(cat "$FLOW_STATE_DIR/flowx-<phase>-prompt-${SCOPE_KEY}.md")" > "$FLOW_STATE_DIR/codex-<phase>-${SCOPE_KEY}-run.log" 2>&1 &
+  "$(cat "$FLOW_STATE_DIR/flowx-<phase>-prompt-${SCOPE_KEY}.md")" < /dev/null > "$FLOW_STATE_DIR/codex-<phase>-${SCOPE_KEY}-run.log" 2>&1 &
 CODEX_PID=$!
 flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 ```
@@ -166,7 +166,7 @@ codex が log 成長後に**プロセス消失・`-o` 未生成**で終わる事
 ```bash
 nohup codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
   -o "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
-  "$(cat "$FLOW_STATE_DIR/flowx-impl-prompt-${SCOPE_KEY}.md")" > "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-run.log" 2>&1 &
+  "$(cat "$FLOW_STATE_DIR/flowx-impl-prompt-${SCOPE_KEY}.md")" < /dev/null > "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-run.log" 2>&1 &
 CODEX_PID=$!
 flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 flow_state_update progress '.gate = "codex-impl"' "$SCOPE_KEY"
@@ -476,7 +476,7 @@ PLAN_PATH="$WORKTREE_PATH/docs/superpowers/plans/<TODAY>-<WORK_ID>.md"
 # プロンプトはファイルに書いて渡す (shell escape 事故回避)
 nohup codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
   -o "$FLOW_STATE_DIR/codex-p2-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
-  "$(cat "$FLOW_STATE_DIR/flowx-plan-prompt-${SCOPE_KEY}.md")" > "$FLOW_STATE_DIR/codex-p2-${SCOPE_KEY}-run.log" 2>&1 &
+  "$(cat "$FLOW_STATE_DIR/flowx-plan-prompt-${SCOPE_KEY}.md")" < /dev/null > "$FLOW_STATE_DIR/codex-p2-${SCOPE_KEY}-run.log" 2>&1 &
 CODEX_PID=$!
 flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 # Monitor で log 成長 + last.txt 生成を監視 (前節参照)。完了後:
@@ -561,7 +561,7 @@ plan は**成果物としてコミットし、作業の PR に含める** (CLAUD
 # 実装プロンプトをファイルに書いて渡す
 nohup codex exec --skip-git-repo-check --dangerously-bypass-approvals-and-sandbox \
   -o "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-last.txt" -c 'model_reasoning_effort="high"' \
-  "$(cat "$FLOW_STATE_DIR/flowx-impl-prompt-${SCOPE_KEY}.md")" > "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-run.log" 2>&1 &
+  "$(cat "$FLOW_STATE_DIR/flowx-impl-prompt-${SCOPE_KEY}.md")" < /dev/null > "$FLOW_STATE_DIR/codex-p3-${SCOPE_KEY}-run.log" 2>&1 &
 CODEX_PID=$!
 flow_state_update context ".codex_pid = $CODEX_PID" "$SCOPE_KEY"
 # 対話モード: Monitor で log 成長 + 完了ファイルを監視 (前節「codex 実行の運用知見」)
@@ -730,7 +730,7 @@ ITER=$(flow_state_read progress '.iter' "$SCOPE_KEY")
 
 **役割逆転**: codex が CodeRabbit 指摘を修正し、Claude がレビューする。
 
-1. **codex exec** (`--dangerously-bypass-approvals-and-sandbox`、前節参照) で各 auto-fixable 指摘を修正させる。指示に「プロジェクト規約厳守、CodeRabbit の指摘でも規約に反するものは適用せず報告」を明示
+1. **codex exec** (`--dangerously-bypass-approvals-and-sandbox`、前節と同じ invocation を参照。detached 起動は prompt を argv で渡し、stdin は `/dev/null` で閉じる) で各 auto-fixable 指摘を修正させる。指示に「プロジェクト規約厳守、CodeRabbit の指摘でも規約に反するものは適用せず報告」を明示
 2. codex がコミット (`CodeRabbit指摘対応: <要約>`)
 3. **Claude が修正 diff をレビュー** (P5 と同じ要領、規約準拠を最優先で判定)。`[P0]`/`[P1]` あれば codex に再修正、なければ通過
 4. push (フォアグラウンド) → 各スレッドへ返信 (修正コミット → push → 返信の順を厳守)

--- a/.claude/skills/flow/SKILL.md
+++ b/.claude/skills/flow/SKILL.md
@@ -26,7 +26,7 @@ argument-hint: [#<issue> | <slug>] [--resume | --from PHASE | --dry-run | --plan
 
 - main worktree からのみ起動可 (追加 worktree からの起動は P1 で物理拒否)
 - 全 phase で `.claude/lib/state-io.sh` の 3 ファイル分離 state を使う (progress / kpi / context)
-- AI ゲート (P2 / P5 / P8 / P9) は `.claude/lib/codex-gate.sh` を使い、fingerprint で重複抑止
+- AI ゲート (P2 / P5 / P8 / P9) は `.claude/lib/codex-gate.sh` を使い、fingerprint で重複抑止。diff / plan を明示的に stdin で渡すため `/dev/null` へ差し替えない
 - worktree は `<repo-parent>/ark-<sanitized-branch>/` のみ (Ark/Conductor 規約)
 - ブランチ名:
   - Issue 紐付けあり: `feature/issue-<N>/<slug>` (例: `feature/issue-123/html-viewer-tab`)

--- a/.claude/skills/flow/SKILL.md
+++ b/.claude/skills/flow/SKILL.md
@@ -341,7 +341,7 @@ fi
 
 PASS 後、`pre-bash-guard.sh` の `gh pr create` ガード用フラグを作成:
 ```bash
-touch "$(git rev-parse --git-dir)/claude-pre-push-review-done"
+touch "$(git -C "$WORKTREE_PATH" rev-parse --absolute-git-dir)/claude-pre-push-review-done"
 ```
 
 このフラグは `pre-bash-guard.sh` の正規パターン (touch + git rev-parse のみ) に準拠している。

--- a/docs/superpowers/plans/2026-08-19-issue-340.md
+++ b/docs/superpowers/plans/2026-08-19-issue-340.md
@@ -14,6 +14,9 @@
 
 ## Task 1: 実セッションで push マーカー失敗点を切り分ける（5分）
 
+> 実測済み: PostToolUse は発火し、marker も更新されるが、同一 HEAD でも 60 秒超過で拒否された。
+> `git -C <worktree>` では marker の repo dir が指定先でなく hook cwd（main worktree）になることも確認済み。
+
 **Files:**
 - Inspect: `.claude/settings.json:52-60`
 - Inspect: `.claude/hooks/post-push-monitor.sh:7-27,63-73`

--- a/docs/superpowers/plans/2026-08-19-issue-340.md
+++ b/docs/superpowers/plans/2026-08-19-issue-340.md
@@ -1,0 +1,206 @@
+# issue-340: ハーネスのガード誤検知と codex 起動の摩擦を解消する Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** flow / flow-x の正規手順を stdin 待ち・mise trust・ガード誤検知・誤った push マーカー照合で止めず、レビュー・git hook・push 品質ゲートの防御は回帰テストで維持する。
+
+**Issue:** 340 (GitHub Issue 紐付けあり)
+
+**Architecture:** 既存の shell splitter / tokenizer を git サブコマンド・グローバルオプション・書き込み先の構造判定へ再利用し、コマンド全文への正規表現を廃止する。各ガード緩和には必ず「正当なコマンドが通る誤検知解消テスト」と「実際のバイパス試行が今も拒否される防御維持テスト」を対で置き、push 品質ゲートは時刻ではなく push 後に記録した repository + HEAD の同一性で fail closed にする。flow / flow-x の phase、ゲート遷移、hook 登録は変えず、bash 3.2 と zsh の双方で動く既存ハーネスへ接続する。
+
+**Tech Stack:** bash hooks / bash test / Markdown
+
+---
+
+## Task 1: 実セッションで push マーカー失敗点を切り分ける（5分）
+
+**Files:**
+- Inspect: `.claude/settings.json:52-60`
+- Inspect: `.claude/hooks/post-push-monitor.sh:7-27,63-73`
+- Inspect: `.claude/hooks/pre-bash-guard.sh:267-316`
+- Inspect: `.claude/push-completed.marker`（git 管理外の実行時 state。存在する場合のみ）
+
+- [ ] この Task だけは nested `codex exec` 内ではなく、PostToolUse hook が実際に発火する flow-x supervisor (Claude Code) の Bash tool で行う。`WORKTREE_PATH`、`BRANCH`、`CLAUDE_PROJECT_DIR`、`date +%s`、マーカーの有無・mtime・1/2 行目を記録し、`.claude/settings.json` 52-60 行で Bash の PostToolUse が `post-push-monitor.sh` に接続済みであることを再確認する。settings ファイルは編集しない。
+- [ ] plan 承認後に既に upstream へ送られている同一 HEAD について、foreground の no-op `git -C "$WORKTREE_PATH" push origin "$BRANCH"` を supervisor の Bash tool から 1 回実行する。push 前後の epoch、マーカー mtime、SHA、repo dir を比較し、(a) hook 未発火、(b) 67 行より前の早期 return、(c) marker 更新後に 60 秒超過、のどこで失敗するか実測する。新しい commit、force push、PR/Issue コメント投稿は行わない。
+- [ ] 同じ `git -C` command を JSON の `.tool_input.command`、`WORKTREE_PATH` を `.cwd` に入れて `post-push-monitor.sh` へ合成 stdin で渡し、実 hook と合成入力の差を取る。合成入力ではマーカーが更新されること、現行の 2 行目が `-C` の指定先ではなく hook cwd になることを確認する。
+- [ ] 実マーカーを退避した上で、同じ SHA / repo dir のマーカーだけを 61 秒超の mtime にして `gh issue comment 340 --body probe` を含む JSON を `pre-bash-guard.sh` へ合成入力し、GitHub へ何も送信せず status 2 と「有効期限60秒」を再現する。直後に退避した実マーカーを戻す。
+- [ ] 後続 Task の前提は「Bash PostToolUse は発火し、`git -C` の repo dir 解決は誤り、同一 HEAD でも 60 秒だけで拒否される」とする。実測がこの前提と異なる場合は実装へ進まず、観測値を supervisor に報告して plan を改訂する。未確認のまま検出ロジックや期限を推測で変更しない。
+
+## Task 2: codex stdin 契約の回帰テストを Red で追加する（3分）
+
+**Files:**
+- Create: `.claude/lib/tests/test-codex-stdin.sh`
+- Reference: `.claude/skills/flow-x/SKILL.md:80-102,165-175,470-484,550-569,733`
+- Reference: `.claude/skills/flow/SKILL.md:29,57-66,231-253,322-345`
+- Reference: `.claude/lib/codex-gate.sh:134-141,209-213`
+
+- [ ] `.claude/lib/tests/test-codex-stdin.sh` を既存 harness と同じ `set -uo pipefail`、`TESTS` / `PASSES` / `FAILURES`、`assert_eq`、終了時サマリーで作る。`SCRIPT_DIR` から repo root を絶対解決し、flow、flow-x、codex-gate の 3 ファイルが無ければ fail する。
+- [ ] `awk` で flow-x の `nohup codex exec` から末尾 `&` までの logical command を抽出し、現行 4 invocation（運用知見、async P3、P2、P3）がすべて `< /dev/null` を持つことを assert する。invocation 数も 4 に固定し、P8 が「同じ invocation」を参照する 733 行を含め、追加された起動例が監査をすり抜けないようにする。
+- [ ] 通常 flow は stdin を閉じてはいけないため、`codex-gate.sh` の 2 個の `_run_codex exec` がそれぞれ `git diff ... |` と `< "$plan_path"` で明示的にレビュー対象を stdin 供給することを assert する。flow SKILL が `codex-gate.sh` を source / call することも assert し、flow と flow-x の全経路を同じテストで監査する。
+- [ ] `/bin/bash .claude/lib/tests/test-codex-stdin.sh` を実行し、flow-x の 4 command に `/dev/null` が無いため Red になることを確認する。通常 flow の明示 stdin assertion は最初から Green でなければならない。
+
+## Task 3: flow-x の全 detached codex 起動で stdin を閉じる（3分）
+
+**Files:**
+- Modify: `.claude/skills/flow-x/SKILL.md:82,90-94,165-170,477-481,562-566,733`
+- Modify: `.claude/skills/flow/SKILL.md:29`
+- Test: `.claude/lib/tests/test-codex-stdin.sh`
+
+- [ ] flow-x の 90-92、167-169、477-479、562-564 行にある 4 個の command で、prompt 引数と既存 log redirect の間へ `< /dev/null` を置く。対象 log は順に `codex-<phase>-${SCOPE_KEY}-run.log`、`codex-p3-${SCOPE_KEY}-run.log`、`codex-p2-${SCOPE_KEY}-run.log`、`codex-p3-${SCOPE_KEY}-run.log` とし、`nohup`、bypass flag、reasoning effort、`-o`、pid 記録、log path、background / park の構造は変えない。
+- [ ] 82 行の運用知見と 733 行の P8 手順に「detached 起動は prompt を argv で渡し、stdin は `/dev/null` で閉じる」契約を明記する。P2 / P3 / P8 / async の phase、retry、gate logic は変更しない。
+- [ ] 通常 flow の 29 行に、`codex-gate.sh` は diff / plan を明示 stdin で渡すため `/dev/null` へ差し替えない、という対になる契約を 1 文追加する。`codex-gate.sh` 本体の 136-140、209-213 行は変更しない。
+- [ ] `/bin/bash .claude/lib/tests/test-codex-stdin.sh` を再実行し、flow-x 4 件の closed stdin と flow 2 件の supplied stdin がすべて Green になることを確認する。
+
+## Task 4: mise trust の安全条件を Red テストで固定する（5分）
+
+**Files:**
+- Create: `.claude/lib/tests/test-setup-worktree.sh`
+- Reference: `.claude/lib/worktree/setup-worktree.sh:20-90`
+- Reference: `.claude/lib/tests/test-flow-state-dir.sh:1-78`
+
+- [ ] `.claude/lib/tests/test-setup-worktree.sh` を既存 harness 形式で作り、`mktemp -d`、repository-local の `user.name` / `user.email`、local bare `origin`、`trap` cleanup を使って network と global Git identity に依存しない main repository fixture を作る。main の baseline に `.mise.toml` を commit し、`CLAUDE_PROJECT_DIR` を実 repo root にして `setup-worktree.sh` を source する。
+- [ ] PATH 先頭に引数を log する fake `mise` を置き、`create_worktree "$MAIN_REPO" 'fix/issue-340/mise-match'` が作った同内容の `.mise.toml` に対して `mise trust --yes "$MISE_MATCH_WORKTREE/.mise.toml"` が厳密に 1 回呼ばれることを assert する。既存 worktree 再利用でも同じ trust check が 1 回行われることを別ケースで固定する。
+- [ ] 誤った config を trust しない防御テストとして、worktree 側 `.mise.toml` を書き換えた再利用ケースでは fake mise が 0 回であることを assert する。main 側 config 不在、worktree 側 config 不在、`mise` command 不在はすべて create/reuse 成功かつ trust skip とする。
+- [ ] fake mise が非 0 を返すケースでは `create_worktree` 自体が非 0 と明示診断を返すことを assert し、trust に失敗した worktree から codex 起動へ進まない fail-fast 契約を置く。
+- [ ] `/bin/bash .claude/lib/tests/test-setup-worktree.sh` を実行し、matching config で trust が呼ばれない現行実装による Red を確認する。
+
+## Task 5: create_worktree に内容一致時だけ mise trust を組み込む（4分）
+
+**Files:**
+- Modify: `.claude/lib/worktree/setup-worktree.sh:20-90`
+- Test: `.claude/lib/tests/test-setup-worktree.sh`
+
+- [ ] `create_worktree` の前に 2 引数 `$main_root` / `$wt_path` を取る private helper `_trust_worktree_mise_config` を追加する。`command -v mise`、両方の `.mise.toml` が regular file、`cmp -s "$main_root/.mise.toml" "$wt_path/.mise.toml"` の 3 条件が揃う場合だけ `mise trust --yes "$wt_path/.mise.toml"` を実行し、それ以外は成功扱いで skip する。
+- [ ] config 不一致時は「main と内容が異なるため trust をスキップ」と stderr に出し、外部 branch が持ち込んだ config を自動 trust しない。mise 実行失敗時は明示エラーを出して非 0 を返す。
+- [ ] 58-90 行の既存 worktree 再利用、local branch、remote branch、新規 branch の全成功出口を、worktree の add/reuse が確定した後に helper を 1 回だけ通る構造へ揃える。branch 命名、main worktree 検証、fetch、作成元 `origin/main` は変えない。
+- [ ] `/bin/bash .claude/lib/tests/test-setup-worktree.sh` を再実行し、内容一致・再利用が trust、内容不一致・config/mise 不在が skip、trust failure が fail-fast で Green になることを確認する。
+
+## Task 6: git hook bypass 判定の正負テストを Red で追加する（4分）
+
+**Files:**
+- Modify: `.claude/hooks/tests/test-push-marker.sh:41-49,98-118,200-235`
+- Reference: `.claude/hooks/pre-bash-guard.sh:11-14,103-123`
+- Reference: `.claude/hooks/push-marker-utils.sh:13-208`
+
+- [ ] `test-push-marker.sh` に command と cwd を JSON 化して `PRE_HOOK` へ渡し status / stderr を保持する `run_pre` helper を追加する。既存 temp repositories と `jq` prerequisite を再利用し、新しい hook test ファイルは作らない。
+- [ ] 誤検知解消側として `printf 'git docs' | grep -n docs.md`、`git status && sed -n '1,3p' file`、`git commit -m 'document --no-verify and -n'`、`git commit -m '-n'`、`git tag -n`、`git push -n` が status 0 になることを assert する。さらに、後段のコンテンツ系ガードとの回帰として `git commit -m '破壊的削除コマンドの扱いを修正'`、`git commit -m '過剰な権限付与のガードを追加'`、`git commit -m '自動 resolve ガードの誤検知を直す'`、review 済みフラグ basename を含む `git commit -m 'claude-pre-push-review-done の誤検知を修正'` もすべて status 0 に固定する。
+- [ ] 防御維持側として `git commit -n -m x`、`git commit -an -m x`、`git -C '$REPO_WORKTREE' commit --no-verify -m x`、`git push --no-verify`、`echo ok && git commit -n -m x` が status 2 になることを assert する。上記の commit message 4 ケースと対にして actual `git commit` の short / long bypass flag が引き続き status 2 であることを明示し、actual `git commit` が 11-14 行の早期 return で通る現行欠陥も Red に含める。
+- [ ] `/bin/bash .claude/hooks/tests/test-push-marker.sh` を実行し、少なくとも無関係な `grep -n` の誤ブロックと actual commit bypass の誤許可の双方で Red になることを確認する。片側だけを期待値変更で Green にしない。
+
+## Task 7: tokenizer で actual git subcommand の bypass flag だけを拒否する（5分）
+
+**Files:**
+- Modify: `.claude/hooks/push-marker-utils.sh:83-208`
+- Modify: `.claude/hooks/pre-bash-guard.sh:7-14,103-123`
+- Test: `.claude/hooks/tests/test-push-marker.sh`
+
+- [ ] `push-marker-utils.sh` に `_push_marker_git_subcommand_index` を追加し、既存 tokenizer の token 配列から値分離形の `-C "$REPO_WORKTREE"` / `-c core.pager=cat` / `--git-dir "$REPO_MAIN/.git"` と値結合形の `--git-dir="$REPO_MAIN/.git"` 等の Git global option をスキップして actual subcommand index を返す。`_push_marker_is_git_push_segment` も同 helper を使い、既存 push 検出契約を一元化する。
+- [ ] 1 引数 `$command` を取る `push_marker_detect_hook_bypass` を追加し、split 済み各 segment の actual subcommand が `commit` のときだけ option position の `-n`（`-an` 等の short cluster を含む）または `--no-verify`、`push` のときだけ `--no-verify` を検出する。`commit -m` / `--message` / `-F` 等の値を取る option の次 token、`--message=...`、`--` 以降、commit message 内の文字列は flag と解釈しない。`push -n` と `tag -n` は意味が異なるため許可する。
+- [ ] `pre-bash-guard.sh` 7-10 行直後で utils を 1 回 source し、まず `push_marker_detect_hook_bypass "$COMMAND"` を実行する。actual `git commit` の short / long bypass flag、または actual `git push` の long bypass flag を検出した場合は、後続の early return より先に既存 status 2 / 診断で拒否する。後段コメント guard での重複 source は削除する。
+- [ ] bypass detector の直後には、コミット・タグのメッセージ内容を後続の review 済みフラグ名、破壊的削除、`git reset --hard`、`git clean -f`、過剰な権限付与、ブロックデバイス書き込み、review comment 自動 resolve の各コンテンツ系ガードへ渡さないため、11-14 行の既存 `git commit` / `git tag` 全体 early return を残す。103-123 行の全文正規表現ブロックだけを削除し、先行 detector へ置き換える。
+- [ ] `/bin/bash .claude/hooks/tests/test-push-marker.sh` を再実行し、正当な調査・message・dry-run が通り、short / long の actual bypass が global option・連結 command を含めて塞がることを確認する。
+
+## Task 8: review 済みフラグ guard の正負テストを Red で追加する（5分）
+
+**Files:**
+- Modify: `.claude/hooks/tests/test-push-marker.sh:200-235`
+- Reference: `.claude/hooks/pre-bash-guard.sh:18-38,183-198`
+- Reference: `.claude/skills/flow/SKILL.md:342-347`
+- Reference: `.claude/skills/flow-x/SKILL.md:647-653`
+
+- [ ] 誤検知解消側として、フラグ basename を含む `grep -r`、`cat`、`ls`、`find`、`gh issue create --body 'claude-pre-push-review-done is documented'`、および `echo 'claude-pre-push-review-done' > "$TMP_TEST_DIR/note.txt"`（出力先は別名）が pre hook status 0 になることを assert する。
+- [ ] 正規 P5 作成側として、`touch "$(git rev-parse --git-dir)/claude-pre-push-review-done"`、`touch "$(git rev-parse --absolute-git-dir)/claude-pre-push-review-done"`、`cd '$REPO_WORKTREE' && touch "$(git rev-parse --absolute-git-dir)/claude-pre-push-review-done"`、`touch "$(git -C '$REPO_WORKTREE' rev-parse --absolute-git-dir)/claude-pre-push-review-done"` が status 0 になることを assert する。
+- [ ] 防御維持側として、任意 path への `touch`、`printf >`、`install`、`cp`、`mv`、`ln`、`tee`、`truncate`、`dd of=` による同 basename 作成が status 2 になることを assert する。canonical touch に `&& touch /tmp/claude-pre-push-review-done` を足した混在 command も status 2 とし、許可 segment が別の作成を隠さないことを固定する。
+- [ ] レビュー未実施 PR 防止の対テストとして、git dir に flag が無い `gh pr create` は status 2、30 分以内の flag がある場合だけ status 0 かつ flag を consume、古い flag は status 2 になることを assert する。
+- [ ] `/bin/bash .claude/hooks/tests/test-push-marker.sh` を実行し、read-only mention と `git -C` canonical command が現行の basename 全文検出で Red、manual creation と review 未実施 PR は Green（拒否）であることを確認する。
+
+## Task 9: フラグの作成 segment だけを guard し flow / flow-x を正規形へ揃える（5分）
+
+**Files:**
+- Modify: `.claude/hooks/pre-bash-guard.sh:18-38,183-198`
+- Modify: `.claude/skills/flow/SKILL.md:342-347`
+- Modify: `.claude/skills/flow-x/SKILL.md:647-653`
+- Test: `.claude/hooks/tests/test-push-marker.sh`
+
+- [ ] pre-bash guard に tokenizer を使う review flag classifier を追加し、basename を引数・書き込み先に持つ `touch` / `install` / `cp` / `mv` / `ln` / `tee` / `truncate`、redirection target、`dd of=` だけを「作成試行」と分類する。read-only command、issue body、別ファイルへの出力で文字列を言及するだけの command は対象外にする。
+- [ ] 許可する作成は、単一 target の `touch` で、その target が `git rev-parse --git-dir`、`git rev-parse --absolute-git-dir`、または `git -C "$WORKTREE_PATH" rev-parse --absolute-git-dir` の command substitution から得た git dir 直下の basename である場合だけに限定する。先行する `cd "$WORKTREE_PATH" &&` は許可するが、同一 command 内に別の review flag 作成 segment があれば status 2 とする。canonical 作成を認識しても即 `exit 0` せず、残りの破壊的 command guard を継続する。`git commit` / `git tag` は Task 7 で bypass 判定後に残す既存 early return がこの classifier より先に効いてメッセージ内容を検査対象外にするため、この継続方針とは矛盾しない。
+- [ ] flow と flow-x の P5 PASS 後 command を双方とも次の同一形へ置換する。phase 更新、P5 PASS 条件、P6 遷移は変えない。
+
+```bash
+touch "$(git -C "$WORKTREE_PATH" rev-parse --absolute-git-dir)/claude-pre-push-review-done"
+```
+
+- [ ] `/bin/bash .claude/hooks/tests/test-push-marker.sh` を再実行し、read-only / canonical 4 形式が Green、manual creation 全形式と review 未実施 / stale flag の PR create が status 2 のままであることを確認する。
+
+## Task 10: `git -C` repo 解決と zsh source の回帰テストを Red にする（4分）
+
+**Files:**
+- Modify: `.claude/hooks/tests/test-push-marker.sh:120-198`
+- Modify: `.claude/lib/tests/test-zsh-compat.sh:13-16,98-164`
+- Reference: `.claude/hooks/push-marker-utils.sh:13-208,297-369`
+
+- [ ] `test-push-marker.sh` 156-158 行の誤った期待値 `MAIN_HEAD` を `WORKTREE_HEAD` へ直し、marker 2 行目も `REPO_WORKTREE` であることを assert する。`git -c key=value -C '$REPO_WORKTREE' --no-pager push`、relative `-C`、連続する `-C` も最終指定先の HEAD / canonical path を記録する positive case に加える。
+- [ ] 防御側として `git -C '$TMP_TEST_DIR/missing-repo' push` は hook cwd へ fallback せず marker absent、`git -C '$REPO_WORKTREE' stash push` と `git -C '$REPO_WORKTREE' push -n` は引き続き marker absent であることを assert する。`push_marker_detect_git_push` が既に `git -C '$REPO_WORKTREE' push` を検出する assertion は残し、検出器を書き直す課題に戻さない。
+- [ ] `test-zsh-compat.sh` に hook utils の絶対 path を追加し、zsh から source 後に (1) `git -C /tmp push` は detect true、(2) `git -C /tmp stash push` は false、(3) `git push -n` は dry-run true、(4) 実在する temp dir への `-C` repo resolver は同 dir を返す、の正負ケースを assert する。
+- [ ] 両テストを実行し、push test は `git -C` が main HEAD を書く現行挙動、zsh test は `${var:i:1}` の `unrecognized modifier 'i'` で Red になることを確認する。
+
+## Task 11: 共通 git parser で `-C` を解決し zsh 互換にする（5分）
+
+**Files:**
+- Modify: `.claude/hooks/push-marker-utils.sh:13-208,210-369`
+- Test: `.claude/hooks/tests/test-push-marker.sh`
+- Test: `.claude/lib/tests/test-zsh-compat.sh`
+
+- [ ] 25、64、95、238 行の `${value:i:1}` 系を bash 3.2 / zsh 共通の `${value:$((i)):1}`、next char は `${value:$((i + 1)):1}` へ置換する。`${cd_arg:0:2}` 等の numeric literal offset は維持できるが、named offset の裸 `i` を utils 内に残さない。
+- [ ] Task 7 の common git subcommand parser に、actual subcommand までに現れる値分離形 `-C "$REPO_WORKTREE"` と値結合形 `-C$REPO_WORKTREE` を順番に適用して effective cwd を返す処理を追加する。absolute path はそのまま、relative path は直前の effective cwd 基準、複数 `-C` は Git と同じく直前の結果基準で canonicalize し、存在しない指定先は非 0 とする。
+- [ ] `push_marker_resolve_repo_dir` 344-358 行で git push segment を見つけたら、segment 内 `-C` の effective cwd を command 内 `cd`、hook input cwd、hook cwd より優先して返す。明示 `-C` の解決失敗を暗黙 cwd に fallback させず、marker を書かない fail-closed を維持する。`push_marker_detect_git_push` の positive / dry-run 判定は変更しない。
+- [ ] `/bin/bash .claude/hooks/tests/test-push-marker.sh` と `/bin/bash .claude/lib/tests/test-zsh-compat.sh` を再実行し、`git -C` / mixed globals / relative and repeated `-C` が指定先 HEAD、missing `-C` / stash / dry-run が marker absent、bash と zsh の detector 結果が一致して Green になることを確認する。
+
+## Task 12: 60 秒誤拒否と HEAD 不一致防御を対テストで Red にする（3分）
+
+**Files:**
+- Modify: `.claude/hooks/tests/test-push-marker.sh:200-235`
+- Reference: `.claude/hooks/pre-bash-guard.sh:267-316`
+
+- [ ] Task 1 の実測前提が成立した場合だけ進む。matching `WORKTREE_HEAD` + `REPO_WORKTREE` を持つ marker の mtime を 61 秒より古くしても、`gh pr comment` と `gh issue comment` の合成入力が status 0 になる誤検知解消テストを追加する。
+- [ ] 防御維持側として、marker 不在、空 SHA、存在しない repo dir、marker SHA と current HEAD 不一致は mtime の新旧に関係なく status 2 とする。matching marker 作成後に fixture repoへ新 commit を積み、返信が status 2 になる実際の「push 後に新しい commit」ケースも置く。さらに、別 repository の HEAD とその repo dir を正しく記録した自己整合的な marker でも、その repository の git common dir が現在の `CLAUDE_PROJECT_DIR` の git common dir と異なる場合は status 2 になることを assert する。
+- [ ] old-but-matching が現行 60 秒 check で Red、別 repository の自己整合 marker が現行 HEAD-only check で Red、missing / malformed / mismatched / newer commit がすべて Green（拒否）であることを `/bin/bash .claude/hooks/tests/test-push-marker.sh` で確認する。
+
+## Task 13: push 品質ゲートを mtime から repository + HEAD 同一性へ移す（3分）
+
+**Files:**
+- Modify: `.claude/hooks/pre-bash-guard.sh:267-316`
+- Test: `.claude/hooks/tests/test-push-marker.sh`
+
+- [ ] 268 行の説明と 282-295 行の GNU/BSD `stat`、`MARKER_AGE`、60 秒 reject を削除する。marker の存在、1 行目の non-empty SHA、2 行目 repo dir（旧 1 行形式は command/cwd から解決）、`git -C "$TARGET_REPO_DIR" rev-parse HEAD` 成功、marker SHA と current HEAD の完全一致を許可条件にする。
+- [ ] marker が別 repository を指して自己整合しているだけでは許可しない。`git -C "$TARGET_REPO_DIR" rev-parse --path-format=absolute --git-common-dir` と `git -C "$CLAUDE_PROJECT_DIR" rev-parse --path-format=absolute --git-common-dir` がともに成功し、絶対 path が完全一致して `TARGET_REPO_DIR` が現在の project の worktree ツリーに属することも許可条件へ加える。不一致・解決失敗は専用診断で status 2 とする。
+- [ ] marker 不在・壊れた repo・SHA 不一致・git common dir 不一致の status 2 と診断を維持し、時刻が古いだけの再 push 指示は出さない。PostToolUse 成功後に書かれた marker が現在の project の worktree ツリーに属し、現在の commit identity と一致する間だけ返信可能という品質ゲートにコメントを更新する。
+- [ ] `/bin/bash .claude/hooks/tests/test-push-marker.sh` を再実行し、old-but-identical の PR / Issue comment が通り、push 無し・malformed・別 HEAD・push 後の追加 commit・git common dir が異なる別 repository の自己整合 marker が塞がる対テストをすべて Green にする。
+
+## Task 14: harness を macOS CI に接続して全スコープを検証する（5分）
+
+**Files:**
+- Modify: `package.json:24-25`
+- Test: `.claude/lib/tests/test-codex-stdin.sh`
+- Test: `.claude/lib/tests/test-setup-worktree.sh`
+- Test: `.claude/hooks/tests/test-push-marker.sh`
+- Test: `.claude/lib/tests/test-zsh-compat.sh`
+- Verify: `.github/workflows/ci.yml:11,28-29`
+
+- [ ] root `package.json` の `test:harness` を次の exact chain に置換し、既存 issue-338 test と今回の全 test を `/bin/bash` で fail-fast 実行する。CI workflow は既に macOS で `pnpm test` を呼ぶため変更しない。
+
+  実装時の注意: root `package.json` は `.claude/lib/deploy-watch.sh` の `_DEPLOY_WATCH_PATHS` に含まれるため、この PR のマージ後は flow P12 が no-target ではなく実際の pm2 deploy を起動する。通常の deploy 監視を省略せず、完了まで確認する。
+
+```json
+"test:harness": "/bin/bash .claude/lib/tests/test-flow-safety-paths.sh && /bin/bash .claude/lib/tests/test-codex-stdin.sh && /bin/bash .claude/lib/tests/test-setup-worktree.sh && /bin/bash .claude/hooks/tests/test-push-marker.sh && /bin/bash .claude/lib/tests/test-zsh-compat.sh"
+```
+
+- [ ] `/bin/bash -n` で `setup-worktree.sh`、`push-marker-utils.sh`、`pre-bash-guard.sh`、`test-codex-stdin.sh`、`test-setup-worktree.sh`、`test-push-marker.sh`、`test-zsh-compat.sh` を構文検査する。bash 4+ 専用の `mapfile` / `readarray` / associative array / `${var^^}` / `&>>` を追加していないことを `rg` で監査し、macOS `/bin/bash` 3.2 互換を保つ。
+- [ ] `pnpm test:harness` を実行し、codex stdin、mise trust、bypass flag、review flag、`git -C` marker、zsh source、old matching marker と全防御 negative caseが pass することを確認する。続けて `pnpm test` と `pnpm check` を実行する。
+- [ ] `git diff --check` と `git diff --name-only origin/main...HEAD` を確認し、変更をこの plan、列挙した `.claude/skills/{flow,flow-x}/SKILL.md`、`.claude/lib/worktree/setup-worktree.sh`、`.claude/hooks/{pre-bash-guard,push-marker-utils}.sh`、既存/新規 test、root `package.json` に限定する。
+- [ ] 次の禁止スコープ監査が無出力になることを確認する。`.claude/settings.json` / `.claude/settings.local.json`、`.github/workflows/`、`packages/` の差分があれば完了扱いにせず除外する。hook 登録、flow / flow-x の phase 見出し・gate 遷移、`push_marker_detect_git_push` の `git -C` positive contract に意図しない差分がないことも最終 diff で確認する。
+
+```bash
+git diff --name-only origin/main...HEAD \
+  | grep -E '^(\.claude/settings(\.local)?\.json$|\.github/workflows/|packages/)' || true
+```

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:e2e": "playwright test",
     "check": "biome check . && tsc -b",
     "test": "vitest run && pnpm test:harness",
-    "test:harness": "/bin/bash .claude/lib/tests/test-flow-safety-paths.sh",
+    "test:harness": "/bin/bash .claude/lib/tests/test-flow-safety-paths.sh && /bin/bash .claude/lib/tests/test-codex-stdin.sh && /bin/bash .claude/lib/tests/test-setup-worktree.sh && /bin/bash .claude/hooks/tests/test-push-marker.sh && /bin/bash .claude/lib/tests/test-zsh-compat.sh",
     "format": "biome check --write .",
     "lint": "biome lint ."
   },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:e2e": "playwright test",
     "check": "biome check . && tsc -b",
     "test": "vitest run && pnpm test:harness",
-    "test:harness": "/bin/bash .claude/lib/tests/test-flow-safety-paths.sh && /bin/bash .claude/lib/tests/test-codex-stdin.sh && /bin/bash .claude/lib/tests/test-setup-worktree.sh && /bin/bash .claude/hooks/tests/test-push-marker.sh && /bin/bash .claude/lib/tests/test-zsh-compat.sh",
+    "test:harness": "/bin/bash .claude/lib/tests/test-flow-safety-paths.sh && /bin/bash .claude/lib/tests/test-codex-stdin.sh && /bin/bash .claude/lib/tests/test-setup-worktree.sh && /bin/bash .claude/lib/tests/test-state-lock.sh && /bin/bash .claude/hooks/tests/test-push-marker.sh && /bin/bash .claude/lib/tests/test-zsh-compat.sh",
     "format": "biome check --write .",
     "lint": "biome lint ."
   },


### PR DESCRIPTION
flow / flow-x の正規手順が、ハーネス自身のガードや起動仕様で止まる問題を 5 件まとめて解消する。**すべての緩和に「誤検知が消えたこと」と「本来の防御が今も効くこと」の対テスト**を置き、CI で維持する。

Closes #340

## 起票時の診断を 1 件訂正した

5 番について「`push_marker_detect_git_push` が `git -C <path> push` を検出できない」と起票したが、**実測したところ検出できていた**。訂正して真因を測り直した（Issue のコメントに詳細）。

実測結果:

| 仮説 | 結果 |
| --- | --- |
| hook 未発火 | 否定。`git -C` 経由でも PostToolUse は発火する |
| 早期 return | 否定。マーカーは更新される |
| **60 秒の期限切れ** | **確定**。内容が同一でも mtime が 61 秒古いだけで拒否 |
| repo dir 解決 | 実バグ。`-C` の指定先ではなく hook の cwd を記録する |

つまり **正しく送信した人が、返信文を用意している間に必ずブロックされる**設計だった。検出ロジックではなく、期限の設計と repo 解決が問題だった。

## 変更内容

### 1. codex の stdin 待ちハング

flow-x の detached 起動 4 箇所に stdin リダイレクトが無く、`Reading additional input from stdin...` で無限停止していた。4 箇所すべてで stdin を閉じ、契約を明文化した。

**通常 flow の `codex-gate.sh` は `git diff |` と `< "$plan_path"` で意図的に stdin を供給している**ため、こちらは差し替えていない。flow の SKILL.md に対になる注意書きを追加した。

### 2. 新規 worktree の `.mise.toml` 未信頼

worktree を作るたびに未信頼となり codex が即死していた。`create_worktree` に trust 処理を組み込んだが、**main worktree の config と `cmp -s` で内容が一致する場合だけ**実行する。外部ブランチが持ち込んだ config を自動 trust しない。trust 失敗時は fail-fast で非 0 を返す。

### 3-4. `pre-bash-guard.sh` の誤検知 2 件

コマンド全文への正規表現をやめ、**既存の `push-marker-utils.sh` のトークナイザを再利用**して、実際の git サブコマンドのオプション位置だけを見るようにした。

レビュー済みフラグのガードも、文字列を含むだけで発火する判定から、**実際にそのファイルを作成しようとする segment だけ**を対象にする分類器へ置き換えた。許可する作成形式に `git -C <path> rev-parse --absolute-git-dir` を追加し、flow / flow-x 側もその正規形へ統一した。

**重要な設計判断**: `git commit` / `git tag` の早期 return は**削除していない**。これは「メッセージ内容を検査しない」ための意図的な防御で、削除するとコミットメッセージに `rm -rf` や `chmod 777` の語が入るだけでブロックされる。bypass フラグ判定を早期 return の**前**に置くことで、「実際の bypass は塞ぐ」と「メッセージ内容で誤発火しない」を両立させた。

### 5. push マーカー

- `git -C <path>` の指定先を解決する共通 parser を追加（相対パス・複数指定・値結合形にも対応）。解決失敗時は暗黙の cwd へ fallback せず、マーカーを書かない fail-closed
- **60 秒の期限を廃止**し、marker の repository + HEAD が現在と一致するかで判定する。あわせて marker の repo が現在の project の git common dir に属することも確認する
- `${var:i:1}` を bash 3.2 / zsh 共通の記法へ直し、zsh から source できるようにした

## 検証

修正後のガードを 22 ケースで実測した。

**防御維持（status 2 が期待）— 全て期待どおり**

```
git commit -n -m x / git commit -an -m x / git commit --no-verify -m x
git push --no-verify / echo ok && git commit -n -m x
破壊的削除 / 過剰な権限付与 / レビューコメントの自動 resolve
フラグファイルの手動作成（touch / リダイレクト / cp）
```

**誤検知解消（status 0 が期待）— 全て期待どおり**

```
grep -n / sed -n / git status && sed -n
git commit -m '過剰な権限付与のガードを追加'
git commit -m '自動 resolve ガードの誤検知を直す'
git commit -m 'claude-pre-push-review-done の誤検知を修正'
git tag -n / git push -n / フラグ名の grep と cat
```

その他:

- `git -C <wt>` の repo 解決が指定先を返す（修正前は main worktree）
- 1 時間前の marker でも HEAD 一致なら通り、HEAD 不一致・marker 不在は拒否
- zsh から source 可能（修正前は `unrecognized modifier 'i'` で失敗）
- ハーネステスト 5 本 182 assertions 全通過（`/bin/bash` と zsh）
- `pnpm test` / `pnpm check` exit 0。warning 47 件は main と同数で既存分
- `.claude/settings*.json` / `.github/workflows/` / `packages/` への変更なし
- flow / flow-x の phase 見出しに差分なし
- bash 4 以降専用記法の追加なし（CI は macos-latest で `/bin/bash` 3.2）

## CI 接続

`package.json` の `test:harness` にハーネステスト 5 本を連結し、`pnpm test` 経由で CI から実行されるようにした。

## 備考

`package.json` を変更しているため、**マージ後の P12 で実際に pm2 deploy が走る**（`_DEPLOY_WATCH_PATHS` に含まれるため）。

本 PR の作業中、修正前のガードに **7 回ブロックされた**。直近のものは、プロンプト本文の `git push` という文字列と、同一コマンド内の `rm -f` が `git ... push ... -f` として一致したケースである。これらはすべて回帰テストのケースに含めた。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * Git 操作の安全性を強化し、レビューを回避する不正なオプションを検出・拒否するようになりました。
  * レビュー完了状態と対象リポジトリの整合性確認を強化し、誤った操作を防止します。
  * worktree での設定信頼処理を改善し、安全に一致した設定のみ適用します。
  * 非同期処理の入力経路を安定化し、処理のハングを防ぎます。

* **テスト**
  * Git、worktree、レビュー状態、zsh 環境などの安全性・互換性テストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->