### PR TITLE
feat(context): ark/context を Ark のセッションライフサイクルへ配線する

### DIFF
--- a/ark/context/scripts/lib/task-template.sh
+++ b/ark/context/scripts/lib/task-template.sh
@@ -26,7 +26,8 @@ ctx_task_render() {
     ctx_validate_xdg_file "$task"
     return $?
   fi
-  ctx_task_input_valid "$goal" 200 || { ctx_error "invalid task input"; return 1; }
+  [ -z "$goal" ] || ctx_task_input_valid "$goal" 200 \
+    || { ctx_error "invalid task input"; return 1; }
   [ -n "$previous" ] || { ctx_error "invalid task input"; return 1; }
   printf '%s' "$previous" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 \
     || { ctx_error "invalid task input"; return 1; }
@@ -57,9 +58,6 @@ ctx_task_render() {
       *) ctx_error "invalid task input"; return 1 ;;
     esac
   done
-  [ "$constraint_count" -gt 0 ] && [ "$plan_count" -gt 0 ] \
-    || { ctx_error "invalid task input"; return 1; }
-
   new="$session/task.md.new"
   if [ -e "$new" ] || [ -L "$new" ]; then ctx_validate_xdg_file "$new" || return 1; fi
   old_umask=$(umask)

--- a/ark/context/scripts/session-init.sh
+++ b/ark/context/scripts/session-init.sh
@@ -79,17 +79,18 @@ while [ "$#" -gt 0 ]; do
     *) session_disabled "invalid arguments" ;;
   esac
 done
-[ -n "$repo" ] && [ -n "$owner_pid" ] && [ -n "$goal" ] && [ -n "$constraints" ] && [ -n "$plans" ] \
-  || session_disabled "invalid arguments"
+[ -n "$repo" ] && [ -n "$owner_pid" ] || session_disabled "invalid arguments"
 case "$owner_pid" in *[!0-9]*) session_disabled "invalid owner pid" ;; esac
 kill -0 "$owner_pid" 2>/dev/null || session_disabled "owner pid is not alive"
-ctx_task_input_valid "$goal" 200 || session_disabled "invalid task input"
-while IFS= read -r value || [ -n "$value" ]; do ctx_task_input_valid "$value" 400 || session_disabled "invalid task input"; done <<EOF
+[ -z "$goal" ] || ctx_task_input_valid "$goal" 200 || session_disabled "invalid task input"
+if [ -n "$constraints" ]; then while IFS= read -r value || [ -n "$value" ]; do ctx_task_input_valid "$value" 400 || session_disabled "invalid task input"; done <<EOF
 $constraints
 EOF
-while IFS= read -r value || [ -n "$value" ]; do ctx_task_input_valid "$value" 400 || session_disabled "invalid task input"; done <<EOF
+fi
+if [ -n "$plans" ]; then while IFS= read -r value || [ -n "$value" ]; do ctx_task_input_valid "$value" 400 || session_disabled "invalid task input"; done <<EOF
 $plans
 EOF
+fi
 for value in "$requested_session" "$restart_session"; do
   [ -z "$value" ] && continue
   case "$value" in *[!0-9a-f]*) session_disabled "invalid session id" ;; esac
@@ -194,12 +195,14 @@ else
   previous='なし（通常起動）'
 fi
 set -- "$ARK_SESSION_DIR" "$goal" "$previous"
-while IFS= read -r value || [ -n "$value" ]; do set -- "$@" --constraint "$value"; done <<EOF
+if [ -n "$constraints" ]; then while IFS= read -r value || [ -n "$value" ]; do set -- "$@" --constraint "$value"; done <<EOF
 $constraints
 EOF
-while IFS= read -r value || [ -n "$value" ]; do set -- "$@" --plan-item "$value"; done <<EOF
+fi
+if [ -n "$plans" ]; then while IFS= read -r value || [ -n "$value" ]; do set -- "$@" --plan-item "$value"; done <<EOF
 $plans
 EOF
+fi
 ctx_task_render "$@" >/dev/null 2>&1 || init_failed "task initialization failed"
 ctx_knowledge_initialize "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" >/dev/null 2>&1 || init_failed "knowledge initialization failed"
 claude_settings_inject "$repo" "$CTX_REPO_STATE_DIR" >/dev/null 2>&1 || init_failed "settings injection failed"
@@ -211,4 +214,5 @@ printf 'ARK_SESSION_DIR\t%s\n' "$ARK_SESSION_DIR"
 printf 'ARK_CACHE_DIR\t%s\n' "$ARK_CACHE_DIR"
 printf 'ARK_RECITE_INTERVAL\t%s\n' "$interval"
 printf 'ARK_KNOWLEDGE_DIR\t%s\n' "$ARK_KNOWLEDGE_DIR"
+printf 'ARK_REPO_KEY\t%s\n' "$ARK_REPO_KEY"
 exit 0

--- a/ark/context/scripts/session-init.sh
+++ b/ark/context/scripts/session-init.sh
@@ -23,6 +23,11 @@ session_disabled() {
   exit 0
 }
 
+owner_pid_valid() {
+  case "$1" in ''|*[!0-9]*) return 1 ;; esac
+  case "$1" in *[1-9]*) return 0 ;; *) return 1 ;; esac
+}
+
 owner_read() {
   local owner=$1 line extra
   OWNER_SESSION=
@@ -35,7 +40,7 @@ $line
 EOF
   case "$OWNER_SESSION" in *[!0-9a-f]*) return 2 ;; esac
   [ "${#OWNER_SESSION}" -eq 32 ] || return 2
-  case "$OWNER_PID" in ''|*[!0-9]*) return 2 ;; esac
+  owner_pid_valid "$OWNER_PID" || return 2
   [ -z "${extra:-}" ] || return 2
 }
 
@@ -80,7 +85,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 [ -n "$repo" ] && [ -n "$owner_pid" ] || session_disabled "invalid arguments"
-case "$owner_pid" in *[!0-9]*) session_disabled "invalid owner pid" ;; esac
+owner_pid_valid "$owner_pid" || session_disabled "invalid owner pid"
 kill -0 "$owner_pid" 2>/dev/null || session_disabled "owner pid is not alive"
 [ -z "$goal" ] || ctx_task_input_valid "$goal" 200 || session_disabled "invalid task input"
 if [ -n "$constraints" ]; then while IFS= read -r value || [ -n "$value" ]; do ctx_task_input_valid "$value" 400 || session_disabled "invalid task input"; done <<EOF

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -65,13 +65,18 @@ chmod 700 "$XDG_DATA_HOME/ark" "$XDG_DATA_HOME/ark/context" \
   "$XDG_DATA_HOME/ark/context/repos" "$invalid_marker_state"
 printf '%s\t0\n' "$invalid_marker_sid" >"$invalid_marker_state/owner"
 chmod 600 "$invalid_marker_state/owner"
+cp "$invalid_marker_state/owner" "$TEST_TMP/invalid-owner-marker-original"
+invalid_marker_mode=$(ctx_stat "$invalid_marker_state/owner" | awk '{print $2}')
 run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" \
   --session-id 07070707070707070707070707070707
 assert_success "PID zero owner marker disables without process failure"
 assert_eq "PID zero owner marker is rejected" $'enabled\t0' "$(sed -n '1p' "$CASE_STDOUT")"
 assert_eq "PID zero owner marker is not treated as live" $'reason\tinvalid owner marker' \
   "$(sed -n '2p' "$CASE_STDOUT")"
-[ -e "$invalid_marker_state/owner" ] || test_fail "invalid owner marker was claimed or removed"
+cmp -s "$invalid_marker_state/owner" "$TEST_TMP/invalid-owner-marker-original" \
+  || test_fail "invalid owner marker content changed"
+assert_eq "invalid owner marker mode is preserved" "$invalid_marker_mode" \
+  "$(ctx_stat "$invalid_marker_state/owner" | awk '{print $2}')"
 [ ! -e "$repo/.claude/settings.local.json" ] || test_fail "invalid owner marker changed settings"
 
 setup_repo lifecycle

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -49,6 +49,31 @@ prepare_lifecycle_output() {
   seed_step_count "$output_cache" 7
 }
 
+setup_repo invalid-owner-pid
+invalid_owner_sid=09090909090909090909090909090909
+run_case /bin/bash "$INIT" --repo "$repo" --owner-pid 0 --session-id "$invalid_owner_sid"
+assert_success "PID zero input disables without process failure"
+assert_eq "PID zero input is rejected" $'enabled\t0' "$(sed -n '1p' "$CASE_STDOUT")"
+assert_eq "PID zero input reports invalid owner PID" $'reason\tinvalid owner pid' "$(sed -n '2p' "$CASE_STDOUT")"
+
+setup_repo invalid-owner-marker
+invalid_marker_sid=08080808080808080808080808080808
+repo_key=$(ctx_sha256 "$repo")
+invalid_marker_state="$XDG_DATA_HOME/ark/context/repos/$repo_key"
+mkdir -p "$invalid_marker_state"
+chmod 700 "$XDG_DATA_HOME/ark" "$XDG_DATA_HOME/ark/context" \
+  "$XDG_DATA_HOME/ark/context/repos" "$invalid_marker_state"
+printf '%s\t0\n' "$invalid_marker_sid" >"$invalid_marker_state/owner"
+chmod 600 "$invalid_marker_state/owner"
+run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" \
+  --session-id 07070707070707070707070707070707
+assert_success "PID zero owner marker disables without process failure"
+assert_eq "PID zero owner marker is rejected" $'enabled\t0' "$(sed -n '1p' "$CASE_STDOUT")"
+assert_eq "PID zero owner marker is not treated as live" $'reason\tinvalid owner marker' \
+  "$(sed -n '2p' "$CASE_STDOUT")"
+[ -e "$invalid_marker_state/owner" ] || test_fail "invalid owner marker was claimed or removed"
+[ ! -e "$repo/.claude/settings.local.json" ] || test_fail "invalid owner marker changed settings"
+
 setup_repo lifecycle
 settings="$repo/.claude/settings.local.json"
 printf '{\n "before" : "日本語"\n}\n\n' >"$settings"; chmod 640 "$settings"

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -57,9 +57,9 @@ sid=11111111111111111111111111111111
 run_case run_init "$sid"
 assert_success "session init succeeds"
 assert_eq "init enabled line" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
