### PR TITLE
fix(context): hook JSON の key 順に依存せず、拒否した入力を無音にしない

### DIFF
--- a/ark/context/adapters/claude-code/post-tool-use-failure.sh
+++ b/ark/context/adapters/claude-code/post-tool-use-failure.sh
@@ -6,15 +6,143 @@ if [ -z "${ARK_SESSION_DIR:-}" ]; then
 fi
 
 ADAPTER_INPUT=
+ADAPTER_RESULT=
 ADAPTER_NORMALIZED=
+ADAPTER_UID=
 
 adapter_cleanup() {
   if [ -n "$ADAPTER_INPUT" ] && [ ! -L "$ADAPTER_INPUT" ] && [ -f "$ADAPTER_INPUT" ]; then
     command rm -f "$ADAPTER_INPUT" >/dev/null 2>&1 || :
   fi
+  if [ -n "$ADAPTER_RESULT" ] && [ ! -L "$ADAPTER_RESULT" ] && [ -f "$ADAPTER_RESULT" ]; then
+    command rm -f "$ADAPTER_RESULT" >/dev/null 2>&1 || :
+  fi
   if [ -n "$ADAPTER_NORMALIZED" ] && [ ! -L "$ADAPTER_NORMALIZED" ] && [ -f "$ADAPTER_NORMALIZED" ]; then
     command rm -f "$ADAPTER_NORMALIZED" >/dev/null 2>&1 || :
   fi
+}
+
+adapter_stat() {
+  local value uid mode size extra
+  value=$(stat -c '%u %a %s' "$1" 2>/dev/null) \
+    || value=$(stat -f '%u %Lp %z' "$1" 2>/dev/null) \
+    || return 1
+  IFS=' ' read -r uid mode size extra <<EOF
+$value
+EOF
+  [ -n "$uid" ] && [ -n "$mode" ] && [ -n "$size" ] && [ -z "$extra" ] || return 1
+  case "$uid" in ''|*[!0-9]*) return 1 ;; esac
+  case "$mode" in ''|*[!0-7]*) return 1 ;; esac
+  case "$size" in ''|*[!0-9]*) return 1 ;; esac
+  while [ "${mode#0}" != "$mode" ]; do mode=${mode#0}; done
+  printf '%s %s %s\n' "$uid" "${mode:-0}" "$size"
+}
+
+adapter_safe_dir() {
+  local value uid mode size extra target=$1
+  [ -n "$target" ] && [ "${target#/}" != "$target" ] || return 1
+  case "$target" in *"
+"*|*""*|*"	"*) return 1 ;; esac
+  [ ! -L "$target" ] && [ -d "$target" ] || return 1
+  value=$(adapter_stat "$target") || return 1
+  IFS=' ' read -r uid mode size extra <<EOF
+$value
+EOF
+  [ -z "$extra" ] && [ "$uid" = "$ADAPTER_UID" ] && [ "$mode" = 700 ]
+}
+
+adapter_safe_file() {
+  local value uid mode size extra target=$1
+  [ ! -L "$target" ] && [ -f "$target" ] || return 1
+  value=$(adapter_stat "$target") || return 1
+  IFS=' ' read -r uid mode size extra <<EOF
+$value
+EOF
+  [ -z "$extra" ] && [ "$uid" = "$ADAPTER_UID" ] && [ "$mode" = 600 ]
+}
+
+adapter_record_rejection() {
+  local session canonical_session errors rejected value uid mode rejected_size extra at
+  ADAPTER_UID=$(id -u) || return 1
+  session=${ARK_SESSION_DIR:-}
+  adapter_safe_dir "$session" || return 1
+  canonical_session=$(cd "$session" 2>/dev/null && pwd -P) || return 1
+  [ "$canonical_session" = "$session" ] || return 1
+  errors="$session/errors"
+  adapter_safe_dir "$errors" || return 1
+  rejected="$errors/rejected.log"
+
+  at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+  case "$at" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z) ;;
+    *) return 1 ;;
+  esac
+  LC_ALL=C jq -ce --arg at "$at" '
+    .rejected
+    | select(
+        type == "object"
+        and (.reason | IN(
+          "input_too_large", "malformed_json", "input_not_object",
+          "field_set_mismatch", "field_type_mismatch", "hook_event_name_mismatch"
+        ))
+        and ((.hook_event_name == null) or ((.hook_event_name | type) == "string" and (.hook_event_name | length) <= 256))
+        and ((.tool_name == null) or ((.tool_name | type) == "string" and (.tool_name | length) <= 256))
+        and (.missing_fields | type) == "array"
+        and (.invalid_type_fields | type) == "array"
+        and (.unexpected_field_count | type) == "number"
+        and .unexpected_field_count >= 0
+        and .unexpected_field_count == (.unexpected_field_count | floor)
+      )
+    | {
+        at:$at,
+        reason:.reason,
+        hook_event_name:.hook_event_name,
+        tool_name:.tool_name,
+        missing_fields:.missing_fields,
+        invalid_type_fields:.invalid_type_fields,
+        unexpected_field_count:.unexpected_field_count
+      }
+  ' "$ADAPTER_RESULT" >"$ADAPTER_NORMALIZED" || return 1
+  [ "$(wc -l <"$ADAPTER_NORMALIZED" | tr -d ' ')" = 1 ] || return 1
+  value=$(adapter_stat "$ADAPTER_NORMALIZED") || return 1
+  IFS=' ' read -r uid mode rejected_size extra <<EOF
+$value
+EOF
+  [ -z "$extra" ] && [ "$rejected_size" -le 4096 ] || return 1
+
+  umask 077
+  if [ -e "$rejected" ] || [ -L "$rejected" ]; then
+    adapter_safe_file "$rejected" || return 1
+  elif (set -C; : >"$rejected") 2>/dev/null; then
+    chmod 600 "$rejected" || return 1
+  else
+    adapter_safe_file "$rejected" || return 1
+  fi
+  adapter_safe_file "$rejected" || return 1
+  value=$(adapter_stat "$rejected") || return 1
+  IFS=' ' read -r uid mode rejected_size extra <<EOF
+$value
+EOF
+  [ -z "$extra" ] && [ "$rejected_size" -le 67108864 ] || return 1
+  command cat "$ADAPTER_NORMALIZED" >>"$rejected" || return 1
+  return 0
+}
+
+adapter_fixed_rejection() {
+  LC_ALL=C jq -cn --arg reason "$1" '
+    {
+      rejected:{
+        reason:$reason,
+        hook_event_name:null,
+        tool_name:null,
+        missing_fields:[],
+        invalid_type_fields:[],
+        unexpected_field_count:0
+      }
+    }
+  ' >"$ADAPTER_RESULT" || return 1
+  adapter_record_rejection || :
+  return 1
 }
 
 adapter_main() {
@@ -25,51 +153,100 @@ adapter_main() {
 "*|*""*|*"	"*) return 1 ;; esac
   umask 077
   ADAPTER_INPUT=$(mktemp "$tmp_root/ark-context-failure-input.XXXXXX") || return 1
+  ADAPTER_RESULT=$(mktemp "$tmp_root/ark-context-failure-result.XXXXXX") || return 1
   ADAPTER_NORMALIZED=$(mktemp "$tmp_root/ark-context-failure-normalized.XXXXXX") || return 1
   [ ! -L "$ADAPTER_INPUT" ] && [ -f "$ADAPTER_INPUT" ] || return 1
+  [ ! -L "$ADAPTER_RESULT" ] && [ -f "$ADAPTER_RESULT" ] || return 1
   [ ! -L "$ADAPTER_NORMALIZED" ] && [ -f "$ADAPTER_NORMALIZED" ] || return 1
-  chmod 600 "$ADAPTER_INPUT" "$ADAPTER_NORMALIZED" || return 1
+  chmod 600 "$ADAPTER_INPUT" "$ADAPTER_RESULT" "$ADAPTER_NORMALIZED" || return 1
 
   head -c 1048577 >"$ADAPTER_INPUT" 2>/dev/null || return 1
   input_size=$(wc -c <"$ADAPTER_INPUT" | tr -d ' ') || return 1
   case "$input_size" in ''|*[!0-9]*) return 1 ;; esac
-  [ "$input_size" -le 1048576 ] || return 1
+  if [ "$input_size" -gt 1048576 ]; then
+    adapter_fixed_rejection input_too_large
+    return 1
+  fi
 
-  LC_ALL=C jq -ce '
-    select(
-      type == "object"
-      and keys_unsorted == [
-        "session_id","transcript_path","cwd","prompt_id","permission_mode","effort",
-        "hook_event_name","tool_name","tool_input","tool_use_id","error","is_interrupt","duration_ms"
+  if ! LC_ALL=C jq -ce '
+    def expected_fields: [
+      "cwd", "duration_ms", "effort", "error", "hook_event_name", "is_interrupt",
+      "permission_mode", "prompt_id", "session_id", "tool_input", "tool_name",
+      "tool_use_id", "transcript_path"
+    ];
+    def safe_label($value):
+      if ($value | type) == "string" then $value[0:256] else null end;
+    def invalid_type_fields($input):
+      [
+        ["session_id", "string"],
+        ["transcript_path", "string"],
+        ["cwd", "string"],
+        ["prompt_id", "string"],
+        ["permission_mode", "string"],
+        ["effort", "object"],
+        ["hook_event_name", "string"],
+        ["tool_name", "string"],
+        ["tool_input", "object"],
+        ["tool_use_id", "string"],
+        ["error", "string"],
+        ["is_interrupt", "boolean"],
+        ["duration_ms", "number"]
       ]
-      and (.session_id | type) == "string"
-      and (.transcript_path | type) == "string"
-      and (.cwd | type) == "string"
-      and (.prompt_id | type) == "string"
-      and (.permission_mode | type) == "string"
-      and (.effort | type) == "object"
-      and .hook_event_name == "PostToolUseFailure"
-      and (.tool_name | type) == "string"
-      and (.tool_input | type) == "object"
-      and (.tool_use_id | type) == "string"
-      and (.error | type) == "string"
-      and (.is_interrupt | type) == "boolean"
-      and (.duration_ms | type) == "number"
-    )
-    | {
-        tool:.tool_name,
-        error_type:"tool_error",
-        exit_code:(
-          if .tool_name == "Bash" and (.error | test("^Exit code [0-9]+$"))
-          then (.error | capture("^Exit code (?<code>[0-9]+)$").code | tonumber)
-          else null
-          end
-        ),
-        is_interrupt:.is_interrupt,
-        error:.error,
-        details:{tool_input:.tool_input,duration_ms:.duration_ms}
-      }
-  ' "$ADAPTER_INPUT" >"$ADAPTER_NORMALIZED" || return 1
+      | map(select(($input[.[0]] | type) != .[1]) | .[0]);
+    def rejected($input; $reason; $missing; $invalid_types; $unexpected_count):
+      {
+        rejected:{
+          reason:$reason,
+          hook_event_name:(if ($input | type) == "object" then safe_label($input.hook_event_name) else null end),
+          tool_name:(if ($input | type) == "object" then safe_label($input.tool_name) else null end),
+          missing_fields:$missing,
+          invalid_type_fields:$invalid_types,
+          unexpected_field_count:$unexpected_count
+        }
+      };
+    . as $input
+    | if type != "object" then
+        rejected($input; "input_not_object"; []; []; 0)
+      elif (keys != expected_fields) then
+        rejected(
+          $input;
+          "field_set_mismatch";
+          (expected_fields - ($input | keys));
+          [];
+          ((($input | keys) - expected_fields) | length)
+        )
+      elif (invalid_type_fields($input) | length) > 0 then
+        rejected($input; "field_type_mismatch"; []; invalid_type_fields($input); 0)
+      elif .hook_event_name != "PostToolUseFailure" then
+        rejected($input; "hook_event_name_mismatch"; []; []; 0)
+      else
+        {
+          accepted:{
+            tool:.tool_name,
+            error_type:"tool_error",
+            exit_code:(
+              if .tool_name == "Bash" and (.error | test("^Exit code [0-9]+$"))
+              then (.error | capture("^Exit code (?<code>[0-9]+)$").code | tonumber)
+              else null
+              end
+            ),
+            is_interrupt:.is_interrupt,
+            error:.error,
+            details:{tool_input:.tool_input,duration_ms:.duration_ms}
+          }
+        }
+      end
+  ' "$ADAPTER_INPUT" >"$ADAPTER_RESULT"; then
+    adapter_fixed_rejection malformed_json
+    return 1
+  fi
+
+  if LC_ALL=C jq -ce '.accepted' "$ADAPTER_RESULT" >"$ADAPTER_NORMALIZED"; then
+    :
+  else
+    adapter_record_rejection || :
+    return 1
+  fi
 
   script_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || return 1
   core=$(cd "$script_dir/../../hooks" 2>/dev/null && pwd -P) || return 1

--- a/ark/context/tests/test-claude-code-post-tool-use-failure.sh
+++ b/ark/context/tests/test-claude-code-post-tool-use-failure.sh
@@ -41,6 +41,12 @@ assert_quiet_success() {
   assert_eq "$label stderr empty" 0 "$(wc -c <"$CASE_STDERR" | tr -d ' ')"
 }
 
+mode_of() {
+  value=$(stat -c '%a' "$1" 2>/dev/null) || value=$(stat -f '%Lp' "$1" 2>/dev/null) || return 1
+  while [ "${value#0}" != "$value" ]; do value=${value#0}; done
+  printf '%s\n' "${value:-0}"
+}
+
 expected="$TEST_TMP/expected.jsonl"
 : >"$expected"
 for case_name in bash-exit-7 mcp-error read-missing; do
@@ -89,19 +95,61 @@ jq -e -s '
 ' "$session/errors/raw.log" >/dev/null 2>&1
 assert_eq "transport envelope excluded" 0 "$?"
 
+reordered="$TEST_TMP/reordered.json"
+jq -S . "$FIXTURES/post-tool-use-failure-bash-exit-7-$version.json" >"$reordered"
+run_wrapper "$reordered"
+assert_quiet_success "reordered valid input"
+assert_eq "reordered valid input is appended" 4 "$(wc -l <"$session/errors/raw.log" | tr -d ' ')"
+jq -e -s '
+  .[3].tool == "Bash"
+  and .[3].exit_code == 7
+  and .[3].error == "Exit code 7"
+  and .[3].details.duration_ms == 80
+  and .[3].details.tool_input.command == "/bin/sh -c '\''exit 7'\''"
+' "$session/errors/raw.log" >/dev/null 2>&1
+assert_eq "reordered valid input mapping" 0 "$?"
+assert_eq "reordered valid input is not rejected" no "$(if [ -e "$session/errors/rejected.log" ]; then printf yes; else printf no; fi)"
+
 invalid_dir="$TEST_TMP/invalid"
 mkdir -m 700 "$invalid_dir"
 printf 'not json\n' >"$invalid_dir/json"
 printf '[]\n' >"$invalid_dir/array"
 jq '.hook_event_name="PostToolUse"' "$FIXTURES/post-tool-use-failure-bash-exit-7-$version.json" >"$invalid_dir/event"
 jq 'del(.error)' "$FIXTURES/post-tool-use-failure-bash-exit-7-$version.json" >"$invalid_dir/missing"
-jq '.duration_ms="slow"' "$FIXTURES/post-tool-use-failure-bash-exit-7-$version.json" >"$invalid_dir/type"
+rejected_secret='issue-352-tool-input-must-not-be-copied'
+jq --arg secret "$rejected_secret" \
+  '.duration_ms="slow" | .tool_input={command:$secret} | .error=$secret' \
+  "$FIXTURES/post-tool-use-failure-bash-exit-7-$version.json" >"$invalid_dir/type"
 before=$(cksum "$session/errors/raw.log")
 for invalid in "$invalid_dir"/*; do
   run_wrapper "$invalid"
   assert_quiet_success "invalid adapter input"
 done
 assert_eq "invalid adapter input preserves raw" "$before" "$(cksum "$session/errors/raw.log")"
+assert_eq "invalid adapter input rejection count" 5 "$(wc -l <"$session/errors/rejected.log" | tr -d ' ')"
+assert_eq "rejected log mode" 600 "$(mode_of "$session/errors/rejected.log")"
+jq -e -s '
+  length == 5
+  and ([.[].reason] | sort) == [
+    "field_set_mismatch", "field_type_mismatch", "hook_event_name_mismatch",
+    "input_not_object", "malformed_json"
+  ]
+  and any(.[]; .reason == "field_set_mismatch" and .missing_fields == ["error"])
+  and any(.[]; .reason == "field_type_mismatch" and .invalid_type_fields == ["duration_ms"])
+  and all(.[].missing_fields[]; IN(
+    "cwd", "duration_ms", "effort", "error", "hook_event_name", "is_interrupt",
+    "permission_mode", "prompt_id", "session_id", "tool_input", "tool_name",
+    "tool_use_id", "transcript_path"
+  ))
+  and all(.[];
+    (has("error") | not)
+    and (has("tool_input") | not)
+    and (has("input") | not)
+  )
+' "$session/errors/rejected.log" >/dev/null 2>&1
+assert_eq "invalid adapter rejection reasons are sanitized" 0 "$?"
+grep -F "$rejected_secret" "$session/errors/rejected.log" >/dev/null 2>&1
+assert_eq "rejected log omits input body" 1 "$?"
 
 oversize="$TEST_TMP/oversize.json"
 printf '%s' '{"session_id":"' >"$oversize"
@@ -111,6 +159,8 @@ before=$(cksum "$session/errors/raw.log")
 run_wrapper "$oversize"
 assert_quiet_success "oversize adapter input"
 assert_eq "oversize adapter input preserves raw" "$before" "$(cksum "$session/errors/raw.log")"
+jq -e -s '.[-1].reason == "input_too_large"' "$session/errors/rejected.log" >/dev/null 2>&1
+assert_eq "oversize adapter rejection is visible" 0 "$?"
 
 pipe_error="$TEST_TMP/pipe-300kb.error"
 pipe_input="$TEST_TMP/pipe-300kb.json"
@@ -136,8 +186,17 @@ jq -e -s --arg command "touch $marker" --arg error "$command_error" \
   'any(.[]; .details.tool_input.command == $command and .error == $error)' "$session/errors/raw.log" >/dev/null 2>&1
 assert_eq "command-shaped data remains data" 0 "$?"
 
-run_case env -u ARK_SESSION_DIR /bin/bash "$WRAPPER" <"$FIXTURES/post-tool-use-failure-bash-exit-7-$version.json"
-assert_quiet_success "Ark outside adapter no-op"
+fifo="$TEST_TMP/unreadable-input"
+mkfifo "$fifo"
+external_out="$TEST_TMP/external.out"
+external_err="$TEST_TMP/external.err"
+env -u ARK_SESSION_DIR /bin/bash "$WRAPPER" <>"$fifo" >"$external_out" 2>"$external_err" &
+external_pid=$!
+wait "$external_pid"
+external_status=$?
+assert_eq "Ark outside adapter no-op exits zero" 0 "$external_status"
+assert_eq "Ark outside adapter no-op stdout empty" 0 "$(wc -c <"$external_out" | tr -d ' ')"
+assert_eq "Ark outside adapter no-op stderr empty" 0 "$(wc -c <"$external_err" | tr -d ' ')"
 
 for forbidden in exitCode errorType failure_type tool_response tool_uses batch PostToolUseSuccess; do
   grep -F "$forbidden" "$WRAPPER" >/dev/null 2>&1


### PR DESCRIPTION
`post-tool-use-failure.sh` の入力検証が hook JSON の **key の並び順まで完全一致**を要求しており、順序が変わると**エラー捕捉が無音で停止する**。

Closes #352

## 修正前の挙動（実測）

`keys_unsorted == [...]` は順序を含む配列比較なので、field 集合と型が完全に正しくても順序が違えば全件落ちる。しかも:

- `jq -ce` は select が全件落として出力ゼロ → exit 4
- `|| return 1` で `adapter_main` が 1 を返す
- 呼び出し側は `adapter_main || :` で握り潰し **exit 0**
- `raw.log` は作られず、stderr も出ず、記録も残らない

同じ入力を main と本ブランチで比較した結果:

```
branch     key 順   raw.log
main       正規     1 行
main       入替     0 行   ← 無音で脱落
fix-352    正規     1 行
fix-352    入替     1 行   ← 修正後
```

**`@anthropic-ai/claude-code` は毎日の bump ワークフローで自動更新される。** バージョン更新で key 順が変われば、その日から捕捉が止まり、止まったことに気付く手段が無い。spec §4-2 の「エラー原文を欠落なく保存する」契約が無音で破れる。

## 修正内容

### 1. 順序非依存にする

`keys`（昇順ソート済み）と昇順の期待 field 配列を比較する形へ変更した。**field 集合、全 field の型、`hook_event_name == "PostToolUseFailure"` の厳密検証は維持**している。緩めたのは順序依存だけ。

出力する `raw.log` の key 順は adapter が構築しているため、入力順に依存しない。`L{n}-L{m}` 参照の安定性は損なわれない。

### 2. 落とした入力を無音にしない

field 集合や型が期待と違って拒否した場合、`$ARK_SESSION_DIR/errors/rejected.log`（mode 0600）へ理由を 1 行 JSON で追記する。

```json
{"at":"...","reason":"field_type_mismatch","hook_event_name":"PostToolUseFailure",
 "tool_name":null,"missing_fields":[],"invalid_type_fields":["tool_name"],
 "unexpected_field_count":0}
```

**入力本文は複製しない。** `error` / `tool_input` の中身には機密が入りうるため、記録するのは理由・欠落 field 名・型違反 field 名・未知 field 数・event 名・tool 名だけ。

機密を含む入力で検証した結果:

```
SECRET_TOKEN  0 件
xyz789        0 件
abc123        0 件
deploy        0 件
boom          0 件
```

`raw.log` も汚さない（拒否時は 0 行のまま）。

`post-tool-batch.sh` に同種の `keys_unsorted` 依存は無かった。

## 検証

- key 順を変えた有効な JSON が受理され `raw.log` に記録される
- 欠落・型違反は従来どおり拒否され、理由が `rejected.log` に残る
- `rejected.log` に入力本文が複製されていない
- mode 0600
- 既存の実機 fixture テストが引き続き通る
- `ARK_SESSION_DIR` 未設定で完全 no-op（stdin も読まない）を維持

`ark/context/tests/run.sh` 全 15 スイート PASS、`pnpm test:harness` 全 PASS。

## 契約の維持

- hook は常に exit 0（記録に失敗しても exit 0）
- `raw.log` を truncate / rotate / rewrite する経路を作っていない
- `ARK_SESSION_DIR` 未設定なら完全 no-op

## スコープ

`ark/context/adapters/claude-code/post-tool-use-failure.sh` とそのテストのみ。`.claude/settings*.json` / `.gitignore` / `packages/` は変更していない。
