### PR TITLE
fix(context): jq を前提条件に明記し、不在時に無音で止まらないようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -385,4 +385,5 @@ claude-code-ark/
 - **pnpm**
 - **tmux**
 - **ttyd**
+- **jq**
 - **cloudflared**（リモートアクセス使用時のみ）

--- a/ark/context/README.md
+++ b/ark/context/README.md
@@ -1,5 +1,10 @@
 # Ark Context runtime data
 
+## 実行環境の前提条件
+
+Ark Context の有効化と hook の実行には `jq` が必要である。macOS では標準で
+インストールされていないため、事前に `brew install jq` などで導入する。
+
 ## 有効化前に確認する repo の前提条件
 
 Ark Context を有効化する対象 repo は、事前に次の条件をすべて満たす必要がある。

--- a/ark/context/adapters/claude-code/post-tool-batch.sh
+++ b/ark/context/adapters/claude-code/post-tool-batch.sh
@@ -4,7 +4,14 @@ if [ -z "${ARK_SESSION_DIR:-}" ] || [ -z "${ARK_CACHE_DIR:-}" ]; then
   exit 0
 fi
 
+adapter_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
+source_root=$(cd "$adapter_dir/../.." 2>/dev/null && pwd -P) || exit 0
+runtime="$source_root/scripts/lib/runtime.sh"
+[ -f "$runtime" ] && [ ! -L "$runtime" ] || exit 0
+. "$runtime" || exit 0
+
 if ! command -v jq >/dev/null 2>&1; then
+  ctx_record_missing_jq
   exit 0
 fi
 
@@ -29,8 +36,6 @@ printf '%s' "$input" | jq -e \
   'type == "object" and .hook_event_name == "PostToolBatch"' >/dev/null 2>&1 \
   || exit 0
 
-adapter_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
-source_root=$(cd "$adapter_dir/../.." 2>/dev/null && pwd -P) || exit 0
 core="$source_root/hooks/recite-todo.sh"
 [ -f "$core" ] && [ ! -L "$core" ] || exit 0
 

--- a/ark/context/adapters/claude-code/post-tool-use-failure.sh
+++ b/ark/context/adapters/claude-code/post-tool-use-failure.sh
@@ -5,6 +5,17 @@ if [ -z "${ARK_SESSION_DIR:-}" ]; then
   exit 0
 fi
 
+adapter_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
+source_root=$(cd "$adapter_dir/../.." 2>/dev/null && pwd -P) || exit 0
+runtime="$source_root/scripts/lib/runtime.sh"
+[ -f "$runtime" ] && [ ! -L "$runtime" ] || exit 0
+. "$runtime" || exit 0
+
+if ! command -v jq >/dev/null 2>&1; then
+  ctx_record_missing_jq
+  exit 0
+fi
+
 ADAPTER_INPUT=
 ADAPTER_RESULT=
 ADAPTER_NORMALIZED=

--- a/ark/context/adapters/claude-code/session-start.sh
+++ b/ark/context/adapters/claude-code/session-start.sh
@@ -4,7 +4,14 @@ if [ -z "${ARK_SESSION_DIR:-}" ]; then
   exit 0
 fi
 
+adapter_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
+source_root=$(cd "$adapter_dir/../.." 2>/dev/null && pwd -P) || exit 0
+runtime="$source_root/scripts/lib/runtime.sh"
+[ -f "$runtime" ] && [ ! -L "$runtime" ] || exit 0
+. "$runtime" || exit 0
+
 if ! command -v jq >/dev/null 2>&1; then
+  ctx_record_missing_jq
   exit 0
 fi
 
@@ -29,8 +36,6 @@ printf '%s' "$input" | jq -e \
   'type == "object" and .hook_event_name == "SessionStart"' >/dev/null 2>&1 \
   || exit 0
 
-adapter_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
-source_root=$(cd "$adapter_dir/../.." 2>/dev/null && pwd -P) || exit 0
 core="$source_root/hooks/inject-context-rules.sh"
 [ -f "$core" ] && [ ! -L "$core" ] || exit 0
 

--- a/ark/context/hooks/capture-error.sh
+++ b/ark/context/hooks/capture-error.sh
@@ -5,6 +5,16 @@ if [ -z "${ARK_SESSION_DIR:-}" ]; then
   exit 0
 fi
 
