### PR TITLE
fix(context): 復唱が無音で止まる条件を解消し、失敗時に理由を残す

### DIFF
--- a/ark/context/hooks/inject-context-rules.sh
+++ b/ark/context/hooks/inject-context-rules.sh
@@ -6,6 +6,9 @@ if [ -z "${ARK_SESSION_DIR:-}" ]; then
 fi
 
 CTX_RULES_HOOK_DIR=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
+CTX_RULES_RUNTIME="$CTX_RULES_HOOK_DIR/../scripts/lib/runtime.sh"
+[ -f "$CTX_RULES_RUNTIME" ] && [ ! -L "$CTX_RULES_RUNTIME" ] || exit 0
+. "$CTX_RULES_RUNTIME" || exit 0
 
 ctx_rules_stat() {
   local value uid mode extra
@@ -53,39 +56,16 @@ ctx_rules_has_failures() {
 }
 
 ctx_rules_parse_task() {
-  local task=$1 section line goal_count now_count item
+  local task=$1
   CTX_RULES_GOAL=
   CTX_RULES_NOW=
-  ctx_rules_safe_task "$task" || return 1
-  command -v iconv >/dev/null 2>&1 || return 1
-  iconv -f UTF-8 -t UTF-8 "$task" >/dev/null 2>&1 || return 1
-  section=
-  goal_count=0
-  now_count=0
-  while IFS= read -r line || [ -n "$line" ]; do
-    line=${line%$'\r'}
-    case "$line" in
-      '## Goal') section=goal; continue ;;
-      '## Plan') section=plan; continue ;;
-      '## '*) section=other; continue ;;
-    esac
-    if [ "$section" = goal ] && [ -n "$line" ]; then
-      goal_count=$((goal_count + 1))
-      CTX_RULES_GOAL=$line
-    elif [ "$section" = plan ]; then
-      case "$line" in
-        '- [ ] '*' ← NOW'|'- [x] '*' ← NOW')
-          now_count=$((now_count + 1))
-          item=${line#- \[ \] }
-          [ "$item" != "$line" ] || item=${line#- \[x\] }
-          CTX_RULES_NOW=${item% ← NOW}
-          ;;
-      esac
-    fi
-  done <"$task"
-  [ "$goal_count" -le 1 ] && [ "$now_count" -le 1 ] || return 1
-  case "$CTX_RULES_GOAL$CTX_RULES_NOW" in *"
-"*|*""*|*"	"*) return 1 ;; esac
+  if ! ctx_parse_task_state "$task"; then
+    ctx_record_task_parse_failure "$CTX_TASK_PARSED_GOAL_COUNT" \
+      "$CTX_TASK_PARSED_NOW_COUNT" "$CTX_TASK_PARSE_REASON"
+    return 1
+  fi
+  CTX_RULES_GOAL=$CTX_TASK_PARSED_GOAL
+  CTX_RULES_NOW=$CTX_TASK_PARSED_NOW
 }
 
 ctx_rules_main() {

--- a/ark/context/hooks/recite-todo.sh
+++ b/ark/context/hooks/recite-todo.sh
@@ -8,6 +8,11 @@ if [ -n "${ZSH_VERSION:-}" ]; then
   setopt nonomatch 2>/dev/null || exit 0
 fi
 
+CTX_RECITE_HOOK_DIR=$(cd "$(dirname "$0")" 2>/dev/null && pwd -P) || exit 0
+CTX_RECITE_RUNTIME="$CTX_RECITE_HOOK_DIR/../scripts/lib/runtime.sh"
+[ -f "$CTX_RECITE_RUNTIME" ] && [ ! -L "$CTX_RECITE_RUNTIME" ] || exit 0
+. "$CTX_RECITE_RUNTIME" || exit 0
+
 ctx_hook_stat() {
   local value uid mode extra
   value=$(stat -c '%u %a' "$1" 2>/dev/null) \
@@ -313,69 +318,19 @@ ctx_step_increment() {
   done
 }
 
-ctx_sanitize_line() {
-  local cleaned expression
-  cleaned=$(printf '%s' "$1" | LC_ALL=C tr '\001-\037\177' ' ') || return 1
-  expression=$(printf 's/\302[\200-\237]/ /g')
-  printf '%s' "$cleaned" | LC_ALL=C sed "$expression"
-}
-
-ctx_limit_utf8() {
-  local value=$1
-  local maximum=$2
-  local bytes count candidate
-  bytes=$(printf '%s' "$value" | wc -c | tr -d ' ')
-  if [ "$bytes" -le "$maximum" ]; then printf '%s' "$value"; return 0; fi
-  count=$maximum
-  while [ "$count" -ge $((maximum - 3)) ]; do
-    candidate=$(printf '%s' "$value" | dd bs=1 count="$count" 2>/dev/null | iconv -f UTF-8 -t UTF-8 2>/dev/null) && {
-      printf '%s' "$candidate"
-      return 0
-    }
-    count=$((count - 1))
-  done
-  return 1
-}
-
 ctx_task_parse() {
   local task=$1
-  local section line goal_count now_count item
-  ctx_hook_safe_file "$task" || return 1
-  iconv -f UTF-8 -t UTF-8 "$task" >/dev/null 2>&1 || return 1
-  section=
-  goal_count=0
-  now_count=0
   CTX_TASK_GOAL=
   CTX_TASK_NOW=
   CTX_TASK_REMAINING=0
-  while IFS= read -r line || [ -n "$line" ]; do
-    line=${line%$'\r'}
-    case "$line" in
-      '## Goal') section=goal; continue ;;
-      '## Plan') section=plan; continue ;;
-      '## '*) section=other; continue ;;
-    esac
-    if [ "$section" = goal ] && [ -n "$line" ]; then
-      goal_count=$((goal_count + 1))
-      CTX_TASK_GOAL=$line
-    elif [ "$section" = plan ]; then
-      case "$line" in '- [ ] '*) CTX_TASK_REMAINING=$((CTX_TASK_REMAINING + 1)) ;; esac
-      case "$line" in
-        '- [ ] '*' ← NOW'|'- [x] '*' ← NOW')
-          now_count=$((now_count + 1))
-          item=${line#- \[ \] }
-          [ "$item" != "$line" ] || item=${line#- \[x\] }
-          CTX_TASK_NOW=${item% ← NOW}
-          ;;
-      esac
-    fi
-  done <"$task"
-  [ "$goal_count" -eq 1 ] && [ "$now_count" -eq 1 ] || return 1
-  [ "$CTX_TASK_REMAINING" -le 999999 ] || return 1
-  CTX_TASK_GOAL=$(ctx_sanitize_line "$CTX_TASK_GOAL") || return 1
-  CTX_TASK_NOW=$(ctx_sanitize_line "$CTX_TASK_NOW") || return 1
-  CTX_TASK_GOAL=$(ctx_limit_utf8 "$CTX_TASK_GOAL" 180) || return 1
-  CTX_TASK_NOW=$(ctx_limit_utf8 "$CTX_TASK_NOW" 300) || return 1
+  if ! ctx_parse_task_state "$task"; then
+    ctx_record_task_parse_failure "$CTX_TASK_PARSED_GOAL_COUNT" \
+      "$CTX_TASK_PARSED_NOW_COUNT" "$CTX_TASK_PARSE_REASON"
+    return 1
+  fi
+  CTX_TASK_GOAL=$CTX_TASK_PARSED_GOAL
+  CTX_TASK_NOW=$CTX_TASK_PARSED_NOW
+  CTX_TASK_REMAINING=$CTX_TASK_PARSED_REMAINING
 }
 
 ctx_recite_main() {
@@ -390,7 +345,7 @@ ctx_recite_main() {
   # additionalContext is best-effort: a due batch is attempted once and never retried.
   ctx_task_parse "${ARK_SESSION_DIR:-}/task.md" || return 0
   output="Goal: $CTX_TASK_GOAL
-NOW: $CTX_TASK_NOW
+NOW: ${CTX_TASK_NOW:-（未設定）}
 Remaining: $CTX_TASK_REMAINING"
   bytes=$(printf '%s\n' "$output" | wc -c | tr -d ' ')
   [ "$bytes" -le 600 ] || return 0

--- a/ark/context/scripts/lib/runtime.sh
+++ b/ark/context/scripts/lib/runtime.sh
@@ -109,17 +109,17 @@ EOF
   rmdir "$lock" >/dev/null 2>&1
 }
 
-_ctx_record_missing_jq_locked() {
-  local raw=$1 marker=$2 at raw_size entry entry_size
-  if [ -f "$raw" ] && grep -F "$marker" "$raw" >/dev/null 2>&1; then
-    return 0
-  fi
+_ctx_record_once_locked() {
+  local raw=$1 dedupe_marker=$2 fields=$3 at raw_size entry entry_size
   if [ -e "$raw" ] || [ -L "$raw" ]; then
     ctx_validate_xdg_file "$raw" || return 1
   else
     (set -C; : >"$raw") 2>/dev/null || return 1
     chmod 600 "$raw" || return 1
     ctx_validate_xdg_file "$raw" || return 1
+  fi
+  if grep -F "$dedupe_marker" "$raw" >/dev/null 2>&1; then
+    return 0
   fi
   raw_size=$(stat -c '%s' "$raw" 2>/dev/null) \
     || raw_size=$(stat -f '%z' "$raw" 2>/dev/null) \
@@ -130,14 +130,15 @@ _ctx_record_missing_jq_locked() {
     [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z) ;;
     *) return 1 ;;
   esac
-  entry=$(printf '{"at":"%s",%s' "$at" "$marker") || return 1
+  entry=$(printf '{"at":"%s",%s' "$at" "$fields") || return 1
   entry_size=$((${#entry} + 1))
   [ "$entry_size" -le $((67108864 - raw_size)) ] || return 1
   printf '%s\n' "$entry" >>"$raw" || return 1
 }
 
-_ctx_record_missing_jq() {
-  local session errors raw lock owner token attempt marker owner_value record_status old_umask
+_ctx_record_once() {
+  local dedupe_marker=$1 fields=$2
+  local session errors raw lock owner token attempt owner_value record_status old_umask
   session=${ARK_SESSION_DIR:-}
   [ -n "$session" ] && [ "${session#/}" != "$session" ] || return 1
   ctx_has_control "$session" && return 1
@@ -181,8 +182,7 @@ _ctx_record_missing_jq() {
   owner_value=$(sed -n '1p' "$owner") || return 1
   [ "$owner_value" = "$$ $token" ] || return 1
 
-  marker='"tool":"ark/context","error_type":"missing_prerequisite","exit_code":null,"is_interrupt":null,"error":"jq command unavailable","details":{}}'
-  _ctx_record_missing_jq_locked "$raw" "$marker"
+  _ctx_record_once_locked "$raw" "$dedupe_marker" "$fields"
   record_status=$?
   owner_value=$(sed -n '1p' "$owner" 2>/dev/null) || owner_value=
   if [ "$owner_value" = "$$ $token" ]; then
@@ -192,9 +192,143 @@ _ctx_record_missing_jq() {
   return "$record_status"
 }
 
+_ctx_record_missing_jq() {
+  local fields
+  fields='"tool":"ark/context","error_type":"missing_prerequisite","exit_code":null,"is_interrupt":null,"error":"jq command unavailable","details":{}}'
+  _ctx_record_once '"tool":"ark/context","error_type":"missing_prerequisite"' "$fields"
+}
+
 ctx_record_missing_jq() {
   _ctx_record_missing_jq >/dev/null 2>&1 || :
   return 0
+}
+
+ctx_record_task_parse_failure() {
+  local goal_lines=${1:-} now_items=${2:-} reason=${3:-} fields
+  case "$goal_lines" in ''|*[!0-9]*) return 0 ;; esac
+  case "$now_items" in ''|*[!0-9]*) return 0 ;; esac
+  case "$reason" in
+    unsafe_task|iconv_unavailable|invalid_utf8|goal_missing|remaining_overflow|sanitize_failed|limit_failed) ;;
+    *) return 0 ;;
+  esac
+  fields=$(printf '%s' \
+    '"tool":"ark/context","error_type":"task_parse_failed","exit_code":null,"is_interrupt":null,"error":"task.md parse failed","details":{' \
+    '"goal_lines":' "$goal_lines" ',"now_items":' "$now_items" ',"reason":"' "$reason" '"}}') \
+    || return 0
+  _ctx_record_once '"tool":"ark/context","error_type":"task_parse_failed"' "$fields" \
+    >/dev/null 2>&1 || :
+  return 0
+}
+
+_ctx_task_trim_marker_space() {
+  local value=$1 original=$1 tab
+  tab=$(printf '\t') || return 1
+  while :; do
+    case "$value" in
+      *' ') value=${value% } ;;
+      *"$tab") value=${value%"$tab"} ;;
+      *'　') value=${value%　} ;;
+      *) break ;;
+    esac
+  done
+  [ "$value" != "$original" ] || return 1
+  CTX_TASK_TRIMMED=$value
+}
+
+_ctx_task_extract_now() {
+  local item=$1 before_now before_arrow
+  case "$item" in
+    *NOW) before_now=${item%NOW} ;;
+    *) return 1 ;;
+  esac
+  _ctx_task_trim_marker_space "$before_now" || return 1
+  case "$CTX_TASK_TRIMMED" in
+    *'←') before_arrow=${CTX_TASK_TRIMMED%←} ;;
+    *'<-') before_arrow=${CTX_TASK_TRIMMED%<-} ;;
+    *) return 1 ;;
+  esac
+  _ctx_task_trim_marker_space "$before_arrow" || return 1
+  CTX_TASK_PARSED_ITEM=$CTX_TASK_TRIMMED
+}
+
+_ctx_task_sanitize_line() {
+  local cleaned expression
+  cleaned=$(printf '%s' "$1" | LC_ALL=C tr '\001-\037\177' ' ') || return 1
+  expression=$(printf 's/\302[\200-\237]/ /g')
+  printf '%s' "$cleaned" | LC_ALL=C sed "$expression"
+}
+
+_ctx_task_limit_utf8() {
+  local value=$1 maximum=$2 bytes count candidate
+  bytes=$(printf '%s' "$value" | wc -c | tr -d ' ')
+  if [ "$bytes" -le "$maximum" ]; then printf '%s' "$value"; return 0; fi
+  count=$maximum
+  while [ "$count" -ge $((maximum - 3)) ]; do
+    candidate=$(printf '%s' "$value" | dd bs=1 count="$count" 2>/dev/null \
+      | iconv -f UTF-8 -t UTF-8 2>/dev/null) && {
+      printf '%s' "$candidate"
+      return 0
+    }
+    count=$((count - 1))
+  done
+  return 1
+}
+
+ctx_parse_task_state() {
+  local task=$1 section line item
+  CTX_TASK_PARSED_GOAL=
+  CTX_TASK_PARSED_NOW=
+  CTX_TASK_PARSED_REMAINING=0
+  CTX_TASK_PARSED_GOAL_COUNT=0
+  CTX_TASK_PARSED_NOW_COUNT=0
+  CTX_TASK_PARSE_REASON=unsafe_task
+  ctx_validate_xdg_file "$task" >/dev/null 2>&1 || return 1
+  CTX_TASK_PARSE_REASON=iconv_unavailable
+  command -v iconv >/dev/null 2>&1 || return 1
+  CTX_TASK_PARSE_REASON=invalid_utf8
+  iconv -f UTF-8 -t UTF-8 "$task" >/dev/null 2>&1 || return 1
+  section=
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=${line%$'\r'}
+    case "$line" in
+      '## Goal') section=goal; continue ;;
+      '## Plan') section=plan; continue ;;
+      '## '*) section=other; continue ;;
+    esac
+    if [ "$section" = goal ] && [ -n "$line" ]; then
+      CTX_TASK_PARSED_GOAL_COUNT=$((CTX_TASK_PARSED_GOAL_COUNT + 1))
+      if [ -n "$CTX_TASK_PARSED_GOAL" ]; then
+        CTX_TASK_PARSED_GOAL="$CTX_TASK_PARSED_GOAL $line"
+      else
+        CTX_TASK_PARSED_GOAL=$line
+      fi
+    elif [ "$section" = plan ]; then
+      case "$line" in '- [ ] '*) CTX_TASK_PARSED_REMAINING=$((CTX_TASK_PARSED_REMAINING + 1)) ;; esac
+      case "$line" in
+        '- [ ] '*|'- [x] '*)
+          item=${line#- \[ \] }
+          [ "$item" != "$line" ] || item=${line#- \[x\] }
+          if _ctx_task_extract_now "$item"; then
+            CTX_TASK_PARSED_NOW_COUNT=$((CTX_TASK_PARSED_NOW_COUNT + 1))
+            if [ "$CTX_TASK_PARSED_NOW_COUNT" -eq 1 ]; then
+              CTX_TASK_PARSED_NOW=$CTX_TASK_PARSED_ITEM
+            fi
+          fi
+          ;;
+      esac
+    fi
+  done <"$task"
+  CTX_TASK_PARSE_REASON=goal_missing
+  [ "$CTX_TASK_PARSED_GOAL_COUNT" -ge 1 ] || return 1
+  CTX_TASK_PARSE_REASON=remaining_overflow
+  [ "$CTX_TASK_PARSED_REMAINING" -le 999999 ] || return 1
+  CTX_TASK_PARSE_REASON=sanitize_failed
+  CTX_TASK_PARSED_GOAL=$(_ctx_task_sanitize_line "$CTX_TASK_PARSED_GOAL") || return 1
+  CTX_TASK_PARSED_NOW=$(_ctx_task_sanitize_line "$CTX_TASK_PARSED_NOW") || return 1
+  CTX_TASK_PARSE_REASON=limit_failed
+  CTX_TASK_PARSED_GOAL=$(_ctx_task_limit_utf8 "$CTX_TASK_PARSED_GOAL" 180) || return 1
+  CTX_TASK_PARSED_NOW=$(_ctx_task_limit_utf8 "$CTX_TASK_PARSED_NOW" 300) || return 1
+  CTX_TASK_PARSE_REASON=
 }
 
 ctx_validate_repo_path() {

--- a/ark/context/templates/context-rules.md
+++ b/ark/context/templates/context-rules.md
@@ -1,6 +1,13 @@
 タスク管理:
 1. task.md だけを正本にし、native todo を使用しない。
 2. 各 tool step の前後で Plan status と ← NOW を現実に合わせる。
+   task.md は次の書式にする:
+   ## Goal
+   <1 行で書く>
+
+   ## Plan
+   - [x] 済んだ項目
+   - [ ] いま進めている項目 ← NOW
 3. Goal / Constraints は空から記入済みへの一方向の初回記入を除いて書き換えず、逸脱が必要なら作業を停止する。
 
 エラー:

--- a/ark/context/tests/run.sh
+++ b/ark/context/tests/run.sh
@@ -13,6 +13,7 @@ for test_script in \
   test-handoff.sh \
   test-failures-knowledge.sh \
   test-recite-todo.sh \
+  test-recite-task-parser.sh \
   test-capture-error.sh \
   test-summarize-errors.sh \
   test-jq-prerequisite.sh \

--- a/ark/context/tests/test-claude-code-session-start.sh
+++ b/ark/context/tests/test-claude-code-session-start.sh
@@ -14,6 +14,16 @@ assert_eq "context rules contain ten numbered rules" 10 \
   "$(grep -Ec '^[1-4]\. ' "$RULES")"
 grep -F '空から記入済みへの一方向の初回記入を除いて' "$RULES" >/dev/null 2>&1
 assert_eq "Goal and Constraints initial-fill exception is explicit" 0 "$?"
+expected_task_format='   ## Goal
+   <1 行で書く>
+
+   ## Plan
+   - [x] 済んだ項目
+   - [ ] いま進めている項目 ← NOW'
+case "$(cat "$RULES")" in
+  *"$expected_task_format"*) TESTS=$((TESTS + 1)); PASSES=$((PASSES + 1)) ;;
+  *) test_fail "context rules omit the exact task.md format" ;;
+esac
 
 fifo="$TEST_TMP/unreadable-input"
 mkfifo "$fifo"

