### PR TITLE
fix(context): hook を Ark ソースの絶対パスで注入する（Ark 自身の repo 以外で全 hook が不発だった）

### DIFF
--- a/ark/context/adapters/claude-code/settings.sh
+++ b/ark/context/adapters/claude-code/settings.sh
@@ -1,12 +1,39 @@
 #!/usr/bin/env bash
 
-CLAUDE_CTX_BATCH_HOOK_JSON='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/post-tool-batch.sh"}]}'
-CLAUDE_CTX_FAILURE_HOOK_JSON='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/post-tool-use-failure.sh"}]}'
-CLAUDE_CTX_SESSION_START_HOOK_JSON='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/session-start.sh"}]}'
+CLAUDE_CTX_BATCH_HOOK_JSON=
+CLAUDE_CTX_FAILURE_HOOK_JSON=
+CLAUDE_CTX_SESSION_START_HOOK_JSON=
 
 claude_settings_error() {
   printf '%s\n' "$*" >&2
   return 1
+}
+
+claude_settings_prepare_hooks() {
+  local source_root=${1:-}
+  local canonical adapter_dir batch failure session_start hook_script
+  command -v jq >/dev/null 2>&1 || { claude_settings_error "jq command unavailable"; return 1; }
+  [ -n "$source_root" ] && [ "${source_root#/}" != "$source_root" ] \
+    || { claude_settings_error "invalid Ark source root"; return 1; }
+  case "$source_root" in *$'\n'*|*$'\r'*|*$'\t'*) claude_settings_error "invalid Ark source root"; return 1 ;; esac
+  canonical=$(cd "$source_root" 2>/dev/null && pwd -P) \
+    || { claude_settings_error "invalid Ark source root"; return 1; }
+  [ "$canonical" = "$source_root" ] \
+    || { claude_settings_error "non-canonical Ark source root"; return 1; }
+  adapter_dir="$source_root/ark/context/adapters/claude-code"
+  batch="$adapter_dir/post-tool-batch.sh"
+  failure="$adapter_dir/post-tool-use-failure.sh"
+  session_start="$adapter_dir/session-start.sh"
+  for hook_script in "$batch" "$failure" "$session_start"; do
+    [ -f "$hook_script" ] && [ ! -L "$hook_script" ] && [ -x "$hook_script" ] \
+      || { claude_settings_error "Ark hook unavailable"; return 1; }
+  done
+  CLAUDE_CTX_BATCH_HOOK_JSON=$(jq -cn --arg command "$batch" \
+    '{hooks:[{type:"command",command:($command|@sh)}]}') || return 1
+  CLAUDE_CTX_FAILURE_HOOK_JSON=$(jq -cn --arg command "$failure" \
+    '{hooks:[{type:"command",command:($command|@sh)}]}') || return 1
+  CLAUDE_CTX_SESSION_START_HOOK_JSON=$(jq -cn --arg command "$session_start" \
+    '{hooks:[{type:"command",command:($command|@sh)}]}') || return 1
 }
 
 claude_settings_validate_schema() {
@@ -252,8 +279,9 @@ claude_settings_manifest_matches() {
 claude_settings_inject() {
   local repo=${1:-}
   local state=${2:-}
+  local source_root=${3:-${ARK_SOURCE_ROOT:-}}
   local settings tmp manifest manifest_new settings_existed mode root range permissions_start deny_start hooks_start batch_start failure_start session_start_start tool
-  command -v jq >/dev/null 2>&1 || { claude_settings_error "jq command unavailable"; return 1; }
+  claude_settings_prepare_hooks "$source_root" || return 1
   settings="$repo/.claude/settings.local.json"
   tmp="$repo/.claude/settings.local.json.ark-context-tmp"
   manifest="$state/settings-ownership.json"

--- a/ark/context/scripts/session-init.sh
+++ b/ark/context/scripts/session-init.sh
@@ -224,7 +224,8 @@ else
   ctx_task_render "$@" >/dev/null 2>&1 || init_failed "task initialization failed"
 fi
 ctx_knowledge_initialize "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" >/dev/null 2>&1 || init_failed "knowledge initialization failed"
-claude_settings_inject "$repo" "$CTX_REPO_STATE_DIR" >/dev/null 2>&1 || init_failed "settings injection failed"
+claude_settings_inject "$repo" "$CTX_REPO_STATE_DIR" "$ARK_SOURCE_ROOT" >/dev/null 2>&1 \
+  || init_failed "settings injection failed"
 release_lock
 
 printf 'enabled\t1\n'

--- a/ark/context/tests/test-claude-code-settings.sh
+++ b/ark/context/tests/test-claude-code-settings.sh
@@ -9,9 +9,18 @@ trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
 . "$ROOT/ark/context/scripts/lib/runtime.sh"
 . "$ROOT/ark/context/adapters/claude-code/settings.sh"
 
-batch_hook='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/post-tool-batch.sh"}]}'
-failure_hook='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/post-tool-use-failure.sh"}]}'
-session_hook='{"hooks":[{"type":"command","command":"\"$CLAUDE_PROJECT_DIR\"/ark/context/adapters/claude-code/session-start.sh"}]}'
+ARK_TEST_SOURCE_ROOT="$TEST_TMP/Ark source's tree"
+ARK_SOURCE_ROOT=$ARK_TEST_SOURCE_ROOT
+adapter_fixture="$ARK_TEST_SOURCE_ROOT/ark/context/adapters/claude-code"
+mkdir -m 700 -p "$adapter_fixture"
+for hook_script in post-tool-batch.sh post-tool-use-failure.sh session-start.sh; do
+  cp "$ROOT/ark/context/adapters/claude-code/$hook_script" "$adapter_fixture/$hook_script"
+  chmod 700 "$adapter_fixture/$hook_script"
+done
+claude_settings_prepare_hooks "$ARK_TEST_SOURCE_ROOT" || exit 1
+batch_hook=$CLAUDE_CTX_BATCH_HOOK_JSON
+failure_hook=$CLAUDE_CTX_FAILURE_HOOK_JSON
+session_hook=$CLAUDE_CTX_SESSION_START_HOOK_JSON
 
 assert_eq "mode extraction rejects empty output in both paths" 2 \
   "$(grep -c '\[ -n "\$mode" \] || return 1' "$ROOT/ark/context/adapters/claude-code/settings.sh" | tr -d ' ')"
@@ -65,13 +74,28 @@ chmod 755 "$repo/.claude"
 cmp -s "$settings" "$TEST_TMP/injected" || test_fail "second injection changed settings"
 cmp -s "$manifest" "$TEST_TMP/manifest" || test_fail "second injection changed ownership"
 
+ARK_RELOCATED_SOURCE_ROOT="$TEST_TMP/relocated Ark source"
+relocated_adapter="$ARK_RELOCATED_SOURCE_ROOT/ark/context/adapters/claude-code"
+mkdir -m 700 -p "$relocated_adapter"
+for hook_script in post-tool-batch.sh post-tool-use-failure.sh session-start.sh; do
+  cp "$ROOT/ark/context/adapters/claude-code/$hook_script" "$relocated_adapter/$hook_script"
+  chmod 700 "$relocated_adapter/$hook_script"
+done
+ARK_SOURCE_ROOT=$ARK_RELOCATED_SOURCE_ROOT
+claude_settings_prepare_hooks "$ARK_SOURCE_ROOT" || exit 1
+manifest_batch_hook=$(jq -c '.entries[] | select(.path == "hooks/PostToolBatch") | .value' "$manifest")
+[ "$manifest_batch_hook" != "$CLAUDE_CTX_BATCH_HOOK_JSON" ]
+assert_eq "source relocation changes the candidate hook identity" 0 "$?"
 run_case claude_settings_restore "$repo" "$state"
-assert_success "existing settings restored"
+assert_success "settings restore uses manifest after Ark source relocation"
 if ! cmp -s "$settings" "$TEST_TMP/original"; then
   test_fail "restore was not byte-identical"
   diff -u "$TEST_TMP/original" "$settings" >&2 || true
 fi
 assert_eq "restored mode" "$original_mode" "$(ctx_stat "$settings" | awk '{print $2}')"
+[ ! -e "$manifest" ] || test_fail "source relocation incorrectly abandoned an unchanged manifest entry"
+ARK_SOURCE_ROOT=$ARK_TEST_SOURCE_ROOT
+claude_settings_prepare_hooks "$ARK_SOURCE_ROOT" || exit 1
 
 setup_repo missing
 settings="$repo/.claude/settings.local.json"
@@ -181,6 +205,26 @@ cmp -s "$settings" "$TEST_TMP/invalid-before" || test_fail "invalid settings was
 [ ! -e "$state/settings-ownership.json" ] || test_fail "invalid settings created ownership"
 [ ! -e "$repo/.claude/settings.local.json.ark-context-tmp" ] || test_fail "invalid settings created tmp"
 
+setup_repo missing-source-hook
+settings="$repo/.claude/settings.local.json"
+printf '{"before":true}\n' >"$settings"; chmod 600 "$settings"
+cp "$settings" "$TEST_TMP/missing-source-hook-before"
+incomplete_source="$TEST_TMP/incomplete Ark source"
+incomplete_adapter="$incomplete_source/ark/context/adapters/claude-code"
+mkdir -m 700 -p "$incomplete_adapter"
+for hook_script in post-tool-batch.sh post-tool-use-failure.sh; do
+  cp "$ROOT/ark/context/adapters/claude-code/$hook_script" "$incomplete_adapter/$hook_script"
+  chmod 700 "$incomplete_adapter/$hook_script"
+done
+ARK_SOURCE_ROOT=$incomplete_source
+run_case claude_settings_inject "$repo" "$state"
+assert_failure_reason "missing Ark source hook fails closed" "Ark hook unavailable"
+cmp -s "$settings" "$TEST_TMP/missing-source-hook-before" \
+  || test_fail "missing Ark source hook changed settings"
+[ ! -e "$state/settings-ownership.json" ] || test_fail "missing Ark source hook created ownership"
+ARK_SOURCE_ROOT=$ARK_TEST_SOURCE_ROOT
+claude_settings_prepare_hooks "$ARK_SOURCE_ROOT" || exit 1
+
 setup_repo invalid-failure-schema
 settings="$repo/.claude/settings.local.json"
 printf '{"hooks":{"PostToolUseFailure":{}}}\n' >"$settings"; chmod 600 "$settings"
@@ -282,7 +326,7 @@ content=${content/post-tool-use-failure.sh/changed-by-user.sh}
 printf '%s\n' "$content" >"$settings"; chmod 600 "$settings"
 run_case claude_settings_restore "$repo" "$state"
 assert_success "changed owner entry does not block restore"
-jq -e '.hooks.PostToolUseFailure[0].hooks[0].command | endswith("changed-by-user.sh")' "$settings" >/dev/null 2>&1 \
+jq -e '.hooks.PostToolUseFailure[0].hooks[0].command | contains("changed-by-user.sh")' "$settings" >/dev/null 2>&1 \
   || test_fail "changed owner hook was removed"
 jq -e 'any(.entries[]; .path == "hooks/PostToolUseFailure" and .abandoned == true)
   and all(.entries[]; select(.path != "hooks/PostToolUseFailure") | .abandoned == false)' "$state/settings-ownership.json" >/dev/null 2>&1 \
@@ -302,7 +346,7 @@ content=${content/session-start.sh/session-start-user.sh}
 printf '%s\n' "$content" >"$settings"; chmod 600 "$settings"
 run_case claude_settings_restore "$repo" "$state"
 assert_success "changed SessionStart owner entry does not block restore"
-jq -e '.hooks.SessionStart[0].hooks[0].command | endswith("session-start-user.sh")' \
+jq -e '.hooks.SessionStart[0].hooks[0].command | contains("session-start-user.sh")' \
   "$settings" >/dev/null 2>&1 || test_fail "changed SessionStart hook was removed"
 jq -e 'any(.entries[]; .path == "hooks/SessionStart" and .abandoned == true)
   and all(.entries[]; select(.path != "hooks/SessionStart") | .abandoned == false)' \

--- a/ark/context/tests/test-live-fixtures.sh
+++ b/ark/context/tests/test-live-fixtures.sh
@@ -101,7 +101,7 @@ git -C "$repo" config user.email fixture@example.invalid
 mkdir -m 755 "$repo/.claude"
 printf '.claude/settings.local.json\n.claude/settings.local.json.ark-context-tmp\n' >"$repo/.gitignore"
 git -C "$repo" add .gitignore && git -C "$repo" commit -qm init
-claude_settings_inject "$repo" "$state" \
+claude_settings_inject "$repo" "$state" "$ROOT" \
   || { printf 'permission settings injection failed\n' >&2; exit 1; }
 settings="$repo/.claude/settings.local.json"
 jq -e '.permissions.deny == ["TodoWrite","TaskCreate","TaskUpdate"]' "$settings" >/dev/null \

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -2,13 +2,24 @@
 set -uo pipefail
 
 ROOT=$(cd "$(dirname "$0")/../../.." && pwd -P)
-INIT="$ROOT/ark/context/scripts/session-init.sh"
-TEARDOWN="$ROOT/ark/context/scripts/session-teardown.sh"
 TEST_TMP=$(mktemp -d)
 TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
 trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
 . "$ROOT/ark/context/tests/test-helper.sh"
 . "$ROOT/ark/context/scripts/lib/runtime.sh"
+
+ARK_SOURCE_FIXTURE="$TEST_TMP/Ark source's tree"
+mkdir -m 700 -p "$ARK_SOURCE_FIXTURE/.claude"
+cp -R "$ROOT/ark" "$ARK_SOURCE_FIXTURE/ark"
+cp -R "$ROOT/.claude/lib" "$ARK_SOURCE_FIXTURE/.claude/lib"
+chmod 755 "$ARK_SOURCE_FIXTURE/.claude"
+INIT="$ARK_SOURCE_FIXTURE/ark/context/scripts/session-init.sh"
+TEARDOWN="$ARK_SOURCE_FIXTURE/ark/context/scripts/session-teardown.sh"
+REGISTERED_BATCH_INPUT="$ROOT/ark/context/adapters/claude-code/tests/fixtures/post-tool-batch-single-2.1.215.json"
+REGISTERED_FAILURE_INPUT="$ROOT/ark/context/adapters/claude-code/tests/fixtures/post-tool-use-failure-bash-exit-7-2.1.237.json"
+REGISTERED_SESSION_INPUT="$TEST_TMP/registered-session-start.json"
+printf '%s\n' '{"session_id":"registered","hook_event_name":"SessionStart","source":"startup"}' \
+  >"$REGISTERED_SESSION_INPUT"
 
 export HOME="$TEST_TMP/home"
 export XDG_CONFIG_HOME="$TEST_TMP/config"
@@ -47,6 +58,48 @@ prepare_lifecycle_output() {
   chmod 600 "$output_session/artifacts/index.md" "$output_session/artifacts/lifecycle.txt" \
     "$output_session/errors/raw.log" "$output_session/stop_once"
   seed_step_count "$output_cache" 7
+}
+
+run_registered_hook() {
+  registered_command=$1
+  registered_input=$2
+  (cd "$repo" && env CLAUDE_PROJECT_DIR="$repo" ARK_SESSION_DIR="$session_dir" \
+    ARK_CACHE_DIR="$cache_dir" ARK_RECITE_INTERVAL=1 /bin/sh -c "$registered_command") \
+    <"$registered_input"
+}
+
+assert_registered_hooks_fire() {
+  registered_label=$1
+  batch_command=$(jq -r '.hooks.PostToolBatch[0].hooks[0].command' "$settings")
+  failure_command=$(jq -r '.hooks.PostToolUseFailure[0].hooks[0].command' "$settings")
+  session_command=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$settings")
+  case "$batch_command$failure_command$session_command" in
+    *'$CLAUDE_PROJECT_DIR'*|*'$ARK_SOURCE_ROOT'*) test_fail "$registered_label hook command retained an environment-relative path" ;;
+    *) TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)) ;;
+  esac
+
+  run_case run_registered_hook "$batch_command" "$REGISTERED_BATCH_INPUT"
+  assert_success "$registered_label registered PostToolBatch command exits zero"
+  jq -e '.hookSpecificOutput.hookEventName == "PostToolBatch"
+    and (.hookSpecificOutput.additionalContext | contains("Goal: Lifecycle goal"))' \
+    "$CASE_STDOUT" >/dev/null 2>&1 \
+    || test_fail "$registered_label registered PostToolBatch command did not recite the task"
+
+  run_case run_registered_hook "$session_command" "$REGISTERED_SESSION_INPUT"
+  assert_success "$registered_label registered SessionStart command exits zero"
+  jq -e '.hookSpecificOutput.hookEventName == "SessionStart"
+    and (.hookSpecificOutput.additionalContext | contains("Lifecycle goal"))' \
+    "$CASE_STDOUT" >/dev/null 2>&1 \
+    || test_fail "$registered_label registered SessionStart command did not inject context"
+
+  raw_before=0
+  [ ! -f "$session_dir/errors/raw.log" ] || raw_before=$(wc -l <"$session_dir/errors/raw.log" | tr -d ' ')
+  run_case run_registered_hook "$failure_command" "$REGISTERED_FAILURE_INPUT"
+  assert_success "$registered_label registered PostToolUseFailure command exits zero"
+  assert_eq "$registered_label registered PostToolUseFailure command stays quiet" 0 \
+    "$(wc -c "$CASE_STDOUT" "$CASE_STDERR" | tail -1 | awk '{print $1}')"
+  assert_eq "$registered_label registered PostToolUseFailure command captures the failure" \
+    "$((raw_before + 1))" "$(wc -l <"$session_dir/errors/raw.log" | tr -d ' ')"
 }
 
 setup_repo invalid-owner-pid
