### PR TITLE
chore(context): lock を ark/context へ移設し .claude/lib への依存を切る（flow 削除の前提工事）

### DIFF
--- a/ark/context/scripts/lib/failures-knowledge.sh
+++ b/ark/context/scripts/lib/failures-knowledge.sh
@@ -77,8 +77,8 @@ ctx_failures_inbox_append() {
   lock="$knowledge/failures-inbox.lock"
   [ -d "$lock" ] && [ ! -L "$lock" ] || return 1
   ctx_validate_repo_path "$lock" directory required || return 1
-  lock_pid=${FLOW_LOCK_ACQUIRED_PID:-}
-  lock_token=${FLOW_LOCK_ACQUIRED_TOKEN:-}
+  lock_pid=${CTX_LOCK_ACQUIRED_PID:-}
+  lock_token=${CTX_LOCK_ACQUIRED_TOKEN:-}
   case "$lock_pid" in ''|*[!0-9]*) return 1 ;; esac
   ctx_failures_value_safe "$lock_token" || return 1
   [ "$(command cat "$lock/pid" 2>/dev/null)" = "$lock_pid" ] || return 1
@@ -244,8 +244,8 @@ ctx_session_failures_inbox_append() {
   lock="$knowledge/failures-inbox.lock"
   [ -d "$lock" ] && [ ! -L "$lock" ] || return 1
   ctx_validate_repo_path "$lock" directory required || return 1
-  lock_pid=${FLOW_LOCK_ACQUIRED_PID:-}
-  lock_token=${FLOW_LOCK_ACQUIRED_TOKEN:-}
+  lock_pid=${CTX_LOCK_ACQUIRED_PID:-}
+  lock_token=${CTX_LOCK_ACQUIRED_TOKEN:-}
   case "$lock_pid" in ''|*[!0-9]*) return 1 ;; esac
   ctx_failures_value_safe "$lock_token" || return 1
   [ "$(command cat "$lock/pid" 2>/dev/null)" = "$lock_pid" ] || return 1

