### PR TITLE
fix(context): teardown の派生物失敗を記録し次回 init の補償対象にする

### DIFF
--- a/ark/context/README.md
+++ b/ark/context/README.md
@@ -50,6 +50,13 @@ rotate、rewrite しない。capture、summary、restart は raw/summary の削�
 持たず、session 終了後も保持する。削除は Ark lifecycle が session directory 全体を
 明示的に削除するときだけ行う。
 
+teardown の summary / handoff / inbox 最終化が失敗した場合も、失敗 stage を
+`session_finalization_failed` として同じ raw.log へ記録し、settings は独立して復元する。
+owner は pending marker として残し、次回 init が settings lock 下で再試行する。再試行は
+3 回までとし、上限到達時は `session_finalization_abandoned` を raw.log へ記録してから
+新しい owner へ進む。Goal / Plan がまだ起票されていない空 task scaffold は handoff の
+最終化対象外であり、それだけを理由に owner を残さない。
+
 機械 summary は時刻・locale 非依存で、raw の error 本文を含めず、必ず raw line
 参照を持つ。LLM summary は `[context.summarize] llm = true` と model、API key がすべて
 揃った明示 opt-in の場合だけ試行する。Anthropic Messages API へ送る入力は機械

--- a/ark/context/scripts/lib/finalization.sh
+++ b/ark/context/scripts/lib/finalization.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+
+ctx_finalization_add_failure() {
+  local stage=$1
+  CTX_FINALIZATION_FAILED_STAGES="${CTX_FINALIZATION_FAILED_STAGES}${CTX_FINALIZATION_FAILED_STAGES:+,}$stage"
+}
+
+ctx_finalization_empty_task_scaffold() {
+  local task=$1
+  ctx_validate_xdg_file "$task" || return 1
+  awk '
+    BEGIN { section = ""; goal = 0; plan = 0; artifacts = 0; invalid = 0 }
+    /^## Goal$/ { goal++; section = "goal"; next }
+    /^## Constraints$/ { section = "constraints"; next }
+    /^## Plan$/ { plan++; section = "plan"; next }
+    /^## Artifacts$/ { artifacts++; section = "artifacts"; next }
+    /^## / { section = "other"; next }
+    section == "goal" && length($0) > 0 { invalid = 1 }
+    section == "plan" && length($0) > 0 { invalid = 1 }
+    END { exit !(goal == 1 && plan == 1 && artifacts == 1 && invalid == 0) }
+  ' "$task"
+}
+
+ctx_finalization_record_failure() {
+  local session=$1 phase=$2 attempt=$3 stage=$4 raw marker
+  case "$phase" in teardown|recovery) ;; *) return 1 ;; esac
+  case "$stage" in summary|handoff|inbox) ;; *) return 1 ;; esac
+  case "$attempt" in ''|*[!0-9]*) return 1 ;; esac
+  raw="$session/errors/raw.log"
+  marker='"tool":"ark/context","error_type":"session_finalization_failed","exit_code":null,"is_interrupt":null,"error":"session finalization failed","details":{"attempt":'"$attempt"',"phase":"'"$phase"'","stage":"'"$stage"'"}}'
+  if ctx_validate_xdg_file "$raw" >/dev/null 2>&1 \
+    && grep -F "$marker" "$raw" >/dev/null 2>&1; then
+    return 0
+  fi
+  printf '%s\n' \
+    '{"tool":"ark/context","error_type":"session_finalization_failed","exit_code":null,"is_interrupt":null,"error":"session finalization failed","details":{"attempt":'"$attempt"',"phase":"'"$phase"'","stage":"'"$stage"'"}}' \
+    | env ARK_SESSION_DIR="$session" /bin/bash "$ARK_SOURCE_ROOT/ark/context/hooks/capture-error.sh" \
+      >/dev/null 2>&1
+  ctx_validate_xdg_file "$raw" >/dev/null 2>&1 \
+    && grep -F "$marker" "$raw" >/dev/null 2>&1
+}
+
+ctx_finalization_record_abandoned() {
+  local session=$1 attempt=$2 stages=$3 raw marker
+  case "$attempt" in ''|*[!0-9]*) return 1 ;; esac
+  case "$stages" in
+    summary|handoff|inbox|summary,handoff|summary,inbox|handoff,inbox|summary,handoff,inbox) ;;
+    *) return 1 ;;
+  esac
+  raw="$session/errors/raw.log"
+  marker='"tool":"ark/context","error_type":"session_finalization_abandoned","exit_code":null,"is_interrupt":null,"error":"pending session finalization abandoned","details":{"attempt":'"$attempt"',"stages":"'"$stages"'"}}'
+  if ctx_validate_xdg_file "$raw" >/dev/null 2>&1 \
+    && grep -F "$marker" "$raw" >/dev/null 2>&1; then
+    return 0
+  fi
+  printf '%s\n' \
+    '{"tool":"ark/context","error_type":"session_finalization_abandoned","exit_code":null,"is_interrupt":null,"error":"pending session finalization abandoned","details":{"attempt":'"$attempt"',"stages":"'"$stages"'"}}' \
+    | env ARK_SESSION_DIR="$session" /bin/bash "$ARK_SOURCE_ROOT/ark/context/hooks/capture-error.sh" \
+      >/dev/null 2>&1
+  ctx_validate_xdg_file "$raw" >/dev/null 2>&1 \
+    && grep -F "$marker" "$raw" >/dev/null 2>&1
+}
+
+ctx_finalization_next_recovery_attempt() {
+  local session=$1 raw attempts value max
+  raw="$session/errors/raw.log"
+  max=0
+  if [ ! -e "$raw" ] && [ ! -L "$raw" ]; then
+    printf '%s\n' 1
+    return 0
+  fi
+  ctx_validate_xdg_file "$raw" || return 1
+  attempts=$(jq -r '
+    select(.tool == "ark/context"
+      and .error_type == "session_finalization_failed"
+      and .details.phase == "recovery")
+    | .details.attempt
+  ' "$raw") || return 1
+  while IFS= read -r value || [ -n "$value" ]; do
+    [ -n "$value" ] || continue
+    case "$value" in ''|*[!0-9]*) return 1 ;; esac
+    [ "$value" -le 3 ] || return 1
+    [ "$value" -le "$max" ] || max=$value
+  done <<EOF
+$attempts
+EOF
+  [ "$max" -lt 3 ] || { printf '%s\n' 3; return 0; }
+  printf '%s\n' "$((max + 1))"
+}
+
+ctx_finalize_session_derivatives() {
+  local session=$1 repo=$2 session_id=$3 phase=$4 attempt=$5
+  local work_id knowledge_lock knowledge_backend knowledge_pid knowledge_token inbox_failed stage
+  CTX_FINALIZATION_FAILED_STAGES=
+
+  env ARK_SESSION_DIR="$session" CTX_CONFIG_FILE="$CTX_CONFIG_FILE" \
+    /bin/bash "$ARK_SOURCE_ROOT/ark/context/scripts/summarize-errors.sh" >/dev/null 2>&1 \
+    || ctx_finalization_add_failure summary
+  if ctx_finalization_empty_task_scaffold "$session/task.md" >/dev/null 2>&1; then
+    :
+  else
+    ctx_handoff_write "$session" "$repo" "$session_id" >/dev/null 2>&1 \
+      || ctx_finalization_add_failure handoff
+  fi
+
+  inbox_failed=0
+  work_id=$(ctx_work_id_from_repo "$repo" 2>/dev/null) || inbox_failed=1
+  if [ "$inbox_failed" -eq 0 ]; then
+    knowledge_lock="$ARK_KNOWLEDGE_DIR/failures-inbox.lock"
+    if ctx_lock_acquire "$knowledge_lock" 8 5 30 mkdir-direct >/dev/null 2>&1; then
+      knowledge_backend=$CTX_LOCK_ACQUIRED_BACKEND
+      knowledge_pid=$CTX_LOCK_ACQUIRED_PID
+      knowledge_token=$CTX_LOCK_ACQUIRED_TOKEN
+      ctx_failures_inbox_append "$session" "$ARK_KNOWLEDGE_DIR" "$work_id" "$session_id" \
+        >/dev/null 2>&1 || inbox_failed=1
+      ctx_session_failures_inbox_append "$session" "$ARK_KNOWLEDGE_DIR" "$work_id" "$session_id" \
+        >/dev/null 2>&1 || inbox_failed=1
+      ctx_lock_release "$knowledge_lock" "$knowledge_backend" "$knowledge_pid" "$knowledge_token" \
+        >/dev/null 2>&1 || inbox_failed=1
+    else
+      inbox_failed=1
+    fi
+  fi
+  [ "$inbox_failed" -eq 0 ] || ctx_finalization_add_failure inbox
+
+  if [ -n "$CTX_FINALIZATION_FAILED_STAGES" ]; then
+    while IFS= read -r stage || [ -n "$stage" ]; do
+      [ -n "$stage" ] || continue
+      ctx_finalization_record_failure "$session" "$phase" "$attempt" "$stage" >/dev/null 2>&1 || true
+    done <<EOF
+$(printf '%s\n' "$CTX_FINALIZATION_FAILED_STAGES" | tr ',' '\n')
+EOF
+    return 1
+  fi
+  return 0
+}