@@ -96,7 +149,7 @@ cache_dir=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
 [ -f "$session_dir/artifacts/index.md" ] || test_fail "init did not create artifacts/index.md"
 assert_eq "artifact index mode" 600 "$(ctx_stat "$session_dir/artifacts/index.md" | awk '{print $2}')"
 assert_eq "artifact index starts empty" 0 "$(wc -c <"$session_dir/artifacts/index.md" | tr -d ' ')"
-grep -Fx "Context rules: $ROOT/ark/context/templates/context-rules.md" "$session_dir/task.md" >/dev/null 2>&1 \
+grep -Fx "Context rules: $ARK_SOURCE_FIXTURE/ark/context/templates/context-rules.md" "$session_dir/task.md" >/dev/null 2>&1 \
   || test_fail "task does not reference context rules by absolute path"
 jq -e '.permissions.deny == ["TodoWrite","TaskCreate","TaskUpdate"]' "$settings" >/dev/null 2>&1 || test_fail "init did not inject deny"
 jq -e '(.hooks.SessionStart | length) == 1' "$settings" >/dev/null 2>&1 \
@@ -116,7 +169,7 @@ empty_session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT"
 grep -F '← NOW' "$empty_session_dir/task.md" >/dev/null 2>&1
 assert_eq "empty task has no NOW marker" 1 "$?"
 assert_eq "empty Goal body" '' "$(sed -n '/^## Goal$/,/^## Constraints$/p' "$empty_session_dir/task.md" | sed '1d;$d' | tr -d '\n')"