--- a/ark/context/scripts/lib/lock.sh
+++ b/ark/context/scripts/lib/lock.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+
+_ctx_lock_file() {
+  local key="$1"
+  printf '%s/flow-%s.lock\n' "$FLOW_STATE_DIR" "$key"
+}
+
+# lock ownership / reclaim directory 用の一意 token を生成する。
+_ctx_lock_generate_token() {
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen | tr '[:upper:]' '[:lower:]'
+  else
+    od -An -tx1 -N16 /dev/urandom | tr -d ' \n'
+  fi
+}
+
+# 現在の shell process の pid を lock directory へ直接書く。command substitution
+# 内で子 shell の PPID を読むと、macOS bash 3.2 では短命な command-substitution
+# process を指す。子 /bin/sh を直接起動すれば、その PPID は lock を保持する実 shell
+# になる。bash 3.2 / zsh 固有の BASHPID / sysparams には依存しない。
+_ctx_lock_write_owner_pid() {
+  local pid_file="$1"
+  /bin/sh -c 'printf "%s\n" "$PPID" > "$1"' ctx-lock-owner "$pid_file"
+}
+
+_ctx_lock_dir() {
+  local lock_file="$1"
+  local backend="$2"
+  if [ "$backend" = "mkdir-direct" ]; then
+    printf '%s\n' "$lock_file"
+  else
+    printf '%s.d\n' "$lock_file"
+  fi
+}
+
+_ctx_lock_mtime() {
+  local lock_dir="$1"
+  stat -c %Y "$lock_dir" 2>/dev/null \
+    || stat -f %m "$lock_dir" 2>/dev/null
+}
+
+_ctx_lock_discard_dir() {
+  local lock_dir="$1"
+  rm -f "$lock_dir/pid" "$lock_dir/token" 2>/dev/null || true
+  rmdir "$lock_dir" 2>/dev/null || true
+}
+
+# mkdir lock が stale なら atomic rename で隔離する。
+# pid の有無にかかわらず mtime が stale_seconds 以上で、かつ owner pid が死亡済み
+# (または未記録) の場合だけ回収する。pid 再利用時は生存扱いとして fail closed にする。
+_ctx_lock_reclaim_stale() {
+  local lock_dir="$1"
+  local stale_seconds="$2"
+  local reclaim_token="$3"
+  local observed_owner observed_token now lock_mtime reclaim_dir
+  local moved_owner moved_token
+
+  observed_owner=$(cat "$lock_dir/pid" 2>/dev/null || true)
+  case "$observed_owner" in ''|*[!0-9]*) observed_owner="" ;; esac
+  observed_token=$(cat "$lock_dir/token" 2>/dev/null || true)
+  now=$(date +%s)
+  lock_mtime=$(_ctx_lock_mtime "$lock_dir" 2>/dev/null || printf '%s\n' "$now")
+  case "$lock_mtime" in ''|*[!0-9]*) lock_mtime="$now" ;; esac
+  [ $((now - lock_mtime)) -ge "$stale_seconds" ] || return 1
+  [ -z "$observed_owner" ] || ! kill -0 "$observed_owner" 2>/dev/null || return 1
+
+  reclaim_dir="${lock_dir}.reclaim.${reclaim_token}"
+  if [ -e "$reclaim_dir" ]; then
+    _ctx_lock_discard_dir "$reclaim_dir"
+    [ ! -e "$reclaim_dir" ] || return 1
+  fi
+  command mv "$lock_dir" "$reclaim_dir" 2>/dev/null || return 1
+
+  # stale 判定後に別 process が lock を作り直していた場合は奪わない。観測した pid と
+  # token の両方が rename した directory と一致するときだけ旧 lock として破棄する。
+  moved_owner=$(cat "$reclaim_dir/pid" 2>/dev/null || true)
+  case "$moved_owner" in ''|*[!0-9]*) moved_owner="" ;; esac
+  moved_token=$(cat "$reclaim_dir/token" 2>/dev/null || true)
+  if [ "$moved_owner" != "$observed_owner" ] \
+    || [ "$moved_token" != "$observed_token" ] \
+    || { [ -n "$moved_owner" ] && kill -0 "$moved_owner" 2>/dev/null; }; then
+    if [ ! -e "$lock_dir" ]; then
+      command mv "$reclaim_dir" "$lock_dir" 2>/dev/null || true
+    fi
+    [ ! -e "$reclaim_dir" ] || _ctx_lock_discard_dir "$reclaim_dir"
+    return 1
+  fi
+  _ctx_lock_discard_dir "$reclaim_dir"
+  return 0
+}
+
+# 排他 lock を取得する共通 API。
+# 引数: $1 lock_file, $2 flock fd, $3 wait 秒 (-1=無期限, 0=non-blocking),
+#       $4 stale とみなす最小経過秒, $5 backend (auto|mkdir|mkdir-direct)
+# auto は flock があれば従来の fd lock、なければ <lock_file>.d の mkdir lock を使う。
+# mkdir-direct は既存の lock directory path を維持するための指定。
+# 成功時の実 backend / owner pid / token は CTX_LOCK_ACQUIRED_BACKEND /
+# CTX_LOCK_ACQUIRED_PID / CTX_LOCK_ACQUIRED_TOKEN に設定する。release は token が
+# 一致する lock だけを削除する。
+ctx_lock_acquire() {
+  local lock_file="${1:-}"
+  local lock_fd="${2:-9}"
+  local wait_seconds="${3:--1}"
+  local stale_seconds="${4:-30}"
+  local requested_backend="${5:-auto}"
+  local lock_backend lock_dir current_pid owner_token deadline now
+  [ -n "$lock_file" ] || return 1
+
+  lock_backend="$requested_backend"
+  if [ "$lock_backend" = "auto" ]; then
+    if command -v flock >/dev/null 2>&1; then
+      lock_backend="flock"
+    else
+      lock_backend="mkdir"
+    fi
+  fi
+
+  if [ "$lock_backend" = "flock" ]; then
+    case "$wait_seconds" in
+      0) command flock -xn "$lock_fd" || return 1 ;;
+      -1) command flock -x "$lock_fd" || return 1 ;;
+      *) command flock -x -w "$wait_seconds" "$lock_fd" || return 1 ;;
+    esac
+    CTX_LOCK_ACQUIRED_BACKEND="flock"
+    CTX_LOCK_ACQUIRED_PID=""
+    CTX_LOCK_ACQUIRED_TOKEN=""
+    return 0
+  fi
+  case "$lock_backend" in mkdir|mkdir-direct) ;; *) return 1 ;; esac
+
+  lock_dir=$(_ctx_lock_dir "$lock_file" "$lock_backend")
+  owner_token=$(_ctx_lock_generate_token) || return 1
+  [ -n "$owner_token" ] || return 1
+  now=$(date +%s)
+  deadline=$((now + wait_seconds))
+  while :; do
+    if mkdir "$lock_dir" 2>/dev/null; then
+      if ! printf '%s\n' "$owner_token" > "$lock_dir/token" 2>/dev/null \
+        || ! _ctx_lock_write_owner_pid "$lock_dir/pid"; then
+        _ctx_lock_discard_dir "$lock_dir"
+        return 1
+      fi
+      current_pid=$(cat "$lock_dir/pid" 2>/dev/null || true)
+      case "$current_pid" in ''|*[!0-9]*) _ctx_lock_discard_dir "$lock_dir"; return 1 ;; esac
+      if [ "$(cat "$lock_dir/token" 2>/dev/null || true)" != "$owner_token" ]; then
+        return 1
+      fi
+      CTX_LOCK_ACQUIRED_BACKEND="$lock_backend"
+      CTX_LOCK_ACQUIRED_PID="$current_pid"
+      CTX_LOCK_ACQUIRED_TOKEN="$owner_token"
+      return 0
+    fi
+    # stale lock を回収できた場合は non-blocking 指定でも直ちに mkdir を再試行する。
+    # ここで先に timeout 判定すると、回収だけして取得失敗を返してしまう。
+    if _ctx_lock_reclaim_stale "$lock_dir" "$stale_seconds" "$owner_token"; then
+      continue
+    fi
+    if [ "$wait_seconds" -eq 0 ]; then
+      return 1
+    fi
+    now=$(date +%s)
+    if [ "$wait_seconds" -gt 0 ] && [ "$now" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+# ctx_lock_acquire で得た lock を解放する。flock は fd close に任せる。
+# 引数: $1 lock_file, $2 backend, $3 acquire 時の owner pid,
+#       $4 acquire 時の owner token
+ctx_lock_release() {
+  local lock_file="${1:-}"
+  local lock_backend="${2:-}"
+  local acquired_pid="${3:-}"
+  local acquired_token="${4:-}"
+  local lock_dir owner_pid owner_token
+  [ -n "$lock_file" ] || return 1
+  [ "$lock_backend" != "flock" ] || return 0
+  case "$lock_backend" in mkdir|mkdir-direct) ;; *) return 1 ;; esac
+
+  lock_dir=$(_ctx_lock_dir "$lock_file" "$lock_backend")
+  [ -d "$lock_dir" ] || return 0
+  owner_pid=$(cat "$lock_dir/pid" 2>/dev/null || true)
+  case "$owner_pid" in ''|*[!0-9]*) owner_pid="" ;; esac
+  owner_token=$(cat "$lock_dir/token" 2>/dev/null || true)
+  if [ -n "$acquired_token" ] && [ "$owner_token" = "$acquired_token" ] \
+    && { [ -z "$acquired_pid" ] || [ "$owner_pid" = "$acquired_pid" ]; }; then
+    _ctx_lock_discard_dir "$lock_dir"
+    return 0
+  fi
+  return 1
+}