--- a/ark/context/tests/test-recite-task-parser.sh
+++ b/ark/context/tests/test-recite-task-parser.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+ROOT=$(cd "$(dirname "$0")/../../.." && pwd -P)
+RECITE="$ROOT/ark/context/hooks/recite-todo.sh"
+INJECT="$ROOT/ark/context/hooks/inject-context-rules.sh"
+POST_TOOL_BATCH="$ROOT/ark/context/adapters/claude-code/post-tool-batch.sh"
+SESSION_START="$ROOT/ark/context/adapters/claude-code/session-start.sh"
+TEST_TMP=$(mktemp -d)
+TEST_TMP=$(cd "$TEST_TMP" && pwd -P)
+trap 'rm -rf "$TEST_TMP"' EXIT HUP INT TERM
+. "$ROOT/ark/context/tests/test-helper.sh"
+
+session="$TEST_TMP/session"
+cache="$TEST_TMP/cache"
+mkdir -m 700 "$session" "$session/errors" "$session/artifacts" \
+  "$session/knowledge" "$cache"
+: >"$session/knowledge/failures.md"
+chmod 600 "$session/knowledge/failures.md"
+
+write_task() {
+  printf '%s\n' "$1" >"$session/task.md"
+  chmod 600 "$session/task.md"
+}
+
+assert_parser_case() {
+  local label=$1 goal=$2 now=$3 remaining=$4 task=$5
+  write_task "$task"
+
+  run_case env ARK_SESSION_DIR="$session" ARK_CACHE_DIR="$cache" \
+    ARK_RECITE_INTERVAL=1 /bin/bash "$RECITE"
+  assert_success "$label recite exits zero"
+  assert_eq "$label recite output" "Goal: $goal
+NOW: $now
+Remaining: $remaining" "$(cat "$CASE_STDOUT")"
+  assert_eq "$label recite stderr" '' "$(cat "$CASE_STDERR")"
+
+  run_case env ARK_SESSION_DIR="$session" /bin/bash "$INJECT"
+  assert_success "$label injection exits zero"
+  assert_eq "$label injection Goal" 1 \
+    "$(grep -Fxc -- "現在の Goal: $goal" "$CASE_STDOUT")"
+  assert_eq "$label injection NOW" 1 \
+    "$(grep -Fxc -- "現在の NOW: $now" "$CASE_STDOUT")"
+  assert_eq "$label injection stderr" '' "$(cat "$CASE_STDERR")"
+}
+
+assert_parser_case 'canonical Unicode marker' 'Single goal' 'current' 2 '# Task
+
+## Goal
+Single goal
+
+## Plan
+- [x] done
+- [ ] current ← NOW
+- [ ] later'
+
+assert_parser_case 'multiline Goal' 'First goal line Second goal line Third goal line' 'current' 1 '# Task
+
+## Goal
+First goal line
+Second goal line
+Third goal line
+
+## Plan
+- [ ] current ← NOW'
+
+assert_parser_case 'ASCII marker' 'ASCII goal' 'ascii current' 1 '# Task
+
+## Goal
+ASCII goal
+
+## Plan
+- [ ] ascii current <- NOW'
+
+mixed_space_task=$(printf '# Task\n\n## Goal\nMixed whitespace\n\n## Plan\n- [ ] spaced\t　 <-　 \tNOW\n')
+assert_parser_case 'mixed repeated marker whitespace' 'Mixed whitespace' 'spaced' 1 \
+  "$mixed_space_task"
+
+assert_parser_case 'multiple NOW markers' 'Choose first' 'first current' 2 '# Task
+
+## Goal
+Choose first
+
+## Plan
+- [ ] first current ← NOW
+- [ ] second current <- NOW'
+
+assert_parser_case 'zero NOW markers' 'Goal remains useful' '（未設定）' 2 '# Task
+
+## Goal
+Goal remains useful
+
+## Plan
+- [ ] ordinary unchecked
+- [ ] contains NOW but has no arrow
+plain text ← NOW
+- note <- NOW'
+
+assert_eq 'successful variants do not create parse errors' no \
+  "$(if [ -e "$session/errors/raw.log" ]; then printf yes; else printf no; fi)"
+
+batch_input="$TEST_TMP/post-tool-batch.json"
+printf '%s\n' '{"hook_event_name":"PostToolBatch","tool_calls":[]}' >"$batch_input"
+run_case env ARK_SESSION_DIR="$session" ARK_CACHE_DIR="$cache" ARK_RECITE_INTERVAL=1 \
+  /bin/bash "$POST_TOOL_BATCH" <"$batch_input"
+assert_success 'PostToolBatch tolerant parse exits zero'
+jq -e '.hookSpecificOutput.hookEventName == "PostToolBatch"
+  and .hookSpecificOutput.additionalContext == "Goal: Goal remains useful\nNOW: （未設定）\nRemaining: 2"' \
+  "$CASE_STDOUT" >/dev/null 2>&1 || test_fail 'PostToolBatch stdout is not valid expected JSON'
+
+bad_session="$TEST_TMP/bad-session"
+bad_cache="$TEST_TMP/bad-cache"
+mkdir -m 700 "$bad_session" "$bad_session/errors" "$bad_session/artifacts" \
+  "$bad_session/knowledge" "$bad_cache"
+: >"$bad_session/knowledge/failures.md"
+chmod 600 "$bad_session/knowledge/failures.md"
+printf '# Task\n\n## Goal\n\n## Plan\n- [ ] orphan item ← NOW\n' \
+  >"$bad_session/task.md"
+chmod 600 "$bad_session/task.md"
+
+run_case env ARK_SESSION_DIR="$bad_session" ARK_CACHE_DIR="$bad_cache" \
+  ARK_RECITE_INTERVAL=1 /bin/bash "$RECITE"
+assert_success 'unparseable recite exits zero'
+assert_eq 'unparseable recite stdout stays empty' '' "$(cat "$CASE_STDOUT")"
+assert_eq 'unparseable recite stderr stays empty' '' "$(cat "$CASE_STDERR")"
+
+run_case env ARK_SESSION_DIR="$bad_session" ARK_CACHE_DIR="$bad_cache" \
+  ARK_RECITE_INTERVAL=1 /bin/bash "$RECITE"
+assert_success 'repeated unparseable recite exits zero'
+assert_eq 'repeated unparseable recite stdout stays empty' '' "$(cat "$CASE_STDOUT")"
+
+run_case env ARK_SESSION_DIR="$bad_session" /bin/bash "$INJECT"
+assert_success 'unparseable injection exits zero'
+grep -F 'Goal が空です。' "$CASE_STDOUT" >/dev/null 2>&1 \
+  || test_fail 'unparseable injection omits the explicit fallback reason'
+
+assert_eq 'parse failure is recorded once per session' 1 \
+  "$(wc -l <"$bad_session/errors/raw.log" | tr -d ' ')"
+jq -e '.tool == "ark/context"
+  and .error_type == "task_parse_failed"
+  and .error == "task.md parse failed"
+  and .details == {"goal_lines":0,"now_items":1,"reason":"goal_missing"}' \
+  "$bad_session/errors/raw.log" >/dev/null 2>&1 \
+  || test_fail 'parse failure raw record lacks exact counts or reason'
+
+session_input="$TEST_TMP/session-start.json"
+printf '%s\n' '{"session_id":"fixture","hook_event_name":"SessionStart","source":"startup"}' \
+  >"$session_input"
+run_case env ARK_SESSION_DIR="$bad_session" /bin/bash "$SESSION_START" <"$session_input"
+assert_success 'SessionStart with unparseable task exits zero'
+jq -e '.hookSpecificOutput.hookEventName == "SessionStart"
+  and (.hookSpecificOutput.additionalContext | contains("Goal が空です。"))' \
+  "$CASE_STDOUT" >/dev/null 2>&1 \
+  || test_fail 'SessionStart stdout JSON is invalid after parse failure'
+assert_eq 'SessionStart does not duplicate parse failure record' 1 \
+  "$(wc -l <"$bad_session/errors/raw.log" | tr -d ' ')"
+
+parallel_session="$TEST_TMP/parallel-session"
+parallel_cache="$TEST_TMP/parallel-cache"
+mkdir -m 700 "$parallel_session" "$parallel_session/errors" "$parallel_cache"
+printf '# Task\n\n## Goal\n\n## Plan\n- [ ] parallel orphan ← NOW\n' \
+  >"$parallel_session/task.md"
+chmod 600 "$parallel_session/task.md"
+parallel_pids=
+parallel_index=1
+while [ "$parallel_index" -le 20 ]; do
+  env ARK_SESSION_DIR="$parallel_session" ARK_CACHE_DIR="$parallel_cache" \
+    ARK_RECITE_INTERVAL=1 /bin/bash "$RECITE" \
+    >"$TEST_TMP/parallel-$parallel_index.out" \
+    2>"$TEST_TMP/parallel-$parallel_index.err" &
+  parallel_pids="$parallel_pids $!"
+  parallel_index=$((parallel_index + 1))
+done
+parallel_status=0
+for parallel_pid in $parallel_pids; do
+  wait "$parallel_pid" || parallel_status=1
+done
+assert_eq 'parallel parse failures all exit zero' 0 "$parallel_status"
+assert_eq 'parallel parse failure is recorded exactly once' 1 \
+  "$(wc -l <"$parallel_session/errors/raw.log" | tr -d ' ')"
+jq -e '.error_type == "task_parse_failed"
+  and .details == {"goal_lines":0,"now_items":1,"reason":"goal_missing"}' \
+  "$parallel_session/errors/raw.log" >/dev/null 2>&1 \
+  || test_fail 'parallel parse failure record is invalid'
+assert_eq 'parallel parse failures keep stdout and stderr empty' 0 \
+  "$(wc -c "$TEST_TMP"/parallel-*.out "$TEST_TMP"/parallel-*.err \
+    | tail -1 | awk '{print $1}')"
+
+if [ -n "$CTX_ZSH" ]; then
+  write_task "$mixed_space_task"
+  run_case env ARK_SESSION_DIR="$session" ARK_CACHE_DIR="$cache" ARK_RECITE_INTERVAL=1 \
+    "$CTX_ZSH" "$RECITE"
+  assert_success 'mixed whitespace recite works in zsh'
+  assert_eq 'zsh recite matches bash parser' 'Goal: Mixed whitespace
+NOW: spaced
+Remaining: 1' "$(cat "$CASE_STDOUT")"
+  run_case env ARK_SESSION_DIR="$session" "$CTX_ZSH" "$INJECT"
+  assert_success 'mixed whitespace injection works in zsh'
+  assert_eq 'zsh injection matches bash parser' 1 \
+    "$(grep -Fxc -- '現在の NOW: spaced' "$CASE_STDOUT")"
+else
+  printf '%s\n' 'SKIP: zsh is unavailable; recite task parser zsh cases skipped'
+fi
+
+finish_tests recite-task-parser

