### PR TITLE
fix(server): ボードプロンプトを SessionStart hook へ移し ps 露出をなくす

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3315,8 +3315,9 @@ export async function startServer(
 
   console.log(`Ark server running on http://localhost:${port}/`);
 
-  // AskUserQuestion hook 入りの claude 用 settings を書き出し、以降の
-  // セッション起動コマンドに --settings として注入する (listen 後 = port 確定後)
+  // Board SessionStart / AskUserQuestion hooks 入りの claude 用 settings を
+  // 書き出し、以降のセッション起動コマンドに --settings として注入する
+  // (listen 後 = port 確定後)
   try {
     const hookSettingsPath = auqHookBridge.writeSettingsFile(port);
     tmuxManager.setClaudeSettingsPath(hookSettingsPath);

--- a/packages/server/src/lib/auq-hook-bridge.test.ts
+++ b/packages/server/src/lib/auq-hook-bridge.test.ts
@@ -5,7 +5,11 @@
  * を保持し、再接続時の再送 (getPending) でも返せることを検証する。
  */
 
-import { describe, expect, it, vi } from "vitest";
+import { execSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("./database.js", () => ({
   db: {
@@ -19,6 +23,110 @@ vi.mock("./paths.js", () => ({
 }));
 
 import { AuqHookBridge } from "./auq-hook-bridge.js";
+import {
+  BOARD_SESSION_CONTEXT,
+  BOARD_SESSION_START_HOOK_FILENAME,
+} from "./board-session-start-hook.js";
+import { getDataDir } from "./paths.js";
+
+const mockedGetDataDir = vi.mocked(getDataDir);
+const tempDirs: string[] = [];
+
+const EXPECTED_BOARD_CONTEXT = [
+  "このセッションにはボードペインがあり、図と文書を表示できる。board_open（ボードに開く）、board_comments（人間が付けたコメントを読む）、board_authoring_guide（作図・文書規約を読む）、board_reply（コメントへ返信する）の 4 つのツールを持っている。",
+  "ユーザーが「図解して」「図で説明して」「フロー図/構成図にして」等、図解・作図・可視化を求めたら、チャットに mermaid や ASCII 図を出すのではなく、.claude/diagrams/ 配下に *.diagram.html を書き、board_open で開くこと。",
+  '設計メモ・仕様・調査結果など「人に読ませる文書」も同じ形式で書ける。model の type を "doc" にすると、ユーザーが本文をテキスト選択してコメントを付けられる、レビュー可能な文書になる。',
+  "ユーザーが「コメントした」「図を見て」等と言ったら、board_comments で未解決コメントを読み、引用された箇所を直してから board_open で開き直し、board_reply で対応内容を返信すること。",
+  "書き込む直前に parent directory が存在しない場合だけ作成する。.diagram.html を書く前に必ず board_authoring_guide で規約を取得し、その内容に従う。",
+].join("\n");
+
+function createDataDir(): string {
+  const dir = fs.realpathSync(
+    fs.mkdtempSync(path.join(os.tmpdir(), "ark-hook-settings-"))
+  );
+  tempDirs.push(dir);
+  mockedGetDataDir.mockReturnValue(dir);
+  return dir;
+}
+
+afterEach(() => {
+  mockedGetDataDir.mockReturnValue("/tmp/ark-test-data");
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("AuqHookBridge - hooks settings", () => {
+  it("SessionStart と PreToolUse を同じ妥当な settings JSON に 0600 で書く", () => {
+    const dataDir = createDataDir();
+    const settingsPath = new AuqHookBridge().writeSettingsFile(4012);
+    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+
+    expect(Object.keys(settings.hooks)).toEqual(["SessionStart", "PreToolUse"]);
+    expect(settings.hooks.SessionStart).toEqual([
+      {
+        hooks: [
+          {
+            type: "command",
+            command: `/bin/sh '${path.join(dataDir, BOARD_SESSION_START_HOOK_FILENAME)}'`,
+          },
+        ],
+      },
+    ]);
+    expect(settings.hooks.PreToolUse).toHaveLength(1);
+    expect(settings.hooks.PreToolUse[0].matcher).toBe("AskUserQuestion");
+    expect(settings.hooks.PreToolUse[0].hooks[0].command).toContain(
+      "/api/internal/auq-event"
+    );
+    expect(settings.hooks.SessionStart[0].hooks[0].command).not.toContain(
+      "このセッションにはボードペイン"
+    );
+    expect(fs.statSync(settingsPath).mode & 0o777).toBe(0o600);
+    expect(
+      fs.statSync(path.join(dataDir, BOARD_SESSION_START_HOOK_FILENAME)).mode &
+        0o777
+    ).toBe(0o600);
+  });
+
+  it("既存 settings と hook の mode を 0600 に矯正する", () => {
+    const dataDir = createDataDir();
+    const settingsPath = path.join(dataDir, "ark-claude-settings.json");
+    const hookPath = path.join(dataDir, BOARD_SESSION_START_HOOK_FILENAME);
+    fs.writeFileSync(settingsPath, "{}\n", { mode: 0o644 });
+    fs.writeFileSync(hookPath, "old\n", { mode: 0o644 });
+    fs.chmodSync(settingsPath, 0o644);
+    fs.chmodSync(hookPath, 0o644);
+
+    new AuqHookBridge().writeSettingsFile(4012);
+
+    expect(fs.statSync(settingsPath).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(hookPath).mode & 0o777).toBe(0o600);
+  });
+
+  it("SessionStart hook は元の 5 文を改行区切りの additionalContext として返す", () => {
+    createDataDir();
+    const settingsPath = new AuqHookBridge().writeSettingsFile(4012);
+    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    const command = settings.hooks.SessionStart[0].hooks[0].command;
+
+    const stdout = execSync(command, {
+      input: '{"hook_event_name":"SessionStart","source":"startup"}\n',
+      encoding: "utf-8",
+    });
+    const output = JSON.parse(stdout);
+
+    expect(output).toEqual({
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: EXPECTED_BOARD_CONTEXT,
+      },
+    });
+    expect(BOARD_SESSION_CONTEXT).toBe(EXPECTED_BOARD_CONTEXT);
+    expect(
+      output.hookSpecificOutput.additionalContext.split("\n")
+    ).toHaveLength(5);
+  });
+});
 
 describe("AuqHookBridge - screen スナップショット", () => {
   it("setPending で渡した screen を getPending が返す", () => {
@@ -35,13 +143,13 @@ describe("AuqHookBridge - screen スナップショット", () => {
   it("screen が null (capture 失敗) でも保持できる", () => {
     const bridge = new AuqHookBridge();
     bridge.setPending("s1", [], null);
-    expect(bridge.getPending("s1")!.screen).toBeNull();
+    expect(bridge.getPending("s1")?.screen).toBeNull();
   });
 
   it("同一セッションの再 setPending で screen も上書きされる", () => {
     const bridge = new AuqHookBridge();
     bridge.setPending("s1", [], "古い画面");
     bridge.setPending("s1", [], "新しい画面");
-    expect(bridge.getPending("s1")!.screen).toBe("新しい画面");
+    expect(bridge.getPending("s1")?.screen).toBe("新しい画面");
   });
 });

--- a/packages/server/src/lib/auq-hook-bridge.ts
+++ b/packages/server/src/lib/auq-hook-bridge.ts
@@ -1,5 +1,5 @@
 /**
- * auq-hook-bridge - AskUserQuestion の PreToolUse hook 連携
+ * auq-hook-bridge - Claude hooks 用 settings の生成と AUQ 連携
  *
  * 背景 (チャット UI v3):
  *   対話版 claude は AskUserQuestion の tool_use を「ユーザーが回答/拒否した
@@ -25,6 +25,10 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import {
+  boardSessionStartHookCommand,
+  writeBoardSessionStartHookFile,
+} from "./board-session-start-hook.js";
 import { db } from "./database.js";
 import { getDataDir } from "./paths.js";
 
@@ -92,11 +96,24 @@ export class AuqHookBridge {
     const dataDir = getDataDir();
     fs.mkdirSync(dataDir, { recursive: true });
     const settingsPath = path.join(dataDir, "ark-claude-settings.json");
+    const boardSessionStartHookPath = writeBoardSessionStartHookFile(dataDir);
     // curl: -m 3 で TUI をブロックしない / 失敗は無視 (hook が claude の
     // 進行を止めないことを最優先)。stdin の JSON をそのまま転送する。
     const command = `curl -s -m 3 -X POST 'http://127.0.0.1:${port}${AUQ_EVENT_PATH}' -H 'Content-Type: application/json' -H '${AUQ_TOKEN_HEADER}: ${this.token}' --data-binary @- >/dev/null 2>&1 || true`;
     const settings = {
       hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: boardSessionStartHookCommand(
+                  boardSessionStartHookPath
+                ),
+              },
+            ],
+          },
+        ],
         PreToolUse: [
           {
             matcher: "AskUserQuestion",

--- a/packages/server/src/lib/board-session-start-hook.ts
+++ b/packages/server/src/lib/board-session-start-hook.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+import path from "node:path";
+import { DIAGRAM_DIR } from "@ark/shared";
+
+export const BOARD_SESSION_START_HOOK_FILENAME =
+  "ark-board-session-start-hook.sh";
+
+/**
+ * Board MCP を使うセッションへ SessionStart hook で渡す説明。
+ * 移設前の 5 文は変えず、1 文ずつ改行して読みやすくする。
+ */
+export const BOARD_SESSION_CONTEXT = [
+  "このセッションにはボードペインがあり、図と文書を表示できる。board_open（ボードに開く）、board_comments（人間が付けたコメントを読む）、board_authoring_guide（作図・文書規約を読む）、board_reply（コメントへ返信する）の 4 つのツールを持っている。",
+  `ユーザーが「図解して」「図で説明して」「フロー図/構成図にして」等、図解・作図・可視化を求めたら、チャットに mermaid や ASCII 図を出すのではなく、${DIAGRAM_DIR}/ 配下に *.diagram.html を書き、board_open で開くこと。`,
+  '設計メモ・仕様・調査結果など「人に読ませる文書」も同じ形式で書ける。model の type を "doc" にすると、ユーザーが本文をテキスト選択してコメントを付けられる、レビュー可能な文書になる。',
+  "ユーザーが「コメントした」「図を見て」等と言ったら、board_comments で未解決コメントを読み、引用された箇所を直してから board_open で開き直し、board_reply で対応内容を返信すること。",
+  "書き込む直前に parent directory が存在しない場合だけ作成する。.diagram.html を書く前に必ず board_authoring_guide で規約を取得し、その内容に従う。",
+].join("\n");
+
+function posixShellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * SessionStart hook の実体を data dir に生成し、そのパスを返す。
+ * hook は静的 JSON を stdout へ返すだけで、文言をコマンド引数へ展開しない。
+ */
+export function writeBoardSessionStartHookFile(dataDir: string): string {
+  const hookPath = path.join(dataDir, BOARD_SESSION_START_HOOK_FILENAME);
+  const output = JSON.stringify({
+    hookSpecificOutput: {
+      hookEventName: "SessionStart",
+      additionalContext: BOARD_SESSION_CONTEXT,
+    },
+  });
+  const script = `#!/bin/sh\nprintf '%s\\n' ${posixShellQuote(output)}\n`;
+
+  fs.writeFileSync(hookPath, script, { mode: 0o600 });
+  // writeFileSync の mode は既存ファイルには適用されないため明示的に矯正する。
+  fs.chmodSync(hookPath, 0o600);
+  return hookPath;
+}
+
+/** settings の command に埋め込むのは hook のパスだけにする。 */
+export function boardSessionStartHookCommand(hookPath: string): string {
+  return `/bin/sh ${posixShellQuote(hookPath)}`;
+}

--- a/packages/server/src/lib/session-orchestrator-context.integration.test.ts
+++ b/packages/server/src/lib/session-orchestrator-context.integration.test.ts
@@ -16,7 +16,6 @@ vi.mock("./tmux-manager.js", async () => {
     getEnv = vi.fn();
     getPaneEnv = vi.fn();
     setClaudeMcpConfigPath = vi.fn();
-    setClaudeAppendSystemPrompt = vi.fn();
   }
   return { tmuxManager: new TmuxManagerStub() };
 });

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -34,7 +34,6 @@ vi.mock("./tmux-manager.js", async () => {
     sendSpecialKey = vi.fn();
     capturePane = vi.fn();
     setClaudeMcpConfigPath = vi.fn();
-    setClaudeAppendSystemPrompt = vi.fn();
     // restoreExistingSessions → detectEnvProfile が参照する (env 無し = null 相当)
     getEnv = vi.fn(() => undefined);
     getPaneEnv = vi.fn(() => undefined);
@@ -89,7 +88,6 @@ vi.mock("node:child_process", () => ({
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { DIAGRAM_DIR } from "@ark/shared";
 import { arkContextHarness } from "./ark-context-harness.js";
 import type { BoardMcpServer } from "./board-mcp-server.js";
 // BoardSessionRegistry は単純な token→worktreePath の in-memory map なので
@@ -804,13 +802,11 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
     createdWorktrees = [];
   });
 
-  it("setBoardMcp 未呼び出しなら MCP config と append system prompt が null になる", async () => {
+  it("setBoardMcp 未呼び出しなら MCP config が null になる", async () => {
     await orchestrator.startSession("wt-1", "/path/to/work", "/repo");
 
     expect(mockedTmux.setClaudeMcpConfigPath).toHaveBeenCalledWith(null);
     expect(mockedTmux.setClaudeMcpConfigPath).toHaveBeenCalledTimes(1);
-    expect(mockedTmux.setClaudeAppendSystemPrompt).toHaveBeenCalledWith(null);
-    expect(mockedTmux.setClaudeAppendSystemPrompt).toHaveBeenCalledTimes(1);
   });
 
   it("setBoardMcp 後の新規セッションで per-session token を生成し、mcp-config を書いて registry に登録する", async () => {
@@ -849,31 +845,6 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
     // bearer token を含むため 0600 で書かれている
     const mode = fs.statSync(cfgPath).mode & 0o777;
     expect(mode).toBe(0o600);
-  });
-
-  it("新規セッションの prompt はボード上の図・文書とコメントの往復手順を案内する", async () => {
-    const registry = new BoardSessionRegistry();
-    orchestrator.setBoardMcp(fakeBoardMcp, registry);
-
-    await orchestrator.startSession("wt-1", "/path/to/work", "/repo");
-
-    const prompt =
-      mockedTmux.setClaudeAppendSystemPrompt.mock.calls.at(-1)?.[0];
-    expect(prompt).not.toContain("\n");
-    expect(prompt).toContain(DIAGRAM_DIR);
-    expect(prompt).not.toContain("docs/diagrams");
-    expect(prompt).toContain("書き込む直前");
-    expect(prompt).toContain("存在しない場合");
-    expect(prompt).toContain("board_open");
-    expect(prompt).toContain("board_comments");
-    expect(prompt).toContain("board_authoring_guide");
-    expect(prompt).toContain("board_reply");
-    expect(prompt).not.toContain("diagram-authoring skill");
-    expect(prompt).toContain('model の type を "doc"');
-    expect(prompt).toContain("本文をテキスト選択してコメントを付けられる");
-    expect(prompt).toContain(
-      "引用された箇所を直してから board_open で開き直し、board_reply で対応内容を返信する"
-    );
   });
 
   it("既存セッション再利用パスでは token を発行しない (setClaudeMcpConfigPath も呼ばれない)", async () => {

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -11,12 +11,11 @@ import { EventEmitter } from "node:events";
 import fs from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  type BridgeSessionStatus,
-  DIAGRAM_DIR,
-  type ManagedSession,
-  type SessionStatus,
-  type SpecialKey,
+import type {
+  BridgeSessionStatus,
+  ManagedSession,
+  SessionStatus,
+  SpecialKey,
 } from "@ark/shared";
 import { stripAnsi } from "./ansi.js";
 import { arkContextHarness } from "./ark-context-harness.js";
@@ -168,7 +167,6 @@ export class SessionOrchestrator extends EventEmitter {
     const port = this.boardMcp?.getPort() ?? null;
     if (port === null || !this.boardRegistry) {
       tmuxManager.setClaudeMcpConfigPath(null);
-      tmuxManager.setClaudeAppendSystemPrompt(null);
       return null;
     }
     const token = randomBytes(24).toString("hex");
@@ -199,19 +197,6 @@ export class SessionOrchestrator extends EventEmitter {
       { mode: 0o600 }
     );
     tmuxManager.setClaudeMcpConfigPath(cfgPath);
-    // ボードの図・文書機能に加え、コメント機能の存在と、コメントを受けて
-    // 修正・再表示する往復手順を全セッションへ伝える。
-    // tmux send-keys に -l がなく、改行は Enter キーとして解釈されるため、
-    // append-system-prompt に渡す文字列は必ず 1 行にする。
-    tmuxManager.setClaudeAppendSystemPrompt(
-      [
-        "このセッションにはボードペインがあり、図と文書を表示できる。board_open（ボードに開く）、board_comments（人間が付けたコメントを読む）、board_authoring_guide（作図・文書規約を読む）、board_reply（コメントへ返信する）の 4 つのツールを持っている。",
-        `ユーザーが「図解して」「図で説明して」「フロー図/構成図にして」等、図解・作図・可視化を求めたら、チャットに mermaid や ASCII 図を出すのではなく、${DIAGRAM_DIR}/ 配下に *.diagram.html を書き、board_open で開くこと。`,
-        '設計メモ・仕様・調査結果など「人に読ませる文書」も同じ形式で書ける。model の type を "doc" にすると、ユーザーが本文をテキスト選択してコメントを付けられる、レビュー可能な文書になる。',
-        "ユーザーが「コメントした」「図を見て」等と言ったら、board_comments で未解決コメントを読み、引用された箇所を直してから board_open で開き直し、board_reply で対応内容を返信すること。",
-        "書き込む直前に parent directory が存在しない場合だけ作成する。.diagram.html を書く前に必ず board_authoring_guide で規約を取得し、その内容に従う。",
-      ].join(" ")
-    );
     return { token, cfgPath };
   }
 
@@ -222,7 +207,6 @@ export class SessionOrchestrator extends EventEmitter {
    */
   private discardBoardMcpConfig(cfgPath: string): void {
     tmuxManager.setClaudeMcpConfigPath(null);
-    tmuxManager.setClaudeAppendSystemPrompt(null);
     try {
       fs.unlinkSync(cfgPath);
     } catch {

--- a/packages/server/src/lib/tmux-manager.test.ts
+++ b/packages/server/src/lib/tmux-manager.test.ts
@@ -314,6 +314,19 @@ describe("TmuxManager.createSession - options互換", () => {
     );
   });
 
+  it("--settings と --mcp-config は渡し、--append-system-prompt は起動コマンドに含めない", async () => {
+    manager.setClaudeSettingsPath("/tmp/ark-claude-settings.json");
+    manager.setClaudeMcpConfigPath("/tmp/sess-mcp.json");
+    await manager.createSession("/path/to/worktree");
+
+    const sendKeys = findCommandSendKeysArgs();
+    if (!sendKeys) throw new Error("send-keys args not found");
+    expect(sendKeys[3]).toBe(
+      "unset CLAUDE_CONFIG_DIR; claude --settings '/tmp/ark-claude-settings.json' --mcp-config '/tmp/sess-mcp.json'"
+    );
+    expect(sendKeys[3]).not.toContain("--append-system-prompt");
+  });
+
   it("setClaudeMcpConfigPath(null) にリセットすると --mcp-config は付与されない (tmuxManager 共有インスタンスの安全確認)", async () => {
     manager.setClaudeMcpConfigPath("/tmp/sess-mcp.json");
     manager.setClaudeMcpConfigPath(null);

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -137,19 +137,13 @@ export class TmuxManager extends EventEmitter {
   private readonly SESSION_PREFIX = "ark-";
   /** パーミッションスキップフラグ（--dangerously-skip-permissions を付与するか） */
   private skipPermissions = false;
-  /** claude 起動時に --settings で注入する settings JSON のパス (AUQ hook 用) */
+  /** claude 起動時に --settings で注入する hooks 設定 JSON のパス */
   private claudeSettingsPath: string | null = null;
   /**
    * claude 起動時に --mcp-config で注入する per-session MCP config JSON のパス
    * (board_write 等)。SessionOrchestrator がセッション起動直前に設定する。
    */
   private claudeMcpConfigPath: string | null = null;
-  /**
-   * claude 起動時に --append-system-prompt で注入する追加指示。
-   * board_write 等のセッション固有ツールの使い方をモデルに促すために使う。
-   * claudeMcpConfigPath と同様、SessionOrchestrator が起動直前に設定する。
-   */
-  private claudeAppendSystemPrompt: string | null = null;
 
   constructor() {
     super();
@@ -168,7 +162,7 @@ export class TmuxManager extends EventEmitter {
 
   /**
    * claude 起動コマンドに `--settings <path>` で注入する settings JSON を
-   * 設定する (AskUserQuestion の PreToolUse hook 等)。
+   * 設定する (SessionStart / AskUserQuestion の hooks 等)。
    * サーバー起動時 (listen 後、port 確定後) に呼ばれる。
    */
   setClaudeSettingsPath(value: string | null): void {
@@ -185,16 +179,6 @@ export class TmuxManager extends EventEmitter {
    */
   setClaudeMcpConfigPath(value: string | null): void {
     this.claudeMcpConfigPath = value;
-  }
-
-  /**
-   * claude 起動コマンドに `--append-system-prompt <text>` で注入する追加指示を
-   * 設定する。board MCP を持つセッションに「図解要求はボードに描く」等を促す。
-   * 共有インスタンスなので、各セッション起動直前に必ず設定し直すこと
-   * (board MCP 非対応セッションでは null を渡して前回値を持ち越さない)。
-   */
-  setClaudeAppendSystemPrompt(value: string | null): void {
-    this.claudeAppendSystemPrompt = value;
   }
 
   /**
@@ -358,11 +342,6 @@ export class TmuxManager extends EventEmitter {
     const mcpConfigArg = this.claudeMcpConfigPath
       ? ` --mcp-config ${posixShellQuote(this.claudeMcpConfigPath)}`
       : "";
-    // board_write 等のツールの使い方をモデルに促す追加 system prompt。
-    // SessionOrchestrator が board MCP を注入するセッションにだけ設定する。
-    const appendPromptArg = this.claudeAppendSystemPrompt
-      ? ` --append-system-prompt ${posixShellQuote(this.claudeAppendSystemPrompt)}`
-      : "";
     // プロファイル未指定のセッションが、Ark サーバープロセス (やその親、
     // tmux サーバー) の CLAUDE_CONFIG_DIR を意図せず継承すると、transcript が
     // 想定外の config dir 配下に書かれ、JSONL tail (チャットビュー) が
@@ -378,7 +357,7 @@ export class TmuxManager extends EventEmitter {
       : "";
     const claudeCmd =
       options?.commandLine ??
-      `${envPrefix}${claudeArg}${skipFlag}${settingsArg}${mcpConfigArg}${appendPromptArg}`;
+      `${envPrefix}${claudeArg}${skipFlag}${settingsArg}${mcpConfigArg}`;
 
     let tmuxCreated = false;
 


### PR DESCRIPTION
ボードの説明を `--append-system-prompt` から SessionStart hook へ移す。

Closes #384

## 問題

ボードの説明 5 文・1,333 バイトを 1 行に連結し、**起動コマンドの引数へ直書き**していた。

```
--append-system-prompt 'このセッションにはボードペインがあり、…（1,333 バイト）'
```

- **`ps` で同一マシンの全ユーザーから読める**（実測 9 プロセス）
- シェルのクォートを通るため改行が使えず、「必ず 1 行にする」制約がコードのコメントに残っていた
- tmux のスクロールバックが毎回 1,333 バイトの壁で汚れる

`--mcp-config` と `--settings` は既にファイル経路を使っており、**プロンプトだけがインライン**だった。

## 変更

**既存の `--settings` ファイルに SessionStart hook を足す。** 新しい経路は作っていない。

`auq-hook-bridge.ts` の `writeSettingsFile()` が生成する `ark-claude-settings.json` は
既に `hooks.PreToolUse`（AUQ 用）を持つ。そこへ `hooks.SessionStart` を追加した。

- `board-session-start-hook.ts` に文言と生成処理を置く
- 実体は `<dataDir>/ark-board-session-start-hook.sh`（0600）として生成
- `session-orchestrator.ts` / `tmux-manager.ts` から `--append-system-prompt` を撤去

**文言は変えていない。** 1 行連結の制約が消えたので、文ごとに改行を入れただけ。

同梱 claude 2.1.238 に `--append-system-prompt-file` は無い
（`--system-prompt` / `--append-system-prompt` / `--exclude-dynamic-system-prompt-sections` のみ）
ため、hook 経路が唯一の選択肢。

## 検証

実装は codex、レビューは Claude（実装者 ≠ レビュアー）。

### 文言の同一性

main の 5 文に含まれる主要語 10 個（`ボードペインがあり` / `board_open` / `board_comments` /
`board_authoring_guide` / `board_reply` / `mermaid` / `diagram.html` / `type を "doc"` /
`コメントした` / `parent directory`）が**すべて新 hook に存在する**ことを確認。

### 撤去の確認

```
main   append-system-prompt の出現: 6
本 PR  append-system-prompt の出現: 0
```

`tmux-manager.ts` と `session-orchestrator.ts` の両方で 0 件。

### テスト

新規 4 ケース（両 hook の生成 / JSON の妥当性 / mode 0600 / 既存 mode の矯正 /
hook stdout の 5 文一致 / 起動引数の `--settings`・`--mcp-config` 維持と append 不在）。

変異テスト 3 種（SessionStart 名の変更 / 文言 1 語の変更 / append フラグの再導入）で
それぞれ 1 件・1 件・10 件の失敗を確認。

```
pnpm check      exit 0
pnpm test       exit 0   67 files / 1,076 tests
pnpm build      exit 0
pnpm test:harness        505/505
ark/context/tests        443/443
```

### deploy 後の確認方法

```
ps -eo args | grep '[a]ppend-system-prompt'
```

**既存セッションは再作成まで旧引数を保持する**ため、新規セッションで確認する。

## 範囲外

`board_authoring_guide` が返す規約（約 9,800 トークン）の短縮は含めない。
経路の移設だけに絞った。規約の分割は他の利用者の体験に影響するため別途判断する。

## レビュー中の失敗（記録）

検証のため `node -e` で `cli.js` を require したところ、**2 つ目の Ark サーバーが
起動しかけた**。ポート衝突を回避して即終了したため実害は無く、本番（pm2 online /
HTTP 200 / tmux 6 セッション / ttyd 本番分のみ）は無傷。

前日に同種の事故を `knowledge/failures.md` へ記録していたが、
「`cli.js` を require するだけでも起動する」という形は書いていなかった。追記した。