--- a/ark/context/scripts/session-init.sh
+++ b/ark/context/scripts/session-init.sh
@@ -7,6 +7,7 @@ ARK_SOURCE_ROOT=$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd -P) || exit 1
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/task-template.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/handoff.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/failures-knowledge.sh"
+. "$ARK_SOURCE_ROOT/ark/context/scripts/lib/finalization.sh"
 . "$ARK_SOURCE_ROOT/ark/context/adapters/claude-code/settings.sh"
 
 session_disabled() {
@@ -130,6 +131,9 @@ if owner_read "$owner"; then
     old_session="$CTX_DATA_ROOT/sessions/$OWNER_SESSION"
     old_cache="$CTX_CACHE_ROOT/$OWNER_SESSION"
     old_session_safe=0
+    finalization_succeeded=1
+    recovery_attempt=0
+    finalization_abandoned=0
     if ctx_validate_xdg_dir "$old_session" >/dev/null 2>&1; then
       old_session_canonical=$(cd "$old_session" 2>/dev/null && pwd -P) || old_session_canonical=
       [ "$old_session_canonical" = "$old_session" ] && old_session_safe=1
@@ -139,22 +143,15 @@ if owner_read "$owner"; then
       ARK_SESSION_DIR=$old_session
       ARK_CACHE_DIR=$old_cache
       export ARK_SESSION_ID ARK_SESSION_DIR ARK_CACHE_DIR
-      env ARK_SESSION_DIR="$ARK_SESSION_DIR" CTX_CONFIG_FILE="$CTX_CONFIG_FILE" \
-        /bin/bash "$ARK_SOURCE_ROOT/ark/context/scripts/summarize-errors.sh" >/dev/null 2>&1 || true
-      ctx_handoff_write "$ARK_SESSION_DIR" "$repo" "$OWNER_SESSION" >/dev/null 2>&1 || true
-      old_work_id=$(ctx_work_id_from_repo "$repo" 2>/dev/null) || old_work_id=
-      if [ -n "$old_work_id" ]; then
-        knowledge_lock="$ARK_KNOWLEDGE_DIR/failures-inbox.lock"
-        if ctx_lock_acquire "$knowledge_lock" 8 5 30 mkdir-direct >/dev/null 2>&1; then
-          knowledge_backend=$CTX_LOCK_ACQUIRED_BACKEND
-          knowledge_pid=$CTX_LOCK_ACQUIRED_PID
-          knowledge_token=$CTX_LOCK_ACQUIRED_TOKEN
-          ctx_failures_inbox_append "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" \
-            "$old_work_id" "$OWNER_SESSION" >/dev/null 2>&1 || true
-          ctx_session_failures_inbox_append "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" \
-            "$old_work_id" "$OWNER_SESSION" >/dev/null 2>&1 || true
-          ctx_lock_release "$knowledge_lock" "$knowledge_backend" "$knowledge_pid" "$knowledge_token" \
-            >/dev/null 2>&1 || true
+      recovery_attempt=$(ctx_finalization_next_recovery_attempt "$ARK_SESSION_DIR" 2>/dev/null) \
+        || recovery_attempt=3
+      if ! ctx_finalize_session_derivatives "$ARK_SESSION_DIR" "$repo" "$OWNER_SESSION" \
+        recovery "$recovery_attempt"; then
+        finalization_succeeded=0
+        if [ "$recovery_attempt" -ge 3 ]; then
+          ctx_finalization_record_abandoned "$ARK_SESSION_DIR" "$recovery_attempt" \
+            "$CTX_FINALIZATION_FAILED_STAGES" >/dev/null 2>&1 || true
+          finalization_abandoned=1
         fi
       fi
       if ctx_validate_xdg_dir "$ARK_CACHE_DIR" >/dev/null 2>&1 \
@@ -170,6 +167,10 @@ if owner_read "$owner"; then
       reason=${CLAUDE_SETTINGS_FAILURE_REASON:-orphan settings restore failed}
       release_lock
       session_disabled "$reason"
+    fi
+    if [ "$finalization_succeeded" -eq 0 ] && [ "$finalization_abandoned" -eq 0 ]; then
+      release_lock
+      session_disabled "pending session finalization retry failed"
     fi
     command rm -f "$owner" || { release_lock; session_disabled "orphan owner cleanup failed"; }
   fi

--- a/ark/context/scripts/session-teardown.sh
+++ b/ark/context/scripts/session-teardown.sh
@@ -5,6 +5,7 @@ ARK_SOURCE_ROOT=$(cd "$(dirname "$0")/../../.." 2>/dev/null && pwd -P) || exit 1
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/lock.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/handoff.sh"
 . "$ARK_SOURCE_ROOT/ark/context/scripts/lib/failures-knowledge.sh"
+. "$ARK_SOURCE_ROOT/ark/context/scripts/lib/finalization.sh"
 . "$ARK_SOURCE_ROOT/ark/context/adapters/claude-code/settings.sh"
 
 repo=
@@ -33,23 +34,9 @@ if ctx_validate_xdg_file "$owner" >/dev/null 2>&1; then
   [ "$owner_session" = "$session" ] && owned=1
 fi
 
-env ARK_SESSION_DIR="$ARK_SESSION_DIR" CTX_CONFIG_FILE="$CTX_CONFIG_FILE" \
-  /bin/bash "$ARK_SOURCE_ROOT/ark/context/scripts/summarize-errors.sh" >/dev/null 2>&1 || true
-ctx_handoff_write "$ARK_SESSION_DIR" "$repo" "$session" >/dev/null 2>&1 || true
-work_id=$(ctx_work_id_from_repo "$repo" 2>/dev/null) || work_id=
-if [ -n "$work_id" ]; then
-  knowledge_lock="$ARK_KNOWLEDGE_DIR/failures-inbox.lock"
-  if ctx_lock_acquire "$knowledge_lock" 8 5 30 mkdir-direct >/dev/null 2>&1; then
-    knowledge_backend=$CTX_LOCK_ACQUIRED_BACKEND
-    knowledge_pid=$CTX_LOCK_ACQUIRED_PID
-    knowledge_token=$CTX_LOCK_ACQUIRED_TOKEN
-    ctx_failures_inbox_append "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" "$work_id" "$session" \
-      >/dev/null 2>&1 || true
-    ctx_session_failures_inbox_append "$ARK_SESSION_DIR" "$ARK_KNOWLEDGE_DIR" "$work_id" "$session" \
-      >/dev/null 2>&1 || true
-    ctx_lock_release "$knowledge_lock" "$knowledge_backend" "$knowledge_pid" "$knowledge_token" \
-      >/dev/null 2>&1 || true
-  fi
+finalization_succeeded=0
+if ctx_finalize_session_derivatives "$ARK_SESSION_DIR" "$repo" "$session" teardown 0; then
+  finalization_succeeded=1
 fi
 
 restore_succeeded=0
@@ -66,7 +53,8 @@ if ctx_validate_xdg_dir "$ARK_SESSION_DIR" >/dev/null 2>&1 \
   && ctx_validate_xdg_file "$ARK_SESSION_DIR/stop_once" >/dev/null 2>&1; then
   command rm -f "$ARK_SESSION_DIR/stop_once" 2>/dev/null || true
 fi
-if [ "$owned" -eq 1 ] && [ "$restore_succeeded" -eq 1 ]; then
+if [ "$owned" -eq 1 ] && [ "$restore_succeeded" -eq 1 ] \
+  && [ "$finalization_succeeded" -eq 1 ]; then
   command rm -f "$owner" "$CTX_REPO_STATE_DIR/owner.new" 2>/dev/null || true
 fi
 ctx_lock_release "$lock" "$lock_backend" "$lock_pid" "$lock_token" >/dev/null 2>&1 || true

--- a/ark/context/tests/test-session-lifecycle.sh
+++ b/ark/context/tests/test-session-lifecycle.sh
@@ -85,6 +85,36 @@ prepare_lifecycle_output() {
   seed_step_count "$output_cache" 7
 }
 
+break_finalization_stage() {
+  broken_stage=$1
+  case "$broken_stage" in
+    summary) broken_target="$ARK_SOURCE_FIXTURE/ark/context/scripts/summarize-errors.sh" ;;
+    handoff) broken_target="$ARK_SOURCE_FIXTURE/ark/context/scripts/lib/handoff.sh" ;;
+    inbox) broken_target="$ARK_SOURCE_FIXTURE/ark/context/scripts/lib/failures-knowledge.sh" ;;
+    *) return 1 ;;
+  esac
+  broken_backup="$TEST_TMP/finalization-$broken_stage.backup"
+  command cp -f "$broken_target" "$broken_backup" || return 1
+  broken_checksum=$(cksum <"$broken_backup") || return 1
+  case "$broken_stage" in
+    summary)
+      printf '%s\n' '#!/usr/bin/env bash' 'exit 1' >"$broken_target" || return 1
+      ;;
+    handoff)
+      printf '%s\n' '' 'ctx_handoff_write() { return 1; }' >>"$broken_target" || return 1
+      ;;
+    inbox)
+      printf '%s\n' '' 'ctx_failures_inbox_append() { return 1; }' >>"$broken_target" || return 1
+      ;;
+  esac
+}
+
+restore_finalization_stage() {
+  command cp -f "$broken_backup" "$broken_target" || return 1
+  [ "$broken_checksum" = "$(cksum <"$broken_target")" ] || return 1
+  command diff -q "$broken_backup" "$broken_target" >/dev/null 2>&1
+}
+
 run_registered_hook() {
   registered_command=$1
   registered_input=$2
@@ -412,6 +442,184 @@ jq -e '.permissions.deny | index("TodoWrite") != null' "$restore_fail_settings" 
 [ ! -e "$restore_fail_cache/steps" ] || test_fail "restore failure left steps"
 [ ! -e "$restore_fail_state/settings.lock" ] || test_fail "restore failure left settings lock"
 [ ! -e "$knowledge/failures-inbox.lock" ] || test_fail "restore failure left knowledge lock"
+
+for failed_stage in summary handoff inbox; do
+  setup_repo "teardown-$failed_stage-failure"
+  failed_settings="$repo/.claude/settings.local.json"
+  printf '{\n  "before": "%s-finalization"\n}\n' "$failed_stage" >"$failed_settings"
+  chmod 640 "$failed_settings"
+  command cp -f "$failed_settings" "$TEST_TMP/$failed_stage-settings-original"
+  case "$failed_stage" in
+    summary)
+      failed_sid=d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4d4
+      recovered_sid=e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4e4
+      ;;
+    handoff)
+      failed_sid=d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5d5
+      recovered_sid=e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5e5
+      ;;
+    inbox)
+      failed_sid=d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6d6
+      recovered_sid=e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6e6
+      ;;
+  esac
+  /bin/sleep 60 & failed_owner_pid=$!
+  run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$failed_owner_pid" \
+    --session-id "$failed_sid" --goal "Finalization $failed_stage" --plan-item "Finish $failed_stage"
+  assert_success "$failed_stage failure source init succeeds"
+  assert_eq "$failed_stage failure source is enabled" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
+  failed_session=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
+  failed_cache=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
+  failed_state="$XDG_DATA_HOME/ark/context/repos/$(ctx_sha256 "$repo")"
+  prepare_lifecycle_output "$failed_session" "$failed_cache"
+  finalization_host_inbox="$XDG_DATA_HOME/ark/context/knowledge/failures-inbox.md"
+  finalization_candidate_before=$(grep -Fc -- \
+    '### Candidate: ark/context / session_finalization_failed' \
+    "$finalization_host_inbox" 2>/dev/null || true)
+  command cp -f "$failed_state/owner" "$TEST_TMP/$failed_stage-owner-original"
+  failed_owner_mode=$(ctx_stat "$failed_state/owner" | awk '{print $2}')
+  break_finalization_stage "$failed_stage" || test_fail "$failed_stage fault injection failed"
+  run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$failed_sid"
+  assert_success "$failed_stage failure teardown reaches the end"
+  cmp -s "$failed_settings" "$TEST_TMP/$failed_stage-settings-original" \
+    || test_fail "$failed_stage failure teardown did not restore settings bytes"
+  assert_eq "$failed_stage failure teardown restores settings mode" 640 \
+    "$(ctx_stat "$failed_settings" | awk '{print $2}')"
+  cmp -s "$failed_state/owner" "$TEST_TMP/$failed_stage-owner-original" \
+    || test_fail "$failed_stage failure changed pending owner content"
+  assert_eq "$failed_stage failure preserves owner mode" "$failed_owner_mode" \
+    "$(ctx_stat "$failed_state/owner" | awk '{print $2}')"
+  assert_eq "$failed_stage failure records exact JSONL stage" 1 \
+    "$(jq -c --arg stage "$failed_stage" '
+      select(.tool == "ark/context"
+        and .error_type == "session_finalization_failed"
+        and .exit_code == null
+        and .is_interrupt == null
+        and .error == "session finalization failed"
+        and .details == {attempt:0,phase:"teardown",stage:$stage})
+    ' "$failed_session/errors/raw.log" | wc -l | tr -d ' ')"
+  restore_finalization_stage || test_fail "$failed_stage fault injection was not restored"
+  kill "$failed_owner_pid"; wait "$failed_owner_pid" 2>/dev/null || true
+  run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id "$recovered_sid" \
+    --goal "Recovered $failed_stage" --plan-item "Continue $failed_stage"
+  assert_success "$failed_stage pending recovery exits successfully"
+  assert_eq "$failed_stage pending recovery enables the new session" $'enabled\t1' \
+    "$(sed -n '1p' "$CASE_STDOUT")"
+  assert_eq "$failed_stage recovery publishes exact new owner session" "$recovered_sid" \
+    "$(cut -f1 "$failed_state/owner")"
+  grep -F 'session_finalization_failed' "$failed_session/errors/summary.md" >/dev/null 2>&1 \
+    || test_fail "$failed_stage recovery summary omits the recorded failure"
+  grep -F "Goal: Finalization $failed_stage" "$failed_session/handoff.md" >/dev/null 2>&1 \
+    || test_fail "$failed_stage recovery handoff content is wrong"
+  assert_eq "$failed_stage recovery inbox adds the recorded error type once" \
+    "$((finalization_candidate_before + 1))" \
+    "$(grep -Fc -- '### Candidate: ark/context / session_finalization_failed' \
+      "$finalization_host_inbox")"
+  run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$recovered_sid"
+  assert_success "$failed_stage recovered session teardown succeeds"
+done
+
+setup_repo finalization-retry-limit
+retry_settings="$repo/.claude/settings.local.json"
+printf '%s\n' '{"retry-limit":"original"}' >"$retry_settings"
+chmod 640 "$retry_settings"
+command cp -f "$retry_settings" "$TEST_TMP/retry-settings-original"
+retry_old_sid=d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7d7
+retry_new_sid=e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7e7
+/bin/sleep 60 & retry_owner_pid=$!
+run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$retry_owner_pid" \
+  --session-id "$retry_old_sid" --goal 'Retry finalization' --plan-item 'Retry handoff'
+assert_success "retry-limit source init succeeds"
+retry_session=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
+retry_cache=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
+retry_state="$XDG_DATA_HOME/ark/context/repos/$(ctx_sha256 "$repo")"
+prepare_lifecycle_output "$retry_session" "$retry_cache"
+command cp -f "$retry_state/owner" "$TEST_TMP/retry-owner-original"
+break_finalization_stage handoff || test_fail "retry-limit fault injection failed"
+run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$retry_old_sid"
+assert_success "retry-limit teardown reaches settings restore"
+cmp -s "$retry_settings" "$TEST_TMP/retry-settings-original" \
+  || test_fail "retry-limit teardown did not restore settings bytes"
+cmp -s "$retry_state/owner" "$TEST_TMP/retry-owner-original" \
+  || test_fail "retry-limit teardown did not preserve owner bytes"
+kill "$retry_owner_pid"; wait "$retry_owner_pid" 2>/dev/null || true
+retry_number=1
+while [ "$retry_number" -le 2 ]; do
+  run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id "$retry_new_sid" \
+    --goal 'After retry limit' --plan-item 'Start replacement'
+  assert_success "pending retry $retry_number exits successfully"
+  assert_eq "pending retry $retry_number stays disabled" $'enabled\t0' "$(sed -n '1p' "$CASE_STDOUT")"
+  assert_eq "pending retry $retry_number reports finalization failure" \
+    $'reason\tpending session finalization retry failed' "$(sed -n '2p' "$CASE_STDOUT")"
+  cmp -s "$retry_state/owner" "$TEST_TMP/retry-owner-original" \
+    || test_fail "pending retry $retry_number changed owner bytes"
+  cmp -s "$retry_settings" "$TEST_TMP/retry-settings-original" \
+    || test_fail "pending retry $retry_number changed restored settings bytes"
+  retry_number=$((retry_number + 1))
+done
+run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id "$retry_new_sid" \
+  --goal 'After retry limit' --plan-item 'Start replacement'
+assert_success "pending retry limit exits successfully"
+assert_eq "pending retry limit gives up and enables replacement" $'enabled\t1' "$(sed -n '1p' "$CASE_STDOUT")"
+assert_eq "retry limit records each exact recovery attempt" '1 2 3' \
+  "$(jq -r '
+    select(.tool == "ark/context"
+      and .error_type == "session_finalization_failed"
+      and .details.phase == "recovery"
+      and .details.stage == "handoff")
+    | .details.attempt
+  ' "$retry_session/errors/raw.log" | tr '\n' ' ' | sed 's/ $//')"
+assert_eq "retry limit records exact abandonment content" 1 \
+  "$(jq -c '
+    select(.tool == "ark/context"
+      and .error_type == "session_finalization_abandoned"
+      and .exit_code == null
+      and .is_interrupt == null
+      and .error == "pending session finalization abandoned"
+      and .details == {attempt:3,stages:"handoff"})
+  ' "$retry_session/errors/raw.log" | wc -l | tr -d ' ')"
+assert_eq "retry limit replaces old owner with requested session" "$retry_new_sid" \
+  "$(cut -f1 "$retry_state/owner")"
+restore_finalization_stage || test_fail "retry-limit fault injection was not restored"
+run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$retry_new_sid"
+assert_success "retry-limit replacement teardown succeeds"
+
+setup_repo concurrent-pending-finalization
+concurrent_old_sid=d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8d8
+/bin/sleep 60 & concurrent_pending_owner=$!
+run_case /bin/bash "$INIT" --repo "$repo" --owner-pid "$concurrent_pending_owner" \
+  --session-id "$concurrent_old_sid" --goal 'Concurrent pending' --plan-item 'Recover once'
+assert_success "concurrent pending source init succeeds"
+concurrent_old_session=$(awk -F '\t' '$1=="ARK_SESSION_DIR"{print $2}' "$CASE_STDOUT")
+concurrent_old_cache=$(awk -F '\t' '$1=="ARK_CACHE_DIR"{print $2}' "$CASE_STDOUT")
+concurrent_pending_state="$XDG_DATA_HOME/ark/context/repos/$(ctx_sha256 "$repo")"
+prepare_lifecycle_output "$concurrent_old_session" "$concurrent_old_cache"
+break_finalization_stage summary || test_fail "concurrent pending fault injection failed"
+run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$concurrent_old_sid"
+assert_success "concurrent pending teardown reaches the end"
+restore_finalization_stage || test_fail "concurrent pending fault injection was not restored"
+kill "$concurrent_pending_owner"; wait "$concurrent_pending_owner" 2>/dev/null || true
+concurrent_pending_out1="$TEST_TMP/concurrent-pending-1.out"
+concurrent_pending_out2="$TEST_TMP/concurrent-pending-2.out"
+/bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id e8e8e8e8e8e8e8e8e8e8e8e8e8e8e8e8 \
+  --goal 'Pending winner one' --plan-item 'Own repo' >"$concurrent_pending_out1" 2>"$TEST_TMP/concurrent-pending-1.err" & pending_p1=$!
+/bin/bash "$INIT" --repo "$repo" --owner-pid "$$" --session-id e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9e9 \
+  --goal 'Pending winner two' --plan-item 'Own repo' >"$concurrent_pending_out2" 2>"$TEST_TMP/concurrent-pending-2.err" & pending_p2=$!
+wait "$pending_p1"; pending_c1=$?; wait "$pending_p2"; pending_c2=$?
+assert_eq "concurrent pending init process one" 0 "$pending_c1"
+assert_eq "concurrent pending init process two" 0 "$pending_c2"
+assert_eq "concurrent pending recovery has one winner" 1 \
+  "$(grep -l $'enabled\t1' "$concurrent_pending_out1" "$concurrent_pending_out2" | wc -l | tr -d ' ')"
+assert_eq "concurrent pending recovery has one loser" 1 \
+  "$(grep -l $'enabled\t0' "$concurrent_pending_out1" "$concurrent_pending_out2" | wc -l | tr -d ' ')"
+concurrent_pending_winner=$(awk -F '\t' '$1=="ARK_SESSION_ID"{print $2}' \
+  "$concurrent_pending_out1" "$concurrent_pending_out2")
+assert_eq "concurrent pending owner content matches winner" "$concurrent_pending_winner" \
+  "$(cut -f1 "$concurrent_pending_state/owner")"
+grep -F 'Goal: Concurrent pending' "$concurrent_old_session/handoff.md" >/dev/null 2>&1 \
+  || test_fail "concurrent pending recovery did not finalize old handoff content"
+run_case /bin/bash "$TEARDOWN" --repo "$repo" --session-id "$concurrent_pending_winner"
+assert_success "concurrent pending winner teardown succeeds"
 
 setup_repo restart-flow
 old_sid=abababababababababababababababab