-assert_eq "init output line count" 6 "$(wc -l <"$CASE_STDOUT" | tr -d ' ')"
-assert_eq "init environment order" 'ARK_SESSION_ID ARK_SESSION_DIR ARK_CACHE_DIR ARK_RECITE_INTERVAL ARK_KNOWLEDGE_DIR' \
-  "$(sed -n '2,6p' "$CASE_STDOUT" | cut -f1 | tr '\n' ' ' | sed 's/ $//')"
+assert_eq "init output line count" 7 "$(wc -l <"$CASE_STDOUT" | tr -d ' ')"
+assert_eq "init environment order" 'ARK_SESSION_ID ARK_SESSION_DIR ARK_CACHE_DIR ARK_RECITE_INTERVAL ARK_KNOWLEDGE_DIR ARK_REPO_KEY' \
+  "$(sed -n '2,7p' "$CASE_STDOUT" | cut -f1 | tr '\n' ' ' | sed 's/ $//')"
 session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
 cache_dir=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
 [ -f "$session_dir/task.md" ] || test_fail "init did not create task.md"
@@ -68,6 +68,27 @@ repo_key=$(ctx_sha256 "$repo")
 state="$XDG_DATA_HOME/ark/context/repos/$repo_key"
 assert_eq "owner marker mode" 600 "$(ctx_stat "$state/owner" | awk '{print $2}')"
 assert_eq "owner marker bytes" "$sid" "$(cut -f1 "$state/owner")"
+
+run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$sid"
+assert_success "populated task teardown before empty scaffold case"
+empty_sid=10101010101010101010101010101010
+run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id "$empty_sid"
+assert_success "session init accepts omitted task arguments"
+assert_eq "empty task init enabled" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
+empty_session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
+grep -F '← NOW' "$empty_session_dir/task.md" >/dev/null 2>&1
+assert_eq "empty task has no NOW marker" 1 "$?"
+assert_eq "empty Goal body" '' "$(sed -n '/^## Goal$/,/^## Constraints$/p' "$empty_session_dir/task.md" | sed '1d;$d' | tr -d '\n')"
+assert_eq "empty Constraints body" 'Previous failure summary: なし（通常起動）' \
+  "$(sed -n '/^## Constraints$/,/^## Plan$/p' "$empty_session_dir/task.md" | sed '1d;$d' | sed '/^$/d')"
+assert_eq "empty Plan body" '' "$(sed -n '/^## Plan$/,/^## Artifacts$/p' "$empty_session_dir/task.md" | sed '1d;$d' | tr -d '\n')"
+run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$empty_sid"
+assert_success "empty task teardown succeeds"
+
+run_case run_init "$sid"
+assert_success "populated task can initialize after empty scaffold case"
+session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
+cache_dir=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
 
 seed_step_count "$cache_dir" 7
 task_before=$(cat "$session_dir/task.md")

--- a/ark/context/tests/test-task-template.sh
+++ b/ark/context/tests/test-task-template.sh
@@ -48,7 +48,32 @@ run_case ctx_task_render "$session" changed changed --constraint changed --plan-
 assert_success "second render is idempotent"
 assert_eq "second render preserves task" "$before" "$(cat "$session/task.md")"
 
-for bad in '' 'line
+empty_session="$TEST_TMP/empty"
+mkdir -m 700 "$empty_session"
+run_case ctx_task_render "$empty_session" '' 'なし（通常起動）'
+assert_success "empty task scaffold rendered"
+empty_expected='# Task
+
+## Goal
+
+
+## Constraints
+
+Previous failure summary: なし（通常起動）
+
+## Plan
+
+## Artifacts
+- (なし)'
+assert_eq "empty task scaffold bytes" "$empty_expected" "$(cat "$empty_session/task.md")"
+empty_cache="$TEST_TMP/empty-cache"
+mkdir -m 700 "$empty_cache"
+run_case env ARK_SESSION_DIR="$empty_session" ARK_CACHE_DIR="$empty_cache" \
+  ARK_RECITE_INTERVAL=1 /bin/bash "$ROOT/ark/context/hooks/recite-todo.sh"
+assert_success "empty task recitation succeeds"
+assert_eq "empty task recitation stays silent" 0 "$(wc -c <"$CASE_STDOUT" | tr -d ' ')"
+
+for bad in 'line
 break' '{{GOAL}}'; do
   fresh="$TEST_TMP/bad-$((TESTS + 1))"
   mkdir -m 700 "$fresh"

--- a/docs/superpowers/specs/ark-context-implementation-spec.md
+++ b/docs/superpowers/specs/ark-context-implementation-spec.md
@@ -254,7 +254,9 @@ Previous failure summary: {{PREV_FAILURE_SUMMARY}}
 - <path> — <1行要約>
 ```
 
-Plan には checkbox を使い、`← NOW` は常にちょうど1個だけ置く。全項目完了時は完了した最後の項目に残す。Goal と Constraints は init 後に編集してはならない。ただし、init 時に空で生成された Goal / Constraints は、空から記入済みへの一方向に限って一度だけ埋めてよい。初回記入後を含め、既に値が入っている Goal / Constraints の書き換えはドリフト防止のため従来どおり禁止する。空の項目を埋める主体と手順は #334 の §5 ループ規約の範囲とし、ここではこの初回記入が許されることだけを定める。作業中にそれ以外で更新できるのは Plan の項目、status、`← NOW` と artifact 参照だけとする。
+Plan には checkbox を使う。Plan が空のあいだは `← NOW` を置かず、Plan 項目を追加した時点で `← NOW` をちょうど1個置く。項目がある状態では `← NOW` を常にちょうど1個だけ置き、全項目完了時は完了した最後の項目に残す。
+
+Goal と Constraints は init 後に編集してはならない。ただし、init 時に空で生成された Goal / Constraints は、空から記入済みへの一方向に限って一度だけ埋めてよい。初回記入後を含め、既に値が入っている Goal / Constraints の書き換えはドリフト防止のため従来どおり禁止する。空の項目を埋める主体と手順は #334 の §5 ループ規約の範囲とし、ここではこの初回記入が許されることだけを定める。作業中にそれ以外で更新できるのは Plan の項目、status、`← NOW` と artifact 参照だけとする。
 
 `task-review.md.tmpl` は、diff 全ファイルの通読、規約遵守、artifact / index の整合、エラー握りつぶし、Goal 逸脱、再発性のある指摘の inbox 候補化を、同じ checkbox schema の Plan に持つ。session ID の SHA-256 を seed にした決定的な順列で提示順だけを変え、観点集合を削らず、同一 session 内では順序を安定させる。
 

--- a/docs/superpowers/specs/ark-context-implementation-spec.md
+++ b/docs/superpowers/specs/ark-context-implementation-spec.md
@@ -254,7 +254,7 @@ Previous failure summary: {{PREV_FAILURE_SUMMARY}}
 - <path> — <1行要約>
 ```
 
-Plan には checkbox を使い、`← NOW` は常にちょうど1個だけ置く。全項目完了時は完了した最後の項目に残す。Goal と Constraints は init 後に編集してはならず、作業中に更新できるのは Plan の項目、status、`← NOW` と artifact 参照だけとする。
+Plan には checkbox を使い、`← NOW` は常にちょうど1個だけ置く。全項目完了時は完了した最後の項目に残す。Goal と Constraints は init 後に編集してはならない。ただし、init 時に空で生成された Goal / Constraints は、空から記入済みへの一方向に限って一度だけ埋めてよい。初回記入後を含め、既に値が入っている Goal / Constraints の書き換えはドリフト防止のため従来どおり禁止する。空の項目を埋める主体と手順は #334 の §5 ループ規約の範囲とし、ここではこの初回記入が許されることだけを定める。作業中にそれ以外で更新できるのは Plan の項目、status、`← NOW` と artifact 参照だけとする。
 
 `task-review.md.tmpl` は、diff 全ファイルの通読、規約遵守、artifact / index の整合、エラー握りつぶし、Goal 逸脱、再発性のある指摘の inbox 候補化を、同じ checkbox schema の Plan に持つ。session ID の SHA-256 を seed にした決定的な順列で提示順だけを変え、観点集合を削らず、同一 session 内では順序を安定させる。
 
