### PR TITLE
feat(context): Ark session で native auto memory を無効化する

### DIFF
--- a/ark/context/scripts/session-init.sh
+++ b/ark/context/scripts/session-init.sh
@@ -240,4 +240,5 @@ printf 'ARK_CACHE_DIR\t%s\n' "$ARK_CACHE_DIR"
 printf 'ARK_RECITE_INTERVAL\t%s\n' "$interval"
 printf 'ARK_KNOWLEDGE_DIR\t%s\n' "$ARK_KNOWLEDGE_DIR"
 printf 'ARK_REPO_KEY\t%s\n' "$ARK_REPO_KEY"
+printf 'CLAUDE_CODE_DISABLE_AUTO_MEMORY\t1\n'
 exit 0

--- a/ark/context/tests/test-claude-code-settings.sh
+++ b/ark/context/tests/test-claude-code-settings.sh
@@ -104,9 +104,24 @@ assert_success "missing settings injected"
 [ -f "$settings" ] || test_fail "missing settings was not created"
 jq -e '.hooks | keys_unsorted == ["PostToolBatch","PostToolUseFailure","SessionStart"]' "$settings" >/dev/null 2>&1 \
   || test_fail "new hooks object property order is not Batch then Failure then SessionStart"
+jq -e 'has("autoMemoryEnabled") | not' "$settings" >/dev/null 2>&1 \
+  || test_fail "settings injection added native auto memory configuration"
 run_case claude_settings_restore "$repo" "$state"
 assert_success "missing settings restored"
 [ ! -e "$settings" ] || test_fail "originally missing settings was not removed"
+
+setup_repo native-memory-setting
+settings="$repo/.claude/settings.local.json"
+printf '{"autoMemoryEnabled":true}\n' >"$settings"; chmod 600 "$settings"
+cp "$settings" "$TEST_TMP/native-memory-setting-original"
+run_case claude_settings_inject "$repo" "$state"
+assert_success "native auto memory setting injected"
+jq -e '.autoMemoryEnabled == true' "$settings" >/dev/null 2>&1 \
+  || test_fail "settings injection changed native auto memory configuration"
+run_case claude_settings_restore "$repo" "$state"
+assert_success "native auto memory setting restored"
+cmp -s "$settings" "$TEST_TMP/native-memory-setting-original" \
+  || test_fail "native auto memory setting was not byte-restored"
 
 setup_repo existing-canonical
 settings="$repo/.claude/settings.local.json"

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -253,9 +253,11 @@ sid=11111111111111111111111111111111
 run_case run_init "$sid"
 assert_success "session init succeeds"
 assert_eq "init enabled line" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
-assert_eq "init output line count" 7 "$(wc -l <"$CASE_STDOUT" | tr -d ' ')"
-assert_eq "init environment order" 'ARK_SESSION_ID ARK_SESSION_DIR ARK_CACHE_DIR ARK_RECITE_INTERVAL ARK_KNOWLEDGE_DIR ARK_REPO_KEY' \
-  "$(sed -n '2,7p' "$CASE_STDOUT" | cut -f1 | tr '\n' ' ' | sed 's/ $//')"
+assert_eq "init output line count" 8 "$(wc -l <"$CASE_STDOUT" | tr -d ' ')"
+assert_eq "init environment order" 'ARK_SESSION_ID ARK_SESSION_DIR ARK_CACHE_DIR ARK_RECITE_INTERVAL ARK_KNOWLEDGE_DIR ARK_REPO_KEY CLAUDE_CODE_DISABLE_AUTO_MEMORY' \
+  "$(sed -n '2,8p' "$CASE_STDOUT" | cut -f1 | tr '\n' ' ' | sed 's/ $//')"
+assert_eq "initial session disables native auto memory" '1' \
+  "$(awk -F '\t' '$1=="CLAUDE_CODE_DISABLE_AUTO_MEMORY"{print $2}' "$CASE_STDOUT")"
 session_dir=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
 cache_dir=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
 [ -f "$session_dir/task.md" ] || test_fail "init did not create task.md"
@@ -437,6 +439,8 @@ run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id "$new_si
   --goal 'Restart lifecycle goal' --constraint 'Preserve raw' --plan-item 'Resume safely'
 assert_success "restart destination init succeeds"
 assert_eq "restart destination enabled" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