--- a/ark/context/tests/test-recite-todo.sh
+++ b/ark/context/tests/test-recite-todo.sh
@@ -89,17 +89,13 @@ Remaining: 0' "$(cat "$CASE_STDOUT")"
 
 for broken in '# Task
 ## Goal
-one
-two
 ## Plan
 - [ ] work ← NOW' '# Task
-## Goal
-one
 ## Plan
 - [ ] a ← NOW
 - [ ] b ← NOW' '# Task
-## Goal
-one
+## Constraints
+- no Goal section
 ## Plan
 - [ ] no marker'; do
   write_task "$broken"


### PR DESCRIPTION
復唱が hook 発火・`task.md` 完備でも**無音で出力しない**問題を直す。

Closes #383

## 原因

`ctx_task_parse` が 2 つの厳密な条件を課しており、外れると `return 1` →
呼び出し側の `|| return 0` で**無音**になっていた。

```bash
[ "$goal_count" -eq 1 ] && [ "$now_count" -eq 1 ] || return 1
'- [ ] '*' ← NOW'|'- [x] '*' ← NOW')
```

- **Goal は空でない行がちょうど 1 行**
- **NOW は `←`（U+2190）でスペース 1 個区切り、ちょうど 1 個**

実験セッションでモデルが書いた `task.md` は Goal が 4 行、NOW が `<- NOW`（ASCII）+
全角スペースで、**両方の条件を外していた**。