-assert_eq "empty Constraints body" "Context rules: $ROOT/ark/context/templates/context-rules.md
+assert_eq "empty Constraints body" "Context rules: $ARK_SOURCE_FIXTURE/ark/context/templates/context-rules.md
 Previous failure summary: なし（通常起動）" \
   "$(sed -n '/^## Constraints$/,/^## Plan$/p' "$empty_session_dir/task.md" | sed '1d;$d' | sed '/^$/d')"
 assert_eq "empty Plan body" '' "$(sed -n '/^## Plan$/,/^## Artifacts$/p' "$empty_session_dir/task.md" | sed '1d;$d' | tr -d '\n')"
@@ -139,6 +192,7 @@ run_case run_init "$sid"
 assert_success "populated task can initialize after empty scaffold case"
 session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
 cache_dir=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
+assert_registered_hooks_fire "non-Ark target repo"
 
 seed_step_count "$cache_dir" 7
 task_before=$(cat "$session_dir/task.md")
@@ -514,6 +568,30 @@ for hook_output in "$TEST_TMP"/ab-failure.out "$TEST_TMP"/ba-failure.out "$TEST_
   grep -E 'decision|continue|additionalContext|hookSpecificOutput' "$hook_output" >/dev/null 2>&1
   assert_eq "failure hook emits no control output" 1 "$?"
 done