--- a/ark/context/scripts/session-init.sh
+++ b/ark/context/scripts/session-init.sh
@@ -1,13 +1,8 @@
 #!/usr/bin/env bash
 
 ARK_SOURCE_ROOT=$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd -P) || exit 1
-CLAUDE_PROJECT_DIR=$ARK_SOURCE_ROOT
-export CLAUDE_PROJECT_DIR
-# shellcheck source=/dev/null
-. "$ARK_SOURCE_ROOT/.claude/lib/state-io.sh"
-set +eu
-set +o pipefail
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/runtime.sh"
+. "$ARK_SOURCE_ROOT/ark/context/scripts/lib/lock.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/config.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/task-template.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/handoff.sh"
@@ -113,11 +108,11 @@ placeholder=${requested_session:-00000000000000000000000000000000}
 ctx_runtime_paths "$repo" "$placeholder" >/dev/null 2>&1 || session_disabled "runtime resolution failed"
 ctx_runtime_prepare_base >/dev/null 2>&1 || session_disabled "runtime preparation failed"
 lock="$CTX_REPO_STATE_DIR/settings.lock"
-flow_lock_acquire "$lock" 9 5 30 mkdir-direct >/dev/null 2>&1 || session_disabled "settings lock unavailable"
-lock_backend=$FLOW_LOCK_ACQUIRED_BACKEND
-lock_pid=$FLOW_LOCK_ACQUIRED_PID
-lock_token=$FLOW_LOCK_ACQUIRED_TOKEN
-release_lock() { flow_lock_release "$lock" "$lock_backend" "$lock_pid" "$lock_token" >/dev/null 2>&1 || true; }
+ctx_lock_acquire "$lock" 9 5 30 mkdir-direct >/dev/null 2>&1 || session_disabled "settings lock unavailable"
+lock_backend=$CTX_LOCK_ACQUIRED_BACKEND
+lock_pid=$CTX_LOCK_ACQUIRED_PID
+lock_token=$CTX_LOCK_ACQUIRED_TOKEN
+release_lock() { ctx_lock_release "$lock" "$lock_backend" "$lock_pid" "$lock_token" >/dev/null 2>&1 || true; }
 
 owner="$CTX_REPO_STATE_DIR/owner"
 same_owner=0
