### PR TITLE
fix(harness): harden schema change guard

### DIFF
--- a/.claude/lib/flow-safety-paths.sh
+++ b/.claude/lib/flow-safety-paths.sh
@@ -11,8 +11,9 @@ FLOW_GUARD_SESSION_LIFECYCLE_PATHS=(
   "packages/server/src/lib/ttyd-manager.ts"
 )
 
-# DB schema の対象 path に schema 語句を含む diff がある場合は 0、
+# DB schema の対象 path に schema 操作を含む diff がある場合は 0、
 # 変更なしは 1、git diff などで評価できない場合は 2 を返す。
+# git config の色設定に関わらず判定するため、すべての diff で --no-color を指定する。
 flow_guard_db_schema_changed() {
   local diff_range="${1:-origin/main...HEAD}"
   local changed_paths
@@ -20,7 +21,7 @@ flow_guard_db_schema_changed() {
   local schema_diff
   local grep_status
 
-  changed_paths=$(git diff --name-only "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}")
+  changed_paths=$(git diff --no-color --name-only "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}")
   git_status=$?
   if [ "$git_status" -ne 0 ]; then
     printf 'DB スキーマ変更の判定不能: git diff が失敗しました (range: %s)\n' "$diff_range" >&2
@@ -28,7 +29,7 @@ flow_guard_db_schema_changed() {
   fi
   [ -n "$changed_paths" ] || return 1
 
-  schema_diff=$(git diff --unified=0 "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}")
+  schema_diff=$(git diff --no-color --unified=0 "$diff_range" -- "${FLOW_GUARD_DB_SCHEMA_PATHS[@]}")
   git_status=$?
   if [ "$git_status" -ne 0 ]; then
     printf 'DB スキーマ変更の判定不能: git diff が失敗しました (range: %s)\n' "$diff_range" >&2
@@ -37,7 +38,7 @@ flow_guard_db_schema_changed() {
 
   grep -E '^[+-]' <<< "$schema_diff" \
     | grep -vE '^(\+\+\+|---)' \
-    | grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN)'
+    | grep -qE '(CREATE TABLE|ALTER TABLE|DROP TABLE|ADD COLUMN|DROP COLUMN|CREATE (UNIQUE )?INDEX|DROP INDEX)'
   grep_status=$?
   case "$grep_status" in
     0) return 0 ;;

--- a/.claude/lib/tests/test-flow-safety-paths.sh
+++ b/.claude/lib/tests/test-flow-safety-paths.sh
@@ -136,13 +136,45 @@ db_schema_invalid_range_status() {
   printf '%s' "$guard_status"
 }
 
+db_schema_operation_changed() {
+  local sql="$1"
+  local commit_message="$2"
+
+  reset_to_baseline
+  printf '%s\n' "$sql" >> "$TMP_REPO/packages/server/src/lib/database.ts"
+  git -C "$TMP_REPO" add packages/server/src/lib/database.ts
+  git -C "$TMP_REPO" commit -q -m "$commit_message"
+  db_schema_changed
+}
+
 echo ""
 echo "=== DB schema guard ==="
-printf '%s\n' 'ALTER TABLE sessions ADD COLUMN archived INTEGER;' \
-  >> "$TMP_REPO/packages/server/src/lib/database.ts"
-git -C "$TMP_REPO" add packages/server/src/lib/database.ts
-git -C "$TMP_REPO" commit -q -m 'database schema change'
-assert_success "database.ts の schema diff を検出する" db_schema_changed
+git -C "$TMP_REPO" config color.ui always
+assert_success "color.ui=always でも database.ts の schema diff を検出する" \
+  db_schema_operation_changed \
+  'ALTER TABLE sessions ADD COLUMN archived INTEGER;' \
+  'database schema change with forced color'
+git -C "$TMP_REPO" config --unset-all color.ui
+assert_success "ALTER TABLE RENAME TO を検出する" \
+  db_schema_operation_changed \
+  'ALTER TABLE sessions RENAME TO archived_sessions;' \
+  'rename table'
+assert_success "ALTER TABLE RENAME COLUMN を検出する" \
+  db_schema_operation_changed \
+  'ALTER TABLE sessions RENAME COLUMN id TO session_id;' \
+  'rename column'
+assert_success "CREATE INDEX を検出する" \
+  db_schema_operation_changed \
+  'CREATE INDEX idx_sessions_id ON sessions(id);' \
+  'create index'
+assert_success "CREATE UNIQUE INDEX を検出する" \
+  db_schema_operation_changed \
+  'CREATE UNIQUE INDEX sessions_id_unique ON sessions(id);' \
+  'create unique index'
+assert_success "DROP INDEX を検出する" \
+  db_schema_operation_changed \
+  'DROP INDEX idx_sessions_id;' \
+  'drop index'
 assert_eq "DB schema halt message" \
   "DB スキーマ変更検出 (packages/server/src/lib/database.ts、人間レビュー必須)" \
   "$(flow_guard_db_schema_halt_message)"


### PR DESCRIPTION
## 概要

PR #342で導入されたDBスキーマ安全ガードを、Gitの色設定に依存しないものへ補強し、現行のDB移行で使われるschema操作の検出漏れを解消します。

## 修正内容

| 領域 | 変更 |
| --- | --- |
| 色付きdiff | `flow_guard_db_schema_changed`内の両方の`git diff`に`--no-color`を指定し、`color.ui=always`でも変更行を正しく検出するようにしました。 |
| schema操作 | `CREATE INDEX`、`CREATE UNIQUE INDEX`、`DROP INDEX`を検出対象へ追加しました。`ALTER TABLE`は従来から対象なので、`RENAME TO`および`RENAME COLUMN`も検出されます。 |
| 回帰テスト | 色付きdiff、テーブルrename、カラムrename、通常・unique index作成、index削除のfixtureを追加しました。 |

## 検証

- `git diff --check`
- `/bin/bash -n .claude/lib/flow-safety-paths.sh`
- `/bin/bash -n .claude/lib/tests/test-flow-safety-paths.sh`
- `pnpm test:harness` — **55/55 passed**

`pnpm test && pnpm check`も実行を試行しましたが、依存インストール後の重い全体処理が実行環境の30秒上限で中断されました。変更はbashの共有ガードとその専用ハーネステストのみであり、対象経路は上記の通り完全に検証済みです。

## 関連

- Follow-up to #342
- Addresses the DB guard findings identified in the recent PR review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * データベーススキーマ変更の検出が、Gitの色設定に左右されず安定して動作するようになりました。
  * テーブルやカラムの変更に加え、通常・一意インデックスの作成および削除も検出できるようになりました。

* **テスト**
  * さまざまなスキーマ変更パターンと色設定を対象とした検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->