### PR TITLE
feat(context): task 規約・観点ローテーション・failures 到達性（Manus P2 + #365）

### DIFF
--- a/ark/context/README.md
+++ b/ark/context/README.md
@@ -4,6 +4,22 @@ Ark Context の session data は XDG data home 配下に保存する。session d
 `errors/` は mode `0700`、`raw.log` と `summary.md` は mode `0600` で、実行 uid が
 所有する non-symlink の regular path だけを受理する。
 
+session init は mode `0600` の空の `artifacts/index.md` も作る。artifact の目次行は
+`- artifacts/<path> — <1行要約>` とし、handoff はこの形式だけを取り込む。
+
+## SessionStart の task 規約
+
+Claude Code adapter は `SessionStart` に agent 非依存の
+`hooks/inject-context-rules.sh` を接続し、10則、`task.md` の絶対 path、artifact 目次の
+形式を `additionalContext` として渡す。Goal が空なら最初のユーザー要求から Goal と
+Plan を起票する指示を、埋まっていれば現在の Goal / NOW を添える。`task.md` 自体には
+規約本文を展開せず、`templates/context-rules.md` の絶対 path だけを1行で置くため、
+recitation の `## Goal` / `## Plan` parse 境界は増えない。
+
+レビュー session は `session-init.sh --review` で作る。通常の任意 Plan の代わりに固定の
+6観点を checkbox として持ち、session ID の SHA-256 を seed に提示順だけを変える。
+同じ session ID では順序が安定し、観点集合は変化しない。
+
 `errors/raw.log` は追記専用 JSONL である。1 entry の上限は 1 MiB、session 全体の
 上限は 64 MiB とし、上限を超える新 entry だけを記録しない。既存 raw を truncate、
 rotate、rewrite しない。capture、summary、restart は raw/summary の削除 API を
@@ -77,4 +93,3 @@ fixture でしか動いていなかった）、移行処理は意図的に実装
   同じ候補が再追加される
 - 旧 `$XDG_DATA_HOME/ark/loop/` と `$XDG_CONFIG_HOME/ark/loop/` は
   参照されなくなるので、不要なら手動で削除する
-

--- a/ark/context/adapters/claude-code/session-start.sh
+++ b/ark/context/adapters/claude-code/session-start.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+if [ -z "${ARK_SESSION_DIR:-}" ]; then
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+LC_ALL=C
+export LC_ALL
+input=
+while :; do
+  chunk=
+  IFS= read -r -n 4096 chunk
+  read_status=$?
+  input="$input$chunk"
+  [ "${#input}" -le 1048576 ] || exit 0
+  if [ "$read_status" -eq 0 ] && [ "${#chunk}" -lt 4096 ]; then
+    input="$input
+"
+    [ "${#input}" -le 1048576 ] || exit 0
+  fi
+  [ "$read_status" -eq 0 ] || break
+done
+
+printf '%s' "$input" | jq -e \
+  'type == "object" and .hook_event_name == "SessionStart"' >/dev/null 2>&1 \
+  || exit 0
+
+adapter_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
+source_root=$(cd "$adapter_dir/../.." 2>/dev/null && pwd -P) || exit 0
+core="$source_root/hooks/inject-context-rules.sh"
+[ -f "$core" ] && [ ! -L "$core" ] || exit 0
+
+context=$(/bin/bash "$core")
+core_status=$?
+[ "$core_status" -eq 0 ] || exit 0
+[ -n "$context" ] || exit 0
+bytes=$(printf '%s\n' "$context" | wc -c | tr -d ' ')
+[ "$bytes" -le 8192 ] 2>/dev/null || exit 0
+
+jq -n --arg context "$context" \
+  '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$context}}' 2>/dev/null \
+  || true
+exit 0

--- a/ark/context/adapters/claude-code/settings.sh
+++ b/ark/context/adapters/claude-code/settings.sh
@@ -2,6 +2,7 @@
 
 CLAUDE_CTX_BATCH_HOOK_JSON='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/post-tool-batch.sh"}]}'
 CLAUDE_CTX_FAILURE_HOOK_JSON='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/post-tool-use-failure.sh"}]}'
+CLAUDE_CTX_SESSION_START_HOOK_JSON='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/session-start.sh"}]}'
 
 claude_settings_error() {
   printf '%s\n' "$*" >&2
@@ -18,7 +19,8 @@ claude_settings_validate_schema() {
     ((has("hooks") | not) or
       (.hooks | type == "object" and
         ((has("PostToolBatch") | not) or (.PostToolBatch | type == "array")) and
-        ((has("PostToolUseFailure") | not) or (.PostToolUseFailure | type == "array"))))
+        ((has("PostToolUseFailure") | not) or (.PostToolUseFailure | type == "array")) and
+        ((has("SessionStart") | not) or (.SessionStart | type == "array"))))
   ' "$1" >/dev/null 2>&1 || { claude_settings_error "invalid Claude settings schema"; return 1; }
 }
 
