### PR TITLE
feat(web): セッションが判断待ちになったことをブラウザ通知で知らせる

### DIFF
--- a/packages/web/src/components/MobileLayout.tsx
+++ b/packages/web/src/components/MobileLayout.tsx
@@ -19,7 +19,7 @@ import type {
   SpecialKey,
   Worktree,
 } from "@ark/shared";
-import { useCallback, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import type { Socket } from "socket.io-client";
 import { BrowserPane } from "@/components/BrowserPane";
 import { MobileSessionList } from "@/components/MobileSessionList";
@@ -164,6 +164,13 @@ interface MobileLayoutProps {
   sessionStatuses: Map<string, BridgeSessionStatus>;
   /** AWAITING 時の確認 UI 生テキストマップ（チャットビューのバナー用） */
   sessionAwaitingTexts: Map<string, string>;
+  notificationControl?: ReactNode;
+  notificationsSupported?: boolean;
+  isSessionNotificationEnabled?: (sessionId: string) => boolean;
+  onSessionNotificationEnabledChange?: (
+    sessionId: string,
+    enabled: boolean
+  ) => void;
 }
 
 export function MobileLayout({
@@ -213,6 +220,10 @@ export function MobileLayout({
   sessionsLoaded,
   sessionStatuses,
   sessionAwaitingTexts,
+  notificationControl,
+  notificationsSupported = false,
+  isSessionNotificationEnabled,
+  onSessionNotificationEnabledChange,
 }: MobileLayoutProps) {
   const [openedSessions, setOpenedSessions] = useState<Set<string>>(() =>
     selectedSessionId ? new Set([selectedSessionId]) : new Set()
@@ -312,6 +323,12 @@ export function MobileLayout({
           onDeleteSession={onDeleteSession}
           onDeleteWorktree={onDeleteWorktree}
           onNewSession={onNewSession}
+          notificationControl={notificationControl}
+          notificationsSupported={notificationsSupported}
+          isSessionNotificationEnabled={isSessionNotificationEnabled}
+          onSessionNotificationEnabledChange={
+            onSessionNotificationEnabledChange
+          }
         />
       </div>
 

--- a/packages/web/src/components/MobileSessionList.tsx
+++ b/packages/web/src/components/MobileSessionList.tsx
@@ -8,6 +8,8 @@
 
 import type { ManagedSession, Worktree } from "@ark/shared";
 import {
+  Bell,
+  BellOff,
   FolderOpen,
   GitBranch,
   MoreVertical,
@@ -15,7 +17,7 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -47,6 +49,13 @@ interface MobileSessionListProps {
   onDeleteSession: (sessionId: string, worktree: Worktree | undefined) => void;
   onDeleteWorktree: (worktree: Worktree) => void;
   onNewSession: () => void;
+  notificationControl?: ReactNode;
+  notificationsSupported?: boolean;
+  isSessionNotificationEnabled?: (sessionId: string) => boolean;
+  onSessionNotificationEnabledChange?: (
+    sessionId: string,
+    enabled: boolean
+  ) => void;
 }
 
 /**
@@ -74,6 +83,10 @@ export function MobileSessionList({
   onDeleteSession,
   onDeleteWorktree,
   onNewSession,
+  notificationControl,
+  notificationsSupported = false,
+  isSessionNotificationEnabled,
+  onSessionNotificationEnabledChange,
 }: MobileSessionListProps) {
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
   const { groupedItems } = useGroupedWorktreeItems(
@@ -89,15 +102,18 @@ export function MobileSessionList({
         <span className="text-sm font-semibold text-sidebar-foreground">
           Ark
         </span>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-12 w-12"
-          onClick={onNewSession}
-          title="新規セッション"
-        >
-          <Plus className="w-4 h-4" />
-        </Button>
+        <div className="flex items-center gap-1">
+          {notificationControl}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-12 w-12"
+            onClick={onNewSession}
+            title="新規セッション"
+          >
+            <Plus className="w-4 h-4" />
+          </Button>
+        </div>
       </div>
 
       {/* リポジトリ別グルーピングリスト */}
@@ -173,19 +189,55 @@ export function MobileSessionList({
                               </DropdownMenuTrigger>
                               <DropdownMenuContent align="end" className="w-48">
                                 {session ? (
-                                  <DropdownMenuItem
-                                    className="text-destructive focus:text-destructive"
-                                    onSelect={() =>
-                                      setDeleteTarget({
-                                        type: "session",
-                                        sessionId: session.id,
-                                        worktree,
-                                      })
-                                    }
-                                  >
-                                    <Trash2 className="w-4 h-4 mr-2" />
-                                    セッションを削除
-                                  </DropdownMenuItem>
+                                  <>
+                                    {notificationsSupported &&
+                                      onSessionNotificationEnabledChange && (
+                                        <DropdownMenuItem
+                                          onSelect={() => {
+                                            const enabled =
+                                              isSessionNotificationEnabled?.(
+                                                session.id
+                                              ) ?? true;
+                                            onSessionNotificationEnabledChange(
+                                              session.id,
+                                              !enabled
+                                            );
+                                          }}
+                                        >
+                                          {(isSessionNotificationEnabled?.(
+                                            session.id
+                                          ) ?? true) ? (
+                                            <BellOff className="w-4 h-4 mr-2" />
+                                          ) : (
+                                            <Bell className="w-4 h-4 mr-2" />
+                                          )}
+                                          通知を
+                                          {(isSessionNotificationEnabled?.(
+                                            session.id
+                                          ) ?? true)
+                                            ? "オフ"
+                                            : "オン"}
+                                          にする
+                                        </DropdownMenuItem>
+                                      )}
+                                    {notificationsSupported &&
+                                      onSessionNotificationEnabledChange && (
+                                        <DropdownMenuSeparator />
+                                      )}
+                                    <DropdownMenuItem
+                                      className="text-destructive focus:text-destructive"
+                                      onSelect={() =>
+                                        setDeleteTarget({
+                                          type: "session",
+                                          sessionId: session.id,
+                                          worktree,
+                                        })
+                                      }
+                                    >
+                                      <Trash2 className="w-4 h-4 mr-2" />
+                                      セッションを削除
+                                    </DropdownMenuItem>
+                                  </>
                                 ) : (
                                   <>
                                     <DropdownMenuItem
@@ -254,6 +306,39 @@ export function MobileSessionList({
                               </Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end" className="w-48">
+                              {notificationsSupported &&
+                                onSessionNotificationEnabledChange && (
+                                  <>
+                                    <DropdownMenuItem
+                                      onSelect={() => {
+                                        const enabled =
+                                          isSessionNotificationEnabled?.(
+                                            session.id
+                                          ) ?? true;
+                                        onSessionNotificationEnabledChange(
+                                          session.id,
+                                          !enabled
+                                        );
+                                      }}
+                                    >
+                                      {(isSessionNotificationEnabled?.(
+                                        session.id
+                                      ) ?? true) ? (
+                                        <BellOff className="w-4 h-4 mr-2" />
+                                      ) : (
+                                        <Bell className="w-4 h-4 mr-2" />
+                                      )}
+                                      通知を
+                                      {(isSessionNotificationEnabled?.(
+                                        session.id
+                                      ) ?? true)
+                                        ? "オフ"
+                                        : "オン"}
+                                      にする
+                                    </DropdownMenuItem>
+                                    <DropdownMenuSeparator />
+                                  </>
+                                )}
                               <DropdownMenuItem
                                 className="text-destructive focus:text-destructive"
                                 onSelect={() =>

--- a/packages/web/src/components/NotificationPermissionButton.test.tsx
+++ b/packages/web/src/components/NotificationPermissionButton.test.tsx
@@ -1,9 +1,28 @@
-import { createElement } from "react";
+import { createElement, type ReactElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationPermissionButton } from "./NotificationPermissionButton";
 
+const state = vi.hoisted(() => ({ requesting: false }));
+
+vi.mock("react", async importOriginal => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useState: () => [
+      state.requesting,
+      (requesting: boolean) => {
+        state.requesting = requesting;
+      },
+    ],
+  };
+});
+
 describe("NotificationPermissionButton", () => {
+  beforeEach(() => {
+    state.requesting = false;
+  });
+
   it("初期描画では権限を自動要求せず、明示操作用ボタンを表示する", () => {
     const onRequestPermission = vi.fn(async () => "granted" as const);
     const html = renderToStaticMarkup(
@@ -27,5 +46,38 @@ describe("NotificationPermissionButton", () => {
       })
     );
     expect(html).toBe("");
+  });
+
+  it("権限要求がrejectしてもボタンを再び押せる状態に戻す", async () => {
+    let rejectRequest: ((reason: Error) => void) | undefined;
+    const onRequestPermission = vi.fn(
+      () =>
+        new Promise<NotificationPermission>((_resolve, reject) => {
+          rejectRequest = reject;
+        })
+    );
+    const renderButton = () =>
+      NotificationPermissionButton({
+        supported: true,
+        permission: "default",
+        onRequestPermission,
+      }) as ReactElement<{
+        disabled: boolean;
+        onClick: () => Promise<void>;
+      }>;
+
+    let button = renderButton();
+    expect(button.props.disabled).toBe(false);
+
+    const request = button.props.onClick();
+    button = renderButton();
+    expect(button.props.disabled).toBe(true);
+
+    rejectRequest?.(new Error("permission request failed"));
+    await expect(request).rejects.toThrow("permission request failed");
+
+    button = renderButton();
+    expect(button.props.disabled).toBe(false);
+    expect(onRequestPermission).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/components/NotificationPermissionButton.test.tsx
+++ b/packages/web/src/components/NotificationPermissionButton.test.tsx
@@ -1,0 +1,31 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { NotificationPermissionButton } from "./NotificationPermissionButton";
+
+describe("NotificationPermissionButton", () => {
+  it("初期描画では権限を自動要求せず、明示操作用ボタンを表示する", () => {
+    const onRequestPermission = vi.fn(async () => "granted" as const);
+    const html = renderToStaticMarkup(
+      createElement(NotificationPermissionButton, {
+        supported: true,
+        permission: "default",
+        onRequestPermission,
+      })
+    );
+
+    expect(onRequestPermission).not.toHaveBeenCalled();
+    expect(html).toContain('aria-label="ブラウザ通知を有効にする"');
+  });
+
+  it("Notification API未対応環境ではUIを表示しない", () => {
+    const html = renderToStaticMarkup(
+      createElement(NotificationPermissionButton, {
+        supported: false,
+        permission: "unsupported",
+        onRequestPermission: async () => "unsupported",
+      })
+    );
+    expect(html).toBe("");
+  });
+});

--- a/packages/web/src/components/NotificationPermissionButton.tsx
+++ b/packages/web/src/components/NotificationPermissionButton.tsx
@@ -1,0 +1,53 @@
+import { Bell, BellOff, Loader2 } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface NotificationPermissionButtonProps {
+  supported: boolean;
+  permission: NotificationPermission | "unsupported";
+  onRequestPermission: () => Promise<NotificationPermission | "unsupported">;
+  className?: string;
+}
+
+export function NotificationPermissionButton({
+  supported,
+  permission,
+  onRequestPermission,
+  className = "h-8 w-8",
+}: NotificationPermissionButtonProps) {
+  const [requesting, setRequesting] = useState(false);
+  if (!supported || permission === "unsupported") return null;
+
+  const denied = permission === "denied";
+  const granted = permission === "granted";
+  const label = granted
+    ? "ブラウザ通知は許可済み"
+    : denied
+      ? "ブラウザ通知はブラウザ設定で拒否されています"
+      : "ブラウザ通知を有効にする";
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className={className}
+      disabled={requesting || denied || granted}
+      onClick={async () => {
+        setRequesting(true);
+        await onRequestPermission();
+        setRequesting(false);
+      }}
+      aria-label={label}
+      title={label}
+    >
+      {requesting ? (
+        <Loader2 className="w-4 h-4 animate-spin" />
+      ) : denied ? (
+        <BellOff className="w-4 h-4" />
+      ) : (
+        <Bell className="w-4 h-4" />
+      )}
+    </Button>
+  );
+}

--- a/packages/web/src/components/NotificationPermissionButton.tsx
+++ b/packages/web/src/components/NotificationPermissionButton.tsx
@@ -35,8 +35,11 @@ export function NotificationPermissionButton({
       disabled={requesting || denied || granted}
       onClick={async () => {
         setRequesting(true);
-        await onRequestPermission();
-        setRequesting(false);
+        try {
+          await onRequestPermission();
+        } finally {
+          setRequesting(false);
+        }
       }}
       aria-label={label}
       title={label}

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -3,7 +3,14 @@ import type {
   ManagedSession,
   Worktree,
 } from "@ark/shared";
-import { MessageSquare, Pencil, RotateCw, Trash2 } from "lucide-react";
+import {
+  Bell,
+  BellOff,
+  MessageSquare,
+  Pencil,
+  RotateCw,
+  Trash2,
+} from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import {
   AlertDialog,
@@ -66,6 +73,10 @@ interface SessionCardProps {
    * 渡されたときだけ編集UI (鉛筆アイコン) が表示される。
    */
   onSetCustomDisplayName?: (displayName: string | null) => void;
+  /** Notification API対応環境でのみセッション別通知設定を表示する。 */
+  notificationsSupported?: boolean;
+  notificationsEnabled?: boolean;
+  onNotificationsEnabledChange?: (enabled: boolean) => void;
 }
 
 export function SessionCard({
@@ -82,6 +93,9 @@ export function SessionCard({
   profileBadgeSlot,
   customDisplayName,
   onSetCustomDisplayName,
+  notificationsSupported = false,
+  notificationsEnabled = true,
+  onNotificationsEnabledChange,
 }: SessionCardProps) {
   const branch =
     worktree?.branch ||
@@ -319,6 +333,20 @@ export function SessionCard({
             <ContextMenuItem onSelect={() => startEditing()}>
               <Pencil className="w-4 h-4 mr-2" />
               表示名を変更
+            </ContextMenuItem>
+          )}
+          {notificationsSupported && onNotificationsEnabledChange && (
+            <ContextMenuItem
+              onSelect={() =>
+                onNotificationsEnabledChange(!notificationsEnabled)
+              }
+            >
+              {notificationsEnabled ? (
+                <BellOff className="w-4 h-4 mr-2" />
+              ) : (
+                <Bell className="w-4 h-4 mr-2" />
+              )}
+              通知を{notificationsEnabled ? "オフ" : "オン"}にする
             </ContextMenuItem>
           )}
           <ContextMenuSeparator />

--- a/packages/web/src/components/SessionSidebar.tsx
+++ b/packages/web/src/components/SessionSidebar.tsx
@@ -30,7 +30,7 @@ import {
   Terminal,
   X,
 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -118,6 +118,13 @@ interface SessionSidebarProps {
    * 未設定 (Map empty) の場合は SessionCard 側のフォールバック判定が使われる。
    */
   gridStatuses?: Map<string, BridgeSessionStatus>;
+  notificationControl?: ReactNode;
+  notificationsSupported?: boolean;
+  isSessionNotificationEnabled?: (sessionId: string) => boolean;
+  onSessionNotificationEnabledChange?: (
+    sessionId: string,
+    enabled: boolean
+  ) => void;
 }
 
 export function SessionSidebar({
@@ -149,6 +156,10 @@ export function SessionSidebar({
   onSelectRepoGrid,
   gridRepoPath,
   gridStatuses,
+  notificationControl,
+  notificationsSupported = false,
+  isSessionNotificationEnabled,
+  onSessionNotificationEnabledChange,
 }: SessionSidebarProps) {
   const { groupedItems } = useGroupedWorktreeItems(
     worktrees,
@@ -406,6 +417,7 @@ export function SessionSidebar({
           <h1 className="font-semibold text-sm text-sidebar-foreground">Ark</h1>
         </div>
         <div className="flex items-center gap-1">
+          {notificationControl}
           {isRemote && onSelectBrowser && (
             <Button
               variant={isBrowserSelected ? "default" : "ghost"}
@@ -620,6 +632,22 @@ export function SessionSidebar({
                                     onSetWorktreeDisplayName(wtPath, name);
                                   }
                                 }
+                              : undefined
+                          }
+                          notificationsSupported={notificationsSupported}
+                          notificationsEnabled={
+                            session
+                              ? (isSessionNotificationEnabled?.(session.id) ??
+                                true)
+                              : true
+                          }
+                          onNotificationsEnabledChange={
+                            session && onSessionNotificationEnabledChange
+                              ? enabled =>
+                                  onSessionNotificationEnabledChange(
+                                    session.id,
+                                    enabled
+                                  )
                               : undefined
                           }
                         />

--- a/packages/web/src/hooks/useSessionNotifications.ts
+++ b/packages/web/src/hooks/useSessionNotifications.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  BrowserNotificationTransport,
+  deliverSessionNotification,
+  isNotificationEnabledForSession,
+  readBrowserNotificationApi,
+  type SessionAuqSignal,
+  SessionNotificationDetector,
+  SessionNotificationLeader,
+  type SessionStatusSignal,
+} from "@/lib/session-notifications";
+
+interface UseSessionNotificationsOptions {
+  statusSignals: Map<string, SessionStatusSignal>;
+  auqSignals: Map<string, SessionAuqSignal>;
+  sessionLabels: Map<string, string>;
+  enabledBySession: Record<string, boolean>;
+  onOpenSession: (sessionId: string) => void;
+}
+
+function getLocalStorage(): Storage | null {
+  try {
+    return typeof window === "undefined" ? null : window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function createTabId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random()}`;
+}
+
+export function useSessionNotifications({
+  statusSignals,
+  auqSignals,
+  sessionLabels,
+  enabledBySession,
+  onOpenSession,
+}: UseSessionNotificationsOptions) {
+  const detectorRef = useRef(new SessionNotificationDetector());
+  const transportRef = useRef(
+    new BrowserNotificationTransport(readBrowserNotificationApi())
+  );
+  const leaderRef = useRef(
+    new SessionNotificationLeader(getLocalStorage(), createTabId())
+  );
+  const [permission, setPermission] = useState(transportRef.current.permission);
+
+  useEffect(() => {
+    const leader = leaderRef.current;
+    leader.claim();
+    const timer = window.setInterval(() => leader.claim(), 2_000);
+    return () => {
+      window.clearInterval(timer);
+      leader.release();
+    };
+  }, []);
+
+  const dispatch = useCallback(
+    (event: {
+      sessionId: string;
+      kind: "awaiting" | "question" | "completed";
+    }) =>
+      deliverSessionNotification({
+        event,
+        sessionLabel: sessionLabels.get(event.sessionId) ?? event.sessionId,
+        enabled: isNotificationEnabledForSession(
+          enabledBySession,
+          event.sessionId
+        ),
+        transport: transportRef.current,
+        isLeader: () => leaderRef.current.claim(),
+        focusWindow: () => {
+          if (typeof window !== "undefined") window.focus();
+        },
+        onOpenSession,
+      }),
+    [enabledBySession, onOpenSession, sessionLabels]
+  );
+
+  useEffect(() => {
+    for (const signal of statusSignals.values()) {
+      const event = detectorRef.current.consumeStatus(signal);
+      if (event) dispatch(event);
+    }
+  }, [dispatch, statusSignals]);
+
+  useEffect(() => {
+    for (const signal of auqSignals.values()) {
+      const event = detectorRef.current.consumeAuq(signal);
+      if (event) dispatch(event);
+    }
+  }, [auqSignals, dispatch]);
+
+  const requestPermission = useCallback(async () => {
+    const next = await transportRef.current.requestPermission();
+    setPermission(next);
+    return next;
+  }, []);
+
+  return {
+    supported: transportRef.current.supported,
+    permission,
+    requestPermission,
+  };
+}

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -38,6 +38,10 @@ import {
   requestDiagramCommentsGet,
 } from "../lib/diagram-comment-transport";
 import { requestDiagramDelete } from "../lib/diagram-delete-transport";
+import type {
+  SessionAuqSignal,
+  SessionStatusSignal,
+} from "../lib/session-notifications";
 import {
   addWorktree,
   clearRepo,
@@ -210,6 +214,12 @@ interface UseSocketReturn {
    */
   sessionStatuses: Map<string, BridgeSessionStatus>;
 
+  /** 通知判定用の最新statusシグナル（既存session:previewsから派生） */
+  sessionStatusSignals: Map<string, SessionStatusSignal>;
+
+  /** 通知判定用の最新AskUserQuestionシグナル（既存session:auqから派生） */
+  sessionAuqSignals: Map<string, SessionAuqSignal>;
+
   /**
    * sessionId → AWAITING 時の確認 UI 生テキスト。
    * チャットビューのバナーで「何を聞かれているか」をそのまま表示する。
@@ -373,6 +383,12 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   // サイドバードット色用。RepoGridView 購読の有無に関わらず常時更新される。
   const [sessionStatuses, setSessionStatuses] = useState<
     Map<string, BridgeSessionStatus>
+  >(new Map());
+  const [sessionStatusSignals, setSessionStatusSignals] = useState<
+    Map<string, SessionStatusSignal>
+  >(new Map());
+  const [sessionAuqSignals, setSessionAuqSignals] = useState<
+    Map<string, SessionAuqSignal>
   >(new Map());
 
   // AWAITING 時の確認 UI 生テキスト (チャットビューのバナーで内容を表示する)。
@@ -773,6 +789,18 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
       setFileContent(data);
     });
 
+    const handleAuqSignal = (data: { sessionId: string; at: number }) => {
+      setSessionAuqSignals(prev => {
+        const current = prev.get(data.sessionId);
+        if (current && current.at >= data.at) return prev;
+        return new Map(prev).set(data.sessionId, {
+          sessionId: data.sessionId,
+          at: data.at,
+        });
+      });
+    };
+    socket.on("session:auq", handleAuqSignal);
+
     socket.on("session:previews", previews => {
       // セッションのstatusをプレビューから更新
       setSessions(prev => {
@@ -805,6 +833,17 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         const next = new Map(prev);
         for (const p of previews) {
           next.set(p.sessionId, p.bridgeStatus);
+        }
+        return next;
+      });
+      setSessionStatusSignals(prev => {
+        const next = new Map(prev);
+        for (const p of previews) {
+          next.set(p.sessionId, {
+            sessionId: p.sessionId,
+            status: p.bridgeStatus,
+            at: p.timestamp,
+          });
         }
         return next;
       });
@@ -1008,6 +1047,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     return () => {
       socket.off("ports:list");
       socket.off("file:content");
+      socket.off("session:auq", handleAuqSignal);
       socket.off("session:previews");
       socket.off("session:grid:snapshot");
       socket.off("browser:started");
@@ -1534,6 +1574,8 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     sessionPreviews,
     sessionActivityTexts,
     sessionAwaitingTexts,
+    sessionStatusSignals,
+    sessionAuqSignals,
     gridSnapshots,
     subscribeGrid,
     unsubscribeGrid,

--- a/packages/web/src/lib/session-notifications.test.ts
+++ b/packages/web/src/lib/session-notifications.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BrowserNotificationTransport,
+  buildSessionNotificationPayload,
+  deliverSessionNotification,
+  isNotificationEnabledForSession,
+  type NotificationApiLike,
+  type NotificationInstanceLike,
+  normalizeSessionNotificationSettings,
+  SessionNotificationDetector,
+  SessionNotificationLeader,
+  type SessionNotificationPayload,
+  type SessionNotificationTransport,
+  updateSessionNotificationSettings,
+} from "./session-notifications";
+
+function createMemoryStorage(): Storage {
+  const values = new Map<string, string>();
+  return {
+    get length() {
+      return values.size;
+    },
+    clear: () => values.clear(),
+    getItem: key => values.get(key) ?? null,
+    key: index => Array.from(values.keys())[index] ?? null,
+    removeItem: key => values.delete(key),
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+describe("SessionNotificationDetector", () => {
+  it("AWAITINGへの遷移だけを通知し、継続中は重複通知しない", () => {
+    const detector = new SessionNotificationDetector();
+
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "READY", at: 0 })
+    ).toBeNull();
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "AWAITING", at: 1 })
+    ).toEqual({ sessionId: "s1", kind: "awaiting" });
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "AWAITING", at: 2 })
+    ).toBeNull();
+  });
+
+  it("AWAITINGから離れて戻ったときは再通知する", () => {
+    const detector = new SessionNotificationDetector();
+    detector.consumeStatus({ sessionId: "s1", status: "READY", at: 0 });
+    detector.consumeStatus({ sessionId: "s1", status: "AWAITING", at: 1 });
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "IDLE", at: 2 })
+    ).toBeNull();
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "AWAITING", at: 3 })
+    ).toEqual({ sessionId: "s1", kind: "awaiting" });
+  });
+
+  it.each([
+    ["TOOL", "IDLE"],
+    ["THINK", "READY"],
+    ["THINK", "ERR"],
+    ["TOOL", "STOP"],
+  ] as const)("実行中 %s から %s への遷移を完了通知にする", (from, to) => {
+    const detector = new SessionNotificationDetector();
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: from, at: 1 })
+    ).toBeNull();
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: to, at: 2 })
+    ).toEqual({ sessionId: "s1", kind: "completed" });
+  });
+
+  it("初回停止状態や実行中から判断待ちへの遷移を完了扱いしない", () => {
+    const detector = new SessionNotificationDetector();
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "IDLE", at: 1 })
+    ).toBeNull();
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "TOOL", at: 2 })
+    ).toBeNull();
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "AWAITING", at: 3 })
+    ).toEqual({ sessionId: "s1", kind: "awaiting" });
+  });
+
+  it("初回snapshotがAWAITINGでもリロードだけでは通知しない", () => {
+    const detector = new SessionNotificationDetector();
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "AWAITING", at: 1 })
+    ).toBeNull();
+  });
+
+  it("AUQは新しいイベントだけを通知する", () => {
+    const detector = new SessionNotificationDetector();
+    expect(detector.consumeAuq({ sessionId: "s1", at: 10 })).toEqual({
+      sessionId: "s1",
+      kind: "question",
+    });
+    expect(detector.consumeAuq({ sessionId: "s1", at: 10 })).toBeNull();
+    expect(detector.consumeAuq({ sessionId: "s1", at: 9 })).toBeNull();
+    expect(detector.consumeAuq({ sessionId: "s1", at: 11 })).toEqual({
+      sessionId: "s1",
+      kind: "question",
+    });
+  });
+
+  it("AUQ通知の直後に同じ質問由来のAWAITING通知を重ねない", () => {
+    const detector = new SessionNotificationDetector();
+    expect(detector.consumeAuq({ sessionId: "s1", at: 10 })).toEqual({
+      sessionId: "s1",
+      kind: "question",
+    });
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "AWAITING", at: 11 })
+    ).toBeNull();
+    detector.consumeStatus({ sessionId: "s1", status: "IDLE", at: 12 });
+    expect(
+      detector.consumeStatus({ sessionId: "s1", status: "AWAITING", at: 13 })
+    ).toEqual({ sessionId: "s1", kind: "awaiting" });
+  });
+});
+
+describe("notification payload and delivery", () => {
+  it.each([
+    [
+      "awaiting",
+      {
+        title: "Ark: 判断を待っています",
+        body: "ark-notify で権限確認が必要です",
+        tag: "ark-session-session-1-awaiting",
+      },
+    ],
+    [
+      "question",
+      {
+        title: "Ark: 質問があります",
+        body: "ark-notify が回答を待っています",
+        tag: "ark-session-session-1-question",
+      },
+    ],
+    [
+      "completed",
+      {
+        title: "Ark: 作業が完了しました",
+        body: "ark-notify の実行が停止しました",
+        tag: "ark-session-session-1-completed",
+      },
+    ],
+  ] as const)("%s通知のタイトル・本文・tagを構築する", (kind, expected) => {
+    expect(
+      buildSessionNotificationPayload(
+        { sessionId: "session-1", kind },
+        "ark-notify"
+      )
+    ).toEqual(expected);
+  });
+
+  it("transportへ実引数を渡し、クリックで正しいセッションを開く", () => {
+    let clickHandler: (() => void) | undefined;
+    const show = vi.fn(
+      (_payload: SessionNotificationPayload, onClick: () => void) => {
+        clickHandler = onClick;
+        return true;
+      }
+    );
+    const transport: SessionNotificationTransport = {
+      supported: true,
+      permission: "granted",
+      requestPermission: async () => "granted",
+      show,
+    };
+    const focusWindow = vi.fn();
+    const onOpenSession = vi.fn();
+
+    expect(
+      deliverSessionNotification({
+        event: { sessionId: "session-42", kind: "question" },
+        sessionLabel: "feature/payment",
+        enabled: true,
+        transport,
+        isLeader: () => true,
+        focusWindow,
+        onOpenSession,
+      })
+    ).toBe(true);
+    expect(show).toHaveBeenCalledWith(
+      {
+        title: "Ark: 質問があります",
+        body: "feature/payment が回答を待っています",
+        tag: "ark-session-session-42-question",
+      },
+      expect.any(Function)
+    );
+
+    clickHandler?.();
+    expect(focusWindow).toHaveBeenCalledTimes(1);
+    expect(onOpenSession).toHaveBeenCalledWith("session-42");
+  });
+
+  it("window focusが拒否されてもクリック先セッションを開く", () => {
+    let clickHandler: (() => void) | undefined;
+    const transport: SessionNotificationTransport = {
+      supported: true,
+      permission: "granted",
+      requestPermission: async () => "granted",
+      show: (_payload, onClick) => {
+        clickHandler = onClick;
+        return true;
+      },
+    };
+    const onOpenSession = vi.fn();
+    deliverSessionNotification({
+      event: { sessionId: "session-7", kind: "completed" },
+      sessionLabel: "ark-notify",
+      enabled: true,
+      transport,
+      isLeader: () => true,
+      focusWindow: () => {
+        throw new Error("focus denied");
+      },
+      onOpenSession,
+    });
+
+    expect(() => clickHandler?.()).not.toThrow();
+    expect(onOpenSession).toHaveBeenCalledWith("session-7");
+  });
+
+  it("セッション設定がoffならtransportを呼ばない", () => {
+    const show = vi.fn(() => true);
+    const transport: SessionNotificationTransport = {
+      supported: true,
+      permission: "granted",
+      requestPermission: async () => "granted",
+      show,
+    };
+    expect(
+      deliverSessionNotification({
+        event: { sessionId: "s1", kind: "completed" },
+        sessionLabel: "ark-notify",
+        enabled: false,
+        transport,
+        isLeader: () => true,
+        focusWindow: vi.fn(),
+        onOpenSession: vi.fn(),
+      })
+    ).toBe(false);
+    expect(show).not.toHaveBeenCalled();
+  });
+
+  it("リーダータブでなければtransportを呼ばない", () => {
+    const show = vi.fn(() => true);
+    const transport: SessionNotificationTransport = {
+      supported: true,
+      permission: "granted",
+      requestPermission: async () => "granted",
+      show,
+    };
+    deliverSessionNotification({
+      event: { sessionId: "s1", kind: "completed" },
+      sessionLabel: "ark-notify",
+      enabled: true,
+      transport,
+      isLeader: () => false,
+      focusWindow: vi.fn(),
+      onOpenSession: vi.fn(),
+    });
+    expect(show).not.toHaveBeenCalled();
+  });
+});
+
+describe("BrowserNotificationTransport", () => {
+  it("granted時だけNotificationを正しい引数で生成し、クリック後に閉じる", () => {
+    const instance: NotificationInstanceLike = {
+      onclick: null,
+      close: vi.fn(),
+    };
+    const create = vi.fn(() => instance);
+    const api: NotificationApiLike = {
+      permission: "granted",
+      requestPermission: async () => "granted",
+      create,
+    };
+    const transport = new BrowserNotificationTransport(api);
+    const onClick = vi.fn();
+
+    expect(
+      transport.show({ title: "Title", body: "Body", tag: "tag-1" }, onClick)
+    ).toBe(true);
+    expect(create).toHaveBeenCalledWith("Title", {
+      body: "Body",
+      tag: "tag-1",
+      renotify: true,
+    });
+    instance.onclick?.(new Event("click"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(instance.close).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["default", "denied"] as const)(
+    "%s権限では例外なく無効になる",
+    permission => {
+      const create = vi.fn();
+      const transport = new BrowserNotificationTransport({
+        permission,
+        requestPermission: async () => permission,
+        create,
+      });
+      expect(
+        transport.show({ title: "Title", body: "Body", tag: "tag" }, vi.fn())
+      ).toBe(false);
+      expect(create).not.toHaveBeenCalled();
+    }
+  );
+
+  it("Notification APIが無い環境で要求・表示とも例外を投げない", async () => {
+    const transport = new BrowserNotificationTransport(null);
+    await expect(transport.requestPermission()).resolves.toBe("unsupported");
+    expect(
+      transport.show({ title: "Title", body: "Body", tag: "tag" }, vi.fn())
+    ).toBe(false);
+  });
+
+  it("ブラウザ実装が例外を投げてもサイレントに無効化する", async () => {
+    const api: NotificationApiLike = {
+      permission: "granted",
+      requestPermission: async () => {
+        throw new Error("blocked");
+      },
+      create: () => {
+        throw new Error("blocked");
+      },
+    };
+    const transport = new BrowserNotificationTransport(api);
+    await expect(transport.requestPermission()).resolves.toBe("granted");
+    expect(
+      transport.show({ title: "Title", body: "Body", tag: "tag" }, vi.fn())
+    ).toBe(false);
+  });
+});
+
+describe("SessionNotificationLeader", () => {
+  it("有効なlease中は1タブだけがleaderになり、期限後に交代できる", () => {
+    const storage = createMemoryStorage();
+    const first = new SessionNotificationLeader(storage, "tab-1", 100);
+    const second = new SessionNotificationLeader(storage, "tab-2", 100);
+
+    expect(first.claim(1_000)).toBe(true);
+    expect(second.claim(1_050)).toBe(false);
+    expect(second.claim(1_101)).toBe(true);
+    first.release();
+    expect(second.claim(1_102)).toBe(true);
+  });
+});
+
+describe("normalizeSessionNotificationSettings", () => {
+  it("boolean値だけを復元し、未設定セッションは呼び出し側で既定onにできる", () => {
+    expect(
+      normalizeSessionNotificationSettings({
+        enabled: true,
+        disabled: false,
+        broken: "false",
+      })
+    ).toEqual({ enabled: true, disabled: false });
+    expect(normalizeSessionNotificationSettings(null)).toEqual({});
+    expect(isNotificationEnabledForSession({}, "new-session")).toBe(true);
+    expect(
+      isNotificationEnabledForSession(
+        { "muted-session": false },
+        "muted-session"
+      )
+    ).toBe(false);
+    expect(
+      updateSessionNotificationSettings(
+        { existing: true, target: true },
+        "target",
+        false
+      )
+    ).toEqual({ existing: true, target: false });
+  });
+});

--- a/packages/web/src/lib/session-notifications.test.ts
+++ b/packages/web/src/lib/session-notifications.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   BrowserNotificationTransport,
   buildSessionNotificationPayload,
+  createSessionNotificationEnabledChangeHandler,
   deliverSessionNotification,
   isNotificationEnabledForSession,
   type NotificationApiLike,
@@ -376,5 +377,26 @@ describe("normalizeSessionNotificationSettings", () => {
         false
       )
     ).toEqual({ existing: true, target: false });
+  });
+
+  it("同一renderのハンドラで2セッションを連続更新しても両方の変更を保持する", () => {
+    const settings: Record<string, unknown> = {};
+    const getSetting = <T>(key: string, defaultValue: T): T =>
+      (settings[key] === undefined ? defaultValue : settings[key]) as T;
+    const setSetting = (key: string, value: unknown) => {
+      settings[key] = value;
+    };
+    const handleChange = createSessionNotificationEnabledChangeHandler(
+      getSetting,
+      setSetting
+    );
+
+    handleChange("session-1", false);
+    handleChange("session-2", false);
+
+    expect(settings["sessionNotifications.enabledBySession"]).toEqual({
+      "session-1": false,
+      "session-2": false,
+    });
   });
 });

--- a/packages/web/src/lib/session-notifications.ts
+++ b/packages/web/src/lib/session-notifications.ts
@@ -1,0 +1,298 @@
+import type { BridgeSessionStatus } from "@ark/shared";
+
+export type SessionNotificationKind = "awaiting" | "question" | "completed";
+
+export interface SessionStatusSignal {
+  sessionId: string;
+  status: BridgeSessionStatus;
+  at: number;
+}
+
+export interface SessionAuqSignal {
+  sessionId: string;
+  at: number;
+}
+
+export interface SessionNotificationEvent {
+  sessionId: string;
+  kind: SessionNotificationKind;
+}
+
+export interface SessionNotificationPayload {
+  title: string;
+  body: string;
+  tag: string;
+}
+
+export interface NotificationInstanceLike {
+  onclick: ((event: Event) => unknown) | null;
+  close: () => void;
+}
+
+/** TypeScript 6.0のlib.domに未収録だがNotifications API標準にあるoption。 */
+export type BrowserNotificationOptions = NotificationOptions & {
+  renotify?: boolean;
+};
+
+export interface NotificationApiLike {
+  readonly permission: NotificationPermission;
+  requestPermission: () => Promise<NotificationPermission>;
+  create: (
+    title: string,
+    options: BrowserNotificationOptions
+  ) => NotificationInstanceLike;
+}
+
+export interface SessionNotificationTransport {
+  readonly supported: boolean;
+  readonly permission: NotificationPermission | "unsupported";
+  requestPermission: () => Promise<NotificationPermission | "unsupported">;
+  show: (payload: SessionNotificationPayload, onClick: () => void) => boolean;
+}
+
+const RUNNING_STATUSES = new Set<BridgeSessionStatus>(["TOOL", "THINK"]);
+const COMPLETED_STATUSES = new Set<BridgeSessionStatus>([
+  "IDLE",
+  "READY",
+  "ERR",
+  "STOP",
+]);
+
+/**
+ * Socket signalsから通知条件だけを判定する状態機械。
+ * Notification APIには依存しないため、将来Web Push transportでも再利用できる。
+ */
+export class SessionNotificationDetector {
+  private readonly statusBySession = new Map<string, BridgeSessionStatus>();
+  private readonly lastAuqAtBySession = new Map<string, number>();
+  private readonly activeAuqSessions = new Set<string>();
+
+  consumeStatus(signal: SessionStatusSignal): SessionNotificationEvent | null {
+    const previous = this.statusBySession.get(signal.sessionId);
+    this.statusBySession.set(signal.sessionId, signal.status);
+
+    if (previous === signal.status) return null;
+    if (signal.status !== "AWAITING") {
+      this.activeAuqSessions.delete(signal.sessionId);
+    }
+    // 初回snapshotは現在値の初期化。リロードだけで既存の待機状態を再通知しない。
+    if (previous === undefined) return null;
+    if (signal.status === "AWAITING") {
+      // AUQは専用イベントの方が具体的なので、同じ質問にAWAITING通知を重ねない。
+      if (this.activeAuqSessions.has(signal.sessionId)) return null;
+      return { sessionId: signal.sessionId, kind: "awaiting" };
+    }
+    if (
+      previous !== undefined &&
+      RUNNING_STATUSES.has(previous) &&
+      COMPLETED_STATUSES.has(signal.status)
+    ) {
+      return { sessionId: signal.sessionId, kind: "completed" };
+    }
+    return null;
+  }
+
+  consumeAuq(signal: SessionAuqSignal): SessionNotificationEvent | null {
+    const previousAt = this.lastAuqAtBySession.get(signal.sessionId);
+    if (previousAt !== undefined && signal.at <= previousAt) return null;
+    this.lastAuqAtBySession.set(signal.sessionId, signal.at);
+    this.activeAuqSessions.add(signal.sessionId);
+    return { sessionId: signal.sessionId, kind: "question" };
+  }
+}
+
+export function readBrowserNotificationApi(): NotificationApiLike | null {
+  if (typeof Notification === "undefined") return null;
+  return {
+    get permission() {
+      return Notification.permission;
+    },
+    requestPermission: () => Notification.requestPermission(),
+    create: (title, options) => new Notification(title, options),
+  };
+}
+
+export class BrowserNotificationTransport
+  implements SessionNotificationTransport
+{
+  constructor(private readonly api: NotificationApiLike | null) {}
+
+  get supported(): boolean {
+    return this.api !== null;
+  }
+
+  get permission(): NotificationPermission | "unsupported" {
+    return this.api?.permission ?? "unsupported";
+  }
+
+  async requestPermission(): Promise<NotificationPermission | "unsupported"> {
+    if (!this.api) return "unsupported";
+    try {
+      return await this.api.requestPermission();
+    } catch {
+      return this.api.permission;
+    }
+  }
+
+  show(payload: SessionNotificationPayload, onClick: () => void): boolean {
+    if (this.api?.permission !== "granted") return false;
+    try {
+      const notification = this.api.create(payload.title, {
+        body: payload.body,
+        tag: payload.tag,
+        renotify: true,
+      });
+      notification.onclick = () => {
+        try {
+          onClick();
+        } finally {
+          notification.close();
+        }
+      };
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export function buildSessionNotificationPayload(
+  event: SessionNotificationEvent,
+  sessionLabel: string
+): SessionNotificationPayload {
+  switch (event.kind) {
+    case "awaiting":
+      return {
+        title: "Ark: 判断を待っています",
+        body: `${sessionLabel} で権限確認が必要です`,
+        tag: `ark-session-${event.sessionId}-awaiting`,
+      };
+    case "question":
+      return {
+        title: "Ark: 質問があります",
+        body: `${sessionLabel} が回答を待っています`,
+        tag: `ark-session-${event.sessionId}-question`,
+      };
+    case "completed":
+      return {
+        title: "Ark: 作業が完了しました",
+        body: `${sessionLabel} の実行が停止しました`,
+        tag: `ark-session-${event.sessionId}-completed`,
+      };
+  }
+}
+
+export function deliverSessionNotification(args: {
+  event: SessionNotificationEvent;
+  sessionLabel: string;
+  enabled: boolean;
+  transport: SessionNotificationTransport;
+  isLeader: () => boolean;
+  onOpenSession: (sessionId: string) => void;
+  focusWindow: () => void;
+}): boolean {
+  if (!args.enabled || !args.isLeader()) return false;
+  return args.transport.show(
+    buildSessionNotificationPayload(args.event, args.sessionLabel),
+    () => {
+      try {
+        args.focusWindow();
+      } catch {
+        // focusがブラウザに拒否されてもセッション遷移は続ける。
+      }
+      args.onOpenSession(args.event.sessionId);
+    }
+  );
+}
+
+export function normalizeSessionNotificationSettings(
+  value: unknown
+): Record<string, boolean> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  return Object.fromEntries(
+    Object.entries(value).filter(
+      (entry): entry is [string, boolean] => typeof entry[1] === "boolean"
+    )
+  );
+}
+
+export function isNotificationEnabledForSession(
+  settings: Record<string, boolean>,
+  sessionId: string
+): boolean {
+  return settings[sessionId] !== false;
+}
+
+export function updateSessionNotificationSettings(
+  settings: Record<string, boolean>,
+  sessionId: string,
+  enabled: boolean
+): Record<string, boolean> {
+  return { ...settings, [sessionId]: enabled };
+}
+
+interface LeaderLease {
+  tabId: string;
+  expiresAt: number;
+}
+
+const LEADER_STORAGE_KEY = "ark-session-notification-leader";
+
+/** localStorageの同期性を使ったbest-effortな複数タブリーダー選出。 */
+export class SessionNotificationLeader {
+  constructor(
+    private readonly storage: Storage | null,
+    private readonly tabId: string,
+    private readonly leaseMs = 5_000
+  ) {}
+
+  claim(now = Date.now()): boolean {
+    if (!this.storage) return true;
+    try {
+      const current = this.readLease();
+      if (current && current.tabId !== this.tabId && current.expiresAt > now) {
+        return false;
+      }
+      const next: LeaderLease = {
+        tabId: this.tabId,
+        expiresAt: now + this.leaseMs,
+      };
+      this.storage.setItem(LEADER_STORAGE_KEY, JSON.stringify(next));
+      return this.readLease()?.tabId === this.tabId;
+    } catch {
+      return true;
+    }
+  }
+
+  release(): void {
+    if (!this.storage) return;
+    try {
+      if (this.readLease()?.tabId === this.tabId) {
+        this.storage.removeItem(LEADER_STORAGE_KEY);
+      }
+    } catch {
+      // Storageが利用不能でも通知機能自体は壊さない。
+    }
+  }
+
+  private readLease(): LeaderLease | null {
+    if (!this.storage) return null;
+    const raw = this.storage.getItem(LEADER_STORAGE_KEY);
+    if (!raw) return null;
+    let value: Partial<LeaderLease>;
+    try {
+      value = JSON.parse(raw) as Partial<LeaderLease>;
+    } catch {
+      return null;
+    }
+    if (
+      typeof value.tabId !== "string" ||
+      typeof value.expiresAt !== "number"
+    ) {
+      return null;
+    }
+    return { tabId: value.tabId, expiresAt: value.expiresAt };
+  }
+}

--- a/packages/web/src/lib/session-notifications.ts
+++ b/packages/web/src/lib/session-notifications.ts
@@ -50,6 +50,12 @@ export interface SessionNotificationTransport {
   show: (payload: SessionNotificationPayload, onClick: () => void) => boolean;
 }
 
+type GetSetting = <T>(key: string, defaultValue: T) => T;
+type SetSetting = (key: string, value: unknown) => void;
+
+const SESSION_NOTIFICATION_SETTINGS_KEY =
+  "sessionNotifications.enabledBySession";
+
 const RUNNING_STATUSES = new Set<BridgeSessionStatus>(["TOOL", "THINK"]);
 const COMPLETED_STATUSES = new Set<BridgeSessionStatus>([
   "IDLE",
@@ -216,6 +222,21 @@ export function normalizeSessionNotificationSettings(
       (entry): entry is [string, boolean] => typeof entry[1] === "boolean"
     )
   );
+}
+
+export function createSessionNotificationEnabledChangeHandler(
+  getSetting: GetSetting,
+  setSetting: SetSetting
+): (sessionId: string, enabled: boolean) => void {
+  return (sessionId, enabled) => {
+    const latestSettings = normalizeSessionNotificationSettings(
+      getSetting<unknown>(SESSION_NOTIFICATION_SETTINGS_KEY, {})
+    );
+    setSetting(
+      SESSION_NOTIFICATION_SETTINGS_KEY,
+      updateSessionNotificationSettings(latestSettings, sessionId, enabled)
+    );
+  };
 }
 
 export function isNotificationEnabledForSession(

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -51,9 +51,9 @@ import {
   type DiagramOpenRequest,
 } from "@/lib/mobile-session-view-mode";
 import {
+  createSessionNotificationEnabledChangeHandler,
   isNotificationEnabledForSession,
   normalizeSessionNotificationSettings,
-  updateSessionNotificationSettings,
 } from "@/lib/session-notifications";
 import { getBaseName } from "@/utils/pathUtils";
 import {
@@ -232,18 +232,9 @@ export default function Dashboard() {
     [sessionNotificationSettings]
   );
 
-  const handleSessionNotificationEnabledChange = useCallback(
-    (sessionId: string, enabled: boolean) => {
-      setSetting(
-        "sessionNotifications.enabledBySession",
-        updateSessionNotificationSettings(
-          sessionNotificationSettings,
-          sessionId,
-          enabled
-        )
-      );
-    },
-    [sessionNotificationSettings, setSetting]
+  const handleSessionNotificationEnabledChange = useMemo(
+    () => createSessionNotificationEnabledChangeHandler(getSetting, setSetting),
+    [getSetting, setSetting]
   );
 
   const notificationControl = (

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import type { ManagedSession, SpecialKey, Worktree } from "@ark/shared";
 import { AlertCircle, Copy, Loader2, Terminal } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { AboutDialog } from "@/components/AboutDialog";
 import { BrowserPane } from "@/components/BrowserPane";
@@ -14,6 +14,7 @@ import {
   normalizeSessionSubView,
   type SessionSubView,
 } from "@/components/MobileLayout";
+import { NotificationPermissionButton } from "@/components/NotificationPermissionButton";
 import { ProfileManagerDialog } from "@/components/ProfileManagerDialog";
 import { RepoGridView } from "@/components/RepoGridView";
 import { RepoSelectDialog } from "@/components/RepoSelectDialog";
@@ -41,6 +42,7 @@ import {
 } from "@/components/ui/select";
 import { useBridgeSnapshot } from "@/hooks/useBridgeSnapshot";
 import { useIsMobile } from "@/hooks/useMobile";
+import { useSessionNotifications } from "@/hooks/useSessionNotifications";
 import { useSettings } from "@/hooks/useSettings";
 import { useSocket } from "@/hooks/useSocket";
 import { useViewerTabs } from "@/hooks/useViewerTabs";
@@ -48,6 +50,11 @@ import {
   createDiagramOpenRequest,
   type DiagramOpenRequest,
 } from "@/lib/mobile-session-view-mode";
+import {
+  isNotificationEnabledForSession,
+  normalizeSessionNotificationSettings,
+  updateSessionNotificationSettings,
+} from "@/lib/session-notifications";
 import { getBaseName } from "@/utils/pathUtils";
 import {
   findRepoForSession,
@@ -56,6 +63,7 @@ import {
 
 export default function Dashboard() {
   const {
+    settings,
     isLoading: isSettingsLoading,
     getSetting,
     setSetting,
@@ -115,6 +123,8 @@ export default function Dashboard() {
     subscribeGrid,
     unsubscribeGrid,
     sessionStatuses,
+    sessionStatusSignals,
+    sessionAuqSignals,
     readFile,
     fileContent,
     browserSessions,
@@ -172,6 +182,78 @@ export default function Dashboard() {
   // null 以外のとき main 領域は RepoGridView に切り替わる。
   // selectedSessionId とは独立。セルクリックで selectedSessionId に切替えてターミナル表示に潜る
   const [gridRepoPath, setGridRepoPath] = useState<string | null>(null);
+
+  const sessionNotificationSettings = useMemo(
+    () =>
+      normalizeSessionNotificationSettings(
+        settings["sessionNotifications.enabledBySession"]
+      ),
+    [settings]
+  );
+
+  const sessionNotificationLabels = useMemo(() => {
+    const labels = new Map<string, string>();
+    for (const session of sessions.values()) {
+      const worktree = worktrees.find(item => item.id === session.worktreeId);
+      const customName = worktreeDisplayNames
+        .get(worktree?.path ?? session.worktreePath)
+        ?.trim();
+      labels.set(
+        session.id,
+        customName || worktree?.branch || getBaseName(session.worktreePath)
+      );
+    }
+    return labels;
+  }, [sessions, worktreeDisplayNames, worktrees]);
+
+  const handleOpenSessionFromNotification = useCallback(
+    (sessionId: string) => {
+      setGridRepoPath(null);
+      setSelectedSessionId(sessionId);
+      if (isMobile) {
+        setMobileActiveTab("session");
+        setMobileSessionSubView("detail");
+      }
+    },
+    [isMobile]
+  );
+
+  const sessionNotifications = useSessionNotifications({
+    statusSignals: sessionStatusSignals,
+    auqSignals: sessionAuqSignals,
+    sessionLabels: sessionNotificationLabels,
+    enabledBySession: sessionNotificationSettings,
+    onOpenSession: handleOpenSessionFromNotification,
+  });
+
+  const isSessionNotificationEnabled = useCallback(
+    (sessionId: string) =>
+      isNotificationEnabledForSession(sessionNotificationSettings, sessionId),
+    [sessionNotificationSettings]
+  );
+
+  const handleSessionNotificationEnabledChange = useCallback(
+    (sessionId: string, enabled: boolean) => {
+      setSetting(
+        "sessionNotifications.enabledBySession",
+        updateSessionNotificationSettings(
+          sessionNotificationSettings,
+          sessionId,
+          enabled
+        )
+      );
+    },
+    [sessionNotificationSettings, setSetting]
+  );
+
+  const notificationControl = (
+    <NotificationPermissionButton
+      supported={sessionNotifications.supported}
+      permission={sessionNotifications.permission}
+      onRequestPermission={sessionNotifications.requestPermission}
+      className={isMobile ? "h-12 w-12" : "h-8 w-8"}
+    />
+  );
 
   /** リポジトリヘッダクリック時: グリッドビューを開く */
   const handleSelectRepoGrid = useCallback((repoPath: string) => {
@@ -641,6 +723,12 @@ export default function Dashboard() {
           sessionsLoaded={sessionsLoaded}
           sessionStatuses={sessionStatuses}
           sessionAwaitingTexts={sessionAwaitingTexts}
+          notificationControl={notificationControl}
+          notificationsSupported={sessionNotifications.supported}
+          isSessionNotificationEnabled={isSessionNotificationEnabled}
+          onSessionNotificationEnabledChange={
+            handleSessionNotificationEnabledChange
+          }
         />
       ) : (
         <SidebarMainLayout
@@ -674,6 +762,12 @@ export default function Dashboard() {
               onSelectRepoGrid={handleSelectRepoGrid}
               gridRepoPath={gridRepoPath}
               gridStatuses={sessionStatuses}
+              notificationControl={notificationControl}
+              notificationsSupported={sessionNotifications.supported}
+              isSessionNotificationEnabled={isSessionNotificationEnabled}
+              onSessionNotificationEnabledChange={
+                handleSessionNotificationEnabledChange
+              }
             />
           }
           main={


### PR DESCRIPTION
セッションが人間の判断を待っていることをブラウザ通知で知らせる。

Closes #351

## なぜ

Ark の存在意義は複数の Claude Code セッションを管理することだが、**判断待ちに気づく手段が
無いと結局ポーリングになる**。実際、本セッション中に codex を 3 本並行で回して、何度も
`pgrep` で覗きに行った。ユーザーが複数セッションを持つときに起きるのと同じこと。

## 経路の選択

Issue の選択肢 1（Notification API）を実装した。**選択肢 2（Electron ネイティブ）と
3（Web Push）は本 PR の範囲外。**

案 3 はモバイル運用の本命だが、VAPID 鍵・Service Worker・購読の永続化が要る別規模の仕事。
先に**「いつ鳴らすか」の判定を固める**ことで、後から案 3 を足す土台にする。

そのため判定と手段を分離してある。

```
SessionNotificationDetector   状態遷移から「鳴らすべきか」を判定
SessionNotificationTransport  実際に鳴らす（今は Notification API）
```

案 3 では transport を差し替えるだけで済む。

## 鳴らす条件

| 条件 | シグナル |
| --- | --- |
| 権限確認待ち | `AWAITING` への遷移 |
| 質問待ち | `session:auq` の新規 timestamp |
| **完了** | `TOOL`/`THINK` → `IDLE`/`READY`/`ERR`/`STOP` |

3 つ目を入れたのは、長い作業を投げて席を離れたときに終了を知る手段が無かったため。

## 重複抑制

状態機械で同一状態の連続通知を抑制する。

- 継続中は鳴らさない。**状態が離れて戻ったときだけ**再通知する
- 初回 snapshot では鳴らさない（リロードのたびに鳴るのを防ぐ）
- AUQ 通知の直後に同じ質問由来の `AWAITING` を重ねない
- 複数タブは `localStorage` の 5 秒 lease で 1 タブに寄せる（best-effort）

## 未対応環境

- `Notification` が無ければ **UI ごと出さない**
- `default` / `denied` では生成しない
- 要求・生成が例外を投げてもサイレントに無効化する
- **起動直後に権限を要求しない。** 明示的なボタン操作でのみ要求する

## 検証

実装は codex、レビューは Claude（実装者 ≠ レビュアー）。

### 範囲の確認

```
ark/context/ .claude/ .gitignore への変更   0 件
新しい npm 依存                              0 件
Service Worker / PWA manifest / web-push     0 件
useEffect 内での権限要求                     なし
```

### テスト 17 ケース

```
初期描画では権限を自動要求せず、明示操作用ボタンを表示する
Notification API未対応環境ではUIを表示しない
AWAITINGへの遷移だけを通知し、継続中は重複通知しない
AWAITINGから離れて戻ったときは再通知する
初回停止状態や実行中から判断待ちへの遷移を完了扱いしない
初回snapshotがAWAITINGでもリロードだけでは通知しない
AUQは新しいイベントだけを通知する
AUQ通知の直後に同じ質問由来のAWAITING通知を重ねない
transportへ実引数を渡し、クリックで正しいセッションを開く
window focusが拒否されてもクリック先セッションを開く
セッション設定がoffならtransportを呼ばない
リーダータブでなければtransportを呼ばない
granted時だけNotificationを正しい引数で生成し、クリック後に閉じる
Notification APIが無い環境で要求・表示とも例外を投げない
ブラウザ実装が例外を投げてもサイレントに無効化する
有効なlease中は1タブだけがleaderになり、期限後に交代できる
boolean値だけを復元し、未設定セッションは呼び出し側で既定onにできる
```

### 変異テスト

権限判定を無効化するとテストが落ちることを確認した。復元後の一致も検証済み。

```
変異なし        exit=0
権限判定を無効化  exit=1  → 検出
復元            一致を確認
復元後          exit=0
```

### テスト全体

```
pnpm check   exit 0
pnpm test    exit 0   67 files / 1071 tests
pnpm build   exit 0
```

## レビュー中に起こした事故（本 PR とは無関係だが記録）

UI を実機で確認しようとして**同じマシンで 2 つ目の Ark サーバーを別ポートで起動した**ところ、
Ark の起動時自動復元が**稼働中の 6 セッションを掴んで競合する ttyd を 6 個起動した**。
71 秒で気づいて停止し、本番への影響は無い（HTTP 200 / tmux 6 セッション / ttyd は本番分のみ）。

分離されているのはポートだけで、**tmux サーバーと `sessions.db` は共有される**。
`knowledge/failures.md` に「共有状態を持つプロセスはポートを分けても分離されない」として
記録した。

この経緯により、**本 PR の UI は実ブラウザでの目視確認をしていない**。テストと型検査、
codex 側の Chromium 390×844 での確認（横 overflow なし・権限自動要求 0 回）に依っている。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * セッションの状態変化や質問をブラウザ通知で受け取れるようになりました。
  * 通知権限をボタンから明示的に許可・変更できるようになりました。
  * セッションごとに通知のオン／オフを切り替えられます。
  * 通知をクリックすると、該当セッションを開けます。
  * モバイル・サイドバーのセッション一覧にも通知設定を追加しました。

* **テスト**
  * 通知権限、非対応環境、通知配信、重複防止などの動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->