```
goal_count=4  now_count=0  → return 1 → 無音
ARK_RECITE_INTERVAL=1 で毎回 due にしても出力 0 件
step は 28 → 44 まで増える（hook 自体は動いている）
```

**規約は正確な書式を教えていなかった。** `context-rules.md` にあったのは散文の 1 行だけで、
「Goal は 1 行」とも「NOW はこの正確な形」とも書かれていない。
**モデルは書式を知らされずに厳密パーサへ入力していた。**

同じパーサが `inject-context-rules.sh` にもあり、SessionStart の Goal / NOW 提示も
同時に死んでいた。

## 変更

### パーサを妥当な揺れに耐えさせる

`recite-todo.sh` と `inject-context-rules.sh` が共通の `ctx_parse_task_state` を使う。

- 矢印は `←` と `<-` の両方
- 空白は半角・全角・タブの複数個を許容
- **Goal 複数行は空白で連結**してから 180 bytes に制限
- **NOW 複数個は先頭を採用**
- **NOW 0 個は `NOW: （未設定）` で出力**（Goal と Remaining には意味があるため）

`- [ ]` / `- [x]` で始まることは要求し続ける（`NOW` を含むだけの行は拾わない）。

### 解析できないときは理由を記録する

無音のまま終わらせない（#377 と同じ扱い）。