--- a/packages/server/src/lib/session-orchestrator-context.integration.test.ts
+++ b/packages/server/src/lib/session-orchestrator-context.integration.test.ts
@@ -66,7 +66,11 @@ const savedXdg = {
 };
 
 beforeAll(() => {
-  testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ark-context-integration-"));
+  // macOS の os.tmpdir() は /var 配下を返すが、/var は /private/var への
+  // symlink。XDG fixture は派生物生成の正常系にするため、先に正規化する。
+  testRoot = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ark-context-integration-"))
+  );
   const realRoot = path.join(testRoot, "real");
   const linkedRoot = path.join(testRoot, "link");
   fs.mkdirSync(realRoot, { mode: 0o700 });


### PR DESCRIPTION
`session-teardown.sh` が派生物の生成失敗を無音で握り潰す問題を直した。

Closes #355

## 何が起きていたか

teardown は summary / handoff / inbox の最終化を `|| true` で握り潰し、成否を記録して
いなかった。owner marker の除去条件は settings 復元の成否だけなので、**派生物の生成に
失敗しても owner は消え、次回 init の補償対象にならなかった**。

失敗が**無音**である点が本質で、#352 / #357 / #365 / #369 / #372 / #373 と同じクラス。
本プロジェクトで 7 回目になる。

## 深刻度は低い

`handoff.md` / `summary.md` / inbox 候補はいずれも `task.md` と `errors/raw.log` から
**再生成可能な派生物**で、teardown は session directory を削除しないため元データは残る。
失われるのは派生ファイルだけ。

そのため**大掛かりな再試行機構は作っていない**。目的は「失敗したことが分かる」ことと
「次回 init が拾える」ことに絞った。

## 変更

`ark/context/scripts/lib/finalization.sh` を新設し、3 つの最終化の成否を個別に集計する。

- 失敗した stage / phase / attempt を**既存の `errors/raw.log`** へ
  `session_finalization_failed` として記録する（新しいファイル形式は増やしていない）
- **settings 復元と全派生物が成功したときだけ** owner を削除する
- **settings 復元は派生物の失敗に関係なく必ず行う。** 復元しないと対象 repo の
  `.claude/settings.json` が Ark の注入したままになる
- 次回 init が既存の settings lock 内で旧 session を再試行する
- **3 回失敗したら `session_finalization_abandoned` を記録して新しい owner へ移る。**
  無限に滞留させない

空の task scaffold は handoff の対象外にしている。

## 検証

実装は codex、レビューは Claude（実装者 ≠ レビュアー）。

### 範囲

```
packages/ .claude/ .gitignore への変更   0 件
新しい設定項目・環境変数                  0 件
```

`CTX_FINALIZATION_FAILED_STAGES` は関数の結果を返す内部変数で、既存の
`CTX_LOCK_ACQUIRED_*` と同じ扱い。ユーザーが設定するものではない。

### テスト

5 シナリオ・55 アサーションを追加。stage 別の失敗、owner の保持と削除、settings 復元、
init の再試行、上限、pending と並行する init を**内容比較**で検証している。

```
pnpm check       exit 0
pnpm test        exit 0   65 files / 1045 tests
pnpm build       exit 0
session-lifecycle         272/272 passed
```

### 変異テスト

レビュー側が独立に測った。

```
失敗の記録名を変える            → 検出
上限 -ge 3 を -ge 4 にする      → 検出
諦め処理を無効化                → 検出
```

**最初の測定でレビュー側が変異箇所を誤った。** `finalization.sh` の `3`（attempt 番号の
計算とその clamp）を変えても検出されず、テスト不足を疑ったが、実際の上限判定は
`session-init.sh` の `[ "$recovery_attempt" -ge 3 ]` だった。正しい箇所を変異させると
両方とも検出される。

`finalization.sh` 側の `3` が変異に耐えるのは、`|| recovery_attempt=3` の fallback と
`[ "$value" -le 3 ]` の入力検証が二重に効いているため。**冗長なガードが変異を打ち消す**
形になっており、テストの不足ではない。

## codex が報告した新しい失敗

> zsh の `status` は read-only parameter なので検証用変数に使わない。
> 異なる path の `cksum file` はファイル名込みで比較不能なため、`cksum <file` と
> `diff -q` を使う

前者は zsh 固有で再発しうるため `knowledge/failures.md` への昇格を検討する。