@@ -307,7 +307,7 @@ init の順序を次で固定する。
 
 `owner` marker の取得・生存確認・消滅 owner からの引継ぎは per-repo で排他的に行う。同じ session の再実行だけは既存 ownership を継続できる。repo state directory と file は owner のみ読み書き可能にする。`settings-ownership.json` は§5-3の契約に従い、注入前の有無とArkが実際に追加したentryだけを所有の根拠とする。
 
-`--repo` と `--owner-pid` は必須とするが、`--goal`、`--constraint`、`--plan-item` はすべて任意とする。省略時も context を有効化し、Goal、Constraints、Plan が空の `task.md` の骨組みを生成する。値が与えられた項目は従来どおり template へ展開する。Manus では自然言語の依頼を受けた agent 自身が `todo.md` を作り、ユーザーへ Goal のフォーム入力を要求しないため、この起動契約もその設計に合わせる。Ark は素のターミナルを開く用途があるので Goal 未設定を正常系とし、task を埋める agent 規約は別途定める。Goal と `← NOW` が空の `task.md` に対して復唱 hook が出力ゼロで沈黙し、両方が埋まった時点から復唱を開始することは実測済みであり、空の骨組みは通常のターミナル利用を妨げない。
+`--repo` と `--owner-pid` は必須とするが、`--goal`、`--constraint`、`--plan-item` はすべて任意とする。省略時も context を有効化し、Goal、Constraints、Plan が空の `task.md` の骨組みを生成する。値が与えられた項目は従来どおり template へ展開する。Manus では自然言語の依頼を受けた agent 自身が `todo.md` を作り、ユーザーへ Goal のフォーム入力を要求しないため、この起動契約もその設計に合わせる。Ark は素のターミナルを開く用途があるので Goal 未設定を正常系とする。空で生成された Goal / Constraints は §5-1 に従い、空から記入済みへの一方向に限って一度だけ埋めてよいが、既に値が入っている Goal / Constraints の書き換えは禁止する。空の項目を埋める主体と手順は #334 の §5 ループ規約の範囲とし、ここでは空から埋める操作が許されることだけを定める。Goal と `← NOW` が空の `task.md` に対して復唱 hook が出力ゼロで沈黙し、両方が埋まった時点から復唱を開始することは実測済みであり、空の骨組みは通常のターミナル利用を妨げない。
 
 注入時は現在の `.claude/settings.local.json` を読み、§5-3 の構文・型を検証する。同一 entry がない候補だけを追加対象としてmanifestへ原子的に記録し、deep mergeする。結果は repo 側の固定名 `.claude/settings.local.json.ark-context-tmp` に書き、既存 file の mode を保持し、新規 file は mode `0600` として、同 filesystem 上の `mv` で原子的に確定する。`mktemp` 等による可変名を使わない。
 

--- a/docs/superpowers/specs/ark-context-implementation-spec.md
+++ b/docs/superpowers/specs/ark-context-implementation-spec.md
@@ -307,6 +307,8 @@ init の順序を次で固定する。
 
 `owner` marker の取得・生存確認・消滅 owner からの引継ぎは per-repo で排他的に行う。同じ session の再実行だけは既存 ownership を継続できる。repo state directory と file は owner のみ読み書き可能にする。`settings-ownership.json` は§5-3の契約に従い、注入前の有無とArkが実際に追加したentryだけを所有の根拠とする。
 
+`--repo` と `--owner-pid` は必須とするが、`--goal`、`--constraint`、`--plan-item` はすべて任意とする。省略時も context を有効化し、Goal、Constraints、Plan が空の `task.md` の骨組みを生成する。値が与えられた項目は従来どおり template へ展開する。Manus では自然言語の依頼を受けた agent 自身が `todo.md` を作り、ユーザーへ Goal のフォーム入力を要求しないため、この起動契約もその設計に合わせる。Ark は素のターミナルを開く用途があるので Goal 未設定を正常系とし、task を埋める agent 規約は別途定める。Goal と `← NOW` が空の `task.md` に対して復唱 hook が出力ゼロで沈黙し、両方が埋まった時点から復唱を開始することは実測済みであり、空の骨組みは通常のターミナル利用を妨げない。
+
 注入時は現在の `.claude/settings.local.json` を読み、§5-3 の構文・型を検証する。同一 entry がない候補だけを追加対象としてmanifestへ原子的に記録し、deep mergeする。結果は repo 側の固定名 `.claude/settings.local.json.ark-context-tmp` に書き、既存 file の mode を保持し、新規 file は mode `0600` として、同 filesystem 上の `mv` で原子的に確定する。`mktemp` 等による可変名を使わない。
 
 復元時は現在の `.claude/settings.local.json` を読み、manifest に記録された entry と同一内容のものだけを除去し、その他の key・値・順序を保持する。変更された entry は残して manifest に `abandoned` と記録する。manifest が元設定なしを示し、除去後に Ark 以外の entry が残らない場合に限り settings file を削除し、それ以外は内容と mode を保持して固定名一時 file 経由の同 filesystem 上の `mv` で原子的に書き戻す。session 中に Claude Code やユーザーが settings.local を更新しうるため、backup による置換はそれらを失う。repo と XDG data が異なる filesystem でも rename に依存せず、安全性を確認できた孤児一時 fileだけを中間状態として除去する。

--- a/packages/server/src/lib/ark-context-harness.test.ts
+++ b/packages/server/src/lib/ark-context-harness.test.ts
@@ -33,6 +33,14 @@ function makeScriptDirectory(
   return directory;
 }
 
