### PR TITLE
fix(context): settings 注入の不整合を自己修復する（manifest だけ残ると hook が永久に入らない）

### DIFF
--- a/ark/context/adapters/claude-code/settings.sh
+++ b/ark/context/adapters/claude-code/settings.sh
@@ -214,6 +214,37 @@ claude_settings_preflight() {
   if [ -f "$tmp" ]; then command rm -f "$tmp" || return 1; fi
 }
 
+claude_settings_manifest_matches() {
+  local settings=$1
+  local manifest=$2
+  [ -e "$settings" ] || return 1
+  jq -e --slurpfile ownership "$manifest" '
+    . as $settings
+    | ($ownership | length) == 1
+      and ($ownership[0].schema_version == 1)
+      and (($ownership[0].settings_existed | type) == "boolean")
+      and (($ownership[0].entries | type) == "array")
+      and (($ownership[0].entries | length) > 0)
+      and all($ownership[0].entries[];
+        . as $entry
+        | (($entry | type) == "object")
+          and (($entry.path | type) == "string")
+          and (($entry.abandoned | type) == "boolean")
+          and ($entry.abandoned == false)
+          and (if $entry.path == "permissions/deny" then
+            (($entry.value | type) == "string")
+              and (($settings.permissions.deny // []) | index($entry.value) != null)
+          elif $entry.path == "hooks/PostToolBatch" then
+            (($settings.hooks.PostToolBatch // []) | index($entry.value) != null)
+          elif $entry.path == "hooks/PostToolUseFailure" then
+            (($settings.hooks.PostToolUseFailure // []) | index($entry.value) != null)
+          else
+            false
+          end)
+      )
+  ' "$settings" >/dev/null 2>&1
+}
+
 claude_settings_inject() {
   local repo=${1:-}
   local state=${2:-}
@@ -224,7 +255,15 @@ claude_settings_inject() {
   manifest="$state/settings-ownership.json"
   manifest_new="$state/settings-ownership.json.new"
   claude_settings_preflight "$repo" "$state" || return 1
-  if [ -e "$manifest" ] || [ -L "$manifest" ]; then ctx_validate_xdg_file "$manifest" || return 1; return 0; fi
+  if [ -e "$manifest" ] || [ -L "$manifest" ]; then
+    ctx_validate_xdg_file "$manifest" || return 1
+    if claude_settings_manifest_matches "$settings" "$manifest"; then return 0; fi
+    claude_settings_restore "$repo" "$state" || return 1
+    if [ -e "$manifest" ] || [ -L "$manifest" ]; then
+      ctx_validate_xdg_file "$manifest" || return 1
+      command rm -f "$manifest" || return 1
+    fi
+  fi
 
   if [ -e "$settings" ] || [ -L "$settings" ]; then
     ctx_validate_repo_path "$settings" file required || return 1

--- a/ark/context/tests/test-claude-code-settings.sh
+++ b/ark/context/tests/test-claude-code-settings.sh
@@ -55,8 +55,10 @@ assert_eq "settings mode preserved" "$original_mode" "$(ctx_stat "$settings" | a
 
 cp "$settings" "$TEST_TMP/injected"
 cp "$manifest" "$TEST_TMP/manifest"
+chmod 555 "$repo/.claude"
 run_case claude_settings_inject "$repo" "$state"
 assert_success "second injection succeeds"
+chmod 755 "$repo/.claude"
 cmp -s "$settings" "$TEST_TMP/injected" || test_fail "second injection changed settings"
 cmp -s "$manifest" "$TEST_TMP/manifest" || test_fail "second injection changed ownership"
 
@@ -200,6 +202,54 @@ run_case claude_settings_restore "$repo" "$state"
 assert_success "manifest-before-settings interruption converges"
 cmp -s "$settings" "$TEST_TMP/interrupted-original" || test_fail "interrupted restore changed original"
 [ ! -e "$state/settings-ownership.json" ] || test_fail "interrupted ownership remained"
+
+setup_repo interrupted-missing-settings
+settings="$repo/.claude/settings.local.json"
+run_case claude_settings_inject "$repo" "$state"
+assert_success "missing-settings interruption fixture injected"
+[ -f "$state/settings-ownership.json" ] || test_fail "missing-settings interruption fixture lacks manifest"
+command rm -f "$settings"
+run_case claude_settings_inject "$repo" "$state"
+assert_success "manifest without settings is reinjected"
+jq -e --argjson batch "$batch_hook" --argjson failure "$failure_hook" '
+  .permissions.deny == ["TodoWrite","TaskCreate","TaskUpdate"]
+  and .hooks.PostToolBatch == [$batch]
+  and .hooks.PostToolUseFailure == [$failure]
+' "$settings" >/dev/null 2>&1 || test_fail "manifest without settings did not regenerate managed entries"
+jq -e '.settings_existed == false and (.entries | length) == 5 and all(.entries[]; .abandoned == false)' \
+  "$state/settings-ownership.json" >/dev/null 2>&1 \
+  || test_fail "regenerated missing settings recorded incorrect ownership"
+run_case claude_settings_restore "$repo" "$state"
+assert_success "regenerated missing settings restored"
+[ ! -e "$settings" ] || test_fail "teardown retained regenerated originally missing settings"
+
+setup_repo interrupted-partial-settings
+settings="$repo/.claude/settings.local.json"
+printf '{"user-before":true}\n' >"$settings"; chmod 600 "$settings"
+run_case claude_settings_inject "$repo" "$state"
+assert_success "partial-settings interruption fixture injected"
+jq 'del(.hooks.PostToolBatch) | .["user-during"] = {"kept":true}' "$settings" >"$settings.changed"
+command mv "$settings.changed" "$settings"; chmod 600 "$settings"
+run_case claude_settings_inject "$repo" "$state"
+assert_success "settings missing a managed entry is reinjected"
+jq -e --argjson batch "$batch_hook" --argjson failure "$failure_hook" '
+  .["user-before"] == true
+  and .["user-during"] == {"kept":true}
+  and .permissions.deny == ["TodoWrite","TaskCreate","TaskUpdate"]
+  and .hooks.PostToolBatch == [$batch]
+  and .hooks.PostToolUseFailure == [$failure]
+' "$settings" >/dev/null 2>&1 \
+  || test_fail "partial settings reinjection lost non-Ark entries or managed entries"
+jq -e '.settings_existed == true and (.entries | length) == 5 and all(.entries[]; .abandoned == false)' \
+  "$state/settings-ownership.json" >/dev/null 2>&1 \
+  || test_fail "partial settings reinjection recorded incorrect ownership"
+run_case claude_settings_restore "$repo" "$state"
+assert_success "reinjected partial settings restored"
+jq -e '.["user-before"] == true and .["user-during"] == {"kept":true}
+  and ((.permissions.deny // []) | length) == 0
+  and ((.hooks.PostToolBatch // []) | length) == 0
+  and ((.hooks.PostToolUseFailure // []) | length) == 0' "$settings" >/dev/null 2>&1 \
+  || test_fail "partial settings teardown lost non-Ark entries or retained Ark entries"
 
 setup_repo changed-owner
 settings="$repo/.claude/settings.local.json"

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -195,6 +195,16 @@ setup_repo missing-settings
 sid=33333333333333333333333333333333
 run_case run_init "$sid"
 assert_success "missing settings init succeeds"
+[ -f "$repo/.claude/settings.local.json" ] || test_fail "missing settings init did not create settings"
+repo_key=$(ctx_sha256 "$repo")
+state="$XDG_DATA_HOME/ark/context/repos/$repo_key"
+[ -f "$state/settings-ownership.json" ] || test_fail "missing settings init did not create manifest"
+command rm -f "$repo/.claude/settings.local.json"
+run_case run_init "$sid"
+assert_success "same session repairs manifest without settings"
+assert_eq "repaired same session remains enabled" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
+jq -e '.hooks.PostToolBatch | length == 1' "$repo/.claude/settings.local.json" >/dev/null 2>&1 \
+  || test_fail "same session reported enabled without repairing settings"
 run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$sid"
 assert_success "missing settings teardown succeeds"
 [ ! -e "$repo/.claude/settings.local.json" ] || test_fail "teardown retained originally missing settings"


### PR DESCRIPTION
`claude_settings_inject` は ownership manifest を settings 置換より**先に**公開する。両者の間で失敗すると manifest だけが残り、以後の init は manifest の存在だけを見て「注入済み」と判断するため、**hook が入らないまま context が有効と報告される**。

Closes #357

## 修正前の挙動（実測で再現）

```
1. 正常な init        → manifest 1 件 / settings の hook 1 件
2. settings だけ削除  → manifest 公開後・settings 置換前に落ちた状態を再現
3. 次の init を実行   → enabled 1 を返す / settings.local.json は再作成されない
```

3 の時点で `session-init.sh` は `enabled 1` と環境変数を返すので、Ark から見れば context は有効。しかし hook が登録されていないため **復唱（#333）もエラー捕捉（#335）も一度も発火せず、エラーも出ない**。その repo の context は誰かが手で manifest を消すまで永久に死んだまま。

#352（hook JSON の key 順変化で無音停止）と同じ「有効に見えて機能していない」クラスの問題。

## 修正内容

manifest の存在だけで早期成功せず、**settings が manifest に記録された管理 entry を実際に含んでいるか**を jq で完全一致検索して検証する。欠落・abandoned・未知 path があれば不整合と判定し、注入をやり直す。

再注入時は旧 manifest に従って既存の Ark entry を restore してから、非 Ark 設定を保持して注入し直す。**`settings_existed` は再注入直前の実在状態から再記録する**ため、teardown が正しく巻き戻せる。

### 順序入れ替え案を採らなかった理由

settings → manifest の順にすると、settings 置換が成功して manifest 書き込みが失敗した場合、次回 init は「未注入」と判断して再注入する。このとき **hook 入りの settings を「元の設定」として `settings_existed=true` で記録**してしまい、teardown が hook を除去しなくなる。

現在の順序と「manifest が正本」という #333 の契約を保ったまま、「manifest はあるが実体が無い」という不整合だけを自己修復する形にした。CodeRabbit も同じ結論。

## 検証

修正前と同じ手順を通した結果。

```
1. 正常 init          → hook 1 件 / manifest 1 件
2. settings だけ削除  → manifest 残存
3. 次の init          → 再注入された（hook 1 件）
4. teardown           → 非 Ark 設定 MyOwnRule は保持 / Ark の hook は除去
```

4 番目は CodeRabbit がレビューで挙げた受け入れ条件のうち最も難しいもの。単に再注入するだけでは不十分で、再注入後の manifest が「元の設定は無かった」を正しく記録していないと、teardown が hook を残すかユーザーの設定を消す。

回帰テストで固定した状態:

- settings 不在
- 管理 entry の部分欠損
- 全 entry 存在時は従来どおり早期成功（無駄な再注入をしない）
- 非 Ark entry の保持
- 再注入後の teardown が所有 entry だけを削除

`ark/context/tests/run.sh` と `pnpm test:harness` は全 PASS。

## スコープ

`ark/context/adapters/claude-code/settings.sh` とそのテストのみ。`.claude/settings*.json` / `.gitignore` / `packages/` は変更していない。