@@ -150,15 +145,15 @@ if owner_read "$owner"; then
       old_work_id=$(ctx_work_id_from_repo "$repo" 2>/dev/null) || old_work_id=
       if [ -n "$old_work_id" ]; then
         knowledge_lock="$ARK_KNOWLEDGE_DIR/failures-inbox.lock"
-        if flow_lock_acquire "$knowledge_lock" 8 5 30 mkdir-direct >/dev/null 2>&1; then
-          knowledge_backend=$FLOW_LOCK_ACQUIRED_BACKEND
-          knowledge_pid=$FLOW_LOCK_ACQUIRED_PID
-          knowledge_token=$FLOW_LOCK_ACQUIRED_TOKEN
+        if ctx_lock_acquire "$knowledge_lock" 8 5 30 mkdir-direct >/dev/null 2>&1; then
+          knowledge_backend=$CTX_LOCK_ACQUIRED_BACKEND
+          knowledge_pid=$CTX_LOCK_ACQUIRED_PID
+          knowledge_token=$CTX_LOCK_ACQUIRED_TOKEN
           ctx_failures_inbox_append "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" \
             "$old_work_id" "$OWNER_SESSION" >/dev/null 2>&1 || true
           ctx_session_failures_inbox_append "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" \
             "$old_work_id" "$OWNER_SESSION" >/dev/null 2>&1 || true
-          flow_lock_release "$knowledge_lock" "$knowledge_backend" "$knowledge_pid" "$knowledge_token" \
+          ctx_lock_release "$knowledge_lock" "$knowledge_backend" "$knowledge_pid" "$knowledge_token" \
             >/dev/null 2>&1 || true
         fi
       fi

--- a/ark/context/scripts/session-teardown.sh
+++ b/ark/context/scripts/session-teardown.sh
@@ -1,12 +1,8 @@
 #!/usr/bin/env bash
 
 ARK_SOURCE_ROOT=$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd -P) || exit 1
-CLAUDE_PROJECT_DIR=$ARK_SOURCE_ROOT
-export CLAUDE_PROJECT_DIR
-. "$ARK_SOURCE_ROOT/.claude/lib/state-io.sh"
-set +eu
-set +o pipefail
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/runtime.sh"
+. "$ARK_SOURCE_ROOT/ark/context/scripts/lib/lock.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/handoff.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/failures-knowledge.sh"
 . "$ARK_SOURCE_ROOT/ark/context/adapters/claude-code/settings.sh"
@@ -25,10 +21,10 @@ case "$session" in *[!0-9a-f]*) exit 0 ;; esac
 ctx_runtime_paths "$repo" "$session" >/dev/null 2>&1 || exit 0
 ctx_runtime_prepare_base >/dev/null 2>&1 || exit 0
 lock="$CTX_REPO_STATE_DIR/settings.lock"