+hook_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
+runtime="$hook_dir/../scripts/lib/runtime.sh"
+[ -f "$runtime" ] && [ ! -L "$runtime" ] || exit 0
+. "$runtime" || exit 0
+
+if ! command -v jq >/dev/null 2>&1; then
+  ctx_record_missing_jq
+  exit 0
+fi
+
 capture_stat() {
   local value uid mode size extra
   value=$(stat -c '%u %a %s' "$1" 2>/dev/null) \
@@ -84,22 +94,7 @@ capture_cleanup() {
 }
 
 capture_try_recover_dead_lock() {
-  local owner_value owner_pid owner_token owner_extra confirmed_owner
-  capture_safe_dir "$CAPTURE_LOCK" || return 1
-  capture_safe_file "$CAPTURE_LOCK_OWNER" || return 1
-  owner_value=$(sed -n '1p' "$CAPTURE_LOCK_OWNER" 2>/dev/null) || return 1
-  IFS=' ' read -r owner_pid owner_token owner_extra <<EOF
-$owner_value
-EOF
-  [ -n "$owner_pid" ] && [ -n "$owner_token" ] && [ -z "$owner_extra" ] || return 1
-  case "$owner_pid" in ''|*[!0-9]*) return 1 ;; esac
-  case "$owner_token" in *[!0-9-]*|'') return 1 ;; esac
-  kill -0 "$owner_pid" >/dev/null 2>&1 && return 1
-  capture_safe_file "$CAPTURE_LOCK_OWNER" || return 1
-  confirmed_owner=$(sed -n '1p' "$CAPTURE_LOCK_OWNER" 2>/dev/null) || return 1
-  [ "$confirmed_owner" = "$owner_value" ] || return 1
-  command rm -f "$CAPTURE_LOCK_OWNER" >/dev/null 2>&1 || return 1
-  rmdir "$CAPTURE_LOCK" >/dev/null 2>&1
+  _ctx_missing_jq_recover_lock "$CAPTURE_LOCK" "$CAPTURE_LOCK_OWNER"
 }
 
 capture_main() {

--- a/ark/context/scripts/lib/runtime.sh
+++ b/ark/context/scripts/lib/runtime.sh
@@ -38,37 +38,163 @@ ctx_sha256() {
 }
 
 ctx_stat() {
-  local stat_value mode
+  local stat_value uid mode extra
   stat_value=$(stat -c '%u %a' "$1" 2>/dev/null) \
     || stat_value=$(stat -f '%u %Lp' "$1" 2>/dev/null) \
     || { ctx_error "stat failed"; return 1; }
-  set -- $stat_value
-  [ "$#" -eq 2 ] || { ctx_error "stat failed"; return 1; }
-  case "$1" in ''|*[!0-9]*) ctx_error "stat failed"; return 1 ;; esac
-  case "$2" in ''|*[!0-7]*) ctx_error "stat failed"; return 1 ;; esac
-  mode=$2
+  IFS=' ' read -r uid mode extra <<EOF
+$stat_value
+EOF
+  [ -n "$uid" ] && [ -n "$mode" ] && [ -z "$extra" ] \
+    || { ctx_error "stat failed"; return 1; }
+  case "$uid" in ''|*[!0-9]*) ctx_error "stat failed"; return 1 ;; esac
+  case "$mode" in ''|*[!0-7]*) ctx_error "stat failed"; return 1 ;; esac
   while [ "${mode#0}" != "$mode" ]; do mode=${mode#0}; done
-  printf '%s %s\n' "$1" "${mode:-0}"
+  printf '%s %s\n' "$uid" "${mode:-0}"
 }
 
 ctx_validate_xdg_dir() {
   local target=${1:-}
-  local values
+  local values uid mode extra
   [ -n "$target" ] && [ ! -L "$target" ] && [ -d "$target" ] \
     || { ctx_error "unsafe XDG directory"; return 1; }
   values=$(ctx_stat "$target") || { ctx_error "unsafe XDG directory"; return 1; }
-  set -- $values
-  [ "$1" = "$(id -u)" ] && [ "$2" = 700 ] || { ctx_error "unsafe XDG directory"; return 1; }
+  IFS=' ' read -r uid mode extra <<EOF
+$values
+EOF
+  [ -z "$extra" ] && [ "$uid" = "$(id -u)" ] && [ "$mode" = 700 ] \
+    || { ctx_error "unsafe XDG directory"; return 1; }
 }
 
 ctx_validate_xdg_file() {
   local target=${1:-}
-  local values
+  local values uid mode extra
   [ -n "$target" ] && [ ! -L "$target" ] && [ -f "$target" ] \
     || { ctx_error "unsafe XDG file"; return 1; }
   values=$(ctx_stat "$target") || { ctx_error "unsafe XDG file"; return 1; }
-  set -- $values
-  [ "$1" = "$(id -u)" ] && [ "$2" = 600 ] || { ctx_error "unsafe XDG file"; return 1; }
+  IFS=' ' read -r uid mode extra <<EOF
+$values
+EOF
+  [ -z "$extra" ] && [ "$uid" = "$(id -u)" ] && [ "$mode" = 600 ] \
+    || { ctx_error "unsafe XDG file"; return 1; }
+}
+
+_ctx_missing_jq_recover_lock() {
+  local lock=$1 owner=$2 owner_value owner_pid owner_token owner_extra confirmed_owner
+  local now lock_mtime
+  ctx_validate_xdg_dir "$lock" || return 1
+  if [ ! -e "$owner" ] && [ ! -L "$owner" ]; then
+    now=$(date +%s) || return 1
+    lock_mtime=$(stat -c '%Y' "$lock" 2>/dev/null) \
+      || lock_mtime=$(stat -f '%m' "$lock" 2>/dev/null) \
+      || return 1
+    case "$now$lock_mtime" in *[!0-9]*) return 1 ;; esac
+    [ $((now - lock_mtime)) -ge 30 ] || return 1
+    rmdir "$lock" >/dev/null 2>&1
+    return $?
+  fi
+  ctx_validate_xdg_file "$owner" || return 1
+  owner_value=$(sed -n '1p' "$owner" 2>/dev/null) || return 1
+  IFS=' ' read -r owner_pid owner_token owner_extra <<EOF
+$owner_value
+EOF
+  [ -n "$owner_pid" ] && [ -n "$owner_token" ] && [ -z "$owner_extra" ] || return 1
+  case "$owner_pid" in ''|*[!0-9]*) return 1 ;; esac
+  case "$owner_token" in *[!0-9-]*|'') return 1 ;; esac
+  kill -0 "$owner_pid" >/dev/null 2>&1 && return 1
+  ctx_validate_xdg_file "$owner" || return 1
+  confirmed_owner=$(sed -n '1p' "$owner" 2>/dev/null) || return 1
+  [ "$confirmed_owner" = "$owner_value" ] || return 1
+  command rm -f "$owner" >/dev/null 2>&1 || return 1
+  rmdir "$lock" >/dev/null 2>&1
+}
+
+_ctx_record_missing_jq_locked() {
+  local raw=$1 marker=$2 at raw_size entry entry_size
+  if [ -f "$raw" ] && grep -F "$marker" "$raw" >/dev/null 2>&1; then
+    return 0
+  fi
+  if [ -e "$raw" ] || [ -L "$raw" ]; then
+    ctx_validate_xdg_file "$raw" || return 1
+  else
+    (set -C; : >"$raw") 2>/dev/null || return 1
+    chmod 600 "$raw" || return 1
+    ctx_validate_xdg_file "$raw" || return 1
+  fi
+  raw_size=$(stat -c '%s' "$raw" 2>/dev/null) \
+    || raw_size=$(stat -f '%z' "$raw" 2>/dev/null) \
+    || return 1
+  case "$raw_size" in ''|*[!0-9]*) return 1 ;; esac
+  at=$(date -u '+%Y-%m-%dT%H:%M:%SZ') || return 1
+  case "$at" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z) ;;
+    *) return 1 ;;
+  esac
+  entry=$(printf '{"at":"%s",%s' "$at" "$marker") || return 1
+  entry_size=$((${#entry} + 1))
+  [ "$entry_size" -le $((67108864 - raw_size)) ] || return 1
+  printf '%s\n' "$entry" >>"$raw" || return 1
+}
+
+_ctx_record_missing_jq() {
+  local session errors raw lock owner token attempt marker owner_value record_status old_umask
+  session=${ARK_SESSION_DIR:-}
+  [ -n "$session" ] && [ "${session#/}" != "$session" ] || return 1
+  ctx_has_control "$session" && return 1
+  ctx_validate_xdg_dir "$session" || return 1
+  errors="$session/errors"
+  ctx_validate_xdg_dir "$errors" || return 1
+  raw="$errors/raw.log"
+  if [ -e "$raw" ] || [ -L "$raw" ]; then
+    ctx_validate_xdg_file "$raw" || return 1
+  fi
+
+  lock="$errors/.raw.lock"
+  owner="$lock/owner"
+  token="$$-0"
+  attempt=0
+  while [ "$attempt" -lt 200 ]; do
+    old_umask=$(umask)
+    umask 077
+    if mkdir -m 700 "$lock" 2>/dev/null; then
+      (set -C; printf '%s %s\n' "$$" "$token" >"$owner") 2>/dev/null || {
+        umask "$old_umask"
+        rmdir "$lock" >/dev/null 2>&1 || :
+        return 1
+      }
+      chmod 600 "$owner" || {
+        umask "$old_umask"
+        command rm -f "$owner" >/dev/null 2>&1 || :
+        rmdir "$lock" >/dev/null 2>&1 || :
+        return 1
+      }
+      umask "$old_umask"
+      break
+    fi
+    umask "$old_umask"
+    _ctx_missing_jq_recover_lock "$lock" "$owner" >/dev/null 2>&1 || :
+    attempt=$((attempt + 1))
+  done
+  [ "$attempt" -lt 200 ] || return 1
+  ctx_validate_xdg_dir "$lock" || return 1
+  ctx_validate_xdg_file "$owner" || return 1
+  owner_value=$(sed -n '1p' "$owner") || return 1
+  [ "$owner_value" = "$$ $token" ] || return 1
+
+  marker='"tool":"ark/context","error_type":"missing_prerequisite","exit_code":null,"is_interrupt":null,"error":"jq command unavailable","details":{}}'
+  _ctx_record_missing_jq_locked "$raw" "$marker"
+  record_status=$?
+  owner_value=$(sed -n '1p' "$owner" 2>/dev/null) || owner_value=
+  if [ "$owner_value" = "$$ $token" ]; then
+    command rm -f "$owner" >/dev/null 2>&1 || return 1
+    rmdir "$lock" >/dev/null 2>&1 || return 1
+  fi
+  return "$record_status"
+}
+
+ctx_record_missing_jq() {
+  _ctx_record_missing_jq >/dev/null 2>&1 || :
+  return 0
 }
 
 ctx_validate_repo_path() {
@@ -76,7 +202,7 @@ ctx_validate_repo_path() {
   local expected=${2:-file}
   local presence=${3:-optional}
   local display=${4:-repo path}
-  local values mode group
+  local values uid mode extra group
   CTX_VALIDATION_ERROR=
   if [ ! -e "$target" ] && [ ! -L "$target" ]; then
     [ "$presence" = optional ] && return 0
@@ -111,13 +237,14 @@ ctx_validate_repo_path() {
     ctx_error "$CTX_VALIDATION_ERROR"
     return 1
   }
-  set -- $values
-  if [ "$1" != "$(id -u)" ]; then
+  IFS=' ' read -r uid mode extra <<EOF
+$values
+EOF
+  if [ -n "$extra" ] || [ "$uid" != "$(id -u)" ]; then
     CTX_VALIDATION_ERROR="unsafe repo path: $display owner mismatch"
     ctx_error "$CTX_VALIDATION_ERROR"
     return 1
   fi
-  mode=$2
   while [ "${#mode}" -lt 3 ]; do mode="0$mode"; done
   group=${mode#${mode%??}}
   case "$group" in

--- a/ark/context/scripts/summarize-errors.sh
+++ b/ark/context/scripts/summarize-errors.sh
@@ -8,6 +8,10 @@ fi
 
 SCRIPT_DIR=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 1
 . "$SCRIPT_DIR/lib/runtime.sh" || exit 1
+if ! command -v jq >/dev/null 2>&1; then
+  ctx_record_missing_jq
+  exit 0
+fi
 . "$SCRIPT_DIR/lib/config.sh" || exit 1
 
 SUMMARY_INDEX=

--- a/ark/context/tests/run.sh
+++ b/ark/context/tests/run.sh
@@ -15,6 +15,7 @@ for test_script in \
   test-recite-todo.sh \
   test-capture-error.sh \
   test-summarize-errors.sh \
+  test-jq-prerequisite.sh \
   test-claude-code-post-tool-use-failure.sh \
   test-claude-code-post-tool-batch.sh \
   test-claude-code-session-start.sh \

--- a/ark/context/tests/test-jq-prerequisite.sh
+++ b/ark/context/tests/test-jq-prerequisite.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../../.." && pwd -P)
+TEST_TMP=$(mktemp -d)
+TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
+trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
+. "$ROOT/ark/context/tests/test-helper.sh"
+
+SESSION_START="$ROOT/ark/context/adapters/claude-code/session-start.sh"
+POST_TOOL_BATCH="$ROOT/ark/context/adapters/claude-code/post-tool-batch.sh"
+POST_TOOL_USE_FAILURE="$ROOT/ark/context/adapters/claude-code/post-tool-use-failure.sh"
+CAPTURE_ERROR="$ROOT/ark/context/hooks/capture-error.sh"
+SUMMARIZE_ERRORS="$ROOT/ark/context/scripts/summarize-errors.sh"
+FIXTURES="$ROOT/ark/context/adapters/claude-code/tests/fixtures"
+
+no_jq_bin="$TEST_TMP/no-jq-bin"
+mkdir -m 700 "$no_jq_bin"
+for required_command in dirname stat id sed rm rmdir mkdir chmod grep; do
+  command_path=$(command -v "$required_command")
+  ln -s "$command_path" "$no_jq_bin/$required_command"
+done
+printf '%s\n' '#!/bin/sh' \
+  'if [ "${1:-}" = +%s ]; then printf "2000000000\\n"; else printf "2026-08-21T00:00:00Z\\n"; fi' \
+  >"$no_jq_bin/date"
+chmod 700 "$no_jq_bin/date"
+if PATH="$no_jq_bin" command -v jq >/dev/null 2>&1; then
+  test_fail "no-jq PATH unexpectedly resolves jq"
+else
+  TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1))
+fi
+
+session="$TEST_TMP/session"
+cache="$TEST_TMP/cache"
+mkdir -m 700 "$session" "$session/errors" "$cache"
+printf '%s\n' \
+  '{"at":"2026-08-20T00:00:00Z","tool":"Bash","error_type":"tool_error","exit_code":7,"is_interrupt":false,"error":"existing","details":{}}' \
+  >"$session/errors/raw.log"
+chmod 600 "$session/errors/raw.log"
+
+session_input="$TEST_TMP/session-start.json"
+printf '%s\n' '{"session_id":"fixture","hook_event_name":"SessionStart","source":"startup"}' \
+  >"$session_input"
+batch_input="$FIXTURES/post-tool-batch-single-2.1.215.json"
+failure_input="$FIXTURES/post-tool-use-failure-bash-exit-7-2.1.237.json"
+capture_input="$ROOT/ark/context/tests/fixtures/capture-interrupt.json"
+
+run_without_jq() {
+  script=$1
+  input=$2
+  run_case env PATH="$no_jq_bin" ARK_SESSION_DIR="$session" ARK_CACHE_DIR="$cache" \
+    /bin/bash "$script" <"$input"
+  assert_success "$(basename "$script") without jq exits zero"
+  assert_eq "$(basename "$script") without jq does not corrupt stdout" 0 \
+    "$(wc -c <"$CASE_STDOUT" | tr -d ' ')"
+  assert_eq "$(basename "$script") without jq keeps stderr quiet" 0 \
+    "$(wc -c <"$CASE_STDERR" | tr -d ' ')"
+}
+
+run_without_jq "$SESSION_START" "$session_input"
+run_without_jq "$POST_TOOL_BATCH" "$batch_input"
+run_without_jq "$POST_TOOL_USE_FAILURE" "$failure_input"
+run_without_jq "$CAPTURE_ERROR" "$capture_input"
+run_without_jq "$SUMMARIZE_ERRORS" /dev/null
+
+expected="$TEST_TMP/expected-raw.log"
+printf '%s\n' \
+  '{"at":"2026-08-20T00:00:00Z","tool":"Bash","error_type":"tool_error","exit_code":7,"is_interrupt":false,"error":"existing","details":{}}' \
+  '{"at":"2026-08-21T00:00:00Z","tool":"ark/context","error_type":"missing_prerequisite","exit_code":null,"is_interrupt":null,"error":"jq command unavailable","details":{}}' \
+  >"$expected"
+TESTS=$((TESTS + 1))
+if cmp -s "$expected" "$session/errors/raw.log"; then
+  PASSES=$((PASSES + 1))
+else
+  test_fail "missing jq raw record bytes mismatch"
+fi
+assert_eq "missing jq is recorded once across one session" 2 \
+  "$(wc -l <"$session/errors/raw.log" | tr -d ' ')"
+assert_eq "missing jq leaves no lock artifacts" 1 \
+  "$(find "$session/errors" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d ' ')"
+
+stale_session="$TEST_TMP/stale-session"
+stale_cache="$TEST_TMP/stale-cache"
+stale_bin="$TEST_TMP/stale-bin"
+mkdir -m 700 "$stale_session" "$stale_session/errors" "$stale_cache" "$stale_bin"
+for required_command in dirname stat id rm rmdir mkdir chmod grep date; do
+  ln -s "$no_jq_bin/$required_command" "$stale_bin/$required_command"
+done
+printf '#!/bin/sh\nexit 1\n' >"$stale_bin/sed"
+chmod 700 "$stale_bin/sed"
+run_case env PATH="$stale_bin" ARK_SESSION_DIR="$stale_session" ARK_CACHE_DIR="$stale_cache" \
+  /bin/bash "$SESSION_START" <"$session_input"
+assert_success "interrupted missing jq writer stays non-blocking"
+stale_owner="$stale_session/errors/.raw.lock/owner"
+if grep -E '^[0-9]+ [0-9]+-0$' "$stale_owner" >/dev/null 2>&1; then
+  TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1))
+else
+  test_fail "missing jq lock owner is incompatible with capture recovery"
+fi
+run_case env PATH="$no_jq_bin:$PATH" ARK_SESSION_DIR="$stale_session" \
+  /bin/bash "$CAPTURE_ERROR" <"$capture_input"
+assert_success "capture recovers missing jq stale lock"
+stale_expected="$TEST_TMP/stale-expected.log"
+printf '%s\n' \
+  '{"at":"2026-08-21T00:00:00Z","tool":"Bash","error_type":"tool_error","exit_code":null,"is_interrupt":true,"error":"Interrupted by user\n停止","details":{"elapsed_ms":12,"signal":null}}' \
+  >"$stale_expected"
+TESTS=$((TESTS + 1))
+if cmp -s "$stale_expected" "$stale_session/errors/raw.log"; then
+  PASSES=$((PASSES + 1))
+else
+  test_fail "capture did not recover and append after missing jq interruption"
+fi
+assert_eq "stale raw lock is removed after recovery" no \
+  "$(if [ -e "$stale_session/errors/.raw.lock" ]; then printf yes; else printf no; fi)"
+
+empty_lock_session="$TEST_TMP/empty-lock-session"
+mkdir -m 700 "$empty_lock_session" "$empty_lock_session/errors" \
+  "$empty_lock_session/errors/.raw.lock"
+touch -t 200001010000 "$empty_lock_session/errors/.raw.lock"
+run_case env PATH="$no_jq_bin:$PATH" ARK_SESSION_DIR="$empty_lock_session" \
+  /bin/bash "$CAPTURE_ERROR" <"$capture_input"
+assert_success "capture recovers an ownerless stale lock"
+TESTS=$((TESTS + 1))
+if cmp -s "$stale_expected" "$empty_lock_session/errors/raw.log"; then
+  PASSES=$((PASSES + 1))
+else
+  test_fail "capture did not recover an ownerless stale lock"
+fi
+assert_eq "ownerless stale lock is removed after recovery" no \
+  "$(if [ -e "$empty_lock_session/errors/.raw.lock" ]; then printf yes; else printf no; fi)"
+
+parallel_session="$TEST_TMP/parallel-session"
+parallel_cache="$TEST_TMP/parallel-cache"
+mkdir -m 700 "$parallel_session" "$parallel_session/errors" "$parallel_cache"
+parallel_pids=
+parallel_index=1
+while [ "$parallel_index" -le 20 ]; do
+  env PATH="$no_jq_bin" ARK_SESSION_DIR="$parallel_session" ARK_CACHE_DIR="$parallel_cache" \
+    /bin/bash "$SESSION_START" <"$session_input" \
+    >"$TEST_TMP/parallel-$parallel_index.out" 2>"$TEST_TMP/parallel-$parallel_index.err" &
+  parallel_pids="$parallel_pids $!"
+  parallel_index=$((parallel_index + 1))
+done
+parallel_status=0
+for parallel_pid in $parallel_pids; do
+  wait "$parallel_pid" || parallel_status=1
+done
+assert_eq "parallel missing jq hooks exit zero" 0 "$parallel_status"
+parallel_expected="$TEST_TMP/parallel-expected.log"
+printf '%s\n' \
+  '{"at":"2026-08-21T00:00:00Z","tool":"ark/context","error_type":"missing_prerequisite","exit_code":null,"is_interrupt":null,"error":"jq command unavailable","details":{}}' \
+  >"$parallel_expected"
+TESTS=$((TESTS + 1))
+if cmp -s "$parallel_expected" "$parallel_session/errors/raw.log"; then
+  PASSES=$((PASSES + 1))
+else
+  test_fail "parallel missing jq record is not exactly once"
+fi
+assert_eq "parallel missing jq hooks keep all output channels empty" 0 \
+  "$(wc -c "$TEST_TMP"/parallel-*.out "$TEST_TMP"/parallel-*.err | tail -1 | awk '{print $1}')"
+
+outside_root="$TEST_TMP/outside-root"
+mkdir -m 700 "$outside_root"
+printf '%s\n' sentinel >"$outside_root/sentinel"
+chmod 600 "$outside_root/sentinel"
+outside_before=$(cksum "$outside_root/sentinel")
+for script in "$SESSION_START" "$POST_TOOL_BATCH" "$POST_TOOL_USE_FAILURE" "$CAPTURE_ERROR" "$SUMMARIZE_ERRORS"; do
+  run_case env -u ARK_SESSION_DIR PATH="$no_jq_bin" HOME="$outside_root" \
+    XDG_DATA_HOME="$outside_root" /bin/bash "$script" </dev/null
+  assert_success "$(basename "$script") without ARK_SESSION_DIR exits zero"
+  assert_eq "$(basename "$script") without ARK_SESSION_DIR writes no output" 0 \
+    "$(wc -c "$CASE_STDOUT" "$CASE_STDERR" | tail -1 | awk '{print $1}')"
+done
+assert_eq "no-session execution preserves existing content" "$outside_before" \
+  "$(cksum "$outside_root/sentinel")"
+assert_eq "no-session execution creates no files" sentinel \
+  "$(find "$outside_root" -mindepth 1 -maxdepth 1 -type f -exec basename {} \;)"
+
+if [ -n "$CTX_ZSH" ]; then
+  zsh_session="$TEST_TMP/zsh-session"
+  zsh_cache="$TEST_TMP/zsh-cache"
+  mkdir -m 700 "$zsh_session" "$zsh_session/errors" "$zsh_cache"
+  for zsh_case in \
+    "$SESSION_START:$session_input" \
+    "$POST_TOOL_BATCH:$batch_input" \
+    "$POST_TOOL_USE_FAILURE:$failure_input" \
+    "$CAPTURE_ERROR:$capture_input" \
+    "$SUMMARIZE_ERRORS:/dev/null"; do
+    zsh_script=${zsh_case%%:*}
+    zsh_input=${zsh_case#*:}
+    run_case env PATH="$no_jq_bin" ARK_SESSION_DIR="$zsh_session" ARK_CACHE_DIR="$zsh_cache" \
+      "$CTX_ZSH" "$zsh_script" <"$zsh_input"
+    assert_success "$(basename "$zsh_script") missing jq path works in zsh"
+    assert_eq "$(basename "$zsh_script") zsh output remains empty" 0 \
+      "$(wc -c "$CASE_STDOUT" "$CASE_STDERR" | tail -1 | awk '{print $1}')"
+  done
+  TESTS=$((TESTS + 1))
+  if cmp -s "$parallel_expected" "$zsh_session/errors/raw.log"; then
+    PASSES=$((PASSES + 1))
+  else
+    test_fail "zsh missing jq record bytes mismatch"
+  fi
+else
+  printf '%s\n' 'SKIP: zsh is unavailable; missing jq zsh case skipped'
+fi
+
+finish_tests jq-prerequisite

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -98,6 +98,23 @@ assert_success "teardown without ARK_SESSION_DIR is a no-op"
 assert_eq "teardown without ARK_SESSION_DIR stdout is empty" 0 "$(wc -c <"$CASE_STDOUT" | tr -d ' ')"
 assert_eq "teardown without ARK_SESSION_DIR stderr is empty" 0 "$(wc -c <"$CASE_STDERR" | tr -d ' ')"
 
+setup_repo missing-jq-init
+no_jq_init_bin="$TEST_TMP/no-jq-init-bin"
+mkdir -m 700 "$no_jq_init_bin"
+for required_command in awk basename cat chmod cp cut date dirname env git grep head iconv id \
+  mkdir mktemp mv od openssl rm rmdir sed shasum sort stat tail tr uniq wc; do
+  command_path=$(command -v "$required_command")
+  ln -s "$command_path" "$no_jq_init_bin/$required_command"
+done
+run_case env PATH="$no_jq_init_bin" /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" \
+  --session-id 07070707070707070707070707070707 --goal 'Missing jq' --plan-item 'Stay disabled'
+assert_init_disabled_reason "missing jq init" "jq command unavailable"
+[ ! -e "$repo/.claude/settings.local.json" ] \
+  || test_fail "missing jq init changed settings"
+missing_jq_state="$XDG_DATA_HOME/ark/context/repos/$(ctx_sha256 "$repo")"
+[ ! -e "$missing_jq_state/settings-ownership.json" ] \
+  || test_fail "missing jq init created settings ownership"
+
 assert_registered_hooks_fire() {
   registered_label=$1
   batch_command=$(jq -r '.hooks.PostToolBatch[0].hooks[0].command' "$settings")


### PR DESCRIPTION
`ark/context` が依存する `jq` を前提条件として明記し、不在時に**無音で機能が消えない**ようにした。

Closes #373

## 何が起きていたか

`jq` は `ark/context` で 71 箇所使われるが、**macOS に標準では入っておらず、CLAUDE.md の前提条件にも書かれていなかった**。

PATH から `jq` を外して実測した結果（main）:

```
session-start.sh          (ルール注入)   exit 0 / stdout 空 / stderr 空
post-tool-batch.sh        (復唱)         exit 0 / stdout 空 / stderr 空
post-tool-use-failure.sh  (エラー捕捉)   exit 0 / stdout 空 / stderr 空
```

対照として `jq` がある場合、`post-tool-batch.sh` は問題があれば stderr に理由を出す。

つまり **`jq` が無いときだけ、何の痕跡も残さずに全機能が消える**。ユーザーからは「有効にしたのに何も起きない」としか見えず、原因に到達する手段が無かった。

#352 / #357 / #365 / #369 / #372 と同じクラスの欠陥で、本プロジェクトで 6 回目になる。

## 変更

### 前提条件の明記

`CLAUDE.md` の「前提条件」節に `jq` を追加（**この 1 行だけ**。他の節には触れていない）。`ark/context/README.md` には macOS での導入方法も書いた。

### 不在時に 1 回だけ記録する

`ctx_record_missing_jq` を追加し、既存の `errors/raw.log` へ既存の JSONL 形式で記録する。**新しいファイル形式も設定項目も増やしていない。**

```json
{"at":"...","tool":"ark/context","error_type":"missing_prerequisite",
 "exit_code":null,"is_interrupt":null,"error":"jq command unavailable","details":{}}
```

- **stdout には書かない**（JSON を返す hook があるため）
- **セッションごとに 1 回**。`errors/.raw.lock` の排他と内容照合で重複を防ぐ
- `ARK_SESSION_DIR` が無いときは従来どおり即 `exit 0`

### 検査していなかった箇所を揃えた

`post-tool-use-failure.sh` / `capture-error.sh` / `summarize-errors.sh` は `jq` の有無を見ずに使っていた。他と同じ扱いにした。

## 検証

実装は codex、レビューは Claude（実装者 ≠ レビュアー）。

### レビュー側の独立検証

codex のテストとは別に、`jq` を含まない PATH を組んで実挙動を測った。

```
jq 不在で 3 hook を呼ぶ    → errors/raw.log に 1 行記録された
さらに 5 回呼ぶ            → 記録は 1 件のまま
ARK_SESSION_DIR 無し       → ファイル数に変化なし
対照: jq あり              → 記録 0 件
```

**この検証は 2 回失敗してから通った。** どちらもレビュー側の fixture 不備で、実装の問題ではなかった。

1. session dir を mode 700 で作っていなかった
2. shim PATH に `id` を入れ忘れていた（`ctx_validate_xdg_dir` が所有者確認に使う）

「記録されない」という観測を実装の欠陥と早合点せず、**codex 側のテストが通る条件との差分を取って**切り分けた。

### 変異テスト

`ctx_record_missing_jq` の呼び出しを外すと `jq-prerequisite` テストが落ちることを確認した。復元後に `diff` で一致も確認済み。

```
変異なし          exit=0  53/53 passed
記録呼び出し削除   exit=1  → 検出
復元              一致を確認
復元後            exit=0  53/53 passed
```

### テスト

```
pnpm check   exit 0（警告 36 件・main と同数の既存分）
pnpm test    exit 0   65 files / 1039 tests
pnpm build   exit 0
jq-prerequisite       53/53 passed
portable command      23/23 passed
```

`jq` 不在の再現、記録内容の完全一致、20 並行時の 1 回性、stdout/stderr 非破壊、`ARK_SESSION_DIR` 不在時の無変更、bash / zsh 両方、stale lock の回収を固定している。

## codex が報告した新しい失敗

> zsh では `set -- $value` が bash と同様には空白分割されないため、`IFS read` を使う必要がある

再発性があるため `knowledge/failures.md` への昇格を検討する（本 PR の範囲外）。

## 範囲外

`jq` 依存そのものの削減（71 箇所を Node 側へ寄せる等）は大きな設計変更のため含めていない。非エンジニア向け配布（#184）と一緒に検討するのが筋だと考える。