+function makeWorktreeDirectory(): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), "ark-context-worktree-")
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
 function enabledOutput(sessionId = "a".repeat(32)): string {
   return [
     "printf 'enabled\\t1\\n'",
@@ -83,11 +91,9 @@ describe("ArkContextHarness", () => {
       ownerPid: 4242,
       readSetting: () => true,
     });
+    const worktreePath = makeWorktreeDirectory();
 
-    const env = await harness.initializeSession(
-      "/worktree path",
-      "b".repeat(32)
-    );
+    const env = await harness.initializeSession(worktreePath, "b".repeat(32));
 
     expect(env).toEqual({
       ARK_SESSION_ID: "a".repeat(32),
@@ -99,7 +105,7 @@ describe("ArkContextHarness", () => {
     });
     expect(fs.readFileSync(argumentsFile, "utf8").trim().split("\n")).toEqual([
       "--repo",
-      "/worktree path",
+      fs.realpathSync(worktreePath),
       "--owner-pid",
       "4242",
       "--restart",
@@ -118,9 +124,10 @@ describe("ArkContextHarness", () => {
       readSetting: () => true,
       logger,
     });
+    const worktreePath = makeWorktreeDirectory();
 
     await expect(
-      harness.initializeSession("/worktree")
+      harness.initializeSession(worktreePath)
     ).resolves.toBeUndefined();
 
     expect(logger.warn).toHaveBeenCalledWith(
@@ -136,9 +143,10 @@ describe("ArkContextHarness", () => {
       readSetting: () => true,
       logger,
     });
+    const worktreePath = makeWorktreeDirectory();
 
     await expect(
-      harness.initializeSession("/worktree")
+      harness.initializeSession(worktreePath)
     ).resolves.toBeUndefined();
 
     expect(logger.error).toHaveBeenCalledWith(
@@ -155,9 +163,10 @@ describe("ArkContextHarness", () => {
       readSetting: () => true,
       logger,
     });
+    const worktreePath = makeWorktreeDirectory();
 
     await expect(
-      harness.initializeSession("/worktree")
+      harness.initializeSession(worktreePath)
     ).resolves.toBeUndefined();
 
     expect(logger.error).toHaveBeenCalledWith(
@@ -171,9 +180,36 @@ describe("ArkContextHarness", () => {
       scriptDirectory,
       readSetting: () => true,
     });
+    const worktreePath = makeWorktreeDirectory();
 
     await expect(
-      harness.teardownSession("/worktree", "a".repeat(32))
+      harness.teardownSession(worktreePath, "a".repeat(32))
     ).rejects.toThrow();
+  });
+
+  it("worktree の実体パスを解決できなければログして無効化する", async () => {
+    const scriptDirectory = makeScriptDirectory(enabledOutput());
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const harness = new ArkContextHarness({
+      scriptDirectory,
+      readSetting: () => true,
+      logger,
+    });
+    const missingWorktreePath = path.join(
+      makeWorktreeDirectory(),
+      "does-not-exist"
+    );
+
+    await expect(
+      harness.initializeSession(missingWorktreePath)
+    ).resolves.toBeUndefined();
+    await expect(
+      harness.teardownSession(missingWorktreePath, "a".repeat(32))
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledTimes(2);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("worktree path resolution failed")
+    );
   });
 });

--- a/packages/server/src/lib/ark-context-harness.test.ts
+++ b/packages/server/src/lib/ark-context-harness.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./database.js", () => ({
+  db: { getSetting: vi.fn(() => undefined) },
+}));
+
+import {
+  ARK_CONTEXT_ENABLED_SETTING_KEY,
+  ArkContextHarness,
+} from "./ark-context-harness.js";
+
+const temporaryDirectories: string[] = [];
+
+function makeScriptDirectory(
+  initBody: string,
+  teardownBody = "exit 0"
+): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "ark-context-test-"));
+  temporaryDirectories.push(directory);
+  fs.writeFileSync(
+    path.join(directory, "session-init.sh"),
+    `#!/usr/bin/env bash\n${initBody}\n`,
+    { mode: 0o700 }
+  );
+  fs.writeFileSync(
+    path.join(directory, "session-teardown.sh"),
+    `#!/usr/bin/env bash\n${teardownBody}\n`,
+    { mode: 0o700 }
+  );
+  return directory;
+}
+
+function enabledOutput(sessionId = "a".repeat(32)): string {
+  return [
+    "printf 'enabled\\t1\\n'",
+    `printf 'ARK_SESSION_ID\\t${sessionId}\\n'`,
+    "printf 'ARK_SESSION_DIR\\t/context/session\\n'",
+    "printf 'ARK_CACHE_DIR\\t/context/cache\\n'",
+    "printf 'ARK_RECITE_INTERVAL\\t10\\n'",
+    "printf 'ARK_KNOWLEDGE_DIR\\t/context/knowledge\\n'",
+    "printf 'ARK_REPO_KEY\\trepo-key\\n'",
+  ].join("\n");
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("ArkContextHarness", () => {
+  it("opt-in が true 以外なら script を実行せず無効のままにする", async () => {
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const readSetting = vi.fn(() => undefined);
+    const harness = new ArkContextHarness({
+      scriptDirectory: "/does/not/exist",
+      readSetting,
+      logger,
+    });
+
+    await expect(
+      harness.initializeSession("/worktree")
+    ).resolves.toBeUndefined();
+
+    expect(readSetting).toHaveBeenCalledWith(ARK_CONTEXT_ENABLED_SETTING_KEY);
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("enabled 1 の TSV を検証して tmux 用 env に変換する", async () => {
+    const argumentsFile = path.join(
+      os.tmpdir(),
+      `ark-context-args-${process.pid}`
+    );
+    const scriptDirectory = makeScriptDirectory(
+      `printf '%s\\n' "$@" >${JSON.stringify(argumentsFile)}\n${enabledOutput()}`
+    );
+    const harness = new ArkContextHarness({
+      scriptDirectory,
+      ownerPid: 4242,
+      readSetting: () => true,
+    });
+
+    const env = await harness.initializeSession(
+      "/worktree path",
+      "b".repeat(32)
+    );
+
+    expect(env).toEqual({
+      ARK_SESSION_ID: "a".repeat(32),
+      ARK_SESSION_DIR: "/context/session",
+      ARK_CACHE_DIR: "/context/cache",
+      ARK_RECITE_INTERVAL: "10",
+      ARK_KNOWLEDGE_DIR: "/context/knowledge",
+      ARK_REPO_KEY: "repo-key",
+    });
+    expect(fs.readFileSync(argumentsFile, "utf8").trim().split("\n")).toEqual([
+      "--repo",
+      "/worktree path",
+      "--owner-pid",
+      "4242",
+      "--restart",
+      "b".repeat(32),
+    ]);
+    fs.rmSync(argumentsFile, { force: true });
+  });
+
+  it("enabled 0 は理由をログして通常起動へフォールバックする", async () => {
+    const scriptDirectory = makeScriptDirectory(
+      "printf 'enabled\\t0\\nreason\\tanother live session owns this repo\\n'"
+    );
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const harness = new ArkContextHarness({
+      scriptDirectory,
+      readSetting: () => true,
+      logger,
+    });
+
+    await expect(
+      harness.initializeSession("/worktree")
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("another live session owns this repo")
+    );
+  });
+
+  it("非0終了は理由をログして通常起動へフォールバックする", async () => {
+    const scriptDirectory = makeScriptDirectory("echo init-broke >&2\nexit 7");
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const harness = new ArkContextHarness({
+      scriptDirectory,
+      readSetting: () => true,
+      logger,
+    });
+
+    await expect(
+      harness.initializeSession("/worktree")
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("session init failed")
+    );
+  });
+
+  it("timeout はログして通常起動へフォールバックする", async () => {
+    const scriptDirectory = makeScriptDirectory("sleep 1");
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const harness = new ArkContextHarness({
+      scriptDirectory,
+      timeoutMs: 20,
+      readSetting: () => true,
+      logger,
+    });
+
+    await expect(
+      harness.initializeSession("/worktree")
+    ).resolves.toBeUndefined();
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("session init failed")
+    );
+  });
+
+  it("teardown の非0終了は呼び出し側へ通知する", async () => {
+    const scriptDirectory = makeScriptDirectory(enabledOutput(), "exit 9");
+    const harness = new ArkContextHarness({
+      scriptDirectory,
+      readSetting: () => true,
+    });
+
+    await expect(
+      harness.teardownSession("/worktree", "a".repeat(32))
+    ).rejects.toThrow();
+  });
+});

--- a/packages/server/src/lib/ark-context-harness.ts
+++ b/packages/server/src/lib/ark-context-harness.ts
@@ -1,0 +1,175 @@
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { db } from "./database.js";
+import { getErrorMessage } from "./errors.js";
+
+const execFileAsync = promisify(execFile);
+
+export const ARK_CONTEXT_ENABLED_SETTING_KEY = "ark_context_enabled";
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_OUTPUT_BYTES = 64 * 1024;
+const CONTEXT_ENV_KEYS = new Set([
+  "ARK_SESSION_ID",
+  "ARK_SESSION_DIR",
+  "ARK_CACHE_DIR",
+  "ARK_RECITE_INTERVAL",
+  "ARK_KNOWLEDGE_DIR",
+  "ARK_REPO_KEY",
+]);
+const REQUIRED_CONTEXT_ENV_KEYS = [
+  "ARK_SESSION_ID",
+  "ARK_SESSION_DIR",
+  "ARK_CACHE_DIR",
+  "ARK_RECITE_INTERVAL",
+  "ARK_KNOWLEDGE_DIR",
+] as const;
+
+type Logger = Pick<Console, "error" | "warn">;
+
+export interface ArkContextHarnessOptions {
+  scriptDirectory?: string;
+  timeoutMs?: number;
+  ownerPid?: number;
+  readSetting?: (key: string) => unknown;
+  logger?: Logger;
+}
+
+interface ParsedInitOutput {
+  enabled: boolean;
+  reason?: string;
+  env?: Record<string, string>;
+}
+
+function resolveScriptDirectory(): string {
+  const moduleDirectory = dirname(fileURLToPath(import.meta.url));
+  const candidates = [
+    join(process.cwd(), "ark", "context", "scripts"),
+    join(moduleDirectory, "..", "..", "..", "ark", "context", "scripts"),
+    join(moduleDirectory, "..", "..", "..", "..", "ark", "context", "scripts"),
+  ];
+  return (
+    candidates.find(candidate =>
+      existsSync(join(candidate, "session-init.sh"))
+    ) ?? candidates[0]
+  );
+}
+
+function parseInitOutput(stdout: string): ParsedInitOutput {
+  const values = new Map<string, string>();
+  for (const line of stdout.split("\n")) {
+    if (line === "") continue;
+    const separator = line.indexOf("\t");
+    if (separator <= 0) throw new Error("invalid TSV output");
+    const key = line.slice(0, separator);
+    const value = line.slice(separator + 1);
+    if (values.has(key)) throw new Error(`duplicate TSV key: ${key}`);
+    values.set(key, value);
+  }
+
+  const enabled = values.get("enabled");
+  if (enabled === "0") {
+    return {
+      enabled: false,
+      reason: values.get("reason") || "no reason returned",
+    };
+  }
+  if (enabled !== "1") throw new Error("missing enabled status");
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of values) {
+    if (key === "enabled") continue;
+    if (!CONTEXT_ENV_KEYS.has(key) || value === "") {
+      throw new Error(`invalid context environment entry: ${key}`);
+    }
+    env[key] = value;
+  }
+  for (const key of REQUIRED_CONTEXT_ENV_KEYS) {
+    if (!(key in env)) throw new Error(`missing context environment: ${key}`);
+  }
+  if (!/^[0-9a-f]{32}$/.test(env.ARK_SESSION_ID)) {
+    throw new Error("invalid ARK_SESSION_ID");
+  }
+  return { enabled: true, env };
+}
+
+export class ArkContextHarness {
+  private readonly scriptDirectory: string;
+  private readonly timeoutMs: number;
+  private readonly ownerPid: number;
+  private readonly readSetting: (key: string) => unknown;
+  private readonly logger: Logger;
+
+  constructor(options: ArkContextHarnessOptions = {}) {
+    this.scriptDirectory = options.scriptDirectory ?? resolveScriptDirectory();
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.ownerPid = options.ownerPid ?? process.pid;
+    this.readSetting = options.readSetting ?? (key => db.getSetting(key));
+    this.logger = options.logger ?? console;
+  }
+
+  async initializeSession(
+    worktreePath: string,
+    restartSessionId?: string
+  ): Promise<Record<string, string> | undefined> {
+    if (this.readSetting(ARK_CONTEXT_ENABLED_SETTING_KEY) !== true) {
+      return undefined;
+    }
+
+    const args = [
+      join(this.scriptDirectory, "session-init.sh"),
+      "--repo",
+      worktreePath,
+      "--owner-pid",
+      String(this.ownerPid),
+    ];
+    if (restartSessionId) args.push("--restart", restartSessionId);
+
+    try {
+      const { stdout } = await execFileAsync("/bin/bash", args, {
+        encoding: "utf8",
+        timeout: this.timeoutMs,
+        maxBuffer: MAX_OUTPUT_BYTES,
+      });
+      const parsed = parseInitOutput(stdout);
+      if (!parsed.enabled) {
+        this.logger.warn(
+          `[ArkContext] session init disabled for ${worktreePath}: ${parsed.reason}`
+        );
+        return undefined;
+      }
+      return parsed.env;
+    } catch (error) {
+      this.logger.error(
+        `[ArkContext] session init failed for ${worktreePath}: ${getErrorMessage(error)}`
+      );
+      return undefined;
+    }
+  }
+
+  async teardownSession(
+    worktreePath: string,
+    contextSessionId: string
+  ): Promise<void> {
+    await execFileAsync(
+      "/bin/bash",
+      [
+        join(this.scriptDirectory, "session-teardown.sh"),
+        "--repo",
+        worktreePath,
+        "--session-id",
+        contextSessionId,
+      ],
+      {
+        encoding: "utf8",
+        timeout: this.timeoutMs,
+        maxBuffer: MAX_OUTPUT_BYTES,
+      }
+    );
+  }
+}
+
+export const arkContextHarness = new ArkContextHarness();

--- a/packages/server/src/lib/ark-context-harness.ts
+++ b/packages/server/src/lib/ark-context-harness.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
@@ -111,6 +111,17 @@ export class ArkContextHarness {
     this.logger = options.logger ?? console;
   }
 
+  private resolveWorktreePath(worktreePath: string): string | undefined {
+    try {
+      return realpathSync(worktreePath);
+    } catch (error) {
+      this.logger.warn(
+        `[ArkContext] context disabled for ${worktreePath}: worktree path resolution failed: ${getErrorMessage(error)}`
+      );
+      return undefined;
+    }
+  }
+
   async initializeSession(
     worktreePath: string,
     restartSessionId?: string
@@ -119,10 +130,13 @@ export class ArkContextHarness {
       return undefined;
     }
 
+    const resolvedWorktreePath = this.resolveWorktreePath(worktreePath);
+    if (!resolvedWorktreePath) return undefined;
+
     const args = [
       join(this.scriptDirectory, "session-init.sh"),
       "--repo",
-      worktreePath,
+      resolvedWorktreePath,
       "--owner-pid",
       String(this.ownerPid),
     ];
@@ -154,12 +168,15 @@ export class ArkContextHarness {
     worktreePath: string,
     contextSessionId: string
   ): Promise<void> {
+    const resolvedWorktreePath = this.resolveWorktreePath(worktreePath);
+    if (!resolvedWorktreePath) return;
+
     await execFileAsync(
       "/bin/bash",
       [
         join(this.scriptDirectory, "session-teardown.sh"),
         "--repo",
-        worktreePath,
+        resolvedWorktreePath,
         "--session-id",
         contextSessionId,
       ],

--- a/packages/server/src/lib/session-orchestrator-context.integration.test.ts
+++ b/packages/server/src/lib/session-orchestrator-context.integration.test.ts
@@ -1,0 +1,152 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("./tmux-manager.js", async () => {
+  const { EventEmitter } = await import("node:events");
+  class TmuxManagerStub extends EventEmitter {
+    getAllSessions = vi.fn(() => []);
+    getSession = vi.fn();
+    getSessionByWorktree = vi.fn();
+    createSession = vi.fn();
+    killSession = vi.fn();
+    getEnv = vi.fn();
+    getPaneEnv = vi.fn();
+    setClaudeMcpConfigPath = vi.fn();
+    setClaudeAppendSystemPrompt = vi.fn();
+  }
+  return { tmuxManager: new TmuxManagerStub() };
+});
+
+vi.mock("./ttyd-manager.js", async () => {
+  const { EventEmitter } = await import("node:events");
+  class TtydManagerStub extends EventEmitter {
+    startInstance = vi.fn(async (sessionId: string) => ({
+      sessionId,
+      port: 7681,
+      tmuxSessionName: "ark-context-integration",
+      basePath: `/ttyd/${sessionId}`,
+    }));
+    stopInstance = vi.fn();
+    getInstance = vi.fn();
+  }
+  return { ttydManager: new TtydManagerStub() };
+});
+
+vi.mock("./database.js", () => ({
+  db: {
+    getSetting: vi.fn((key: string) =>
+      key === "ark_context_enabled" ? true : undefined
+    ),
+    getRepoProfileLink: vi.fn(() => null),
+    getWorktreeProfileLink: vi.fn(() => null),
+    getProfile: vi.fn(() => null),
+    getSessionByWorktreePath: vi.fn(() => null),
+    upsertSession: vi.fn(),
+    replaceSession: vi.fn(),
+    updateSessionRepoPath: vi.fn(),
+    updateSessionStatus: vi.fn(),
+    deleteSession: vi.fn(),
+  },
+}));
+
+import { SessionOrchestrator } from "./session-orchestrator.js";
+import { tmuxManager } from "./tmux-manager.js";
+
+const mockedTmux = vi.mocked(tmuxManager);
+let testRoot: string;
+let worktreePath: string;
+const savedXdg = {
+  config: process.env.XDG_CONFIG_HOME,
+  data: process.env.XDG_DATA_HOME,
+  cache: process.env.XDG_CACHE_HOME,
+};
+
+beforeAll(() => {
+  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ark-context-integration-"));
+  worktreePath = path.join(testRoot, "worktree");
+  fs.mkdirSync(worktreePath, { mode: 0o700 });
+  fs.mkdirSync(path.join(worktreePath, ".claude"), { mode: 0o755 });
+  fs.writeFileSync(
+    path.join(worktreePath, ".gitignore"),
+    ".claude/settings.local.json\n.claude/settings.local.json.ark-context-tmp\n"
+  );
+  execFileSync("git", ["-C", worktreePath, "init", "-q"]);
+  execFileSync("git", ["-C", worktreePath, "config", "user.name", "fixture"]);
+  execFileSync("git", [
+    "-C",
+    worktreePath,
+    "config",
+    "user.email",
+    "fixture@example.invalid",
+  ]);
+  execFileSync("git", ["-C", worktreePath, "add", ".gitignore"]);
+  execFileSync("git", ["-C", worktreePath, "commit", "-qm", "init"]);
+
+  for (const [name, directory] of [
+    ["XDG_CONFIG_HOME", path.join(testRoot, "config")],
+    ["XDG_DATA_HOME", path.join(testRoot, "data")],
+    ["XDG_CACHE_HOME", path.join(testRoot, "cache")],
+  ] as const) {
+    fs.mkdirSync(directory, { mode: 0o700 });
+    process.env[name] = directory;
+  }
+});
+
+afterAll(() => {
+  if (savedXdg.config === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = savedXdg.config;
+  if (savedXdg.data === undefined) delete process.env.XDG_DATA_HOME;
+  else process.env.XDG_DATA_HOME = savedXdg.data;
+  if (savedXdg.cache === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = savedXdg.cache;
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe("SessionOrchestrator + real Ark context harness", () => {
+  it("session-init の env を tmux に渡し、空 task を生成して stop 後に teardown する", async () => {
+    const tmuxSession = {
+      id: "tmux-context-integration",
+      tmuxSessionName: "ark-context-integration",
+      worktreePath,
+      createdAt: new Date(),
+      lastActivity: new Date(),
+      status: "running" as const,
+    };
+    mockedTmux.getSessionByWorktree.mockReturnValue(undefined);
+    mockedTmux.createSession.mockResolvedValue(tmuxSession);
+    mockedTmux.getSession.mockReturnValue(tmuxSession);
+
+    const orchestrator = new SessionOrchestrator();
+    const managed = await orchestrator.startSession(
+      "wt-context-integration",
+      worktreePath
+    );
+    const createOptions = mockedTmux.createSession.mock.calls[0]?.[1];
+    const contextEnv = createOptions?.env;
+
+    expect(contextEnv?.ARK_SESSION_ID).toMatch(/^[0-9a-f]{32}$/);
+    expect(contextEnv?.ARK_SESSION_DIR).toBeTruthy();
+    expect(contextEnv?.ARK_REPO_KEY).toMatch(/^[0-9a-f]{64}$/);
+    const taskPath = path.join(contextEnv?.ARK_SESSION_DIR ?? "", "task.md");
+    expect(fs.readFileSync(taskPath, "utf8")).toContain("## Goal\n\n");
+    expect(fs.readFileSync(taskPath, "utf8")).not.toContain("← NOW");
+
+    mockedTmux.getEnv.mockImplementation((_sessionId, name) =>
+      contextEnv?.[name] ? contextEnv[name] : null
+    );
+    orchestrator.stopSession(managed.id);
+
+    const settingsPath = path.join(
+      worktreePath,
+      ".claude",
+      "settings.local.json"
+    );
+    await vi.waitFor(() => expect(fs.existsSync(settingsPath)).toBe(false), {
+      timeout: 5_000,
+      interval: 20,
+    });
+  });
+});

--- a/packages/server/src/lib/session-orchestrator-context.integration.test.ts
+++ b/packages/server/src/lib/session-orchestrator-context.integration.test.ts
@@ -165,10 +165,15 @@ describe("SessionOrchestrator + real Ark context harness", () => {
     );
     orchestrator.stopSession(managed.id);
 
-    await vi.waitFor(() => expect(fs.existsSync(settingsPath)).toBe(false), {
-      timeout: 5_000,
-      interval: 20,
-    });
-    expect(fs.existsSync(ownerPath)).toBe(false);
+    await vi.waitFor(
+      () => {
+        expect(fs.existsSync(settingsPath)).toBe(false);
+        expect(fs.existsSync(ownerPath)).toBe(false);
+      },
+      {
+        timeout: 5_000,
+        interval: 20,
+      }
+    );
   });
 });

--- a/packages/server/src/lib/session-orchestrator-context.integration.test.ts
+++ b/packages/server/src/lib/session-orchestrator-context.integration.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -66,7 +67,11 @@ const savedXdg = {
 
 beforeAll(() => {
   testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ark-context-integration-"));
-  worktreePath = path.join(testRoot, "worktree");
+  const realRoot = path.join(testRoot, "real");
+  const linkedRoot = path.join(testRoot, "link");
+  fs.mkdirSync(realRoot, { mode: 0o700 });
+  fs.symlinkSync(realRoot, linkedRoot, "dir");
+  worktreePath = path.join(linkedRoot, "worktree");
   fs.mkdirSync(worktreePath, { mode: 0o700 });
   fs.mkdirSync(path.join(worktreePath, ".claude"), { mode: 0o755 });
   fs.writeFileSync(
@@ -106,7 +111,7 @@ afterAll(() => {
 });
 
 describe("SessionOrchestrator + real Ark context harness", () => {
-  it("session-init の env を tmux に渡し、空 task を生成して stop 後に teardown する", async () => {
+  it("symlink 経由でも context を有効化し、同じ repo state を teardown する", async () => {
     const tmuxSession = {
       id: "tmux-context-integration",
       tmuxSessionName: "ark-context-integration",
@@ -127,26 +132,43 @@ describe("SessionOrchestrator + real Ark context harness", () => {
     const createOptions = mockedTmux.createSession.mock.calls[0]?.[1];
     const contextEnv = createOptions?.env;
 
+    expect(fs.realpathSync(worktreePath)).not.toBe(worktreePath);
     expect(contextEnv?.ARK_SESSION_ID).toMatch(/^[0-9a-f]{32}$/);
     expect(contextEnv?.ARK_SESSION_DIR).toBeTruthy();
-    expect(contextEnv?.ARK_REPO_KEY).toMatch(/^[0-9a-f]{64}$/);
+    const expectedRepoKey = createHash("sha256")
+      .update(fs.realpathSync(worktreePath))
+      .digest("hex");
+    expect(contextEnv?.ARK_REPO_KEY).toBe(expectedRepoKey);
+    const repoStateDirectory = path.join(
+      process.env.XDG_DATA_HOME ?? "",
+      "ark",
+      "context",
+      "repos",
+      expectedRepoKey
+    );
+    const ownerPath = path.join(repoStateDirectory, "owner");
+    expect(fs.readFileSync(ownerPath, "utf8")).toContain(
+      contextEnv?.ARK_SESSION_ID
+    );
     const taskPath = path.join(contextEnv?.ARK_SESSION_DIR ?? "", "task.md");
     expect(fs.readFileSync(taskPath, "utf8")).toContain("## Goal\n\n");
     expect(fs.readFileSync(taskPath, "utf8")).not.toContain("← NOW");
+    const settingsPath = path.join(
+      worktreePath,
+      ".claude",
+      "settings.local.json"
+    );
+    expect(fs.existsSync(settingsPath)).toBe(true);
 
     mockedTmux.getEnv.mockImplementation((_sessionId, name) =>
       contextEnv?.[name] ? contextEnv[name] : null
     );
     orchestrator.stopSession(managed.id);
 
-    const settingsPath = path.join(
-      worktreePath,
-      ".claude",
-      "settings.local.json"
-    );
     await vi.waitFor(() => expect(fs.existsSync(settingsPath)).toBe(false), {
       timeout: 5_000,
       interval: 20,
     });
+    expect(fs.existsSync(ownerPath)).toBe(false);
   });
 });

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -11,6 +11,13 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("./ark-context-harness.js", () => ({
+  arkContextHarness: {
+    initializeSession: vi.fn(async () => undefined),
+    teardownSession: vi.fn(async () => undefined),
+  },
+}));
+
 // TmuxManager / TtydManager / SessionDatabase のシングルトンをモック化。
 // SessionOrchestrator は constructor で `tmuxManager.getAllSessions()` を呼ぶため、
 // 必ず import 前にスタブを用意する。
@@ -83,6 +90,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DIAGRAM_DIR } from "@ark/shared";
+import { arkContextHarness } from "./ark-context-harness.js";
 import type { BoardMcpServer } from "./board-mcp-server.js";
 // BoardSessionRegistry は単純な token→worktreePath の in-memory map なので
 // モック化せず実体を使い、register/resolve/unregister の実挙動を検証する。
@@ -93,6 +101,7 @@ import { tmuxManager } from "./tmux-manager.js";
 import { ttydManager } from "./ttyd-manager.js";
 
 const mockedDb = vi.mocked(db);
+const mockedContext = vi.mocked(arkContextHarness);
 const mockedTmux = vi.mocked(tmuxManager);
 const mockedTtyd = vi.mocked(ttydManager);
 
@@ -208,6 +217,57 @@ describe("SessionOrchestrator - プロファイル切替", () => {
       expect(callArgs[1]).toBeUndefined();
       expect(managed.profileId).toBeNull();
     });
+
+    it("context が無効なら従来どおり env 無しで起動する", async () => {
+      mockedContext.initializeSession.mockResolvedValueOnce(undefined);
+
+      await orchestrator.startSession("wt-1", "/path/to/work", "/repo");
+
+      expect(mockedContext.initializeSession).toHaveBeenCalledWith(
+        "/path/to/work"
+      );
+      expect(mockedTmux.createSession).toHaveBeenCalledWith(
+        "/path/to/work",
+        undefined
+      );
+    });
+
+    it("context が有効なら TSV 由来 env を profile env とマージする", async () => {
+      mockedDb.getRepoProfileLink.mockReturnValue({
+        repoPath: "/repo",
+        profileId: "prof-1",
+        updatedAt: 0,
+      });
+      mockedDb.getProfile.mockReturnValue({
+        id: "prof-1",
+        name: "work",
+        configDir: "/home/user/.claude-work",
+        createdAt: 0,
+        updatedAt: 0,
+      });
+      mockedContext.initializeSession.mockResolvedValueOnce({
+        ARK_SESSION_ID: "a".repeat(32),
+        ARK_SESSION_DIR: "/context/session",
+        ARK_CACHE_DIR: "/context/cache",
+        ARK_RECITE_INTERVAL: "10",
+        ARK_KNOWLEDGE_DIR: "/context/knowledge",
+        ARK_REPO_KEY: "repo-key",
+      });
+
+      await orchestrator.startSession("wt-1", "/path/to/work", "/repo");
+
+      expect(mockedTmux.createSession).toHaveBeenCalledWith("/path/to/work", {
+        env: {
+          CLAUDE_CONFIG_DIR: "/home/user/.claude-work",
+          ARK_SESSION_ID: "a".repeat(32),
+          ARK_SESSION_DIR: "/context/session",
+          ARK_CACHE_DIR: "/context/cache",
+          ARK_RECITE_INTERVAL: "10",
+          ARK_KNOWLEDGE_DIR: "/context/knowledge",
+          ARK_REPO_KEY: "repo-key",
+        },
+      });
+    });
   });
 
   // ============================================================
@@ -215,6 +275,14 @@ describe("SessionOrchestrator - プロファイル切替", () => {
   // ============================================================
 
   describe("startSession (既存セッション再利用)", () => {
+    it("復元パスでは context init を再実行しない", async () => {
+      mockedTmux.getSessionByWorktree.mockReturnValue(makeTmuxSession());
+
+      await orchestrator.startSession("wt-1", "/path/to/work", "/repo");
+
+      expect(mockedContext.initializeSession).not.toHaveBeenCalled();
+    });
+
     it("既存セッションのprofileIdが現在の紐付けと異なる: staleProfile=true", async () => {
       // まず prof-1 で新規作成
       mockedDb.getRepoProfileLink.mockReturnValue({
@@ -386,6 +454,65 @@ describe("SessionOrchestrator - プロファイル切替", () => {
   // ============================================================
 
   describe("restartSession", () => {
+    it("旧 context を teardown してから restart 情報付きで再 init する", async () => {
+      const oldSession = makeTmuxSession({ id: "sess-id-1" });
+      const oldContextId = "b".repeat(32);
+      const newContextId = "c".repeat(32);
+      mockedTmux.getSession.mockReturnValue(oldSession);
+      mockedTmux.getEnv.mockReturnValue(oldContextId);
+      mockedDb.getSessionByWorktreePath.mockReturnValue({
+        id: "sess-id-1",
+        worktreeId: "wt-1",
+        worktreePath: "/path/to/work",
+        repoPath: "/repo",
+        status: "active",
+        createdAt: "2026-04-25T00:00:00Z",
+        updatedAt: "2026-04-25T00:00:00Z",
+      } as never);
+      mockedContext.initializeSession.mockResolvedValueOnce({
+        ARK_SESSION_ID: newContextId,
+        ARK_SESSION_DIR: "/context/new-session",
+        ARK_CACHE_DIR: "/context/new-cache",
+        ARK_RECITE_INTERVAL: "10",
+        ARK_KNOWLEDGE_DIR: "/context/knowledge",
+      });
+      mockedTmux.createSession.mockResolvedValue(
+        makeTmuxSession({ id: "sess-id-2", tmuxSessionName: "ark-sess2" })
+      );
+      mockedTtyd.startInstance.mockResolvedValue({
+        sessionId: "sess-id-2",
+        port: 7682,
+        tmuxSessionName: "ark-sess2",
+        basePath: "/ttyd/sess-id-2",
+      } as never);
+
+      await orchestrator.restartSession("sess-id-1");
+
+      expect(mockedTmux.getEnv).toHaveBeenCalledWith(
+        "sess-id-1",
+        "ARK_SESSION_ID"
+      );
+      expect(mockedContext.teardownSession).toHaveBeenCalledWith(
+        "/path/to/work",
+        oldContextId
+      );
+      expect(mockedContext.initializeSession).toHaveBeenCalledWith(
+        "/path/to/work",
+        oldContextId
+      );
+      expect(
+        mockedContext.teardownSession.mock.invocationCallOrder[0]
+      ).toBeLessThan(
+        mockedContext.initializeSession.mock.invocationCallOrder[0]
+      );
+      expect(mockedTmux.createSession).toHaveBeenCalledWith(
+        "/path/to/work",
+        expect.objectContaining({
+          env: expect.objectContaining({ ARK_SESSION_ID: newContextId }),
+        })
+      );
+    });
+
     it("既存セッションをkillし、新しい env で再起動する", async () => {
       // 1) prof-1 で起動（古いセッション）
       mockedDb.getRepoProfileLink.mockReturnValue({
@@ -576,6 +703,27 @@ describe("SessionOrchestrator - プロファイル切替", () => {
       expect(r2.id).toBe("sess-id-2");
     });
   });
+
+  describe("stopSession", () => {
+    it("fire-and-forget teardown の失敗をログへ残す", async () => {
+      const contextSessionId = "e".repeat(32);
+      mockedTmux.getSession.mockReturnValue(makeTmuxSession());
+      mockedTmux.getEnv.mockReturnValue(contextSessionId);
+      mockedContext.teardownSession.mockRejectedValueOnce(
+        new Error("teardown timeout")
+      );
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      orchestrator.stopSession("sess-id-1");
+
+      await vi.waitFor(() => {
+        expect(errorSpy).toHaveBeenCalledWith(
+          expect.stringContaining("teardown timeout")
+        );
+      });
+      errorSpy.mockRestore();
+    });
+  });
 });
 
 /**
@@ -750,11 +898,24 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
 
     // stopSession は tmuxManager.getSession() から worktreePath を得る
     mockedTmux.getSession.mockReturnValue(makeTmuxSession());
+    const contextSessionId = "d".repeat(32);
+    mockedTmux.getEnv.mockReturnValue(contextSessionId);
 
     orchestrator.stopSession(managed.id);
 
     expect(registry.resolve(token)).toBeNull();
     expect(fs.existsSync(cfgPath)).toBe(false);
+    expect(mockedTmux.getEnv).toHaveBeenCalledWith(
+      managed.id,
+      "ARK_SESSION_ID"
+    );
+    expect(mockedContext.teardownSession).toHaveBeenCalledWith(
+      "/path/to/work",
+      contextSessionId
+    );
+    expect(mockedTmux.killSession.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      mockedContext.teardownSession.mock.invocationCallOrder.at(-1) ?? 0
+    );
   });
 
   it("getAllSessions の孤児クリーンアップ (worktree 削除済み) でも token を unregister し mcp-config を削除する", async () => {

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -19,12 +19,14 @@ import {
   type SpecialKey,
 } from "@ark/shared";
 import { stripAnsi } from "./ansi.js";
+import { arkContextHarness } from "./ark-context-harness.js";
 import type {
   BoardMcpServer,
   BoardSessionRegistry,
 } from "./board-mcp-server.js";
 import { analyzeBridgeStatus } from "./bridge-collector.js";
 import { db } from "./database.js";
+import { getErrorMessage } from "./errors.js";
 import { type TmuxSession, tmuxManager } from "./tmux-manager.js";
 import { ttydManager } from "./ttyd-manager.js";
 
@@ -576,6 +578,23 @@ export class SessionOrchestrator extends EventEmitter {
   }
 
   /**
+   * Ark context の teardown を実行し、失敗を必ずログへ残す。
+   * stopSession() からは fire-and-forget、restart/rollback からは await して使う。
+   */
+  private async teardownArkContext(
+    worktreePath: string,
+    contextSessionId: string
+  ): Promise<void> {
+    try {
+      await arkContextHarness.teardownSession(worktreePath, contextSessionId);
+    } catch (error) {
+      console.error(
+        `[ArkContext] session teardown failed for ${worktreePath} (${contextSessionId}): ${getErrorMessage(error)}`
+      );
+    }
+  }
+
+  /**
    * 新規セッションを開始
    */
   async startSession(
@@ -621,6 +640,10 @@ export class SessionOrchestrator extends EventEmitter {
       worktreePath,
       resolvedRepoPath
     );
+    const contextEnv = await arkContextHarness.initializeSession(worktreePath);
+    const sessionEnv =
+      env || contextEnv ? { ...(env ?? {}), ...(contextEnv ?? {}) } : undefined;
+    const contextSessionId = contextEnv?.ARK_SESSION_ID;
 
     // board MCP (ark-board / board_write) 用の per-session token/config を用意する。
     // 未起動/未注入なら tmuxManager の --mcp-config 設定を null にリセットする
@@ -632,10 +655,13 @@ export class SessionOrchestrator extends EventEmitter {
     try {
       tmuxSession = await tmuxManager.createSession(
         worktreePath,
-        env ? { env } : undefined
+        sessionEnv ? { env: sessionEnv } : undefined
       );
     } catch (e) {
       if (boardPrep) this.discardBoardMcpConfig(boardPrep.cfgPath);
+      if (contextSessionId) {
+        await this.teardownArkContext(worktreePath, contextSessionId);
+      }
       throw e;
     }
     if (boardPrep) {
@@ -661,22 +687,35 @@ export class SessionOrchestrator extends EventEmitter {
     } catch (e) {
       this.unregisterBoardToken(tmuxSession.id);
       tmuxManager.killSession(tmuxSession.id);
+      if (contextSessionId) {
+        await this.teardownArkContext(worktreePath, contextSessionId);
+      }
       throw e;
     }
 
     // DBに保存（既存レコードがあればupsertで更新）
-    db.upsertSession({
-      id: tmuxSession.id,
-      worktreeId,
-      worktreePath,
-      repoPath: resolvedRepoPath,
-      status: "active",
-      profileId: snapshot?.id ?? null,
-      profileConfigDir: snapshot?.configDir ?? null,
-      // サーバー再起動後に token を registry へ復帰させるため、
-      // mcp-config のパスを永続化する (token 自体は 0600 のファイル内のみ)
-      boardMcpConfigPath: boardPrep?.cfgPath ?? null,
-    });
+    try {
+      db.upsertSession({
+        id: tmuxSession.id,
+        worktreeId,
+        worktreePath,
+        repoPath: resolvedRepoPath,
+        status: "active",
+        profileId: snapshot?.id ?? null,
+        profileConfigDir: snapshot?.configDir ?? null,
+        // サーバー再起動後に token を registry へ復帰させるため、
+        // mcp-config のパスを永続化する (token 自体は 0600 のファイル内のみ)
+        boardMcpConfigPath: boardPrep?.cfgPath ?? null,
+      });
+    } catch (error) {
+      ttydManager.stopInstance(tmuxSession.id);
+      tmuxManager.killSession(tmuxSession.id);
+      this.unregisterBoardToken(tmuxSession.id);
+      if (contextSessionId) {
+        await this.teardownArkContext(worktreePath, contextSessionId);
+      }
+      throw error;
+    }
 
     // プロファイルスナップショットをsession-id毎に記憶
     // (restartSession / staleProfile判定用)
@@ -703,17 +742,17 @@ export class SessionOrchestrator extends EventEmitter {
    * 稼働中セッションを kill して、現在の紐付けで再起動する。
    * staleProfile となったセッションをユーザが「再起動」した際に呼ぶ。
    *
-   * 失敗時の安全性: 新セッションの起動 (tmux/ttyd) が成功するまで旧セッション
-   * には触らない。新側で失敗したら旧は無傷で残り、エラーが上に伝播するだけ。
-   * 旧tmux/ttyd は「新セッションが usable と確認できた後」にだけ停止する。
+   * 失敗時の安全性: 旧 tmux/ttyd は新セッションが usable と確認できるまで
+   * 停止しない。context を有効にしていた場合だけ、repo 所有権を渡すため旧 context は
+   * 新 init より先に teardown する。新側で失敗しても旧 terminal process は残る。
    *
    * 内部処理:
-   * 1. プロファイル解決 (envと configDir スナップショット)
+   * 1. プロファイル解決、旧 context teardown、新 context init
    * 2. 新tmuxセッションを **別ID** で作成 (旧と並走)
-   * 3. 新ttydを起動。失敗時は新tmuxを kill して throw
-   * 4. 旧 ttyd 停止 / 旧 tmux kill / sessionProfiles/repoPathCache クリア
-   * 5. DB を upsert (worktree_path UNIQUE により旧行が新IDで上書きされる)
-   * 6. session:stopped (旧ID) → session:created (新ID) を emit
+   * 3. 新ttydを起動。失敗時は新tmuxと新 context を teardown して throw
+   * 4. DB を transaction で新セッションへ置換
+   * 5. 旧 ttyd 停止 / 旧 tmux kill / sessionProfiles/repoPathCache クリア
+   * 6. session:created → session:restarted → session:stopped を emit
    *
    * @throws sessionId に対応する tmux セッションが見つからない場合
    * @throws 新セッション起動失敗 (旧セッションは無傷)
@@ -755,6 +794,20 @@ export class SessionOrchestrator extends EventEmitter {
       repoPath
     );
 
+    // context owner を旧セッションから解放してから新セッションを init する。
+    // tmux env はサーバー再起動後も残るため、永続化を追加せず session ID を復元できる。
+    const oldContextSessionId = tmuxManager.getEnv(sessionId, "ARK_SESSION_ID");
+    if (oldContextSessionId) {
+      await this.teardownArkContext(worktreePath, oldContextSessionId);
+    }
+    const contextEnv = await arkContextHarness.initializeSession(
+      worktreePath,
+      oldContextSessionId ?? undefined
+    );
+    const sessionEnv =
+      env || contextEnv ? { ...(env ?? {}), ...(contextEnv ?? {}) } : undefined;
+    const newContextSessionId = contextEnv?.ARK_SESSION_ID;
+
     // 2. board MCP 用の per-session token/config を用意してから、
     //    新tmuxセッションを別IDで作成する (失敗時は旧セッション無傷)。
     //    旧セッションの token はまだ解除しない (新側が usable と確認できてから)。
@@ -763,10 +816,13 @@ export class SessionOrchestrator extends EventEmitter {
     try {
       newTmux = await tmuxManager.createSession(
         worktreePath,
-        env ? { env } : undefined
+        sessionEnv ? { env: sessionEnv } : undefined
       );
     } catch (e) {
       if (boardPrep) this.discardBoardMcpConfig(boardPrep.cfgPath);
+      if (newContextSessionId) {
+        await this.teardownArkContext(worktreePath, newContextSessionId);
+      }
       throw e;
     }
 
@@ -780,6 +836,9 @@ export class SessionOrchestrator extends EventEmitter {
     } catch (e) {
       tmuxManager.killSession(newTmux.id);
       if (boardPrep) this.discardBoardMcpConfig(boardPrep.cfgPath);
+      if (newContextSessionId) {
+        await this.teardownArkContext(worktreePath, newContextSessionId);
+      }
       throw e;
     }
 
@@ -814,6 +873,9 @@ export class SessionOrchestrator extends EventEmitter {
       ttydManager.stopInstance(newTmux.id);
       tmuxManager.killSession(newTmux.id);
       if (boardPrep) this.discardBoardMcpConfig(boardPrep.cfgPath);
+      if (newContextSessionId) {
+        await this.teardownArkContext(worktreePath, newContextSessionId);
+      }
       throw e;
     }
     this.sessionProfiles.set(newTmux.id, snapshot);
@@ -918,9 +980,15 @@ export class SessionOrchestrator extends EventEmitter {
     const repoPath =
       dbSession?.repoPath ||
       (worktreePath ? this.deriveRepoPath(worktreePath) : undefined);
+    const contextSessionId = tmuxSession
+      ? tmuxManager.getEnv(sessionId, "ARK_SESSION_ID")
+      : null;
 
     ttydManager.stopInstance(sessionId);
     tmuxManager.killSession(sessionId);
+    if (worktreePath && contextSessionId) {
+      void this.teardownArkContext(worktreePath, contextSessionId);
+    }
     db.deleteSession(sessionId);
     this.sessionProfiles.delete(sessionId);
     this.unregisterBoardToken(sessionId);


### PR DESCRIPTION
`ark/context/` のハーネスを Ark のセッション起動・停止に配線し、**実際に発火する状態**にする。これまで実装・テストは済んでいたが Ark から一度も呼ばれていなかった。

Closes #350

## 配線前の状態（実測）

| 検証 | 結果 |
| --- | --- |
| `packages/` 内の `session-init` / `ark/context` / `ARK_SESSION_DIR` 参照 | **0 件** |
| 稼働中の `ark-*` tmux セッションの `ARK_SESSION_DIR` | **全て未設定** |
| `session-init.sh` の呼び出し元 | テストのみ |

各 hook は「`ARK_SESSION_DIR` 未設定なら完全 no-op」という契約なので、**全 hook が無条件に何もせず終了していた**。復唱（#333）もエラー捕捉（#335）も teardown（#336）も一度も動いていない。

## 設計判断: 起動時に Goal を要求しない

`session-init.sh` の `--goal` / `--constraint` / `--plan-item` を**必須から任意へ**変えた。spec §6-1 も更新している。

**Manus では `todo.md` を作るのは agent 自身**で、ユーザーは自然言語でタスクを渡すだけ。人間が Goal をフォームに入力する設計ではない。また Manus には「とりあえずターミナルを開く」モードが無いので「Goal が無い場合」が発生しない。必須引数は spec（我々）が持ち込んだもので、Manus の設計ではなかった。

Ark は素のターミナルを開くのが主用途なので、**Goal 未設定を正常系として許す**必要がある。

**この変更が安全である根拠は実測済み。** Goal が空の `task.md` で復唱フックを叩くと**出力ゼロで沈黙**し、Goal と `← NOW` が埋まった瞬間から復唱が動く。

```
使い方              挙動
素のターミナル      Goal 空のまま → 復唱は沈黙し何も邪魔しない
タスクとして使う    モデルが task.md を埋める → 足場が立ち上がる
```

別立ての「ループセッション」も起動ダイアログも不要になる。`task.md` を埋めさせる規約は #334 の範囲なので本 PR には含まない。

## 実装

```
packages/server/src/lib/ark-context-harness.ts   （script 実行・TSV 検証・opt-in 判定）
packages/server/src/lib/session-orchestrator.ts  （起動時 init / 停止時 teardown）
ark/context/scripts/session-init.sh              （引数の任意化）
```

| 項目 | 実装 |
| --- | --- |
| 起動 | `resolveProfileForWorktree()` 直後に init、TSV を検証して profile env とマージ |
| 停止 | `stopSession()` の `killSession` 後に teardown（fire-and-forget、失敗は必ずログ） |
| 再起動・ロールバック | teardown を `await`（孤児を残さない） |
| session ID | `tmuxManager.getEnv(sessionId, "ARK_SESSION_ID")`。**新規永続化なし** |
| opt-in | `ark_context_enabled`（既存 `settings` テーブル）。**DB スキーマ変更 0 行** |
| 失敗時 | `enabled 0` / 非0終了 / 15秒タイムアウト / 不正 TSV は理由をログして通常起動 |

## 既定は無効。deploy しても挙動は変わらない

```
db.getSetting は未設定キーで undefined を返す
本番 DB の settings に ark_context_enabled は存在しない
判定は `!== true` の厳格比較
```

**明示的に有効化するまで、現在と完全に同じ挙動。** 無効時に script を実行しないことと tmux 引数が変わらないことを回帰テストで固定した。

## 既存の不変条件を壊していないこと

`session-orchestrator.ts:163` に「`prepareBoardMcpConfig()` 呼び出し直後（await を挟まず）に `createSession()` を呼ぶこと。claudeMcpConfigPath は tmuxManager の共有状態のため、間に他の非同期処理を挟むと並行する別セッションの起動と競合し得る」という規約がある。

`await initializeSession()` は **643 行目**（`prepareBoardMcpConfig()` は 651、`createSession()` は 656）に置き、**間に await を挟んでいない**。再起動パス（803 / 814 / 817）も同じ形。

復元パスは `session:restored` で早期 return するため、**再 init は構造的に起こらない**（追加ガード不要）。

## 検証

```
pnpm check      : exit 0
pnpm test       : 868 tests / 45 files 全通過
pnpm test:harness: 全通過（session-lifecycle 98 → 107）
```

統合テストは tmux / ttyd / DB をモックしつつ**実物の `session-init.sh` を SessionOrchestrator 経由で実行**し、次を確認している。

```
ARK_SESSION_ID : ^[0-9a-f]{32}$
ARK_REPO_KEY   : ^[0-9a-f]{64}$
task.md        : "## Goal\n\n"（空の骨組み）
               : "← NOW" を含まない（= 復唱は沈黙）
stop 後        : settings.local.json が消える（teardown 実行）
```

**実 Ark プロセスの起動による確認は未実施。** マージ・deploy 後に `ark_context_enabled` を有効化して行う。

## 関連

- #357: settings 注入が manifest 先行公開のため途中失敗すると hook 無しで「有効」になる（既存欠陥。有効化前に直す価値がある）
- #352: hook JSON の key 順が変わるとエラー捕捉が無音停止する
- #334: `task.md` を埋めさせる規約（本 PR の骨組みを活かすために必要）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * セッション開始時に Ark Context を自動初期化し、環境変数を開発セッションへ引き継げるようになりました。
  * セッションの再起動・終了時に Context を適切に後処理します。
  * Goal、制約、計画項目を省略して、空のタスクテンプレートからセッションを開始できるようになりました。

* **改善**
  * 初期化や終了時の失敗を安全に処理し、セッション状態の不整合を防ぎます。
  * Context が無効な環境でも、従来どおりセッションを利用できます。

* **ドキュメント**
  * 任意入力によるセッション開始と空のタスク構成に関する仕様を追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->