@@ -238,6 +240,8 @@ claude_settings_manifest_matches() {
             (($settings.hooks.PostToolBatch // []) | index($entry.value) != null)
           elif $entry.path == "hooks/PostToolUseFailure" then
             (($settings.hooks.PostToolUseFailure // []) | index($entry.value) != null)
+          elif $entry.path == "hooks/SessionStart" then
+            (($settings.hooks.SessionStart // []) | index($entry.value) != null)
           else
             false
           end)
@@ -248,7 +252,7 @@ claude_settings_manifest_matches() {
 claude_settings_inject() {
   local repo=${1:-}
   local state=${2:-}
-  local settings tmp manifest manifest_new settings_existed mode root range permissions_start deny_start hooks_start batch_start failure_start tool
+  local settings tmp manifest manifest_new settings_existed mode root range permissions_start deny_start hooks_start batch_start failure_start session_start_start tool
   command -v jq >/dev/null 2>&1 || { claude_settings_error "jq command unavailable"; return 1; }
   settings="$repo/.claude/settings.local.json"
   tmp="$repo/.claude/settings.local.json.ark-context-tmp"
@@ -303,9 +307,10 @@ claude_settings_inject() {
   fi
 
   if ! printf '%s' "$CLAUDE_CONTENT" | jq -e 'has("hooks")' >/dev/null; then
-    claude_content_add_to_container "$root" "\"hooks\"                   :{\"PostToolBatch\":[${CLAUDE_CTX_BATCH_HOOK_JSON}],\"PostToolUseFailure\":[${CLAUDE_CTX_FAILURE_HOOK_JSON}]}" || return 1
+    claude_content_add_to_container "$root" "\"hooks\"                   :{\"PostToolBatch\":[${CLAUDE_CTX_BATCH_HOOK_JSON}],\"PostToolUseFailure\":[${CLAUDE_CTX_FAILURE_HOOK_JSON}],\"SessionStart\":[${CLAUDE_CTX_SESSION_START_HOOK_JSON}]}" || return 1
     claude_manifest_add_json hooks/PostToolBatch "$CLAUDE_CTX_BATCH_HOOK_JSON" || return 1
     claude_manifest_add_json hooks/PostToolUseFailure "$CLAUDE_CTX_FAILURE_HOOK_JSON" || return 1
+    claude_manifest_add_json hooks/SessionStart "$CLAUDE_CTX_SESSION_START_HOOK_JSON" || return 1
   else
     range=$(claude_content_property "$root" hooks) || return 1
     set -- $range; hooks_start=$3
@@ -326,6 +331,15 @@ claude_settings_inject() {
       set -- $range; failure_start=$3
       claude_content_add_to_container "$failure_start" "$CLAUDE_CTX_FAILURE_HOOK_JSON" || return 1
       claude_manifest_add_json hooks/PostToolUseFailure "$CLAUDE_CTX_FAILURE_HOOK_JSON" || return 1
+    fi
+    if ! printf '%s' "$CLAUDE_CONTENT" | jq -e '.hooks | has("SessionStart")' >/dev/null; then
+      claude_content_add_to_container "$hooks_start" "\"SessionStart\"                 :[${CLAUDE_CTX_SESSION_START_HOOK_JSON}]" || return 1
+      claude_manifest_add_json hooks/SessionStart "$CLAUDE_CTX_SESSION_START_HOOK_JSON" || return 1
+    elif ! printf '%s' "$CLAUDE_CONTENT" | jq -e --argjson hook "$CLAUDE_CTX_SESSION_START_HOOK_JSON" '.hooks.SessionStart | index($hook) != null' >/dev/null; then
+      range=$(claude_content_property "$hooks_start" SessionStart) || return 1
+      set -- $range; session_start_start=$3
+      claude_content_add_to_container "$session_start_start" "$CLAUDE_CTX_SESSION_START_HOOK_JSON" || return 1
+      claude_manifest_add_json hooks/SessionStart "$CLAUDE_CTX_SESSION_START_HOOK_JSON" || return 1
     fi
   fi
 
@@ -352,8 +366,8 @@ claude_settings_inject() {
 claude_settings_restore() {
   local repo=${1:-}
   local state=${2:-}
-  local settings tmp manifest settings_existed mode entries entry path value index range root permissions_start deny_start hooks_start batch_start failure_start item_range
-  local abandoned=false batch_abandoned=false failure_abandoned=false property_between deny_length batch_length failure_length hooks_items_length LC_ALL=C
+  local settings tmp manifest settings_existed mode entries entry path value index range root permissions_start deny_start hooks_start batch_start failure_start session_start_start item_range
+  local abandoned=false batch_abandoned=false failure_abandoned=false session_start_abandoned=false property_between deny_length batch_length failure_length session_start_length hooks_items_length LC_ALL=C
   command -v jq >/dev/null 2>&1 || { claude_settings_error "jq command unavailable"; return 1; }
   settings="$repo/.claude/settings.local.json"
   tmp="$repo/.claude/settings.local.json.ark-context-tmp"
@@ -410,6 +424,19 @@ claude_settings_restore() {
         item_range=$(printf '%s' "$CLAUDE_CONTENT" | claude_json_array_item_range "$failure_start" "$index"); set -- $item_range
         claude_content_remove_value "$1" "$2" "$failure_start" || return 1
         ;;
+      hooks/SessionStart)
+        value=$(printf '%s' "$entry" | jq -c '.value') || return 1
+        index=$(printf '%s' "$CLAUDE_CONTENT" | jq -r --argjson value "$value" '.hooks.SessionStart // [] | index($value) // -1')
+        if [ "$index" -lt 0 ]; then
+          session_start_length=$(printf '%s' "$CLAUDE_CONTENT" | jq -r '.hooks.SessionStart // [] | length')
+          if [ "$session_start_length" -ne 0 ]; then abandoned=true; session_start_abandoned=true; fi
+          continue
+        fi
+        range=$(claude_content_property "$root" hooks); set -- $range; hooks_start=$3
+        range=$(claude_content_property "$hooks_start" SessionStart); set -- $range; session_start_start=$3
+        item_range=$(printf '%s' "$CLAUDE_CONTENT" | claude_json_array_item_range "$session_start_start" "$index"); set -- $item_range
+        claude_content_remove_value "$1" "$2" "$session_start_start" || return 1
+        ;;
     esac
   done <<EOF
 $entries
@@ -458,6 +485,17 @@ EOF
           [ "$property_between" != '                 :' ] || claude_content_remove_value "$1" "$4" "$hooks_start"
         fi
       fi
+      root=$(printf '%s' "$CLAUDE_CONTENT" | LC_ALL=C awk '{if(NR>1)s=s"\n";s=s$0}END{for(i=1;i<=length(s);i++)if(substr(s,i,1)=="{"){print i;exit}}')
+      range=$(claude_content_property "$root" hooks || true)
+      if [ -n "$range" ]; then
+        set -- $range; hooks_start=$3
+        session_start_length=$(printf '%s' "$CLAUDE_CONTENT" | jq -r '.hooks.SessionStart // [] | length')
+        range=$(claude_content_property "$hooks_start" SessionStart || true)
+        if [ -n "$range" ] && [ "$session_start_length" -eq 0 ]; then
+          set -- $range; property_between=${CLAUDE_CONTENT:$2:$(( $3 - $2 - 1 ))}
+          [ "$property_between" != '                 :' ] || claude_content_remove_value "$1" "$4" "$hooks_start"
+        fi
+      fi
     fi
   fi
 
@@ -472,9 +510,11 @@ EOF
     command mv "$tmp" "$settings" || return 1
   fi
   if [ "$abandoned" = true ]; then
-    jq --argjson batch "$batch_abandoned" --argjson failure "$failure_abandoned" '
+    jq --argjson batch "$batch_abandoned" --argjson failure "$failure_abandoned" \
+      --argjson session_start "$session_start_abandoned" '
       if $batch then (.entries[] | select(.path == "hooks/PostToolBatch")).abandoned = true else . end
       | if $failure then (.entries[] | select(.path == "hooks/PostToolUseFailure")).abandoned = true else . end
+      | if $session_start then (.entries[] | select(.path == "hooks/SessionStart")).abandoned = true else . end
     ' "$manifest" >"$manifest.new" || return 1
     chmod 600 "$manifest.new" || return 1
     command mv "$manifest.new" "$manifest" || return 1

--- a/ark/context/hooks/inject-context-rules.sh
+++ b/ark/context/hooks/inject-context-rules.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Keep this guard before stdin reads and before all optional environment use.
+if [ -z "${ARK_SESSION_DIR:-}" ]; then
+  exit 0
+fi
+
+CTX_RULES_HOOK_DIR=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
+
+ctx_rules_stat() {
+  local value uid mode extra
+  value=$(stat -c '%u %a' "$1" 2>/dev/null) \
+    || value=$(stat -f '%u %Lp' "$1" 2>/dev/null) \
+    || return 1
+  IFS=' ' read -r uid mode extra <<EOF
+$value
+EOF
+  [ -n "$uid" ] && [ -n "$mode" ] && [ -z "$extra" ] || return 1
+  case "$uid" in *[!0-9]*) return 1 ;; esac
+  case "$mode" in *[!0-7]*) return 1 ;; esac
+  while [ "${mode#0}" != "$mode" ]; do mode=${mode#0}; done
+  printf '%s %s\n' "$uid" "${mode:-0}"
+}
+
+ctx_rules_safe_session() {
+  local value uid mode extra canonical
+  [ -n "$1" ] && [ "${1#/}" != "$1" ] && [ ! -L "$1" ] && [ -d "$1" ] || return 1
+  case "$1" in *"
+"*|*""*|*"	"*) return 1 ;; esac
+  canonical=$(cd "$1" 2>/dev/null && pwd -P) || return 1
+  [ "$canonical" = "$1" ] || return 1
+  value=$(ctx_rules_stat "$1") || return 1
+  IFS=' ' read -r uid mode extra <<EOF
+$value
+EOF
+  [ -z "$extra" ] && [ "$uid" = "$CTX_RULES_UID" ] && [ "$mode" = 700 ]
+}
+
+ctx_rules_safe_task() {
+  local value uid mode extra
+  [ ! -L "$1" ] && [ -f "$1" ] || return 1
+  value=$(ctx_rules_stat "$1") || return 1
+  IFS=' ' read -r uid mode extra <<EOF
+$value
+EOF
+  [ -z "$extra" ] && [ "$uid" = "$CTX_RULES_UID" ] && [ "$mode" = 600 ]
+}
+
+ctx_rules_parse_task() {
+  local task=$1 section line goal_count now_count item
+  CTX_RULES_GOAL=
+  CTX_RULES_NOW=
+  ctx_rules_safe_task "$task" || return 1
+  command -v iconv >/dev/null 2>&1 || return 1
+  iconv -f UTF-8 -t UTF-8 "$task" >/dev/null 2>&1 || return 1
+  section=
+  goal_count=0
+  now_count=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%$'\r'}
+    case "$line" in
+      '## Goal') section=goal; continue ;;
+      '## Plan') section=plan; continue ;;
+      '## '*) section=other; continue ;;
+    esac
+    if [ "$section" = goal ] && [ -n "$line" ]; then
+      goal_count=$((goal_count + 1))
+      CTX_RULES_GOAL=$line
+    elif [ "$section" = plan ]; then
+      case "$line" in
+        '- [ ] '*' ← NOW'|'- [x] '*' ← NOW')
+          now_count=$((now_count + 1))
+          item=${line#- \[ \] }
+          [ "$item" != "$line" ] || item=${line#- \[x\] }
+          CTX_RULES_NOW=${item% ← NOW}
+          ;;
+      esac
+    fi
+  done <"$task"
+  [ "$goal_count" -le 1 ] && [ "$now_count" -le 1 ] || return 1
+  case "$CTX_RULES_GOAL$CTX_RULES_NOW" in *"
+"*|*""*|*"	"*) return 1 ;; esac
+}
+
+ctx_rules_main() {
+  local session=${ARK_SESSION_DIR:-} task context_root rules state_context context bytes
+  CTX_RULES_UID=$(id -u 2>/dev/null) || return 1
+  ctx_rules_safe_session "$session" || return 1
+  task="$session/task.md"
+  context_root=$(cd "$CTX_RULES_HOOK_DIR/.." 2>/dev/null && pwd -P) || return 1
+  rules="$context_root/templates/context-rules.md"
+  [ -f "$rules" ] && [ ! -L "$rules" ] || return 1
+  command -v iconv >/dev/null 2>&1 || return 1
+  iconv -f UTF-8 -t UTF-8 "$rules" >/dev/null 2>&1 || return 1
+
+  CTX_RULES_GOAL=
+  CTX_RULES_NOW=
+  ctx_rules_parse_task "$task" >/dev/null 2>&1 || true
+  if [ -z "$CTX_RULES_GOAL" ]; then
+    state_context='Goal が空です。最初のユーザー要求から Goal と Plan を task.md に起票し、Plan に項目を置いた時点で ← NOW をちょうど1個置くこと。'
+  else
+    state_context="現在の Goal: $CTX_RULES_GOAL
+現在の NOW: ${CTX_RULES_NOW:-（未設定）}"
+  fi
+  context=$({
+    command cat "$rules"
+    printf '\ntask.md: %s\n' "$task"
+    printf '%s\n' 'artifacts/index.md の追記形式: - artifacts/<path> — <1行要約>'
+    printf '%s\n' "$state_context"
+  }) || return 1
+  bytes=$(printf '%s\n' "$context" | wc -c | tr -d ' ')
+  [ "$bytes" -le 8192 ] 2>/dev/null || return 1
+  printf '%s\n' "$context"
+}
+
+ctx_rules_main 2>/dev/null || true
+exit 0

--- a/ark/context/hooks/inject-context-rules.sh
+++ b/ark/context/hooks/inject-context-rules.sh
@@ -46,6 +46,12 @@ EOF
   [ -z "$extra" ] && [ "$uid" = "$CTX_RULES_UID" ] && [ "$mode" = 600 ]
 }
 
+ctx_rules_has_failures() {
+  ctx_rules_safe_task "$1" || return 1
+  [ -s "$1" ] || return 1
+  LC_ALL=C grep -q '[^[:space:]]' "$1" 2>/dev/null
+}
+
 ctx_rules_parse_task() {
   local task=$1 section line goal_count now_count item
   CTX_RULES_GOAL=
@@ -83,10 +89,11 @@ ctx_rules_parse_task() {
 }
 
 ctx_rules_main() {
-  local session=${ARK_SESSION_DIR:-} task context_root rules state_context context bytes
+  local session=${ARK_SESSION_DIR:-} task failures context_root rules state_context failures_context context bytes
   CTX_RULES_UID=$(id -u 2>/dev/null) || return 1
   ctx_rules_safe_session "$session" || return 1
   task="$session/task.md"
+  failures="$session/knowledge/failures.md"
   context_root=$(cd "$CTX_RULES_HOOK_DIR/.." 2>/dev/null && pwd -P) || return 1
   rules="$context_root/templates/context-rules.md"
   [ -f "$rules" ] && [ ! -L "$rules" ] || return 1
@@ -102,10 +109,16 @@ ctx_rules_main() {
     state_context="現在の Goal: $CTX_RULES_GOAL
 現在の NOW: ${CTX_RULES_NOW:-（未設定）}"
   fi
+  failures_context=
+  if ctx_rules_has_failures "$failures"; then
+    failures_context="knowledge/failures.md: $failures
+作業開始前と、失敗して再試行する前に上記 knowledge/failures.md を読むこと。"
+  fi
   context=$({
     command cat "$rules"
     printf '\ntask.md: %s\n' "$task"
     printf '%s\n' 'artifacts/index.md の追記形式: - artifacts/<path> — <1行要約>'
+    [ -z "$failures_context" ] || printf '%s\n' "$failures_context"
     printf '%s\n' "$state_context"
   }) || return 1
   bytes=$(printf '%s\n' "$context" | wc -c | tr -d ' ')

--- a/ark/context/scripts/lib/task-template.sh
+++ b/ark/context/scripts/lib/task-template.sh
@@ -18,7 +18,7 @@ ctx_task_render() {
   local session=${1:-}
   local goal=${2:-}
   local previous=${3:-}
-  local task constraints plans constraint_count plan_count option value marker new old_umask write_status
+  local task constraints plans constraint_count plan_count option value marker new old_umask write_status context_rules
   shift 3 2>/dev/null || { ctx_error "invalid task input"; return 1; }
   ctx_validate_xdg_dir "$session" || return 1
   task="$session/task.md"
@@ -31,6 +31,10 @@ ctx_task_render() {
   [ -n "$previous" ] || { ctx_error "invalid task input"; return 1; }
   printf '%s' "$previous" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 \
     || { ctx_error "invalid task input"; return 1; }
+  context_rules="${ARK_SOURCE_ROOT:-}/ark/context/templates/context-rules.md"
+  [ "${context_rules#/}" != "$context_rules" ] && [ -f "$context_rules" ] && [ ! -L "$context_rules" ] \
+    || { ctx_error "context rules unavailable"; return 1; }
+  ctx_has_control "$context_rules" && { ctx_error "context rules unavailable"; return 1; }
 
   constraints=
   plans=
@@ -65,6 +69,7 @@ ctx_task_render() {
   {
     printf '# Task\n\n## Goal\n%s\n\n## Constraints\n' "$goal"
     printf '%s' "$constraints"
+    printf '\nContext rules: %s\n' "$context_rules"
     printf '\nPrevious failure summary: %s\n\n## Plan\n' "$previous"
     printf '%s' "$plans"
     printf '\n## Artifacts\n- (なし)\n'
@@ -76,6 +81,68 @@ ctx_task_render() {
   ctx_validate_xdg_file "$new" || return 1
   command mv "$new" "$task" || { ctx_error "task publish failed"; return 1; }
   ctx_validate_xdg_file "$task"
+}
+
+ctx_artifacts_index_initialize() {
+  local session=${1:-} artifacts index old_umask write_status
+  ctx_validate_xdg_dir "$session" || return 1
+  artifacts="$session/artifacts"
+  ctx_validate_xdg_dir "$artifacts" || return 1
+  index="$artifacts/index.md"
+  if [ -e "$index" ] || [ -L "$index" ]; then
+    ctx_validate_xdg_file "$index"
+    return $?
+  fi
+  old_umask=$(umask)
+  umask 077
+  (set -C; : >"$index") 2>/dev/null
+  write_status=$?
+  umask "$old_umask"
+  if [ "$write_status" -ne 0 ]; then
+    ctx_validate_xdg_file "$index"
+    return $?
+  fi
+  chmod 600 "$index" || { ctx_error "artifact index create failed"; return 1; }
+  ctx_validate_xdg_file "$index"
+}
+
+ctx_review_plan_items() {
+  local session_id=${1:-} seed review_id score tab sorted
+  case "$session_id" in ''|*[!0-9a-f]*) ctx_error "invalid session id"; return 1 ;; esac
+  [ "${#session_id}" -eq 32 ] || { ctx_error "invalid session id"; return 1; }
+  seed=$(ctx_sha256 "$session_id") || return 1
+  sorted=
+  for review_id in diff rules artifacts errors goal inbox; do
+    score=$(ctx_sha256 "$seed:$review_id") || return 1
+    sorted="${sorted}${score}	${review_id}
+"
+  done
+  tab=$(printf '\t')
+  printf '%s' "$sorted" | LC_ALL=C sort | while IFS="$tab" read -r score review_id; do
+    case "$review_id" in
+      diff) printf '%s\n' 'diff 全ファイルを通読する' ;;
+      rules) printf '%s\n' 'artifacts/index.md の更新を含む規約遵守を検査する' ;;
+      artifacts) printf '%s\n' 'artifact 本文と artifacts/index.md の整合を検査する' ;;
+      errors) printf '%s\n' 'エラー握りつぶしがないことを検査する' ;;
+      goal) printf '%s\n' 'Goal からの逸脱がないことを検査する' ;;
+      inbox) printf '%s\n' '再発性のある指摘を failures-inbox.md 候補にする' ;;
+      *) return 1 ;;
+    esac
+  done
+}
+
+ctx_task_render_review() {
+  local session=${1:-} session_id=${2:-} goal=${3:-} previous=${4:-} review_items item
+  shift 4 2>/dev/null || { ctx_error "invalid task input"; return 1; }
+  review_items=$(ctx_review_plan_items "$session_id") || return 1
+  set -- "$session" "$goal" "$previous" "$@"
+  while IFS= read -r item || [ -n "$item" ]; do
+    [ -n "$item" ] || continue
+    set -- "$@" --plan-item "$item"
+  done <<EOF
+$review_items
+EOF
+  ctx_task_render "$@"
 }
 
 ctx_utf8_file_prefix() {

--- a/ark/context/scripts/session-init.sh
+++ b/ark/context/scripts/session-init.sh
@@ -65,9 +65,14 @@ restart_session=
 goal=
 constraints=
 plans=
+review=0
 while [ "$#" -gt 0 ]; do
   option=$1; shift
   case "$option" in
+    --review)
+      [ "$review" -eq 0 ] || session_disabled "invalid arguments"
+      review=1
+      ;;
     --repo|--owner-pid|--session-id|--restart|--goal|--constraint|--plan-item)
       [ "$#" -gt 0 ] || session_disabled "invalid arguments"
       value=$1; shift
@@ -85,6 +90,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 [ -n "$repo" ] && [ -n "$owner_pid" ] || session_disabled "invalid arguments"
+[ "$review" -eq 0 ] || [ -z "$plans" ] || session_disabled "review task does not accept plan items"
 owner_pid_valid "$owner_pid" || session_disabled "invalid owner pid"
 kill -0 "$owner_pid" 2>/dev/null || session_disabled "owner pid is not alive"
 [ -z "$goal" ] || ctx_task_input_valid "$goal" 200 || session_disabled "invalid task input"
@@ -193,6 +199,8 @@ init_failed() {
 ctx_config_ensure >/dev/null 2>&1 || init_failed "config initialization failed"
 interval=$(ctx_config_read_recite_interval 2>/dev/null) || init_failed "config parse failed"
 ctx_runtime_prepare_session >/dev/null 2>&1 || init_failed "session preparation failed"
+ctx_artifacts_index_initialize "$ARK_SESSION_DIR" >/dev/null 2>&1 \
+  || init_failed "artifact index initialization failed"
 if [ -n "$restart_session" ]; then
   old_session="$CTX_DATA_ROOT/sessions/$restart_session"
   previous=$(ctx_previous_failure_summary "$old_session" 2>/dev/null) || init_failed "restart summary unavailable"
@@ -208,7 +216,13 @@ if [ -n "$plans" ]; then while IFS= read -r value || [ -n "$value" ]; do set -- 
 $plans
 EOF
 fi
-ctx_task_render "$@" >/dev/null 2>&1 || init_failed "task initialization failed"
+if [ "$review" -eq 1 ]; then
+  shift 3
+  ctx_task_render_review "$ARK_SESSION_DIR" "$ARK_SESSION_ID" "$goal" "$previous" "$@" \
+    >/dev/null 2>&1 || init_failed "review task initialization failed"
+else
+  ctx_task_render "$@" >/dev/null 2>&1 || init_failed "task initialization failed"
+fi
 ctx_knowledge_initialize "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" >/dev/null 2>&1 || init_failed "knowledge initialization failed"
 claude_settings_inject "$repo" "$CTX_REPO_STATE_DIR" >/dev/null 2>&1 || init_failed "settings injection failed"
 release_lock

--- a/ark/context/templates/context-rules.md
+++ b/ark/context/templates/context-rules.md
@@ -1,0 +1,15 @@
+タスク管理:
+1. task.md だけを正本にし、native todo を使用しない。
+2. 各 tool step の前後で Plan status と ← NOW を現実に合わせる。
+3. Goal / Constraints は空から記入済みへの一方向の初回記入を除いて書き換えず、逸脱が必要なら作業を停止する。
+
+エラー:
+1. 失敗 action と原文を errors/raw.log に残す。
+2. 再試行前に直前の失敗と既知の禁止手を読む。
+3. 回復結果と再発性のある知見を failures-inbox.md 候補にする。
+
+外部化:
+1. 20行を超える中間成果は artifacts/ に外部化する。
+2. artifacts/index.md に path と1行要約を append する。
+3. artifact 本文の再掲より path 参照を優先する。
+4. 可逆な compaction を尽くした後にだけ不可逆な summary を行う。

--- a/ark/context/templates/task-review.md.tmpl
+++ b/ark/context/templates/task-review.md.tmpl
@@ -11,7 +11,7 @@ Context rules: {{CONTEXT_RULES}}
 Previous failure summary: {{PREV_FAILURE_SUMMARY}}
 
 ## Plan
-{{PLAN_ITEMS}}
+{{REVIEW_PLAN_ITEMS}}
 
 ## Artifacts
 - (なし)

--- a/ark/context/tests/run.sh
+++ b/ark/context/tests/run.sh
@@ -7,6 +7,7 @@ for test_script in \
   test-runtime.sh \
   test-config.sh \
   test-task-template.sh \
+  test-review-template.sh \
   test-portable-commands.sh \
   test-stop-gate.sh \
   test-handoff.sh \
@@ -16,6 +17,7 @@ for test_script in \
   test-summarize-errors.sh \
   test-claude-code-post-tool-use-failure.sh \
   test-claude-code-post-tool-batch.sh \
+  test-claude-code-session-start.sh \
   test-claude-code-settings.sh \
   test-session-lifecycle.sh \
   test-claude-code-fixtures.sh; do

--- a/ark/context/tests/test-claude-code-session-start.sh
+++ b/ark/context/tests/test-claude-code-session-start.sh
@@ -29,10 +29,11 @@ for hook in "$CORE" "$WRAPPER"; do
 done
 
 session="$TEST_TMP/session"
-mkdir -m 700 "$session"
+mkdir -m 700 "$session" "$session/knowledge"
 printf '# Task\n\n## Goal\n\n\n## Constraints\n\n## Plan\n\n## Artifacts\n- (なし)\n' \
   >"$session/task.md"
-chmod 600 "$session/task.md"
+: >"$session/knowledge/failures.md"
+chmod 600 "$session/task.md" "$session/knowledge/failures.md"
 
 run_case env ARK_SESSION_DIR="$session" /bin/bash "$CORE"
 assert_success "empty task context is generated"
@@ -48,6 +49,56 @@ grep -F '最初のユーザー要求から Goal と Plan を task.md に起票' 
 assert_eq "empty task receives initial filing instruction" 0 "$?"
 grep -F -- 'artifacts/index.md の追記形式: - artifacts/<path> — <1行要約>' "$CASE_STDOUT" >/dev/null 2>&1
 assert_eq "artifact append format is injected" 0 "$?"
+assert_eq "empty failures path is not injected" 0 \
+  "$(grep -Fc -- "$session/knowledge/failures.md" "$CASE_STDOUT")"
+empty_failures_context=$(cat "$CASE_STDOUT")
+
+failure_sentinel='FAILURES_CONTENT_MUST_STAY_OUT_OF_CONTEXT'
+printf '%s\n' '   ' "$failure_sentinel" \
+  >"$session/knowledge/failures.md"
+chmod 600 "$session/knowledge/failures.md"
+run_case env ARK_SESSION_DIR="$session" /bin/bash "$CORE"
+assert_success "non-empty failures context is generated"
+assert_eq "non-empty failures absolute path is injected once" 1 \
+  "$(grep -Fxc -- "knowledge/failures.md: $session/knowledge/failures.md" "$CASE_STDOUT")"
+grep -F '作業開始前と、失敗して再試行する前に上記 knowledge/failures.md を読むこと。' \
+  "$CASE_STDOUT" >/dev/null 2>&1
+assert_eq "failures read instruction is injected" 0 "$?"
+assert_eq "failures contents are not injected" 0 \
+  "$(grep -Fc -- "$failure_sentinel" "$CASE_STDOUT")"
+grep -F '最初のユーザー要求から Goal と Plan を task.md に起票' "$CASE_STDOUT" >/dev/null 2>&1
+assert_eq "failures hint preserves empty Goal branch" 0 "$?"
+
+: >"$session/knowledge/failures.md"
+printf ' \t\n' >>"$session/knowledge/failures.md"
+chmod 600 "$session/knowledge/failures.md"
+run_case env ARK_SESSION_DIR="$session" /bin/bash "$CORE"
+assert_success "whitespace-only failures context is generated"
+assert_eq "whitespace-only failures path is not injected" 0 \
+  "$(grep -Fc -- "$session/knowledge/failures.md" "$CASE_STDOUT")"
+assert_eq "empty failures leaves existing context unchanged" "$empty_failures_context" "$(cat "$CASE_STDOUT")"
+
+printf '%s\n' 'unsafe mode knowledge' >"$session/knowledge/failures.md"
+chmod 644 "$session/knowledge/failures.md"
+run_case env ARK_SESSION_DIR="$session" /bin/bash "$CORE"
+assert_success "unsafe failures mode does not block context"
+assert_eq "unsafe failures mode path is not injected" 0 \
+  "$(grep -Fc -- "$session/knowledge/failures.md" "$CASE_STDOUT")"
+assert_eq "unsafe failures mode preserves other injection" "$empty_failures_context" "$(cat "$CASE_STDOUT")"
+
+unsafe_target="$TEST_TMP/unsafe-failures-target"
+printf '%s\n' 'unsafe knowledge' >"$unsafe_target"
+chmod 600 "$unsafe_target"
+command rm -f "$session/knowledge/failures.md"
+ln -s "$unsafe_target" "$session/knowledge/failures.md"
+run_case env ARK_SESSION_DIR="$session" /bin/bash "$CORE"
+assert_success "unsafe failures does not block context"
+assert_eq "unsafe failures path is not injected" 0 \
+  "$(grep -Fc -- "$session/knowledge/failures.md" "$CASE_STDOUT")"
+assert_eq "unsafe failures preserves other injection" "$empty_failures_context" "$(cat "$CASE_STDOUT")"
+command rm -f "$session/knowledge/failures.md"
+: >"$session/knowledge/failures.md"
+chmod 600 "$session/knowledge/failures.md"
 
 printf '# Task\n\n## Goal\nCurrent goal\n\n## Constraints\n- fixed\n\n## Plan\n- [ ] Current step ← NOW\n' \
   >"$session/task.md"
@@ -63,6 +114,8 @@ else
   printf '%s\n' 'SKIP: zsh is unavailable; populated task context zsh case skipped'
 fi
 
+printf '%s\n' "$failure_sentinel" >"$session/knowledge/failures.md"
+chmod 600 "$session/knowledge/failures.md"
 input="$TEST_TMP/session-start.json"
 printf '%s\n' '{"session_id":"fixture","hook_event_name":"SessionStart","source":"startup"}' >"$input"
 run_case env ARK_SESSION_DIR="$session" /bin/bash "$WRAPPER" <"$input"
@@ -72,6 +125,11 @@ jq -e 'keys == ["hookSpecificOutput"]
   and (.hookSpecificOutput.additionalContext | contains("タスク管理:"))
   and (.hookSpecificOutput.additionalContext | contains("現在の Goal: Current goal"))' \
   "$CASE_STDOUT" >/dev/null 2>&1 || test_fail "SessionStart output schema or context is invalid"
+adapter_context=$(jq -r '.hookSpecificOutput.additionalContext' "$CASE_STDOUT")
+assert_eq "SessionStart additionalContext includes failures absolute path once" 1 \
+  "$(printf '%s\n' "$adapter_context" | grep -Fxc -- "knowledge/failures.md: $session/knowledge/failures.md")"
+assert_eq "SessionStart additionalContext excludes failures contents" 0 \
+  "$(printf '%s\n' "$adapter_context" | grep -Fc -- "$failure_sentinel")"
 
 printf '%s\n' '{"hook_event_name":"PostToolBatch"}' >"$TEST_TMP/other.json"
 run_case env ARK_SESSION_DIR="$session" /bin/bash "$WRAPPER" <"$TEST_TMP/other.json"

--- a/ark/context/tests/test-claude-code-session-start.sh
+++ b/ark/context/tests/test-claude-code-session-start.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../../.." && pwd -P)
+CORE="$ROOT/ark/context/hooks/inject-context-rules.sh"
+WRAPPER="$ROOT/ark/context/adapters/claude-code/session-start.sh"
+RULES="$ROOT/ark/context/templates/context-rules.md"
+TEST_TMP=$(mktemp -d)
+TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
+trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
+. "$ROOT/ark/context/tests/test-helper.sh"
+
+assert_eq "context rules contain ten numbered rules" 10 \
+  "$(grep -Ec '^[1-4]\. ' "$RULES")"
+grep -F '空から記入済みへの一方向の初回記入を除いて' "$RULES" >/dev/null 2>&1
+assert_eq "Goal and Constraints initial-fill exception is explicit" 0 "$?"
+
+fifo="$TEST_TMP/unreadable-input"
+mkfifo "$fifo"
+for hook in "$CORE" "$WRAPPER"; do
+  external_out="$TEST_TMP/$(basename "$hook").external.out"
+  external_err="$TEST_TMP/$(basename "$hook").external.err"
+  env -u ARK_SESSION_DIR /bin/bash "$hook" <>"$fifo" >"$external_out" 2>"$external_err" &
+  external_pid=$!
+  wait "$external_pid"
+  assert_eq "Ark outside $(basename "$hook") exits zero" 0 "$?"
+  assert_eq "Ark outside $(basename "$hook") stdout empty" 0 "$(wc -c <"$external_out" | tr -d ' ')"
+  assert_eq "Ark outside $(basename "$hook") stderr empty" 0 "$(wc -c <"$external_err" | tr -d ' ')"
+done
+
+session="$TEST_TMP/session"
+mkdir -m 700 "$session"
+printf '# Task\n\n## Goal\n\n\n## Constraints\n\n## Plan\n\n## Artifacts\n- (なし)\n' \
+  >"$session/task.md"
+chmod 600 "$session/task.md"
+
+run_case env ARK_SESSION_DIR="$session" /bin/bash "$CORE"
+assert_success "empty task context is generated"
+rules_body=$(cat "$RULES")
+context=$(cat "$CASE_STDOUT")
+case "$context" in
+  "$rules_body"*) TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)) ;;
+  *) test_fail "additional context does not begin with the canonical rules" ;;
+esac
+assert_eq "additional context includes absolute task path" 1 \
+  "$(grep -Fxc -- "task.md: $session/task.md" "$CASE_STDOUT")"
+grep -F '最初のユーザー要求から Goal と Plan を task.md に起票' "$CASE_STDOUT" >/dev/null 2>&1
+assert_eq "empty task receives initial filing instruction" 0 "$?"
+grep -F -- 'artifacts/index.md の追記形式: - artifacts/<path> — <1行要約>' "$CASE_STDOUT" >/dev/null 2>&1
+assert_eq "artifact append format is injected" 0 "$?"
+
+printf '# Task\n\n## Goal\nCurrent goal\n\n## Constraints\n- fixed\n\n## Plan\n- [ ] Current step ← NOW\n' \
+  >"$session/task.md"
+chmod 600 "$session/task.md"
+run_case env ARK_SESSION_DIR="$session" /usr/bin/zsh "$CORE"
+assert_success "populated task context works in zsh"
+grep -F '現在の Goal: Current goal' "$CASE_STDOUT" >/dev/null 2>&1
+assert_eq "populated context presents current Goal" 0 "$?"
+grep -F '現在の NOW: Current step' "$CASE_STDOUT" >/dev/null 2>&1
+assert_eq "populated context presents current NOW" 0 "$?"
+
+input="$TEST_TMP/session-start.json"
+printf '%s\n' '{"session_id":"fixture","hook_event_name":"SessionStart","source":"startup"}' >"$input"
+run_case env ARK_SESSION_DIR="$session" /bin/bash "$WRAPPER" <"$input"
+assert_success "SessionStart adapter accepts event"
+jq -e 'keys == ["hookSpecificOutput"]
+  and .hookSpecificOutput.hookEventName == "SessionStart"
+  and (.hookSpecificOutput.additionalContext | contains("タスク管理:"))
+  and (.hookSpecificOutput.additionalContext | contains("現在の Goal: Current goal"))' \
+  "$CASE_STDOUT" >/dev/null 2>&1 || test_fail "SessionStart output schema or context is invalid"
+
+printf '%s\n' '{"hook_event_name":"PostToolBatch"}' >"$TEST_TMP/other.json"
+run_case env ARK_SESSION_DIR="$session" /bin/bash "$WRAPPER" <"$TEST_TMP/other.json"
+assert_success "non-SessionStart event does not block"
+assert_eq "non-SessionStart event is quiet" 0 "$(wc -c <"$CASE_STDOUT" | tr -d ' ')"
+
+chmod 644 "$session/task.md"
+run_case env ARK_SESSION_DIR="$session" /bin/bash "$WRAPPER" <"$input"
+assert_success "unsafe task does not block SessionStart"
+jq -e '.hookSpecificOutput.additionalContext
+  | contains("最初のユーザー要求から Goal と Plan を task.md に起票")' \
+  "$CASE_STDOUT" >/dev/null 2>&1 || test_fail "unsafe task content was trusted"
+
+finish_tests claude-session-start

--- a/ark/context/tests/test-claude-code-session-start.sh
+++ b/ark/context/tests/test-claude-code-session-start.sh
@@ -52,12 +52,16 @@ assert_eq "artifact append format is injected" 0 "$?"
 printf '# Task\n\n## Goal\nCurrent goal\n\n## Constraints\n- fixed\n\n## Plan\n- [ ] Current step ← NOW\n' \
   >"$session/task.md"
 chmod 600 "$session/task.md"
-run_case env ARK_SESSION_DIR="$session" /usr/bin/zsh "$CORE"
-assert_success "populated task context works in zsh"
-grep -F '現在の Goal: Current goal' "$CASE_STDOUT" >/dev/null 2>&1
-assert_eq "populated context presents current Goal" 0 "$?"
-grep -F '現在の NOW: Current step' "$CASE_STDOUT" >/dev/null 2>&1
-assert_eq "populated context presents current NOW" 0 "$?"
+if [ -n "$CTX_ZSH" ]; then
+  run_case env ARK_SESSION_DIR="$session" "$CTX_ZSH" "$CORE"
+  assert_success "populated task context works in zsh"
+  grep -F '現在の Goal: Current goal' "$CASE_STDOUT" >/dev/null 2>&1
+  assert_eq "populated context presents current Goal" 0 "$?"
+  grep -F '現在の NOW: Current step' "$CASE_STDOUT" >/dev/null 2>&1
+  assert_eq "populated context presents current NOW" 0 "$?"
+else
+  printf '%s\n' 'SKIP: zsh is unavailable; populated task context zsh case skipped'
+fi
 
 input="$TEST_TMP/session-start.json"
 printf '%s\n' '{"session_id":"fixture","hook_event_name":"SessionStart","source":"startup"}' >"$input"

--- a/ark/context/tests/test-claude-code-settings.sh
+++ b/ark/context/tests/test-claude-code-settings.sh
@@ -11,6 +11,7 @@ trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
 
 batch_hook='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/post-tool-batch.sh"}]}'
 failure_hook='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/post-tool-use-failure.sh"}]}'
+session_hook='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/session-start.sh"}]}'
 
 assert_eq "mode extraction rejects empty output in both paths" 2 \
   "$(grep -c '\[ -n "\$mode" \] || return 1' "$ROOT/ark/context/adapters/claude-code/settings.sh" | tr -d ' ')"
@@ -47,8 +48,10 @@ jq -e '(.hooks.PostToolBatch | length) == 1 and (.hooks.PostToolBatch[0] | has("
   || test_fail "PostToolBatch hook is missing or has matcher"
 jq -e '(.hooks.PostToolUseFailure | length) == 1 and (.hooks.PostToolUseFailure[0] | has("matcher") | not)' "$settings" >/dev/null 2>&1 \
   || test_fail "PostToolUseFailure hook is missing or has matcher"
-jq -e '.schema_version == 1 and .settings_existed == true and (.entries | length) == 5 and
-  ([.entries[].path] | sort) == ["hooks/PostToolBatch","hooks/PostToolUseFailure","permissions/deny","permissions/deny","permissions/deny"] and
+jq -e '(.hooks.SessionStart | length) == 1 and (.hooks.SessionStart[0] | has("matcher") | not)' "$settings" >/dev/null 2>&1 \
+  || test_fail "SessionStart hook is missing or has matcher"
+jq -e '.schema_version == 1 and .settings_existed == true and (.entries | length) == 6 and
+  ([.entries[].path] | sort) == ["hooks/PostToolBatch","hooks/PostToolUseFailure","hooks/SessionStart","permissions/deny","permissions/deny","permissions/deny"] and
   all(.entries[]; .abandoned == false)' "$manifest" >/dev/null 2>&1 \
   || test_fail "ownership manifest schema is invalid"
 assert_eq "settings mode preserved" "$original_mode" "$(ctx_stat "$settings" | awk '{print $2}')"
@@ -75,16 +78,16 @@ settings="$repo/.claude/settings.local.json"
 run_case claude_settings_inject "$repo" "$state"
 assert_success "missing settings injected"
 [ -f "$settings" ] || test_fail "missing settings was not created"
-jq -e '.hooks | keys_unsorted == ["PostToolBatch","PostToolUseFailure"]' "$settings" >/dev/null 2>&1 \
-  || test_fail "new hooks object property order is not Batch then Failure"
+jq -e '.hooks | keys_unsorted == ["PostToolBatch","PostToolUseFailure","SessionStart"]' "$settings" >/dev/null 2>&1 \
+  || test_fail "new hooks object property order is not Batch then Failure then SessionStart"
 run_case claude_settings_restore "$repo" "$state"
 assert_success "missing settings restored"
 [ ! -e "$settings" ] || test_fail "originally missing settings was not removed"
 
 setup_repo existing-canonical
 settings="$repo/.claude/settings.local.json"
-jq -n --argjson batch "$batch_hook" --argjson failure "$failure_hook" \
-  '{permissions:{deny:["TodoWrite","TaskCreate","TaskUpdate"]},hooks:{PostToolBatch:[$batch],PostToolUseFailure:[$failure]}}' >"$settings"
+jq -n --argjson batch "$batch_hook" --argjson failure "$failure_hook" --argjson session "$session_hook" \
+  '{permissions:{deny:["TodoWrite","TaskCreate","TaskUpdate"]},hooks:{PostToolBatch:[$batch],PostToolUseFailure:[$failure],SessionStart:[$session]}}' >"$settings"
 chmod 600 "$settings"
 cp "$settings" "$TEST_TMP/canonical"
 run_case claude_settings_inject "$repo" "$state"
@@ -105,7 +108,8 @@ run_case claude_settings_restore "$repo" "$state"
 assert_success "session change restored"
 jq -e '.existing == 1 and .["user-added"] == true and .permissions.deny == []
   and .hooks.PostToolBatch == []
-  and .hooks.PostToolUseFailure == [{"hooks":[{"type":"command","command":"user-added.sh"}]}]' "$settings" >/dev/null 2>&1 \
+  and .hooks.PostToolUseFailure == [{"hooks":[{"type":"command","command":"user-added.sh"}]}]
+  and .hooks.SessionStart == []' "$settings" >/dev/null 2>&1 \
   || test_fail "restore lost non-Ark session changes"
 
 setup_repo batch-only
@@ -116,13 +120,15 @@ chmod 600 "$settings"
 cp "$settings" "$TEST_TMP/batch-only-original"
 run_case claude_settings_inject "$repo" "$state"
 assert_success "batch-only settings injected"
-jq -e --argjson batch "$batch_hook" --argjson failure "$failure_hook" '
+jq -e --argjson batch "$batch_hook" --argjson failure "$failure_hook" --argjson session "$session_hook" '
   .hooks.PostToolBatch == [$batch] and .hooks.PostToolUseFailure == [$failure]
+  and .hooks.SessionStart == [$session]
 ' "$settings" >/dev/null 2>&1 || test_fail "batch-only settings did not gain canonical failure hook"
-jq -e --argjson failure "$failure_hook" '
-  .entries == [{path:"hooks/PostToolUseFailure",value:$failure,abandoned:false}]
+jq -e --argjson failure "$failure_hook" --argjson session "$session_hook" '
+  .entries == [{path:"hooks/PostToolUseFailure",value:$failure,abandoned:false},
+    {path:"hooks/SessionStart",value:$session,abandoned:false}]
 ' "$state/settings-ownership.json" >/dev/null 2>&1 \
-  || test_fail "batch-only manifest owns more than the added failure hook"
+  || test_fail "batch-only manifest does not own exactly the added hooks"
 run_case claude_settings_restore "$repo" "$state"
 assert_success "batch-only settings restored"
 cmp -s "$settings" "$TEST_TMP/batch-only-original" || test_fail "batch-only restore was not byte-identical"
@@ -136,11 +142,12 @@ chmod 640 "$settings"
 cp "$settings" "$TEST_TMP/existing-failure-original"
 run_case claude_settings_inject "$repo" "$state"
 assert_success "existing failure hook injected"
-jq -e --argjson user "$user_failure" --argjson batch "$batch_hook" --argjson failure "$failure_hook" '
+jq -e --argjson user "$user_failure" --argjson batch "$batch_hook" --argjson failure "$failure_hook" --argjson session "$session_hook" '
   .hooks.PostToolBatch == [$batch]
   and .hooks.PostToolUseFailure == [$user,$failure]
+  and .hooks.SessionStart == [$session]
 ' "$settings" >/dev/null 2>&1 || test_fail "existing failure hook was not preserved"
-jq -e '([.entries[].path] | sort) == ["hooks/PostToolBatch","hooks/PostToolUseFailure"]' \
+jq -e '([.entries[].path] | sort) == ["hooks/PostToolBatch","hooks/PostToolUseFailure","hooks/SessionStart"]' \
   "$state/settings-ownership.json" >/dev/null 2>&1 \
   || test_fail "existing failure manifest paths mismatch"
 run_case claude_settings_restore "$repo" "$state"
@@ -155,10 +162,12 @@ jq -n --argjson failure "$failure_hook" \
 chmod 600 "$settings"
 run_case claude_settings_inject "$repo" "$state"
 assert_success "canonical failure remains unique"
-jq -e --argjson failure "$failure_hook" --argjson batch "$batch_hook" '
+jq -e --argjson failure "$failure_hook" --argjson batch "$batch_hook" --argjson session "$session_hook" '
   .hooks.PostToolUseFailure == [$failure] and .hooks.PostToolBatch == [$batch]
+  and .hooks.SessionStart == [$session]
 ' "$settings" >/dev/null 2>&1 || test_fail "canonical failure was duplicated"
-jq -e '.entries == [{path:"hooks/PostToolBatch",value:.entries[0].value,abandoned:false}]' \
+jq -e '([.entries[].path] | sort) == ["hooks/PostToolBatch","hooks/SessionStart"]
+  and all(.entries[]; .abandoned == false)' \
   "$state/settings-ownership.json" >/dev/null 2>&1 \
   || test_fail "canonical failure was incorrectly recorded as owned"
 
@@ -179,6 +188,15 @@ cp "$settings" "$TEST_TMP/invalid-failure-before"
 run_case claude_settings_inject "$repo" "$state"
 assert_failure_reason "invalid failure hook schema rejected" "invalid Claude settings schema"
 cmp -s "$settings" "$TEST_TMP/invalid-failure-before" || test_fail "invalid failure settings was modified"
+
+setup_repo invalid-session-start-schema
+settings="$repo/.claude/settings.local.json"
+printf '{"hooks":{"SessionStart":{}}}\n' >"$settings"; chmod 600 "$settings"
+cp "$settings" "$TEST_TMP/invalid-session-start-before"
+run_case claude_settings_inject "$repo" "$state"
+assert_failure_reason "invalid SessionStart hook schema rejected" "invalid Claude settings schema"
+cmp -s "$settings" "$TEST_TMP/invalid-session-start-before" \
+  || test_fail "invalid SessionStart settings was modified"
 
 setup_repo no-jq
 settings="$repo/.claude/settings.local.json"
@@ -211,12 +229,13 @@ assert_success "missing-settings interruption fixture injected"
 command rm -f "$settings"
 run_case claude_settings_inject "$repo" "$state"
 assert_success "manifest without settings is reinjected"
-jq -e --argjson batch "$batch_hook" --argjson failure "$failure_hook" '
+jq -e --argjson batch "$batch_hook" --argjson failure "$failure_hook" --argjson session "$session_hook" '
   .permissions.deny == ["TodoWrite","TaskCreate","TaskUpdate"]
   and .hooks.PostToolBatch == [$batch]
   and .hooks.PostToolUseFailure == [$failure]
+  and .hooks.SessionStart == [$session]
 ' "$settings" >/dev/null 2>&1 || test_fail "manifest without settings did not regenerate managed entries"
-jq -e '.settings_existed == false and (.entries | length) == 5 and all(.entries[]; .abandoned == false)' \
+jq -e '.settings_existed == false and (.entries | length) == 6 and all(.entries[]; .abandoned == false)' \
   "$state/settings-ownership.json" >/dev/null 2>&1 \
   || test_fail "regenerated missing settings recorded incorrect ownership"
 run_case claude_settings_restore "$repo" "$state"
@@ -232,15 +251,16 @@ jq 'del(.hooks.PostToolBatch) | .["user-during"] = {"kept":true}' "$settings" >"
 command mv "$settings.changed" "$settings"; chmod 600 "$settings"
 run_case claude_settings_inject "$repo" "$state"
 assert_success "settings missing a managed entry is reinjected"
-jq -e --argjson batch "$batch_hook" --argjson failure "$failure_hook" '
+jq -e --argjson batch "$batch_hook" --argjson failure "$failure_hook" --argjson session "$session_hook" '
   .["user-before"] == true
   and .["user-during"] == {"kept":true}
   and .permissions.deny == ["TodoWrite","TaskCreate","TaskUpdate"]
   and .hooks.PostToolBatch == [$batch]
   and .hooks.PostToolUseFailure == [$failure]
+  and .hooks.SessionStart == [$session]
 ' "$settings" >/dev/null 2>&1 \
   || test_fail "partial settings reinjection lost non-Ark entries or managed entries"
-jq -e '.settings_existed == true and (.entries | length) == 5 and all(.entries[]; .abandoned == false)' \
+jq -e '.settings_existed == true and (.entries | length) == 6 and all(.entries[]; .abandoned == false)' \
   "$state/settings-ownership.json" >/dev/null 2>&1 \
   || test_fail "partial settings reinjection recorded incorrect ownership"
 run_case claude_settings_restore "$repo" "$state"
@@ -248,7 +268,8 @@ assert_success "reinjected partial settings restored"
 jq -e '.["user-before"] == true and .["user-during"] == {"kept":true}
   and ((.permissions.deny // []) | length) == 0
   and ((.hooks.PostToolBatch // []) | length) == 0
-  and ((.hooks.PostToolUseFailure // []) | length) == 0' "$settings" >/dev/null 2>&1 \
+  and ((.hooks.PostToolUseFailure // []) | length) == 0
+  and ((.hooks.SessionStart // []) | length) == 0' "$settings" >/dev/null 2>&1 \
   || test_fail "partial settings teardown lost non-Ark entries or retained Ark entries"
 
 setup_repo changed-owner
@@ -268,6 +289,28 @@ jq -e 'any(.entries[]; .path == "hooks/PostToolUseFailure" and .abandoned == tru
   || test_fail "changed owner hook was not abandoned"
 jq -e '(.hooks.PostToolBatch // []) | length == 0' "$settings" >/dev/null 2>&1 \
   || test_fail "unchanged batch hook was not restored"
+jq -e '(.hooks.SessionStart // []) | length == 0' "$settings" >/dev/null 2>&1 \
+  || test_fail "unchanged SessionStart hook was not restored"
+
+setup_repo changed-session-start-owner
+settings="$repo/.claude/settings.local.json"
+printf '{}\n' >"$settings"; chmod 600 "$settings"
+run_case claude_settings_inject "$repo" "$state"
+assert_success "changed SessionStart owner fixture injected"
+content=$(cat "$settings")
+content=${content/session-start.sh/session-start-user.sh}
+printf '%s\n' "$content" >"$settings"; chmod 600 "$settings"
+run_case claude_settings_restore "$repo" "$state"
+assert_success "changed SessionStart owner entry does not block restore"
+jq -e '.hooks.SessionStart[0].hooks[0].command | endswith("session-start-user.sh")' \
+  "$settings" >/dev/null 2>&1 || test_fail "changed SessionStart hook was removed"
+jq -e 'any(.entries[]; .path == "hooks/SessionStart" and .abandoned == true)
+  and all(.entries[]; select(.path != "hooks/SessionStart") | .abandoned == false)' \
+  "$state/settings-ownership.json" >/dev/null 2>&1 \
+  || test_fail "changed SessionStart hook was not abandoned"
+jq -e '((.hooks.PostToolBatch // []) | length) == 0
+  and ((.hooks.PostToolUseFailure // []) | length) == 0' "$settings" >/dev/null 2>&1 \
+  || test_fail "unchanged existing hooks were not restored around abandoned SessionStart"
 
 assert_preflight_rejects() {
   description=$1

--- a/ark/context/tests/test-helper.sh
+++ b/ark/context/tests/test-helper.sh
@@ -6,6 +6,7 @@ FAILURES=${FAILURES:-0}
 CASE_STATUS=0
 CASE_STDOUT=
 CASE_STDERR=
+CTX_ZSH=$(command -v zsh 2>/dev/null || true)
 
 test_fail() {
   FAILURES=$((FAILURES + 1))

--- a/ark/context/tests/test-portable-commands.sh
+++ b/ark/context/tests/test-portable-commands.sh
@@ -149,12 +149,18 @@ scan_file() {
   simple_commands='(rg|timeout|sha256sum|realpath|flock|xxd|stdbuf|setsid)([[:space:]]|$)'
   option_commands='(readlink[[:space:]]+-f|stat[[:space:]]+-c)([[:space:]]|$)'
   all_commands="(${simple_commands}|${option_commands})"
+  absolute_interpreters='(/bin/zsh|/usr/bin/zsh|/usr/local/bin/[^[:space:];&|()]+|/opt/homebrew/bin/[^[:space:];&|()]+)([[:space:]]|$)'
   environment_prefix='env[[:space:]]+(((-i|--ignore-environment)[[:space:]]+|(-u|--unset)[[:space:]]+[^[:space:]]+[[:space:]]+|--unset=[^[:space:]]+[[:space:]]+|[[:alpha:]_][[:alnum:]_]*=([^[:space:];&|()]|q)+[[:space:]]+)*)'
   : >"$scan_output"
   sanitize_shell "$scan_target" >"$sanitized_output" || return 2
-  grep -nE "${command_prefix}${all_commands}|${command_prefix}(command|exec)[[:space:]]+(--[[:space:]]+)?${all_commands}|${command_prefix}${environment_prefix}${all_commands}|[$][(][[:space:]]*(rg|timeout|sha256sum|realpath|flock|xxd|stdbuf|setsid)[)]" \
+  grep -nE "${command_prefix}(${all_commands}|${absolute_interpreters})|${command_prefix}(command|exec)[[:space:]]+(--[[:space:]]+)?(${all_commands}|${absolute_interpreters})|${command_prefix}${environment_prefix}(${all_commands}|${absolute_interpreters})|[$][(][[:space:]]*(rg|timeout|sha256sum|realpath|flock|xxd|stdbuf|setsid)[)]" \
     "$sanitized_output" >"${sanitized_output}.candidates" || :
   while IFS=: read -r scan_line scan_source; do
+    if printf '%s\n' "$scan_source" | grep -E "${command_prefix}${absolute_interpreters}" >/dev/null 2>&1 \
+      || printf '%s\n' "$scan_source" | grep -E "${command_prefix}(command|exec)[[:space:]]+(--[[:space:]]+)?${absolute_interpreters}" >/dev/null 2>&1 \
+      || printf '%s\n' "$scan_source" | grep -E "${command_prefix}${environment_prefix}${absolute_interpreters}" >/dev/null 2>&1; then
+      printf '%s:%s: absolute interpreter path\n' "$scan_target" "$scan_line" >>"$scan_output"
+    fi
     for scan_command in rg timeout sha256sum realpath readlink stat flock xxd stdbuf setsid; do
       scan_pattern=$(command_pattern "$scan_command")
       if printf '%s\n' "$scan_source" | grep -E "${command_prefix}${scan_pattern}" >/dev/null 2>&1 \
@@ -300,6 +306,9 @@ name_flock=fl; name_flock=${name_flock}ock
 name_xxd=x; name_xxd=${name_xxd}xd
 name_stdbuf=std; name_stdbuf=${name_stdbuf}buf
 name_setsid=set; name_setsid=${name_setsid}sid
+path_zsh=/usr/bin/z; path_zsh=${path_zsh}sh
+path_local=/usr/local/bin/py; path_local=${path_local}thon3
+path_homebrew=/opt/homebrew/bin/ba; path_homebrew=${path_homebrew}sh
 
 for prohibited in \
   "$name_rg -n file" \
@@ -337,6 +346,20 @@ printf 'first=%s\nprintf "%s\\n" "%s"\n' \
   "'$name_flock $name_timeout $name_sha'" '%s' "$name_rg $name_real" >"$TEST_TMP/literals.sh"
 run_case scan_file "$TEST_TMP/literals.sh" "$TEST_TMP/literals.out"
 assert_success "guard ignores quoted literal mentions"
+
+for absolute_interpreter in "$path_zsh" "$path_local" "$path_homebrew"; do
+  printf 'env MODE=test %s script\n' "$absolute_interpreter" >"$TEST_TMP/absolute-interpreter.sh"
+  run_case scan_file "$TEST_TMP/absolute-interpreter.sh" "$TEST_TMP/absolute-interpreter.out"
+  assert_eq "guard rejects absolute interpreter $absolute_interpreter" 1 "$CASE_STATUS"
+done
+
+printf '%s\n' '#!/bin/zsh' 'printf portable' >"$TEST_TMP/shebang.sh"
+run_case scan_file "$TEST_TMP/shebang.sh" "$TEST_TMP/shebang.out"
+assert_success "absolute interpreter guard ignores shebang"
+
+printf '%s\n' '/bin/bash script' '/bin/sh script' >"$TEST_TMP/allowed-system-shells.sh"
+run_case scan_file "$TEST_TMP/allowed-system-shells.sh" "$TEST_TMP/allowed-system-shells.out"
+assert_success "absolute interpreter guard allows system bash and sh"
 
 tab_escape='\'
 tab_escape=${tab_escape}t

--- a/ark/context/tests/test-recite-todo.sh
+++ b/ark/context/tests/test-recite-todo.sh
@@ -153,11 +153,15 @@ assert_success "legacy token mismatch residue does not block"
 assert_eq "batch after token mismatch is counted" 1 "$(step_count "$cache")"
 
 seed_step_count "$cache" 9
-run_case env ARK_SESSION_DIR="$session" ARK_CACHE_DIR="$cache" ARK_RECITE_INTERVAL=10 /bin/zsh "$HOOK"
-assert_success "zsh invocation exits zero"
-assert_eq "zsh invocation increments" 10 "$(step_count "$cache")"
-assert_eq "zsh invocation recites" 1 "$(grep -c '^Goal:' "$CASE_STDOUT" | tr -d ' ')"
-assert_eq "zsh invocation stderr" '' "$(cat "$CASE_STDERR")"
+if [ -n "$CTX_ZSH" ]; then
+  run_case env ARK_SESSION_DIR="$session" ARK_CACHE_DIR="$cache" ARK_RECITE_INTERVAL=10 "$CTX_ZSH" "$HOOK"
+  assert_success "zsh invocation exits zero"
+  assert_eq "zsh invocation increments" 10 "$(step_count "$cache")"
+  assert_eq "zsh invocation recites" 1 "$(grep -c '^Goal:' "$CASE_STDOUT" | tr -d ' ')"
+  assert_eq "zsh invocation stderr" '' "$(cat "$CASE_STDERR")"
+else
+  printf '%s\n' 'SKIP: zsh is unavailable; recite-todo zsh case skipped'
+fi
 
 bash_env="$TEST_TMP/bash-env"
 nounset_out="$TEST_TMP/nounset.out"

--- a/ark/context/tests/test-review-template.sh
+++ b/ark/context/tests/test-review-template.sh
@@ -32,10 +32,14 @@ order_one=$(cat "$CASE_STDOUT")
 run_case ctx_review_plan_items "$sid_one"
 assert_success "same session review order generated again"
 assert_eq "same session review order is stable" "$order_one" "$(cat "$CASE_STDOUT")"
-run_case /usr/bin/zsh -c '. "$1"; . "$2"; ctx_review_plan_items "$3"' review-zsh \
-  "$ROOT/ark/context/scripts/lib/runtime.sh" "$ROOT/ark/context/scripts/lib/task-template.sh" "$sid_one"
-assert_success "review order works in zsh"
-assert_eq "zsh review order matches bash" "$order_one" "$(cat "$CASE_STDOUT")"
+if [ -n "$CTX_ZSH" ]; then
+  run_case "$CTX_ZSH" -c '. "$1"; . "$2"; ctx_review_plan_items "$3"' review-zsh \
+    "$ROOT/ark/context/scripts/lib/runtime.sh" "$ROOT/ark/context/scripts/lib/task-template.sh" "$sid_one"
+  assert_success "review order works in zsh"
+  assert_eq "zsh review order matches bash" "$order_one" "$(cat "$CASE_STDOUT")"
+else
+  printf '%s\n' 'SKIP: zsh is unavailable; review order zsh case skipped'
+fi
 run_case ctx_review_plan_items "$sid_two"
 assert_success "consecutive review order generated"
 order_two=$(cat "$CASE_STDOUT")

--- a/ark/context/tests/test-review-template.sh
+++ b/ark/context/tests/test-review-template.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../../.." && pwd -P)
+TEST_TMP=$(mktemp -d)
+TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
+trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
+. "$ROOT/ark/context/tests/test-helper.sh"
+. "$ROOT/ark/context/scripts/lib/runtime.sh"
+. "$ROOT/ark/context/scripts/lib/task-template.sh"
+ARK_SOURCE_ROOT=$ROOT
+
+template=$(cat "$ROOT/ark/context/templates/task-review.md.tmpl")
+last=0
+for token in '# Task' '## Goal' '{{GOAL}}' '## Constraints' '{{CONSTRAINTS}}' \
+  'Context rules: {{CONTEXT_RULES}}' 'Previous failure summary: {{PREV_FAILURE_SUMMARY}}' \
+  '## Plan' '{{REVIEW_PLAN_ITEMS}}' '## Artifacts'; do
+  line=$(printf '%s\n' "$template" | grep -nF "$token" | head -1 | cut -d: -f1)
+  if [ -z "$line" ] || [ "$line" -le "$last" ]; then
+    test_fail "review template token order: $token"
+  else
+    TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1))
+  fi
+  last=${line:-$last}
+done
+
+sid_one=00000000000000000000000000000000
+sid_two=00000000000000000000000000000001
+run_case ctx_review_plan_items "$sid_one"
+assert_success "first review order generated"
+order_one=$(cat "$CASE_STDOUT")
+run_case ctx_review_plan_items "$sid_one"
+assert_success "same session review order generated again"
+assert_eq "same session review order is stable" "$order_one" "$(cat "$CASE_STDOUT")"
+run_case /usr/bin/zsh -c '. "$1"; . "$2"; ctx_review_plan_items "$3"' review-zsh \
+  "$ROOT/ark/context/scripts/lib/runtime.sh" "$ROOT/ark/context/scripts/lib/task-template.sh" "$sid_one"
+assert_success "review order works in zsh"
+assert_eq "zsh review order matches bash" "$order_one" "$(cat "$CASE_STDOUT")"
+run_case ctx_review_plan_items "$sid_two"
+assert_success "consecutive review order generated"
+order_two=$(cat "$CASE_STDOUT")
+TESTS=$((TESTS + 1))
+if [ "$order_one" != "$order_two" ]; then
+  PASSES=$((PASSES + 1))
+else
+  test_fail "consecutive session review order did not rotate"
+fi
+
+assert_eq "review perspective count" 6 "$(printf '%s\n' "$order_one" | wc -l | tr -d ' ')"
+for perspective in \
+  'diff 全ファイルを通読する' \
+  'artifacts/index.md の更新を含む規約遵守を検査する' \
+  'artifact 本文と artifacts/index.md の整合を検査する' \
+  'エラー握りつぶしがないことを検査する' \
+  'Goal からの逸脱がないことを検査する' \
+  '再発性のある指摘を failures-inbox.md 候補にする'; do
+  assert_eq "review perspective retained: $perspective" 1 \
+    "$(printf '%s\n' "$order_one" | grep -Fxc -- "$perspective")"
+done
+
+review_session="$TEST_TMP/review-session"
+review_cache="$TEST_TMP/review-cache"
+mkdir -m 700 "$review_session" "$review_cache"
+run_case ctx_task_render_review "$review_session" "$sid_one" 'Review the implementation' \
+  'なし（通常起動）' --constraint '観点を削らない'
+assert_success "review task rendered"
+assert_eq "review task has all checklist items" 6 \
+  "$(grep -c '^- \[ \] ' "$review_session/task.md")"
+assert_eq "review task has one NOW" 1 "$(grep -Fc ' ← NOW' "$review_session/task.md")"
+first_perspective=$(printf '%s\n' "$order_one" | sed -n '1p')
+grep -Fx -- "- [ ] $first_perspective ← NOW" "$review_session/task.md" >/dev/null 2>&1
+assert_eq "review task uses seeded first perspective" 0 "$?"
+
+run_case env ARK_SESSION_DIR="$review_session" ARK_CACHE_DIR="$review_cache" \
+  ARK_RECITE_INTERVAL=1 /bin/bash "$ROOT/ark/context/hooks/recite-todo.sh"
+assert_success "review task recitation succeeds"
+assert_eq "review recitation keeps three-line contract" "Goal: Review the implementation
+NOW: $first_perspective
+Remaining: 6" "$(cat "$CASE_STDOUT")"
+
+finish_tests review-template

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -93,7 +93,14 @@ assert_eq "init environment order" 'ARK_SESSION_ID ARK_SESSION_DIR ARK_CACHE_DIR
 session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
 cache_dir=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
 [ -f "$session_dir/task.md" ] || test_fail "init did not create task.md"
+[ -f "$session_dir/artifacts/index.md" ] || test_fail "init did not create artifacts/index.md"
+assert_eq "artifact index mode" 600 "$(ctx_stat "$session_dir/artifacts/index.md" | awk '{print $2}')"
+assert_eq "artifact index starts empty" 0 "$(wc -c <"$session_dir/artifacts/index.md" | tr -d ' ')"
+grep -Fx "Context rules: $ROOT/ark/context/templates/context-rules.md" "$session_dir/task.md" >/dev/null 2>&1 \
+  || test_fail "task does not reference context rules by absolute path"
 jq -e '.permissions.deny == ["TodoWrite","TaskCreate","TaskUpdate"]' "$settings" >/dev/null 2>&1 || test_fail "init did not inject deny"
+jq -e '(.hooks.SessionStart | length) == 1' "$settings" >/dev/null 2>&1 \
+  || test_fail "init did not inject SessionStart"
 repo_key=$(ctx_sha256 "$repo")
 state="$XDG_DATA_HOME/ark/context/repos/$repo_key"
 assert_eq "owner marker mode" 600 "$(ctx_stat "$state/owner" | awk '{print $2}')"
@@ -109,11 +116,24 @@ empty_session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT"
 grep -F '← NOW' "$empty_session_dir/task.md" >/dev/null 2>&1
 assert_eq "empty task has no NOW marker" 1 "$?"
 assert_eq "empty Goal body" '' "$(sed -n '/^## Goal$/,/^## Constraints$/p' "$empty_session_dir/task.md" | sed '1d;$d' | tr -d '\n')"
-assert_eq "empty Constraints body" 'Previous failure summary: なし（通常起動）' \
+assert_eq "empty Constraints body" "Context rules: $ROOT/ark/context/templates/context-rules.md
+Previous failure summary: なし（通常起動）" \
   "$(sed -n '/^## Constraints$/,/^## Plan$/p' "$empty_session_dir/task.md" | sed '1d;$d' | sed '/^$/d')"
 assert_eq "empty Plan body" '' "$(sed -n '/^## Plan$/,/^## Artifacts$/p' "$empty_session_dir/task.md" | sed '1d;$d' | tr -d '\n')"
 run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$empty_sid"
 assert_success "empty task teardown succeeds"
+
+review_sid=13131313131313131313131313131313
+run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id "$review_sid" \
+  --review --goal 'Review lifecycle' --constraint 'Keep every perspective'
+assert_success "review session init succeeds"
+review_session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
+assert_eq "review session has six checklist items" 6 \
+  "$(grep -c '^- \[ \] ' "$review_session_dir/task.md")"
+assert_eq "review session has exactly one NOW" 1 \
+  "$(grep -Fc ' ← NOW' "$review_session_dir/task.md")"
+run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$review_sid"
+assert_success "review session teardown succeeds"
 
 run_case run_init "$sid"
 assert_success "populated task can initialize after empty scaffold case"
@@ -254,7 +274,8 @@ command rm -f "$repo/.claude/settings.local.json"
 run_case run_init "$sid"
 assert_success "same session repairs manifest without settings"
 assert_eq "repaired same session remains enabled" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
-jq -e '.hooks.PostToolBatch | length == 1' "$repo/.claude/settings.local.json" >/dev/null 2>&1 \
+jq -e '(.hooks.PostToolBatch | length) == 1 and (.hooks.SessionStart | length) == 1' \
+  "$repo/.claude/settings.local.json" >/dev/null 2>&1 \
   || test_fail "same session reported enabled without repairing settings"
 run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$sid"
 assert_success "missing settings teardown succeeds"

--- a/ark/context/tests/test-task-template.sh
+++ b/ark/context/tests/test-task-template.sh
@@ -8,11 +8,14 @@ trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
 . "$ROOT/ark/context/tests/test-helper.sh"
 . "$ROOT/ark/context/scripts/lib/runtime.sh"
 . "$ROOT/ark/context/scripts/lib/task-template.sh"
+ARK_SOURCE_ROOT=$ROOT
+context_rules="$ROOT/ark/context/templates/context-rules.md"
 
 template=$(cat "$ROOT/ark/context/templates/task.md.tmpl")
 last=0
 for token in '# Task' '## Goal' '{{GOAL}}' '## Constraints' '{{CONSTRAINTS}}' \
-  'Previous failure summary: {{PREV_FAILURE_SUMMARY}}' '## Plan' '{{PLAN_ITEMS}}' '## Artifacts'; do
+  'Context rules: {{CONTEXT_RULES}}' 'Previous failure summary: {{PREV_FAILURE_SUMMARY}}' \
+  '## Plan' '{{PLAN_ITEMS}}' '## Artifacts'; do
   line=$(printf '%s\n' "$template" | grep -nF "$token" | head -1 | cut -d: -f1)
   if [ -z "$line" ] || [ "$line" -le "$last" ]; then test_fail "template token order: $token"; else TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)); fi
   last=${line:-$last}
@@ -32,6 +35,8 @@ expected='# Task
 - 壊さない
 - 速くする
 
+Context rules: CONTEXT_RULES_PATH
+
 Previous failure summary: なし（通常起動）
 
 ## Plan
@@ -40,6 +45,7 @@ Previous failure summary: なし（通常起動）
 
 ## Artifacts
 - (なし)'
+expected=${expected/CONTEXT_RULES_PATH/$context_rules}
 assert_eq "rendered task bytes" "$expected" "$(cat "$session/task.md")"
 assert_eq "task mode" 600 "$(ctx_stat "$session/task.md" | awk '{print $2}')"
 
@@ -59,12 +65,15 @@ empty_expected='# Task
 
 ## Constraints
 
+Context rules: CONTEXT_RULES_PATH
+
 Previous failure summary: なし（通常起動）
 
 ## Plan
 
 ## Artifacts
 - (なし)'
+empty_expected=${empty_expected/CONTEXT_RULES_PATH/$context_rules}
 assert_eq "empty task scaffold bytes" "$empty_expected" "$(cat "$empty_session/task.md")"
 empty_cache="$TEST_TMP/empty-cache"
 mkdir -m 700 "$empty_cache"
@@ -72,6 +81,18 @@ run_case env ARK_SESSION_DIR="$empty_session" ARK_CACHE_DIR="$empty_cache" \
   ARK_RECITE_INTERVAL=1 /bin/bash "$ROOT/ark/context/hooks/recite-todo.sh"
 assert_success "empty task recitation succeeds"
 assert_eq "empty task recitation stays silent" 0 "$(wc -c <"$CASE_STDOUT" | tr -d ' ')"
+
+artifact_session="$TEST_TMP/artifact-session"
+mkdir -m 700 "$artifact_session" "$artifact_session/artifacts"
+run_case ctx_artifacts_index_initialize "$artifact_session"
+assert_success "artifact index initialized"
+assert_eq "artifact index starts empty" 0 "$(wc -c <"$artifact_session/artifacts/index.md" | tr -d ' ')"
+assert_eq "artifact index mode" 600 "$(ctx_stat "$artifact_session/artifacts/index.md" | awk '{print $2}')"
+printf '%s\n' '- artifacts/evidence.md — 1行要約' >>"$artifact_session/artifacts/index.md"
+run_case ctx_artifacts_index_initialize "$artifact_session"
+assert_success "artifact index initialization is idempotent"
+assert_eq "artifact index keeps append format" '- artifacts/evidence.md — 1行要約' \
+  "$(cat "$artifact_session/artifacts/index.md")"
 
 for bad in 'line
 break' '{{GOAL}}'; do

--- a/docs/superpowers/specs/ark-context-implementation-spec.md
+++ b/docs/superpowers/specs/ark-context-implementation-spec.md
@@ -287,6 +287,8 @@ Goal と Constraints は init 後に編集してはならない。ただし、in
 
 Claude Code adapter だけが、既存 `.claude/settings.local.json` の有無の記録・非破壊な context settings 注入・復元、hook matcher、hook input JSON、`additionalContext` output、Claude Code の `allowed-tools` / permission deny を扱う。agent 非依存の template、規約、session file format に Claude Code 固有 key を入れない。
 
+SessionStart の `additionalContext` は、安全性を検証した session の `knowledge/failures.md` が size 0 でなく、かつ非空白行を1行以上持つ場合だけ、その絶対 path と「作業開始前および失敗後の再試行前に読む」という指示を加える。file 本文は注入しない。空の file、symlink、mode または所有者が契約と異なる file は案内せず、他の規約、`task.md` path、artifact 形式、Goal 分岐の注入を継続する。これにより §6-1 の read-only copy を配布だけで終わらせず、モデルが参照する consumer 経路を定義する。
+
 repo state directory の `settings-ownership.json` は、注入前の settings file の有無と、Ark が実際に追加した entry ごとの配列／key pathおよび canonical な permission 文字列または hook objectだけを記録し、従来の元ファイル有無 markerを置き換える。追加候補と同一の entry が既にあれば追加も記録もせず、存在しない場合だけ非破壊に追加して manifest に記録する。settings schema に所有判定用の `id` 等を加えてはならない。
 
 復元は manifest に記録された entry のうち現在も注入時と同一内容のものだけを除去する。変更された entry は所有を放棄して残し、manifest の該当 entry に `abandoned` と記録する。manifest が元ファイルなしを示し、除去後に Ark 以外の entry が1つも残らない場合だけ settings file を削除する。既存の MCP、permission、hook、その他の key を削除・置換・並べ替えてはならない。解析不能、§2-2 の path・ownership・mode 検証失敗、または§2-3の事前ignore・tracked検証失敗の場合は、settingsを変更せずcontextを無効化する。#333 は既存設定・注入・teardown・孤児回収を通す round-trip fixture と、`PostToolBatch` entry に `matcher` がない fixture を完了条件とする。


### PR DESCRIPTION
Manus の P2（コンテキスト外部化の規約 + レビュー観点ローテーション）を実装する。**`task.md` の起票と更新を自動化し、Manus 式が人手なしで立ち上がるようにする。**

Closes #334

## この PR が埋める穴

`ark/context` は本番稼働している。復唱・エラー捕捉・teardown は hook なので**自動で動く**。

**しかし `task.md` を埋めるのは人間の手作業だった。** 空のままだと復唱は沈黙し続けるので足場が立ち上がらない。実際、本番セッションで手で書いた。

```
層                                自動か（本 PR 前）
復唱・エラー捕捉・teardown        自動（hook）
TodoWrite の遮断                  自動（deny）
task.md の起票                    手動  ← 本 PR
進捗に応じた ← NOW の更新          手動  ← 本 PR
```

## 強制力は SessionStart hook で持たせた

規約を `task.md` に埋めるだけでは効かない。モデルが `task.md` を読む保証が無いため。

**`TodoWrite` / `TaskCreate` / `TaskUpdate` は permission deny されており、#335 の実測で「deny された tool は tool catalog から除外され PreToolUse hook も発火しない」ことが分かっている。** つまりモデルは `TodoWrite` の存在自体を知らないので、「使おうとして怒られて学ぶ」経路が無い。**先に教えるしかない。**

そこで **SessionStart hook の `additionalContext`** で規約を注入する。既存の `recite-todo.sh` + `post-tool-batch.sh` と同じく、agent 非依存 core（`hooks/inject-context-rules.sh`）と Claude Code adapter（`adapters/claude-code/session-start.sh`）に分けた。

### 実際に注入される内容（Goal が空のとき）

```
タスク管理:
1. task.md だけを正本にし、native todo を使用しない。
2. 各 tool step の前後で Plan status と ← NOW を現実に合わせる。
3. Goal / Constraints は空から記入済みへの一方向の初回記入を除いて書き換えず、
   逸脱が必要なら作業を停止する。

エラー:
1. 失敗 action と原文を errors/raw.log に残す。
2. 再試行前に直前の失敗と既知の禁止手を読む。
3. 回復結果と再発性のある知見を failures-inbox.md 候補にする。

外部化:
1. 20行を超える中間成果は artifacts/ に外部化する。
2. artifacts/index.md に path と1行要約を append する。
3. artifact 本文の再掲より path 参照を優先する。
4. 可逆な compaction を尽くした後にだけ不可逆な summary を行う。

task.md: <絶対パス>
artifacts/index.md の追記形式: - artifacts/<path> — <1行要約>
Goal が空です。最初のユーザー要求から Goal と Plan を task.md に起票し、
Plan に項目を置いた時点で ← NOW をちょうど1個置くこと。
```

Goal が埋まっている場合は末尾が「現在の Goal: ...」「現在の NOW: ...」に切り替わる。毎セッション注入されるため簡潔に保った。

## 規約本文を task.md に入れない

`task.md` には **`context-rules.md` への絶対パス 1 行だけ**を置いた。

#333 で「`summary.md` の `## Goal` が復唱を無言で止める」欠陥が実際に起きている。`task.md` に `## ` 見出しを増やすと同じ轍を踏むため、本文は SessionStart 経由でだけ配る。復唱の 3 行契約が変わらないことを回帰テストで固定した。

## レビュー観点ローテーション（few-shot 汚染対策）

`templates/task-review.md.tmpl` は Plan を 6 観点のチェックリストにした変種。**session ID の SHA-256 を seed にした決定的な順列で提示順だけを変える。**

同じ順序の観点列が反復パターン化すると後半の観点が毎回浅くなる（Manus の「均一なコンテキストは行動を硬直させる」）。

実測した 3 セッションの順序:

```
session 1  エラー握りつぶし → inbox 候補 → artifact 整合 → 規約遵守 → Goal 逸脱 → diff 通読
session 2  規約遵守 → inbox 候補 → Goal 逸脱 → artifact 整合 → diff 通読 → エラー握りつぶし
session 3  エラー握りつぶし → artifact 整合 → diff 通読 → inbox 候補 → Goal 逸脱 → 規約遵守
```

**観点は 1 つも欠けない**（順序だけ変わる）。同一 session ID では順序が安定することも確認した（2 回生成して hash 一致）。

## 検証

supervisor が独立に実測した結果。

```
SessionStart の注入   10則 + task.md パス + 空 Goal なら起票指示
Goal 記入後            「現在の Goal / NOW」表示へ切り替わる
task.md               context-rules.md のパス1行のみ
復唱の3行契約          Goal: / NOW: / Remaining: 変わらず
artifacts/index.md    mode 0600 で生成
観点ローテーション      3 セッションとも順序が異なり 6 観点は欠けない
同一 session の安定性   2 回生成して順序 hash 一致
settings round-trip   3 hook 注入 → teardown で完全復元
```

自動テストは `test-claude-code-session-start.sh` / `test-review-template.sh` を追加し、`pnpm check` / `pnpm test`（1110 件）/ `ark/context/tests/run.sh` / `pnpm test:harness` すべて通過。

### テストできない範囲

Issue の完了条件のうち次は**モデルの挙動**なので自動テストにできない。

- 実セッションで 20 行超の中間成果物が `artifacts/` に保存される
- 過去成果物を「パス + 要約」形式で参照する
- レビューセッションで観点漏れなく完走する

固定できたのは「`artifacts/index.md` が生成されること」「追記形式」「規約が `additionalContext` に含まれること」「順序がローテーションすること」まで。**実 Claude セッションでの挙動確認は未実施。**

## settings 注入

既存の `PostToolBatch` / `PostToolUseFailure` に `SessionStart` を追加した。同じ ownership manifest で所有し、byte 単位復元・既存 entry の非破壊保持・変更済み entry の `abandoned` 記録を検証済み。