-flow_lock_acquire "$lock" 9 5 30 mkdir-direct >/dev/null 2>&1 || exit 0
-lock_backend=$FLOW_LOCK_ACQUIRED_BACKEND
-lock_pid=$FLOW_LOCK_ACQUIRED_PID
-lock_token=$FLOW_LOCK_ACQUIRED_TOKEN
+ctx_lock_acquire "$lock" 9 5 30 mkdir-direct >/dev/null 2>&1 || exit 0
+lock_backend=$CTX_LOCK_ACQUIRED_BACKEND
+lock_pid=$CTX_LOCK_ACQUIRED_PID
+lock_token=$CTX_LOCK_ACQUIRED_TOKEN
 owner="$CTX_REPO_STATE_DIR/owner"
 owned=0
 if ctx_validate_xdg_file "$owner" >/dev/null 2>&1; then
@@ -43,15 +39,15 @@ ctx_handoff_write "$ARK_SESSION_DIR" "$repo" "$session" >/dev/null 2>&1 || true
 work_id=$(ctx_work_id_from_repo "$repo" 2>/dev/null) || work_id=
 if [ -n "$work_id" ]; then
   knowledge_lock="$ARK_KNOWLEDGE_DIR/failures-inbox.lock"
-  if flow_lock_acquire "$knowledge_lock" 8 5 30 mkdir-direct >/dev/null 2>&1; then
-    knowledge_backend=$FLOW_LOCK_ACQUIRED_BACKEND
-    knowledge_pid=$FLOW_LOCK_ACQUIRED_PID
-    knowledge_token=$FLOW_LOCK_ACQUIRED_TOKEN
+  if ctx_lock_acquire "$knowledge_lock" 8 5 30 mkdir-direct >/dev/null 2>&1; then
+    knowledge_backend=$CTX_LOCK_ACQUIRED_BACKEND
+    knowledge_pid=$CTX_LOCK_ACQUIRED_PID
+    knowledge_token=$CTX_LOCK_ACQUIRED_TOKEN
     ctx_failures_inbox_append "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" "$work_id" "$session" \
       >/dev/null 2>&1 || true
     ctx_session_failures_inbox_append "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" "$work_id" "$session" \
       >/dev/null 2>&1 || true
-    flow_lock_release "$knowledge_lock" "$knowledge_backend" "$knowledge_pid" "$knowledge_token" \
+    ctx_lock_release "$knowledge_lock" "$knowledge_backend" "$knowledge_pid" "$knowledge_token" \
       >/dev/null 2>&1 || true
   fi
 fi
@@ -73,5 +69,5 @@ fi
 if [ "$owned" -eq 1 ] && [ "$restore_succeeded" -eq 1 ]; then
   command rm -f "$owner" "$CTX_REPO_STATE_DIR/owner.new" 2>/dev/null || true
 fi
-flow_lock_release "$lock" "$lock_backend" "$lock_pid" "$lock_token" >/dev/null 2>&1 || true
+ctx_lock_release "$lock" "$lock_backend" "$lock_pid" "$lock_token" >/dev/null 2>&1 || true
 exit 0

--- a/ark/context/tests/test-failures-knowledge.sh
+++ b/ark/context/tests/test-failures-knowledge.sh
@@ -8,6 +8,7 @@ TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
 trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
 . "$ROOT/ark/context/tests/test-helper.sh"
 . "$ROOT/ark/context/scripts/lib/runtime.sh"
+. "$ROOT/ark/context/scripts/lib/lock.sh"
 . "$ROOT/ark/context/scripts/lib/task-template.sh"
 
 if [ ! -f "$FAILURES_LIB" ]; then
@@ -16,10 +17,6 @@ if [ ! -f "$FAILURES_LIB" ]; then
   finish_tests "failures knowledge tests"
 fi
 . "$FAILURES_LIB"
-CLAUDE_PROJECT_DIR=$ROOT
-export CLAUDE_PROJECT_DIR
-. "$ROOT/.claude/lib/state-io.sh"
-set +e
 set -uo pipefail
 
 export HOME="$TEST_TMP/home"