+
+repo=$ARK_SOURCE_FIXTURE
+git -C "$repo" init -q
+git -C "$repo" config user.name fixture
+git -C "$repo" config user.email fixture@example.invalid
+printf '.claude/settings.local.json\n.claude/settings.local.json.ark-context-tmp\n' >"$repo/.gitignore"
+git -C "$repo" add .gitignore
+git -C "$repo" commit -qm init
+settings="$repo/.claude/settings.local.json"
+printf '{\n  "source-repo-before": true\n}\n\n' >"$settings"
+chmod 640 "$settings"
+cp "$settings" "$TEST_TMP/source-repo-original"
+source_repo_sid=12121212121212121212121212121212
+run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id "$source_repo_sid" \
+  --goal 'Lifecycle goal' --constraint 'Preserve bytes' --plan-item 'Run lifecycle'
+assert_success "Ark source target session init succeeds"
+assert_eq "Ark source target session is enabled" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
+session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
+cache_dir=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
+assert_registered_hooks_fire "Ark source target repo"
+run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$source_repo_sid"
+assert_success "Ark source target teardown succeeds"
+cmp -s "$settings" "$TEST_TMP/source-repo-original" \
+  || test_fail "Ark source target teardown did not byte-restore settings"
 
 if grep -F '.gitignore' "$INIT" "$TEARDOWN" >/dev/null 2>&1; then test_fail "lifecycle script references .gitignore writes"; else TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)); fi
 