+assert_eq "restart session disables native auto memory" '1' \
+  "$(awk -F '\t' '$1=="CLAUDE_CODE_DISABLE_AUTO_MEMORY"{print $2}' "$CASE_STDOUT")"
 new_session=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
 new_cache=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
 [ "$new_session" != "$old_session" ] || test_fail "restart reused old session directory"

--- a/packages/server/src/lib/ark-context-harness.test.ts
+++ b/packages/server/src/lib/ark-context-harness.test.ts
@@ -50,6 +50,7 @@ function enabledOutput(sessionId = "a".repeat(32)): string {
     "printf 'ARK_RECITE_INTERVAL\\t10\\n'",
     "printf 'ARK_KNOWLEDGE_DIR\\t/context/knowledge\\n'",
     "printf 'ARK_REPO_KEY\\trepo-key\\n'",
+    "printf 'CLAUDE_CODE_DISABLE_AUTO_MEMORY\\t1\\n'",
   ].join("\n");
 }
 
@@ -62,7 +63,7 @@ afterEach(() => {
 describe("ArkContextHarness", () => {
   it("opt-in が true 以外なら script を実行せず無効のままにする", async () => {
     const logger = { error: vi.fn(), warn: vi.fn() };
-    const readSetting = vi.fn(() => undefined);
+    const readSetting = vi.fn(() => false);
     const harness = new ArkContextHarness({
       scriptDirectory: "/does/not/exist",
       readSetting,
@@ -102,6 +103,7 @@ describe("ArkContextHarness", () => {
       ARK_RECITE_INTERVAL: "10",
       ARK_KNOWLEDGE_DIR: "/context/knowledge",
       ARK_REPO_KEY: "repo-key",
+      CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1",
     });
     expect(fs.readFileSync(argumentsFile, "utf8").trim().split("\n")).toEqual([
       "--repo",
@@ -112,6 +114,76 @@ describe("ArkContextHarness", () => {
       "b".repeat(32),
     ]);
     fs.rmSync(argumentsFile, { force: true });
+  });
+
+  it("auto memory 無効化 key が欠落していれば通常起動へフォールバックする", async () => {
+    const scriptDirectory = makeScriptDirectory(
+      enabledOutput().replace(
+        "printf 'CLAUDE_CODE_DISABLE_AUTO_MEMORY\\t1\\n'",
+        ""
+      )
+    );
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const harness = new ArkContextHarness({
+      scriptDirectory,
+      readSetting: () => true,
+      logger,
+    });
+
+    await expect(
+      harness.initializeSession(makeWorktreeDirectory())
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "missing context environment: CLAUDE_CODE_DISABLE_AUTO_MEMORY"
+      )
+    );
+  });
+
+  it.each(["", "0", "true", "2"])(
+    "auto memory 無効化の不正値 %j を拒否する",
+    async invalidValue => {
+      const scriptDirectory = makeScriptDirectory(
+        enabledOutput().replace(
+          "CLAUDE_CODE_DISABLE_AUTO_MEMORY\\t1",
+          `CLAUDE_CODE_DISABLE_AUTO_MEMORY\\t${invalidValue}`
+        )
+      );
+      const logger = { error: vi.fn(), warn: vi.fn() };
+      const harness = new ArkContextHarness({
+        scriptDirectory,
+        readSetting: () => true,
+        logger,
+      });
+
+      await expect(
+        harness.initializeSession(makeWorktreeDirectory())
+      ).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining("CLAUDE_CODE_DISABLE_AUTO_MEMORY")
+      );
+    }
+  );
+
+  it("許可されていない余分な TSV key を拒否する", async () => {
+    const scriptDirectory = makeScriptDirectory(
+      `${enabledOutput()}\nprintf 'UNEXPECTED_CONTEXT_KEY\\tvalue\\n'`
+    );
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const harness = new ArkContextHarness({
+      scriptDirectory,
+      readSetting: () => true,
+      logger,
+    });
+
+    await expect(
+      harness.initializeSession(makeWorktreeDirectory())
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "invalid context environment entry: UNEXPECTED_CONTEXT_KEY"
+      )
+    );
   });
 
   it("enabled 0 は理由をログして通常起動へフォールバックする", async () => {

--- a/packages/server/src/lib/ark-context-harness.ts
+++ b/packages/server/src/lib/ark-context-harness.ts
@@ -19,6 +19,7 @@ const CONTEXT_ENV_KEYS = new Set([
   "ARK_RECITE_INTERVAL",
   "ARK_KNOWLEDGE_DIR",
   "ARK_REPO_KEY",
+  "CLAUDE_CODE_DISABLE_AUTO_MEMORY",
 ]);
 const REQUIRED_CONTEXT_ENV_KEYS = [
   "ARK_SESSION_ID",
@@ -26,6 +27,7 @@ const REQUIRED_CONTEXT_ENV_KEYS = [
   "ARK_CACHE_DIR",
   "ARK_RECITE_INTERVAL",
   "ARK_KNOWLEDGE_DIR",
+  "CLAUDE_CODE_DISABLE_AUTO_MEMORY",
 ] as const;
 
 type Logger = Pick<Console, "error" | "warn">;
@@ -92,6 +94,9 @@ function parseInitOutput(stdout: string): ParsedInitOutput {
   }
   if (!/^[0-9a-f]{32}$/.test(env.ARK_SESSION_ID)) {
     throw new Error("invalid ARK_SESSION_ID");
+  }
+  if (env.CLAUDE_CODE_DISABLE_AUTO_MEMORY !== "1") {
+    throw new Error("invalid CLAUDE_CODE_DISABLE_AUTO_MEMORY");
   }
   return { enabled: true, env };
 }

--- a/packages/server/src/lib/session-orchestrator-context.integration.test.ts
+++ b/packages/server/src/lib/session-orchestrator-context.integration.test.ts
@@ -135,6 +135,7 @@ describe("SessionOrchestrator + real Ark context harness", () => {
     expect(fs.realpathSync(worktreePath)).not.toBe(worktreePath);
     expect(contextEnv?.ARK_SESSION_ID).toMatch(/^[0-9a-f]{32}$/);
     expect(contextEnv?.ARK_SESSION_DIR).toBeTruthy();
+    expect(contextEnv?.CLAUDE_CODE_DISABLE_AUTO_MEMORY).toBe("1");
     const expectedRepoKey = createHash("sha256")
       .update(fs.realpathSync(worktreePath))
       .digest("hex");

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -252,6 +252,7 @@ describe("SessionOrchestrator - プロファイル切替", () => {
         ARK_RECITE_INTERVAL: "10",
         ARK_KNOWLEDGE_DIR: "/context/knowledge",
         ARK_REPO_KEY: "repo-key",
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1",
       });
 
       await orchestrator.startSession("wt-1", "/path/to/work", "/repo");
@@ -265,6 +266,7 @@ describe("SessionOrchestrator - プロファイル切替", () => {
           ARK_RECITE_INTERVAL: "10",
           ARK_KNOWLEDGE_DIR: "/context/knowledge",
           ARK_REPO_KEY: "repo-key",
+          CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1",
         },
       });
     });
@@ -475,6 +477,7 @@ describe("SessionOrchestrator - プロファイル切替", () => {
         ARK_CACHE_DIR: "/context/new-cache",
         ARK_RECITE_INTERVAL: "10",
         ARK_KNOWLEDGE_DIR: "/context/knowledge",
+        CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1",
       });
       mockedTmux.createSession.mockResolvedValue(
         makeTmuxSession({ id: "sess-id-2", tmuxSessionName: "ark-sess2" })
@@ -508,7 +511,10 @@ describe("SessionOrchestrator - プロファイル切替", () => {
       expect(mockedTmux.createSession).toHaveBeenCalledWith(
         "/path/to/work",
         expect.objectContaining({
-          env: expect.objectContaining({ ARK_SESSION_ID: newContextId }),
+          env: expect.objectContaining({
+            ARK_SESSION_ID: newContextId,
+            CLAUDE_CODE_DISABLE_AUTO_MEMORY: "1",
+          }),
         })
       );
     });


### PR DESCRIPTION
Ark Context が有効なセッションで、Claude Code の native auto memory を無効化する。

Closes #368

## なぜ

Ark Context は Goal / Plan / Position / Failure を構造化し、実行イベントごとに更新・再注入する。native auto memory も同じ「動的記憶」をリポジトリ単位で持つため、**両方を有効にすると同じものを異なる更新者・寿命・検証規則で二重管理する**ことになる。

古い推論、別 worktree の学習、未検証の自動メモが Ark の作業状態へ混入すると、単一正本という前提が壊れる。

## 変更

実装は 3 行。

```diff
# ark/context/scripts/session-init.sh（成功 TSV）
+printf 'CLAUDE_CODE_DISABLE_AUTO_MEMORY\t1\n'

# packages/server/src/lib/ark-context-harness.ts
+  "CLAUDE_CODE_DISABLE_AUTO_MEMORY",   // 許可 key
+  "CLAUDE_CODE_DISABLE_AUTO_MEMORY",   // 必須 key
+  if (env.CLAUDE_CODE_DISABLE_AUTO_MEMORY !== "1") {
+    throw new Error("invalid CLAUDE_CODE_DISABLE_AUTO_MEMORY");
+  }
```

注入は既存の `session-orchestrator` の env マージをそのまま使う。**新しい経路も設定項目も増やしていない。**

`.claude/settings.local.json` へ `autoMemoryEnabled` は書かない。Ark が settings へ hook を一時注入・復元する既存責務と、ユーザーの native memory 設定を混ぜないため（Issue の方針どおり）。

## 前提の確認

Issue が挙げる環境変数が**実在するか**を、同梱 claude 2.1.238 の native binary で確認してから着手した。

```
CLAUDE_CODE_DISABLE_AUTO_MEMORY   4 箇所
autoMemoryEnabled                 6 箇所
autoMemoryDirectory               9 箇所

陽性対照
CLAUDE_CONFIG_DIR                35 箇所
CLAUDE_PROJECT_DIR               18 箇所
```

`node_modules` に対する最初の `grep` は 0 件を返したが、実体が symlink 経由の 336MB native binary だったためで、`strings` で拾い直した。**「0 件」を存在しないことの根拠にしない**（`knowledge/failures.md` に記録済みの教訓）。

## 検証

実装は codex、レビューは Claude（実装者 ≠ レビュアー）。

### 注入経路の実機確認

**稼働中の Ark セッションの tmux env** を調べ、`session-init.sh` が出力する TSV の変数がそのまま届いていることを確認した。

```
$ tmux show-environment | grep ^ARK_
ARK_CACHE_DIR / ARK_KNOWLEDGE_DIR / ARK_RECITE_INTERVAL
ARK_REPO_KEY / ARK_SESSION_DIR / ARK_SESSION_ID
```

これは `session-init.sh` の 237〜242 行が出力する 6 変数と完全に一致する。本 PR が足す 243 行目は**同じ TSV の同じ経路**に乗るため、届くことが既存の実績で裏付けられている。

### 変異テスト

2 種類の変異でテストが落ちることを確認した。復元後の一致も `diff` で検証済み。

```
変異なし              vitest=0  ark/context=0
注入を削除            vitest=1  ark/context=1   → 検出
値の検証を無効化       vitest=1  ark/context=0   → 検出
復元後                vitest=0  ark/context=0
```

### テスト

```
pnpm check      exit 0
pnpm test       exit 0   65 files / 1045 tests
pnpm build      exit 0
session-lifecycle        217/217 passed
```

受入条件は 4 つとも固定してある。

- `ark_context_enabled=false` では注入しない
- 初回起動で `CLAUDE_CODE_DISABLE_AUTO_MEMORY=1` が tmux env に入る
- **restart 経路でも同じ key/value が渡る**
- key 欠落・空値・`0`・`true`・`2`・未知の余分な TSV key を拒否する

## 非スコープ

既存 `MEMORY.md` や auto memory directory の削除・移動は**していない**。Ark 外で直接起動した Claude Code にも干渉しない。`ark_context_enabled=false` のセッションは完全に後方互換。

## codex が報告した新しい失敗

> パッチの多重エスケープで shell の `awk` 条件に不要な `\"` が残った。対象テストで検出し、生成後の shell ソースを直接確認して修正

再発性は低いと判断し `failures.md` への昇格は見送る。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * セッション開始時に、自動メモリ機能を無効化する設定が適用されるようになりました。
  * 新規セッションおよび再起動時にも設定が引き継がれます。

* **バグ修正**
  * 不正な設定値や想定外の環境設定を検出し、通常起動へのフォールバックとエラー通知を行うよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->