@@ -81,13 +78,13 @@ append_with_lock() {
   target_work=$3
   target_sid=$4
   target_lock="$target_knowledge/failures-inbox.lock"
-  flow_lock_acquire "$target_lock" 9 30 30 mkdir-direct >/dev/null 2>&1 || return 1
-  target_backend=$FLOW_LOCK_ACQUIRED_BACKEND
-  target_pid=$FLOW_LOCK_ACQUIRED_PID
-  target_token=$FLOW_LOCK_ACQUIRED_TOKEN
+  ctx_lock_acquire "$target_lock" 9 30 30 mkdir-direct >/dev/null 2>&1 || return 1
+  target_backend=$CTX_LOCK_ACQUIRED_BACKEND
+  target_pid=$CTX_LOCK_ACQUIRED_PID
+  target_token=$CTX_LOCK_ACQUIRED_TOKEN
   ctx_failures_inbox_append "$target_session" "$target_knowledge" "$target_work" "$target_sid"
   append_status=$?
-  flow_lock_release "$target_lock" "$target_backend" "$target_pid" "$target_token" >/dev/null 2>&1 || return 1
+  ctx_lock_release "$target_lock" "$target_backend" "$target_pid" "$target_token" >/dev/null 2>&1 || return 1
   return "$append_status"
 }
 
@@ -97,13 +94,13 @@ append_session_with_lock() {
   target_work=$3
   target_sid=$4
   target_lock="$target_knowledge/failures-inbox.lock"
-  flow_lock_acquire "$target_lock" 9 30 30 mkdir-direct >/dev/null 2>&1 || return 1
-  target_backend=$FLOW_LOCK_ACQUIRED_BACKEND
-  target_pid=$FLOW_LOCK_ACQUIRED_PID
-  target_token=$FLOW_LOCK_ACQUIRED_TOKEN
+  ctx_lock_acquire "$target_lock" 9 30 30 mkdir-direct >/dev/null 2>&1 || return 1
+  target_backend=$CTX_LOCK_ACQUIRED_BACKEND
+  target_pid=$CTX_LOCK_ACQUIRED_PID
+  target_token=$CTX_LOCK_ACQUIRED_TOKEN
   ctx_session_failures_inbox_append "$target_session" "$target_knowledge" "$target_work" "$target_sid"
   append_status=$?
-  flow_lock_release "$target_lock" "$target_backend" "$target_pid" "$target_token" >/dev/null 2>&1 || return 1
+  ctx_lock_release "$target_lock" "$target_backend" "$target_pid" "$target_token" >/dev/null 2>&1 || return 1
   return "$append_status"
 }
 

--- a/ark/context/tests/test-recite-todo.sh
+++ b/ark/context/tests/test-recite-todo.sh
@@ -138,7 +138,7 @@ bytes=$(wc -c <"$CASE_STDOUT" | tr -d ' ')
 iconv -f UTF-8 -t UTF-8 "$CASE_STDOUT" >/dev/null 2>&1 || test_fail "recitation is invalid UTF-8"
 assert_eq "recitation has three lines" 3 "$(wc -l <"$CASE_STDOUT" | tr -d ' ')"
 
-if grep -F '.claude/lib/state-io.sh' "$HOOK" >/dev/null 2>&1; then test_fail "hook sources state-io.sh"; else TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)); fi
+if grep -F 'scripts/lib/lock.sh' "$HOOK" >/dev/null 2>&1; then test_fail "hook sources lock.sh"; else TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)); fi
 if grep -E '\$(ARK_SESSION_DIR|ARK_CACHE_DIR|ARK_RECITE_INTERVAL)([^:{A-Za-z0-9_]|$)' "$HOOK" >/dev/null 2>&1; then test_fail "hook has unsafe env expansion"; else TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)); fi
 if grep -E 'step_count\.lock|ctx_step_(lock|discard_lock)|/bin/sleep|flock' "$HOOK" >/dev/null 2>&1; then test_fail "hook retains lock or wait path"; else TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)); fi
 

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -11,7 +11,6 @@ trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
 ARK_SOURCE_FIXTURE="$TEST_TMP/Ark source's tree"
 mkdir -m 700 -p "$ARK_SOURCE_FIXTURE/.claude"
 cp -R "$ROOT/ark" "$ARK_SOURCE_FIXTURE/ark"
-cp -R "$ROOT/.claude/lib" "$ARK_SOURCE_FIXTURE/.claude/lib"
 chmod 755 "$ARK_SOURCE_FIXTURE/.claude"
 INIT="$ARK_SOURCE_FIXTURE/ark/context/scripts/session-init.sh"
 TEARDOWN="$ARK_SOURCE_FIXTURE/ark/context/scripts/session-teardown.sh"