### PR DESCRIPTION
注入する hook のコマンドが `$CLAUDE_PROJECT_DIR`（＝**対象 repo**）からの相対パスだったため、**Ark のソース repo 以外では 3 つの hook がすべて解決できなかった**。

Ark は任意のリポジトリを管理するツールなので、**実質ほぼ全てのセッションでハーネスが動いていなかった**。

Closes #369

## 発見の経緯

「Manus 式が効いているか分からない」という指摘を受けて効果測定を試みた際、Ark とは無関係な repo にセッションを起動したところ claude の画面に次が出た。

```
SessionStart:startup hook error
Failed with non-blocking status code: /bin/sh: 1:
/tmp/ark-flow-1000/exp-repo/ark/context/adapters/claude-code/session-start.sh: not found
```

注入されていたコマンド:

```
PostToolBatch      → "$CLAUDE_PROJECT_DIR"/ark/context/adapters/claude-code/post-tool-batch.sh
PostToolUseFailure → "$CLAUDE_PROJECT_DIR"/ark/context/adapters/claude-code/post-tool-use-failure.sh
SessionStart       → "$CLAUDE_PROJECT_DIR"/ark/context/adapters/claude-code/session-start.sh
```

`ark/context/` は Ark のソース repo にしか存在しない。

## 影響