- 既存の `errors/raw.log` へ `task_parse_failed` として JSONL 追記
- Goal 行数・NOW 個数・理由を含める
- **セッションごとに 1 回だけ**（既存の raw lock と dedupe marker）
- stdout には書かない

### 規約に真似できる書式を置く

`context-rules.md` に Goal / Plan の正確な例を 7 行追加。

## 検証

実装は codex、レビューは Claude（実装者 ≠ レビュアー）。

### 実際に無音だった入力で前後比較

実験で記録された `task.md` をそのまま与えた。`ARK_RECITE_INTERVAL=1` で
due 判定を交絡から外している。

| 入力 | main | 本 PR |
| --- | --- | --- |
| Goal 4 行 + `<- NOW` + 全角スペース | **無音** | 出力あり |
| NOW が 0 個 | **無音** | `NOW: （未設定）` で出力 |
| 規約どおり（Goal 1 行 + `← NOW`） | 出力あり | 出力あり |

Goal 4 行は空白連結され、`<- NOW` からも `DONE ファイル作成` を正しく抽出している。

### 解析失敗の記録

```
解析できない task.md で 5 回実行 → 記録 1 件
{"at":"…","tool":"ark/context","error_type":"task_parse_failed",…}
```

### テスト

専用テスト 60 アサーションを追加し `run.sh` に登録。変異テスト 4 種
（ASCII 矢印の無効化 / Goal 上書き / 最後の NOW 採用 / dedupe 無効化）を
すべて検出することを確認。

```
pnpm check      exit 0
pnpm test       exit 0   67 files / 1073 tests
pnpm build      exit 0
既存 test-recite-todo.sh  83/83
bash 3.2 専用テスト        56/56
SessionStart              41/41
```

## 補足

この問題は #367（復唱の効果測定）の予備試行で見つかった。
**復唱は Manus 4 機構のうち唯一効果が未確認だったが、その理由が
「効果が小さい」ではなく「出ていない条件があった」可能性がある。**

#367 の本試行は、本 PR のマージ後に課題を作り直してから再検討する。