### PR DESCRIPTION
`ark/context` が `.claude/lib/state-io.sh` に持っていた依存を切り、lock を `ark/context` 配下へ移した。

**flow / flow-x / flow-loop 削除の前提工事**であり、削除自体は含まない。

## なぜ必要か

`ark/context` は **Ark に同梱されて他のユーザーの環境で動く**。一方 `.claude/skills/` と `.claude/lib/` は**このリポジトリの開発用**で、削除が決まっている。

```
ark/context/     57 ファイル → Ark に同梱
.claude/skills/  8 個         → このリポジトリの開発用のみ
```

`ark/context/scripts/session-{init,teardown}.sh` が `.claude/lib/state-io.sh` を source していたため、**削除すると context が動かなくなる**状態だった。

## 変更

`flow_lock_acquire` / `flow_lock_release` と内部 7 関数を `ark/context/scripts/lib/lock.sh` へ移し、`ctx_lock_*` / `_ctx_lock_*` へリネームした。

**実装は変えていない。** 関数名と結果変数名を正規化して旧実装と比較した結果:

```
旧 lock 実装: 153 行 / 新: 153 行
正規化後の差分: 7 箇所（すべて FLOW_ → CTX_ の変数名）
```

flock 優先 / mkdir fallback、pid+token による stale 再取得、削除直前に owner の `pid token` を再読して一致確認する TOCTOU 対策はそのまま維持している。

### `set -euo pipefail` の打ち消しを削除

`state-io.sh` は source 時に `set -euo pipefail` を有効化するため、`session-init.sh` / `session-teardown.sh` は直後に `set +eu; set +o pipefail` で打ち消していた。新 `lock.sh` は shell option を変えないため、この打ち消しごと削除した。

bash・zsh の両方で source 前後の shell option が不変であることを確認済み。

## 検証

### 依存の切断（本作業の目的）

```
grep -rnE 'claude/lib|flow_lock|flow_state' ark/context/  → 0 件
```

### lock の実動作

supervisor が独立に実測した。

```
 2 プロセス同時 → 2 / 2
 3 プロセス同時 → 3 / 3
 5 プロセス同時 → 5 / 5
10 回逐次       → 10 / 10
lock ディレクトリの残留 → 0 件
```

20 プロセス同時では 10〜11 しか取れないが、**これは移設による退行ではない**。`main` の `flow_lock` を同条件で測ると同じく 10/20 で、`sleep 1` のポーリング刻みに対して待ち行列が長すぎるという**元からの構造**。

この lock は同一 repo に対する init/teardown の排他であり、**Ark が同じ repo に 20 セッションを同時作成することはない**ため実運用に影響しない。

### テスト

`pnpm check` / `pnpm test`（65 files / 1039 tests）/ `ark/context/tests/run.sh` / `pnpm test:harness` すべて PASS。**flow / flow-x / flow-loop のテストも通る**（`state-io.sh` は変更していないため）。

## 一時的な重複について

`.claude/lib/state-io.sh` の lock 実装は**そのまま残している**。flow 系がまだ使っているため。flow 削除時に元が消えて重複が解消する。

## codex への failures.md 提供（副次的な実験）

本 PR から、codex のプロンプトで **9 項目の地雷リストを `failures.md` への 1 行参照に置き換えた**。

```
作業開始前に /home/admin/.local/share/ark/context/knowledge/failures.md を読むこと。
```

結果、codex は次を報告した。

> `failures.md` から得たもの: `flock` capability fallback、GNU/BSD `stat` fallback、
> bash 3.2/zsh 互換を変更せず維持

プロンプトは 150 行 → 104 行に縮み、**CI 失敗も発生しなかった**（直近 3 回は macOS 環境固有の失敗が出ていた）。

`failures.md` が **Claude Code のセッション以外でも機能する**ことの実例になった。

## 新しく踏んだ失敗（codex 報告）

> lifecycle fixture の `.claude/lib` 削除時、対象リポジトリ用の空 `.claude` ディレクトリまで
> 削除して初回テストが失敗。依存物コピーと fixture 構造の役割を分け、空ディレクトリは維持する必要がある

再発性は低いと判断し `failures.md` への昇格は見送った。