**復唱・エラー捕捉・SessionStart の規約注入がすべて機能していなかった。** Manus 式の中核そのもの。

teardown / init は Ark サーバーが絶対パスで直接実行するため影響を受けず、`task.md` 生成・settings 注入・復元・handoff は動いていた。`session-init.sh` は `enabled 1` を返し `ARK_SESSION_DIR` も立つので、**Ark から見れば有効に見えていた**。

#350（未配線）・#352（key 順で無音停止）・#357（manifest だけ残ると永久に死ぬ）・#365（`failures.md` に consumer がいない）と同じ「有効に見えて機能しない」クラス。

## なぜ検証をすり抜けたか

これまでのドッグフーディングは 2 通りで、**どちらも穴を避けていた**。

1. **Ark のソース repo でセッションを起動** → `$CLAUDE_PROJECT_DIR` が Ark 自身なので解決できてしまう
2. **スクラッチ repo で hook スクリプトを絶対パスで直接実行** → 登録内容を経由しない

**hook の「スクリプト」を検証して「登録」を検証していなかった。** 自動テストも、注入される JSON の中身は見ていたが、そのコマンドが対象 repo で解決可能かは見ていなかった。

## 修正

hook のコマンドを **Ark のソースツリーの絶対パス**にする。`session-init.sh` が解決済みの `ARK_SOURCE_ROOT` を adapter へ渡し、shell-safe に引用して埋め込む。

