### PR TITLE
fix(web): サイドバーでリポジトリ名が見えなくなるのを直す

### DIFF
--- a/packages/web/src/components/SessionSidebar.tsx
+++ b/packages/web/src/components/SessionSidebar.tsx
@@ -182,20 +182,20 @@ export function SessionSidebar({
   );
 
   // リポジトリヘッダのプロファイルキャプション。
-  // ピル型バッジではなく "・ デフォルト: KB2" のような小さなテキストで表示し、
+  // ピル型バッジではなく "・ KB2" のような小さなテキストで表示し、
   // worktree 側のピル型バッジと視覚的に区別する。
   // クリックでプロファイル選択ドロップダウンを開ける (3点リーダーからは撤去済)。
   const renderRepoProfileCaption = (repoPath: string | undefined) => {
     if (!multiProfileEnabled || !repoPath) return null;
     const linkedId = repoProfileLinks?.get(repoPath) ?? null;
     const profile = linkedId ? profileById.get(linkedId) : undefined;
-    const labelText = profile ? profile.name : "既定 (~/.claude)";
+    const labelText = profile ? profile.name : "既定";
     const canChange = !!onSetRepoProfile && !!onOpenProfileManager;
 
     const caption = (
-      <span className="shrink-0 normal-case text-[11px] text-muted-foreground/80">
+      <span className="min-w-[3.5rem] max-w-[45%] shrink normal-case text-[11px] text-muted-foreground/80 truncate">
         <span className="mr-1">・</span>
-        デフォルト: <span className="text-foreground/80">{labelText}</span>
+        <span className="text-foreground/80">{labelText}</span>
       </span>
     );
 
@@ -217,15 +217,15 @@ export function SessionSidebar({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className="shrink-0 normal-case text-[11px] text-muted-foreground/80 hover:text-foreground transition-colors"
+            className="min-w-[3.5rem] max-w-[45%] shrink normal-case text-[11px] text-muted-foreground/80 hover:text-foreground transition-colors truncate"
             title={
               profile
-                ? `リポジトリのデフォルトプロファイル: ${profile.name} (クリックで変更)`
-                : "リポジトリのデフォルトプロファイル: 既定 (~/.claude) (クリックで変更)"
+                ? `リポジトリのデフォルトプロファイル: ${profile.name} (${profile.configDir})。クリックで変更`
+                : "リポジトリのデフォルトプロファイル: 既定 (~/.claude を使用)。クリックで変更"
             }
           >
             <span className="mr-1">・</span>
-            デフォルト: <span className="text-foreground/80">{labelText}</span>
+            <span className="text-foreground/80">{labelText}</span>
           </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-56">
@@ -514,7 +514,7 @@ export function SessionSidebar({
                     <button
                       type="button"
                       onClick={() => onSelectRepoGrid(repoPath)}
-                      className={`text-xs font-medium uppercase tracking-wider truncate text-left hover:text-foreground transition-colors ${
+                      className={`min-w-0 flex-1 basis-0 text-xs font-medium uppercase tracking-wider truncate text-left hover:text-foreground transition-colors ${
                         gridRepoPath === repoPath
                           ? "text-foreground"
                           : "text-muted-foreground"
@@ -530,7 +530,7 @@ export function SessionSidebar({
                     </button>
                   ) : (
                     <span
-                      className="text-xs font-medium text-muted-foreground uppercase tracking-wider truncate"
+                      className="min-w-0 flex-1 basis-0 text-xs font-medium text-muted-foreground uppercase tracking-wider truncate"
                       title={repoPath}
                     >
                       {repoName}


### PR DESCRIPTION
サイドバーでリポジトリ名が見えなくなる問題を直す。

## 原因

プロファイル表示のキャプション `・ デフォルト: 既定 (~/.claude)` が `shrink-0` で
**縮まない**のに対し、リポジトリ名側は `truncate` だけだった。結果として
**名前だけが削られて消える**構造になっていた。

## 変更

- ラベルを `既定 (~/.claude)` → `既定` に短縮し、`デフォルト: ` の接頭辞も外す（表示は `・ 既定`）
- リポジトリ名に `min-w-0 flex-1 basis-0` を与え、残り幅を優先させる
- キャプションに `min-w-[3.5rem] max-w-[45%]` を課し、**上限**と**最低クリック領域**の両方を保証する
- 設定済みプロファイルの `title` に `configDir` を追加
- 実装と不一致だったコメントを修正

選択メニュー側（`RepoProfileMenu`、`SessionSidebar` のメニュー項目）は
**詳細情報のフォールバックとして `既定 (~/.claude)` のまま残す**。
tooltip が出ないタッチ環境で情報へ到達する手段になるため。

## レビューで見つかった見落とし 2 件

実装は Claude、レビューは codex（実装者 ≠ レビュアー）。**1 回目の修正は表示に一切影響していなかった。**

### 触った分岐が本番経路ではなかった

Dashboard は `onSelectRepoGrid` を渡すため、実際に使われるのは `<button>` 分岐
（`SessionSidebar.tsx:513`）。最初の修正は `<span>` 分岐（同 532）にしか幅制御を
入れておらず、**本番では何も変わらなかった**。

### `flex-1` だけでは優先されない

レビュー側の実測で、長いプロファイル名のとき
**キャプション 169px に対しリポジトリ名が約 1px** まで潰れた。
`basis-0` と、キャプション側の上限幅で明示的に配分する形に直した。

## 検証

```
pnpm check   exit 0
pnpm test    exit 0   67 files / 1073 tests
```

`SessionSidebar` のレイアウトを直接検証する既存テストは無い（レビュー指摘）。
本 PR でも追加していないため、**実機での目視確認が必要**。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **表示改善**
  * リポジトリのプロファイル表示から「デフォルト:」の接頭辞を削除し、未設定時の表示を「既定」に短縮しました。
  * 長いプロファイル名を省略表示し、限られた表示幅でもレイアウトが崩れにくくなりました。
  * クリック可能なプロファイル表示に、名前・設定ディレクトリ・変更操作を確認できる説明を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->