環境変数（`$ARK_SOURCE_ROOT`）を使う案も検討したが、**hook のコマンド文字列内で展開されるかを確認できていない**ため採らなかった。絶対パス埋め込みは展開に依存しない。

### manifest との整合

注入時の絶対パスが ownership manifest の正本になるため、**Ark を別の場所へ移設しても `abandoned` にならず byte 単位で復元できる**。既存 session は teardown まで旧パスを保持し、次回 init で新パスを注入する。

### 対象 repo への絶対パス記録

`.claude/settings.local.json` に Ark の設置場所が書かれることになる。gitignore 済みで共有されず、設置場所は秘密情報ではないため許容と判断した。

## 検証

**完了条件を「hook スクリプトが動く」ではなく「hook が対象 repo で実際に発火する」にした。**

supervisor が独立に実測した結果（対象 repo は Ark ではない一時 repo）:

```
注入コマンド → '/home/admin/.../ark-fix-issue-369-hook-path/ark/context/adapters/claude-code/...'

PostToolBatch      exit=0（10 batch 未満なので出力なしが正常）
PostToolUseFailure exit=0 → errors/raw.log に 1 件記録
SessionStart       exit=0 → hookSpecificOutput を出力
```

復唱も実際に発火した。

```
Goal: Ark 以外の repo で復唱が出るか
NOW: 最初の項目
Remaining: 2
```

#365 との連携（`failures.md` の path 到達）も確認:

```
作業開始前と、失敗して再試行する前に上記 knowledge/failures.md を読むこと。
現在の Goal: ...
現在の NOW: ...
```

自動テストにも次を追加した。

- Ark 外 / Ark 自身の repo それぞれからの 3 hook 発火
- shell-safe な絶対パス（スペース・引用符を含む Ark パス）
- Ark 移設後の manifest 復元
- teardown の byte 単位復元
- hook 欠落時の fail-closed

`ark/context/tests/run.sh` 全 17 suite PASS（settings 49/49、lifecycle 137/137）。`pnpm test:harness` も全 PASS。

## これで Manus 式の効果測定ができる

本 PR が入るまで、4 機構のうち**モデルのコンテキストに触る 3 つが Ark 自身の repo でしか動いていなかった**。マージ後に失敗継承の効果を実験する。
