### PR TITLE
fix(diagram): 図解コメントの mutation に操作 ID を導入し再試行を冪等にする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,23 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 - **カードを閉じる**: JSONL に解決イベントが出現したとき (`hasResolvedAuqSince`)
 - permission prompt 等は AWAITING バナー (+[1][2] クイックキー + ターミナル誘導)
 
+### 図解コメントの操作 ID（operationId）
+
+コメントの mutation（create / reply / resolve / delete / send）はクライアント側
+（transport）の ACK タイムアウトがサーバー処理を取り消さないため、再試行で
+同じ操作が二重に適用されうる（#306）。そのため mutation payload には
+クライアント生成の `operationId` を必須で載せ、サーバーはプロセス内 LRU
+（`diagram-comment-operation-log.ts`）で適用済み ID を記録して、同じ ID の
+再送は再適用せず現在の sidecar を返す。
+
+- `operationId` は iframe のコメント層が「ユーザー操作」単位で生成し、
+  タイムアウト後にユーザーが同じ操作をやり直しても同じ値を送る（成功時に破棄）
+- transport は ACK が 5 秒戻らなければ同じ payload をそのまま 1 回再送する
+  （合計 10 秒。iframe 側 watchdog の 15 秒より短い）
+- MCP 経由（Claude の `board_reply` 等）は `operationId` 無しで呼び、冪等化しない
+- 記録は sidecar に持たせない（成果物に再試行の都合を混ぜない。再起動をまたぐ
+  再試行は socket も切れるため稀）
+
 ### セッション永続化
 
 - **tmuxセッション**: サーバー再起動後も維持される（`cleanup()`でttydのみ停止、tmuxは残す）
@@ -300,6 +317,12 @@ claude-code-ark/
 | `session:jsonl-unsubscribe` | `sessionId: string`           | JSONL 購読解除                   |
 | `session:jsonl-load-more` | `{ sessionId, limit }`          | 過去履歴を limit 行で snapshot 再送 |
 | `session:send-literal` | `{ sessionId, text }`              | Enter 無しの literal 送信（AUQ 自由入力用）|
+| `diagram:comments:get` | `{ sessionId, relPath }, callback`  | 図のコメント sidecar を取得（コールバック） |
+| `diagram:comment:create` | `{ sessionId, relPath, operationId, anchorId, body, anchorQuote?, anchorOccurrence? }, callback` | コメント thread 作成 |
+| `diagram:comment:reply` | `{ sessionId, relPath, operationId, threadId, body }, callback` | thread へ返信 |
+| `diagram:comment:resolve` | `{ sessionId, relPath, operationId, threadId }, callback` | thread を解決済みにする |
+| `diagram:comment:delete` | `{ sessionId, relPath, operationId, threadId }, callback` | thread を削除 |
+| `diagram:comment:send` | `{ sessionId, relPath, operationId, threadId }, callback` | thread の内容を会話セッションへ送る |
 | `diagram:subscribe` | `{ worktreePath, relPath }`           | 図ファイルの更新監視を開始（1セッション1図を想定） |
 | `diagram:unsubscribe` | `{ worktreePath, relPath }`         | 図ファイルの更新監視を解除                       |
 | `slash:list`      | `sessionId, callback`                   | slash command 候補一覧（コールバック）|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 - MCP 経由（Claude の `board_reply` 等）は `operationId` 無しで呼び、冪等化しない
 - 記録は sidecar に持たせない（成果物に再試行の都合を混ぜない。再起動をまたぐ
   再試行は socket も切れるため稀）
+- サーバー再起動をまたぐ再試行は冪等化の対象外とする
 
 ### セッション永続化
 

--- a/packages/server/src/lib/diagram-comment-layer.test.ts
+++ b/packages/server/src/lib/diagram-comment-layer.test.ts
@@ -1423,6 +1423,21 @@ describe("comment layer の operationId (#306)", () => {
     );
   });
 
+  it("本文や引用に改行が含まれても別の操作と key が衝突しない", () => {
+    const helpers = loadHelpers();
+
+    const bodyWithNewline = helpers.operationKeyFor(
+      "ark:diagram-comment-create",
+      { anchorId: "s1", body: "x\ny", anchorQuote: "z" }
+    );
+    const quoteWithNewline = helpers.operationKeyFor(
+      "ark:diagram-comment-create",
+      { anchorId: "s1", body: "x", anchorQuote: "y\nz" }
+    );
+
+    expect(bodyWithNewline).not.toBe(quoteWithNewline);
+  });
+
   it("crypto.randomUUID があればそれを使い、無ければ時刻と乱数で代替する", () => {
     const secure = loadHelpers({ randomUUID: () => "uuid-fixed" });
     expect(secure.operationIdFor("k")).toBe("op-uuid-fixed-1");

--- a/packages/server/src/lib/diagram-comment-layer.test.ts
+++ b/packages/server/src/lib/diagram-comment-layer.test.ts
@@ -1292,3 +1292,156 @@ describe("injectDiagramCommentLayer", () => {
     expect(injected).toContain("data.requestId!==pendingRequestId");
   });
 });
+
+describe("comment layer の operationId (#306)", () => {
+  type OperationHelpers = {
+    operationKeyFor: (
+      type: string,
+      payload?: Record<string, unknown>
+    ) => string;
+    operationIdFor: (key: string) => string;
+    operationIds: Map<string, string>;
+  };
+
+  const loadHelpers = (
+    options: { limit?: number; randomUUID?: () => string } = {}
+  ): OperationHelpers => {
+    const source = COMMENT_LAYER.slice(
+      COMMENT_LAYER.indexOf("function newOperationId"),
+      COMMENT_LAYER.indexOf("function anchorEntry")
+    );
+    const context: Record<string, unknown> = {
+      window: {
+        crypto:
+          options.randomUUID === undefined
+            ? undefined
+            : { randomUUID: options.randomUUID },
+      },
+      Date,
+      Math,
+      Map,
+      String,
+      operationIds: new Map<string, string>(),
+      operationSequence: 0,
+      OPERATION_ID_LIMIT: options.limit ?? 100,
+    };
+    runInNewContext(
+      `${source};this.operationKeyFor=operationKeyFor;this.operationIdFor=operationIdFor;`,
+      context
+    );
+    return context as unknown as OperationHelpers;
+  };
+
+  it("mutation だけに operationId を載せ、load には載せない", () => {
+    const injected = injectDiagramCommentLayer(minimalDoc);
+
+    expect(injected).toContain(
+      'if(type!=="ark:diagram-comments-load"){\n      pendingAction.operationKey=operationKeyFor(type,payload);\n      message.operationId=operationIdFor(pendingAction.operationKey);\n    }'
+    );
+    expect(injected.indexOf("message.operationId=")).toBeGreaterThan(
+      injected.indexOf("var message={type:type,requestId:pendingRequestId};")
+    );
+    expect(injected.indexOf("message.operationId=")).toBeLessThan(
+      injected.indexOf("port.postMessage(message);")
+    );
+    expect(injected.match(/message\.operationId=/gu)).toHaveLength(1);
+  });
+
+  it("成功した操作の operationId だけを捨て、失敗・タイムアウトでは残す", () => {
+    const injected = injectDiagramCommentLayer(minimalDoc);
+    const success = injected.indexOf(
+      "if(data.ok){\n      if(completedAction&&completedAction.operationKey)operationIds.delete(completedAction.operationKey);"
+    );
+
+    expect(success).toBeGreaterThan(0);
+    expect(
+      injected.match(/operationIds\.delete\(completedAction/gu)
+    ).toHaveLength(1);
+    const timeoutHandler = injected.slice(
+      injected.indexOf("pendingTimer=window.setTimeout(function(){"),
+      injected.indexOf("},15000);")
+    );
+    expect(timeoutHandler).not.toContain("operationIds");
+  });
+
+  it("同じ操作の再試行は同じ operationId を返し、成功後は新しい ID になる", () => {
+    const helpers = loadHelpers();
+    const key = helpers.operationKeyFor("ark:diagram-comment-create", {
+      anchorId: "s1",
+      body: "本文",
+    });
+
+    const first = helpers.operationIdFor(key);
+    const retried = helpers.operationIdFor(key);
+    helpers.operationIds.delete(key);
+    const afterSuccess = helpers.operationIdFor(key);
+
+    expect(retried).toBe(first);
+    expect(afterSuccess).not.toBe(first);
+    expect(first).toMatch(/^op-[A-Za-z0-9-]+-1$/u);
+  });
+
+  it("操作の種別・対象・本文のどれかが違えば別の operationId になる", () => {
+    const helpers = loadHelpers();
+    const keys = [
+      helpers.operationKeyFor("ark:diagram-comment-create", {
+        anchorId: "s1",
+        body: "本文",
+      }),
+      helpers.operationKeyFor("ark:diagram-comment-create", {
+        anchorId: "s1",
+        body: "本文を直した",
+      }),
+      helpers.operationKeyFor("ark:diagram-comment-create", {
+        anchorId: "s1",
+        anchorQuote: "引用",
+        anchorOccurrence: 0,
+        body: "本文",
+      }),
+      helpers.operationKeyFor("ark:diagram-comment-create", {
+        anchorId: "s1",
+        anchorQuote: "引用",
+        anchorOccurrence: 1,
+        body: "本文",
+      }),
+      helpers.operationKeyFor("ark:diagram-comment-resolve", {
+        threadId: "th-1",
+      }),
+      helpers.operationKeyFor("ark:diagram-comment-delete", {
+        threadId: "th-1",
+      }),
+      helpers.operationKeyFor("ark:diagram-comment-send", { threadId: "th-1" }),
+      helpers.operationKeyFor("ark:diagram-comment-reply", {
+        threadId: "th-1",
+        body: "返信",
+      }),
+    ];
+
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(new Set(keys.map(key => helpers.operationIdFor(key))).size).toBe(
+      keys.length
+    );
+  });
+
+  it("crypto.randomUUID があればそれを使い、無ければ時刻と乱数で代替する", () => {
+    const secure = loadHelpers({ randomUUID: () => "uuid-fixed" });
+    expect(secure.operationIdFor("k")).toBe("op-uuid-fixed-1");
+
+    const insecure = loadHelpers();
+    const generated = insecure.operationIdFor("k");
+    expect(generated).toMatch(/^op-[a-z0-9]+-[a-z0-9]+-1$/u);
+    expect(generated).not.toBe(insecure.operationIdFor("other"));
+  });
+
+  it("覚える operationId は上限を超えると古いものから捨てる", () => {
+    const helpers = loadHelpers({ limit: 2 });
+
+    const first = helpers.operationIdFor("a");
+    helpers.operationIdFor("b");
+    helpers.operationIdFor("c");
+
+    expect(helpers.operationIds.size).toBe(2);
+    expect(helpers.operationIds.has("a")).toBe(false);
+    expect(helpers.operationIdFor("a")).not.toBe(first);
+  });
+});

--- a/packages/server/src/lib/diagram-comment-layer.ts
+++ b/packages/server/src/lib/diagram-comment-layer.ts
@@ -29,6 +29,13 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
   var sentThreadIds=new Set();
   var showResolved=false;
   var requestSequence=0;
+  // ACK タイムアウト後にユーザーが同じ操作をやり直しても、サーバーへは同じ
+  // operationId を送る（#306）。サーバーは適用済みの ID を再適用しないので
+  // 二重作成・二重送信にならない。成功した操作の ID は捨て、失敗・タイムアウト
+  // した操作の ID は次の再試行まで残す。
+  var OPERATION_ID_LIMIT=100;
+  var operationIds=new Map();
+  var operationSequence=0;
   var root=null;
   var anchors=[];
   var composerAnchorId=null;
@@ -59,6 +66,36 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
   }
   function clear(value){while(value.firstChild)value.removeChild(value.firstChild);}
   function requestId(){requestSequence+=1;return "comment-"+Date.now()+"-"+requestSequence;}
+  function newOperationId(){
+    operationSequence+=1;
+    var random=window.crypto&&typeof window.crypto.randomUUID==="function"
+      ?window.crypto.randomUUID()
+      :Date.now().toString(36)+"-"+Math.random().toString(36).slice(2);
+    return "op-"+random+"-"+operationSequence;
+  }
+  function operationKeyFor(type,payload){
+    var source=payload||{};
+    return [
+      type,
+      source.anchorId||"",
+      source.threadId||"",
+      source.body||"",
+      source.anchorQuote||"",
+      source.anchorOccurrence===undefined||source.anchorOccurrence===null?"":String(source.anchorOccurrence)
+    ].join("\\n");
+  }
+  function operationIdFor(operationKey){
+    var existing=operationIds.get(operationKey);
+    if(existing)return existing;
+    var created=newOperationId();
+    operationIds.set(operationKey,created);
+    while(operationIds.size>OPERATION_ID_LIMIT){
+      var oldest=operationIds.keys().next();
+      if(oldest.done)break;
+      operationIds.delete(oldest.value);
+    }
+    return created;
+  }
   function anchorEntry(anchorId){
     return anchors.filter(function(entry){return entry.anchorId===anchorId;})[0]||null;
   }
@@ -139,6 +176,10 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
     operationError=null;
     var message={type:type,requestId:pendingRequestId};
     Object.keys(payload||{}).forEach(function(key){message[key]=payload[key];});
+    if(type!=="ark:diagram-comments-load"){
+      pendingAction.operationKey=operationKeyFor(type,payload);
+      message.operationId=operationIdFor(pendingAction.operationKey);
+    }
     if(!pendingAction.passive)updatePendingControls();
     pendingTimer=window.setTimeout(function(){
       var timedOutAction=pendingAction;
@@ -910,6 +951,7 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
     pendingRequestId=null;
     pendingAction=null;
     if(data.ok){
+      if(completedAction&&completedAction.operationKey)operationIds.delete(completedAction.operationKey);
       var previousThreadIds=new Set(comments.threads.map(function(thread){return thread.id;}));
       comments=data.comments;
       operationError=null;

--- a/packages/server/src/lib/diagram-comment-layer.ts
+++ b/packages/server/src/lib/diagram-comment-layer.ts
@@ -74,15 +74,17 @@ export const COMMENT_LAYER = `<script id="${DIAGRAM_COMMENT_LAYER_MARKER}" data-
     return "op-"+random+"-"+operationSequence;
   }
   function operationKeyFor(type,payload){
+    // 本文や引用は改行を含みうるので、区切り文字の連結ではなく JSON で符号化し、
+    // 別の操作が同じ key に潰れないようにする。
     var source=payload||{};
-    return [
+    return JSON.stringify([
       type,
       source.anchorId||"",
       source.threadId||"",
       source.body||"",
       source.anchorQuote||"",
       source.anchorOccurrence===undefined||source.anchorOccurrence===null?"":String(source.anchorOccurrence)
-    ].join("\\n");
+    ]);
   }
   function operationIdFor(operationKey){
     var existing=operationIds.get(operationKey);

--- a/packages/server/src/lib/diagram-comment-operation-log.test.ts
+++ b/packages/server/src/lib/diagram-comment-operation-log.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  DiagramCommentOperationLog,
+  diagramCommentOperationKey,
+} from "./diagram-comment-operation-log.js";
+
+describe("DiagramCommentOperationLog", () => {
+  it("記録した key だけを適用済みと判定する", () => {
+    const log = new DiagramCommentOperationLog();
+
+    expect(log.has("a")).toBe(false);
+    log.record("a");
+    expect(log.has("a")).toBe(true);
+    expect(log.has("b")).toBe(false);
+  });
+
+  it("上限を超えると最も古いエントリから捨てる", () => {
+    const log = new DiagramCommentOperationLog(2);
+
+    log.record("a");
+    log.record("b");
+    log.record("c");
+
+    expect(log.size).toBe(2);
+    expect(log.has("a")).toBe(false);
+    expect(log.has("b")).toBe(true);
+    expect(log.has("c")).toBe(true);
+  });
+
+  it("参照されたエントリは延命され、未参照のものが先に捨てられる", () => {
+    const log = new DiagramCommentOperationLog(2);
+
+    log.record("a");
+    log.record("b");
+    expect(log.has("a")).toBe(true);
+    log.record("c");
+
+    expect(log.has("b")).toBe(false);
+    expect(log.has("a")).toBe(true);
+    expect(log.has("c")).toBe(true);
+  });
+
+  it("同じ key の再記録は重複エントリを作らない", () => {
+    const log = new DiagramCommentOperationLog(2);
+
+    log.record("a");
+    log.record("a");
+    log.record("b");
+
+    expect(log.size).toBe(2);
+    expect(log.has("a")).toBe(true);
+  });
+
+  it("clear で全エントリを捨てる", () => {
+    const log = new DiagramCommentOperationLog();
+    log.record("a");
+    log.clear();
+    expect(log.has("a")).toBe(false);
+    expect(log.size).toBe(0);
+  });
+
+  it("不正な上限は拒否する", () => {
+    expect(() => new DiagramCommentOperationLog(0)).toThrow(RangeError);
+    expect(() => new DiagramCommentOperationLog(1.5)).toThrow(RangeError);
+  });
+});
+
+describe("diagramCommentOperationKey", () => {
+  it("種別・対象・操作 ID のいずれかが違えば別 key になる", () => {
+    const base = diagramCommentOperationKey("create", "/a.comments.json", "op");
+    expect(
+      diagramCommentOperationKey("delete", "/a.comments.json", "op")
+    ).not.toBe(base);
+    expect(
+      diagramCommentOperationKey("create", "/b.comments.json", "op")
+    ).not.toBe(base);
+    expect(
+      diagramCommentOperationKey("create", "/a.comments.json", "op2")
+    ).not.toBe(base);
+    expect(diagramCommentOperationKey("create", "/a.comments.json", "op")).toBe(
+      base
+    );
+  });
+
+  it("区切り文字を含む入力でも文字列連結による衝突を起こさない", () => {
+    expect(diagramCommentOperationKey("create", "/a", "b\0c")).not.toBe(
+      diagramCommentOperationKey("create", "/a\0b", "c")
+    );
+    expect(diagramCommentOperationKey("create", "/a", 'b","c')).not.toBe(
+      diagramCommentOperationKey("create", '/a","b', "c")
+    );
+  });
+});

--- a/packages/server/src/lib/diagram-comment-operation-log.ts
+++ b/packages/server/src/lib/diagram-comment-operation-log.ts
@@ -1,0 +1,70 @@
+/**
+ * 図解コメント mutation の「適用済み操作 ID」を覚えるプロセス内 LRU。
+ *
+ * クライアント側の ACK タイムアウトはサーバー処理を取り消さないため、
+ * 再試行で同じ操作 ID が届いたときに再適用しないための記録として使う。
+ *
+ * sidecar に持たせない理由:
+ * - sidecar は Claude / 人間が読む成果物で、再試行の都合を混ぜたくない
+ * - 再試行はタイムアウト直後の秒〜分単位で起こる。サーバー再起動をまたぐ
+ *   再試行は socket も切れるため稀で、プロセス内の記録で実用上足りる
+ *
+ * 値（レスポンス）は保持しない。sidecar は最大 1MiB あり、応答を保持すると
+ * エントリ数 × 1MiB のメモリを抱えるため、再適用時は sidecar を読み直して返す。
+ */
+export const DIAGRAM_COMMENT_OPERATION_LOG_MAX_ENTRIES = 1000;
+
+export class DiagramCommentOperationLog {
+  private readonly entries = new Set<string>();
+
+  constructor(
+    private readonly maxEntries = DIAGRAM_COMMENT_OPERATION_LOG_MAX_ENTRIES
+  ) {
+    if (!Number.isSafeInteger(maxEntries) || maxEntries < 1) {
+      throw new RangeError("maxEntries は 1 以上の整数が必要です");
+    }
+  }
+
+  /** 記録済みなら true。参照されたエントリは最近使用として延命する。 */
+  has(key: string): boolean {
+    if (!this.entries.has(key)) return false;
+    this.entries.delete(key);
+    this.entries.add(key);
+    return true;
+  }
+
+  /** 適用済みとして記録する。上限を超えたら最も古いエントリを捨てる。 */
+  record(key: string): void {
+    this.entries.delete(key);
+    this.entries.add(key);
+    while (this.entries.size > this.maxEntries) {
+      const oldest = this.entries.values().next();
+      if (oldest.done) break;
+      this.entries.delete(oldest.value);
+    }
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+}
+
+/**
+ * 操作 ID の衝突範囲を (操作種別, 対象) に限定する key を作る。
+ * クライアントが別ファイル・別種別で同じ ID を使い回しても混線しない。
+ * 単純な文字列連結だと区切り文字を含む入力で衝突しうるため JSON で符号化する。
+ */
+export function diagramCommentOperationKey(
+  kind: "create" | "reply" | "resolve" | "delete" | "send",
+  scope: string,
+  operationId: string
+): string {
+  return JSON.stringify([kind, scope, operationId]);
+}
+
+/** プロセス内で共有する適用済み操作の記録。 */
+export const diagramCommentOperationLog = new DiagramCommentOperationLog();

--- a/packages/server/src/lib/diagram-comment-retry.integration.test.ts
+++ b/packages/server/src/lib/diagram-comment-retry.integration.test.ts
@@ -1,0 +1,217 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type {
+  ClientToServerEvents,
+  DiagramCommentsResponse,
+  ServerToClientEvents,
+} from "@ark/shared";
+import type { Socket } from "socket.io-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DIAGRAM_COMMENT_ACK_TIMEOUT_MS,
+  requestDiagramCommentCreate,
+  requestDiagramCommentDelete,
+} from "../../../web/src/lib/diagram-comment-transport.js";
+import { diagramCommentOperationLog } from "./diagram-comment-operation-log.js";
+import {
+  createDiagramComment,
+  readDiagramCommentsFile,
+} from "./diagram-comments.js";
+import {
+  createDiagramCommentsSocketHandlers,
+  type DiagramCommentsHandlerDeps,
+  diagramCommentsStore,
+} from "./diagram-comments-handler.js";
+
+type DiagramCommentSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
+type SocketHandlers = ReturnType<typeof createDiagramCommentsSocketHandlers>;
+type SocketHandler = (data: unknown, callback: unknown) => void;
+
+const sessionId = "session-1";
+const relPath = ".claude/diagrams/order-flow.diagram.html";
+let worktree: string;
+
+function writeDiagram(): void {
+  const nodes = [{ id: "s1-p1", label: "注文を受け付ける" }];
+  fs.mkdirSync(path.join(worktree, ".claude/diagrams"), { recursive: true });
+  fs.writeFileSync(
+    path.join(worktree, relPath),
+    `<!doctype html><html><body><script type="application/json" id="ark-diagram-model">${JSON.stringify({ version: 1, type: "doc", nodes, edges: [], groups: [] })}</script><p data-ark-id="s1-p1">注文を受け付ける</p></body></html>`
+  );
+}
+
+function dependencies(): DiagramCommentsHandlerDeps {
+  return {
+    getSession: requestedId =>
+      requestedId === sessionId
+        ? { id: sessionId, worktreePath: worktree }
+        : null,
+    resolveManagedWorktreePath: requestedPath =>
+      requestedPath === worktree ? worktree : null,
+    ...diagramCommentsStore,
+    sendMessage: vi.fn(),
+    operationLog: diagramCommentOperationLog,
+  };
+}
+
+function handlerForEvent(
+  handlers: SocketHandlers,
+  event: string
+): SocketHandler {
+  const byEvent: Record<string, SocketHandler> = {
+    "diagram:comments:get": handlers.get,
+    "diagram:comment:create": handlers.create,
+    "diagram:comment:reply": handlers.reply,
+    "diagram:comment:resolve": handlers.resolve,
+    "diagram:comment:delete": handlers.delete,
+    "diagram:comment:send": handlers.send,
+  };
+  const handler = byEvent[event];
+  if (handler === undefined) throw new Error(`unexpected event: ${event}`);
+  return handler;
+}
+
+/** 実 handler から返る最初の ACK だけをネットワーク上で破棄する socket。 */
+function socketDroppingFirstAck(handlers: SocketHandlers): {
+  socket: DiagramCommentSocket;
+  firstAckDropped: Promise<DiagramCommentsResponse>;
+  emittedPayloads: unknown[];
+  serverAckCount: () => number;
+} {
+  let acknowledgeDrop: (response: DiagramCommentsResponse) => void = () =>
+    undefined;
+  const firstAckDropped = new Promise<DiagramCommentsResponse>(resolve => {
+    acknowledgeDrop = resolve;
+  });
+  const emittedPayloads: unknown[] = [];
+  let serverAckCount = 0;
+  const socket = {
+    connected: true,
+    emit: vi.fn(
+      (
+        event: string,
+        payload: unknown,
+        clientAck: (response: DiagramCommentsResponse) => void
+      ) => {
+        emittedPayloads.push(payload);
+        handlerForEvent(handlers, event)(
+          payload,
+          (response: DiagramCommentsResponse) => {
+            serverAckCount += 1;
+            if (serverAckCount === 1) {
+              acknowledgeDrop(response);
+              return;
+            }
+            clientAck(response);
+          }
+        );
+      }
+    ),
+  } as unknown as DiagramCommentSocket;
+  return {
+    socket,
+    firstAckDropped,
+    emittedPayloads,
+    serverAckCount: () => serverAckCount,
+  };
+}
+
+describe("diagram comment ACK timeout retry integration (#306)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    diagramCommentOperationLog.clear();
+    worktree = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "ark-comment-retry-"))
+    );
+    writeDiagram();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    diagramCommentOperationLog.clear();
+    fs.rmSync(worktree, { recursive: true, force: true });
+  });
+
+  it("create の ACK 欠落後に同じ payload を再送しても thread は 1 件だけ", async () => {
+    const fake = socketDroppingFirstAck(
+      createDiagramCommentsSocketHandlers(dependencies())
+    );
+    const pending = requestDiagramCommentCreate(
+      fake.socket,
+      sessionId,
+      relPath,
+      "op-create-retry",
+      "s1-p1",
+      "本文"
+    );
+
+    const droppedResponse = await fake.firstAckDropped;
+    expect(droppedResponse.ok && droppedResponse.comments.threads).toHaveLength(
+      1
+    );
+    const writtenAfterFirstAttempt = await readDiagramCommentsFile(
+      worktree,
+      relPath
+    );
+    expect(
+      writtenAfterFirstAttempt.ok && writtenAfterFirstAttempt.comments.threads
+    ).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(DIAGRAM_COMMENT_ACK_TIMEOUT_MS);
+    const retriedResponse = await pending;
+
+    expect(fake.serverAckCount()).toBe(2);
+    expect(fake.emittedPayloads).toHaveLength(2);
+    expect(fake.emittedPayloads[1]).toStrictEqual(fake.emittedPayloads[0]);
+    expect(retriedResponse.ok && retriedResponse.comments.threads).toHaveLength(
+      1
+    );
+    const stored = await readDiagramCommentsFile(worktree, relPath);
+    expect(stored.ok && stored.comments.threads).toHaveLength(1);
+  });
+
+  it("delete の ACK 欠落後も再適用せず現在の空 sidecar を返す", async () => {
+    const created = await createDiagramComment(
+      worktree,
+      relPath,
+      "s1-p1",
+      "削除対象",
+      undefined,
+      undefined,
+      { operationId: "op-create-for-delete" }
+    );
+    if (!created.ok) throw new Error(created.error);
+    const threadId = created.comments.threads[0]?.id;
+    if (threadId === undefined) throw new Error("thread expected");
+    const fake = socketDroppingFirstAck(
+      createDiagramCommentsSocketHandlers(dependencies())
+    );
+    const pending = requestDiagramCommentDelete(
+      fake.socket,
+      sessionId,
+      relPath,
+      "op-delete-retry",
+      threadId
+    );
+
+    const droppedResponse = await fake.firstAckDropped;
+    expect(droppedResponse).toMatchObject({
+      ok: true,
+      comments: { threads: [] },
+    });
+
+    await vi.advanceTimersByTimeAsync(DIAGRAM_COMMENT_ACK_TIMEOUT_MS);
+    const retriedResponse = await pending;
+
+    expect(fake.serverAckCount()).toBe(2);
+    expect(fake.emittedPayloads).toHaveLength(2);
+    expect(fake.emittedPayloads[1]).toStrictEqual(fake.emittedPayloads[0]);
+    expect(retriedResponse).toMatchObject({
+      ok: true,
+      comments: { threads: [] },
+    });
+    const stored = await readDiagramCommentsFile(worktree, relPath);
+    expect(stored).toMatchObject({ ok: true, comments: { threads: [] } });
+  });
+});

--- a/packages/server/src/lib/diagram-comments-handler.test.ts
+++ b/packages/server/src/lib/diagram-comments-handler.test.ts
@@ -1,5 +1,6 @@
 import type { DiagramCommentsResponse } from "@ark/shared";
 import { describe, expect, it, vi } from "vitest";
+import { DiagramCommentOperationLog } from "./diagram-comment-operation-log.js";
 import {
   createDiagramCommentsSocketHandlers,
   type DiagramCommentsHandlerDeps,
@@ -33,6 +34,8 @@ function deps(): DiagramCommentsHandlerDeps {
     deleteComment: vi.fn(async () => snapshot),
     resolveComment: vi.fn(async () => snapshot),
     sendMessage: vi.fn(),
+    // send の冪等化記録はプロセス共有なので、テスト間で漏れないよう毎回新しくする
+    operationLog: new DiagramCommentOperationLog(),
   };
 }
 
@@ -43,6 +46,7 @@ describe("handleDiagramCommentReply", () => {
     await handleDiagramCommentReply(dependencies, {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       threadId: "th-1",
       body: " 人間の返信 ",
     });
@@ -51,7 +55,8 @@ describe("handleDiagramCommentReply", () => {
       "/managed/worktree",
       "sample.diagram.html",
       "th-1",
-      { body: "人間の返信" }
+      { body: "人間の返信" },
+      { operationId: "op-1" }
     );
   });
 });
@@ -158,24 +163,28 @@ describe("diagram comments handler core", () => {
     {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       anchorId: "",
       body: "本文",
     },
     {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       anchorId: "a".repeat(257),
       body: "本文",
     },
     {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       anchorId: "s1",
       body: " ",
     },
     {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       anchorId: "s1",
       body: "b".repeat(4001),
     },
@@ -195,6 +204,7 @@ describe("diagram comments handler core", () => {
       handleDiagramCommentCreate(dependencies, {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         anchorId: "s1",
         author: "Reviewer",
         body: "本文",
@@ -210,11 +220,13 @@ describe("diagram comments handler core", () => {
     {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       threadId: "th-1\0",
     },
     {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       threadId: "t".repeat(257),
     },
   ])("resolve の不正 payload %j を BAD_REQUEST にする", async payload => {
@@ -233,6 +245,7 @@ describe("diagram comments handler core", () => {
       handleDiagramCommentDelete(dependencies, {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "th-1",
       })
     ).resolves.toEqual(snapshot);
@@ -243,7 +256,8 @@ describe("diagram comments handler core", () => {
     expect(dependencies.deleteComment).toHaveBeenCalledWith(
       "/managed/worktree",
       "sample.diagram.html",
-      "th-1"
+      "th-1",
+      { operationId: "op-1" }
     );
   });
 
@@ -253,6 +267,7 @@ describe("diagram comments handler core", () => {
     {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       threadId: "th-1",
       unknown: true,
     },
@@ -263,6 +278,165 @@ describe("diagram comments handler core", () => {
       handleDiagramCommentDelete(dependencies, payload)
     ).resolves.toMatchObject({ ok: false, code: "BAD_REQUEST" });
     expect(dependencies.deleteComment).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "create",
+      handle: handleDiagramCommentCreate,
+      store: "createComment",
+    },
+    { name: "reply", handle: handleDiagramCommentReply, store: "replyComment" },
+    {
+      name: "resolve",
+      handle: handleDiagramCommentResolve,
+      store: "resolveComment",
+    },
+    {
+      name: "delete",
+      handle: handleDiagramCommentDelete,
+      store: "deleteComment",
+    },
+    { name: "send", handle: handleDiagramCommentSend, store: "getComments" },
+  ] as const)(
+    "$name は operationId が無い・不正な payload を BAD_REQUEST にする",
+    async ({ handle, store }) => {
+      const base = {
+        sessionId: "session-1",
+        relPath: "sample.diagram.html",
+        anchorId: "s1",
+        threadId: "th-1",
+        body: "本文",
+      };
+      const { anchorId, threadId, body, ...common } = base;
+      const valid =
+        handle === handleDiagramCommentCreate
+          ? { ...common, anchorId, body }
+          : handle === handleDiagramCommentReply
+            ? { ...common, threadId, body }
+            : { ...common, threadId };
+      for (const operationId of [
+        undefined,
+        "",
+        " ",
+        "o".repeat(257),
+        "op\0",
+        1,
+      ]) {
+        const dependencies = deps();
+        const payload =
+          operationId === undefined ? valid : { ...valid, operationId };
+
+        await expect(handle(dependencies, payload)).resolves.toMatchObject({
+          ok: false,
+          code: "BAD_REQUEST",
+        });
+        expect(dependencies[store]).not.toHaveBeenCalled();
+        expect(dependencies.sendMessage).not.toHaveBeenCalled();
+      }
+    }
+  );
+
+  it("resolve は operationId を store へ渡す", async () => {
+    const dependencies = deps();
+
+    await expect(
+      handleDiagramCommentResolve(dependencies, {
+        sessionId: "session-1",
+        relPath: "sample.diagram.html",
+        operationId: "op-resolve",
+        threadId: "th-1",
+      })
+    ).resolves.toEqual(snapshot);
+
+    expect(dependencies.resolveComment).toHaveBeenCalledWith(
+      "/managed/worktree",
+      "sample.diagram.html",
+      "th-1",
+      { operationId: "op-resolve" }
+    );
+  });
+
+  it("同じ operationId の send 再送は二重に sendMessage しない", async () => {
+    const dependencies = deps();
+    vi.mocked(dependencies.getComments).mockResolvedValue(sendSnapshot);
+    const payload = {
+      sessionId: "session-1",
+      relPath: "sample.diagram.html",
+      operationId: "op-send",
+      threadId: "th-send",
+    };
+
+    await expect(
+      handleDiagramCommentSend(dependencies, payload)
+    ).resolves.toEqual(sendSnapshot);
+    await expect(
+      handleDiagramCommentSend(dependencies, payload)
+    ).resolves.toEqual(sendSnapshot);
+
+    expect(dependencies.sendMessage).toHaveBeenCalledOnce();
+  });
+
+  it("別の operationId の send は改めて sendMessage する", async () => {
+    const dependencies = deps();
+    vi.mocked(dependencies.getComments).mockResolvedValue(sendSnapshot);
+
+    await handleDiagramCommentSend(dependencies, {
+      sessionId: "session-1",
+      relPath: "sample.diagram.html",
+      operationId: "op-send-1",
+      threadId: "th-send",
+    });
+    await handleDiagramCommentSend(dependencies, {
+      sessionId: "session-1",
+      relPath: "sample.diagram.html",
+      operationId: "op-send-2",
+      threadId: "th-send",
+    });
+
+    expect(dependencies.sendMessage).toHaveBeenCalledTimes(2);
+  });
+
+  it("send が失敗した operationId は記録せず、再送で送信する", async () => {
+    const dependencies = deps();
+    const failing = structuredClone(sendSnapshot);
+    if (!failing.ok) throw new Error("successful comments response expected");
+    const thread = failing.comments.threads[0];
+    if (!thread) throw new Error("comment thread expected");
+    thread.messages = [];
+    vi.mocked(dependencies.getComments).mockResolvedValueOnce(failing);
+    vi.mocked(dependencies.getComments).mockResolvedValue(sendSnapshot);
+    const payload = {
+      sessionId: "session-1",
+      relPath: "sample.diagram.html",
+      operationId: "op-send",
+      threadId: "th-send",
+    };
+
+    await expect(
+      handleDiagramCommentSend(dependencies, payload)
+    ).resolves.toMatchObject({ ok: false, code: "INVALID_SIDECAR" });
+    await expect(
+      handleDiagramCommentSend(dependencies, payload)
+    ).resolves.toEqual(sendSnapshot);
+
+    expect(dependencies.sendMessage).toHaveBeenCalledOnce();
+  });
+
+  it("operationLog 省略時はプロセス共有の記録で send を冪等化する", async () => {
+    const { operationLog: _omitted, ...shared } = deps();
+    vi.mocked(shared.getComments).mockResolvedValue(sendSnapshot);
+    const payload = {
+      sessionId: "session-1",
+      relPath: "sample.diagram.html",
+      operationId: `op-shared-${Math.random()}`,
+      threadId: "th-send",
+    };
+
+    await handleDiagramCommentSend(shared, payload);
+    await handleDiagramCommentSend(shared, payload);
+
+    expect(shared.sendMessage).toHaveBeenCalledOnce();
   });
 
   it("存在しない session を SESSION_NOT_FOUND にする", async () => {
@@ -317,6 +491,7 @@ describe("diagram comments handler core", () => {
     await handleDiagramCommentSend(dependencies, {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       threadId: "th-send",
     });
 
@@ -337,6 +512,7 @@ describe("diagram comments handler core", () => {
       handleDiagramCommentSend(dependencies, {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "missing",
       })
     ).resolves.toMatchObject({ ok: false, code: "THREAD_NOT_FOUND" });
@@ -351,6 +527,7 @@ describe("diagram comments handler core", () => {
       handleDiagramCommentSend(dependencies, {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "th-send",
       })
     ).resolves.toEqual(sendSnapshot);
@@ -391,6 +568,7 @@ describe("diagram comments handler core", () => {
     await handleDiagramCommentSend(dependencies, {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       threadId: "th-send",
     });
 
@@ -418,6 +596,7 @@ describe("diagram comments handler core", () => {
     await handleDiagramCommentSend(dependencies, {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       threadId: "th-send",
     });
 
@@ -440,6 +619,7 @@ describe("diagram comments handler core", () => {
       handleDiagramCommentSend(dependencies, {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "th-send",
       })
     ).resolves.toEqual({
@@ -456,6 +636,7 @@ describe("diagram comments handler core", () => {
     await handleDiagramCommentCreate(dependencies, {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       anchorId: "s1",
       body: "  本文  ",
     });
@@ -466,7 +647,8 @@ describe("diagram comments handler core", () => {
       "s1",
       "本文",
       undefined,
-      undefined
+      undefined,
+      { operationId: "op-1" }
     );
   });
 
@@ -476,6 +658,7 @@ describe("diagram comments handler core", () => {
     await handleDiagramCommentCreate(dependencies, {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       anchorId: "s1",
       anchorQuote: "選択した本文",
       anchorOccurrence: 1,
@@ -488,7 +671,8 @@ describe("diagram comments handler core", () => {
       "s1",
       "本文",
       "選択した本文",
-      1
+      1,
+      { operationId: "op-1" }
     );
   });
 
@@ -498,6 +682,7 @@ describe("diagram comments handler core", () => {
     await handleDiagramCommentCreate(dependencies, {
       sessionId: "session-1",
       relPath: "sample.diagram.html",
+      operationId: "op-1",
       anchorId: "s1",
       anchorQuote: "選択した本文",
       body: "本文",
@@ -509,7 +694,8 @@ describe("diagram comments handler core", () => {
       "s1",
       "本文",
       "選択した本文",
-      undefined
+      undefined,
+      { operationId: "op-1" }
     );
   });
 
@@ -541,6 +727,7 @@ describe("diagram comments handler core", () => {
       handleDiagramCommentCreate(dependencies, {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         anchorId: "s1",
         body: "本文",
         ...extra,
@@ -579,6 +766,7 @@ describe("diagram comments handler core", () => {
       handleDiagramCommentResolve(dependencies, {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "th-1",
       })
     ).resolves.toEqual({
@@ -629,6 +817,7 @@ describe("createDiagramCommentsSocketHandlers", () => {
           {
             sessionId: "session-1",
             relPath: "sample.diagram.html",
+            operationId: "op-1",
             anchorId: "s1",
             body: "本文",
           },
@@ -652,6 +841,7 @@ describe("createDiagramCommentsSocketHandlers", () => {
       {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "th-1",
       },
       callback

--- a/packages/server/src/lib/diagram-comments-handler.ts
+++ b/packages/server/src/lib/diagram-comments-handler.ts
@@ -444,7 +444,7 @@ export async function handleDiagramCommentSend(
   const operationLog = deps.operationLog ?? diagramCommentOperationLog;
   const operationKey = diagramCommentOperationKey(
     "send",
-    `${context.worktreeReal}\0${context.relPath}`,
+    JSON.stringify([context.worktreeReal, context.relPath]),
     payload.operationId
   );
   return containStoreError(async () => {

--- a/packages/server/src/lib/diagram-comments-handler.ts
+++ b/packages/server/src/lib/diagram-comments-handler.ts
@@ -1,7 +1,13 @@
 import type { DiagramCommentsResponse } from "@ark/shared";
 import {
+  type DiagramCommentOperationLog,
+  diagramCommentOperationKey,
+  diagramCommentOperationLog,
+} from "./diagram-comment-operation-log.js";
+import {
   appendDiagramCommentMessage,
   createDiagramComment,
+  type DiagramCommentMutationOptions,
   deleteDiagramComment,
   readDiagramCommentsFile,
   resolveDiagramComment,
@@ -16,13 +22,18 @@ const MAX_BODY_LENGTH = 4000;
 const MAX_ANCHOR_QUOTE_LENGTH = 1000;
 
 type GetPayload = { sessionId: string; relPath: string };
-type CreatePayload = GetPayload & {
+/**
+ * mutation は操作 ID を必須とする。クライアントの ACK タイムアウトは
+ * サーバー処理を取り消さないため、再試行を同じ ID で受けて冪等に扱う。
+ */
+type MutationPayload = GetPayload & { operationId: string };
+type CreatePayload = MutationPayload & {
   anchorId: string;
   anchorQuote?: string;
   anchorOccurrence?: number;
   body: string;
 };
-type ResolvePayload = GetPayload & { threadId: string };
+type ResolvePayload = MutationPayload & { threadId: string };
 type ReplyPayload = ResolvePayload & { body: string };
 
 export interface DiagramCommentsHandlerDeps {
@@ -40,25 +51,34 @@ export interface DiagramCommentsHandlerDeps {
     anchorId: string,
     body: string,
     anchorQuote?: string,
-    anchorOccurrence?: number
+    anchorOccurrence?: number,
+    options?: DiagramCommentMutationOptions
   ) => Promise<DiagramCommentsResponse>;
   replyComment: (
     worktreeReal: string,
     relPath: string,
     threadId: string,
-    input: { body: string; author?: string }
+    input: { body: string; author?: string },
+    options?: DiagramCommentMutationOptions
   ) => Promise<DiagramCommentsResponse>;
   resolveComment: (
     worktreeReal: string,
     relPath: string,
-    threadId: string
+    threadId: string,
+    options?: DiagramCommentMutationOptions
   ) => Promise<DiagramCommentsResponse>;
   deleteComment: (
     worktreeReal: string,
     relPath: string,
-    threadId: string
+    threadId: string,
+    options?: DiagramCommentMutationOptions
   ) => Promise<DiagramCommentsResponse>;
   sendMessage: (sessionId: string, message: string) => void;
+  /**
+   * send の二重送信防止に使う適用済み操作の記録。省略時はプロセス共有の
+   * 記録を使う（sidecar mutation 側も同じ記録を共有する）。
+   */
+  operationLog?: DiagramCommentOperationLog;
 }
 
 /** get でも mutation と同じ diagram/anchor trust boundary を通す。 */
@@ -141,6 +161,7 @@ function parseCreatePayload(value: unknown): CreatePayload | null {
       [
         "sessionId",
         "relPath",
+        "operationId",
         "anchorId",
         "anchorQuote",
         "anchorOccurrence",
@@ -149,6 +170,7 @@ function parseCreatePayload(value: unknown): CreatePayload | null {
     ) ||
     !validString(value.sessionId, MAX_SESSION_OR_PATH_LENGTH) ||
     !validString(value.relPath, MAX_SESSION_OR_PATH_LENGTH) ||
+    !validString(value.operationId, MAX_ANCHOR_OR_ID_LENGTH) ||
     !validString(value.anchorId, MAX_ANCHOR_OR_ID_LENGTH) ||
     typeof value.body !== "string"
   ) {
@@ -171,6 +193,7 @@ function parseCreatePayload(value: unknown): CreatePayload | null {
   const payload: CreatePayload = {
     sessionId: value.sessionId,
     relPath: value.relPath,
+    operationId: value.operationId,
     anchorId: value.anchorId,
     body,
   };
@@ -186,9 +209,10 @@ function parseCreatePayload(value: unknown): CreatePayload | null {
 function parseResolvePayload(value: unknown): ResolvePayload | null {
   if (
     !isRecord(value) ||
-    !hasOnlyKeys(value, ["sessionId", "relPath", "threadId"]) ||
+    !hasOnlyKeys(value, ["sessionId", "relPath", "operationId", "threadId"]) ||
     !validString(value.sessionId, MAX_SESSION_OR_PATH_LENGTH) ||
     !validString(value.relPath, MAX_SESSION_OR_PATH_LENGTH) ||
+    !validString(value.operationId, MAX_ANCHOR_OR_ID_LENGTH) ||
     !validString(value.threadId, MAX_ANCHOR_OR_ID_LENGTH)
   ) {
     return null;
@@ -196,6 +220,7 @@ function parseResolvePayload(value: unknown): ResolvePayload | null {
   return {
     sessionId: value.sessionId,
     relPath: value.relPath,
+    operationId: value.operationId,
     threadId: value.threadId,
   };
 }
@@ -203,9 +228,16 @@ function parseResolvePayload(value: unknown): ResolvePayload | null {
 function parseReplyPayload(value: unknown): ReplyPayload | null {
   if (
     !isRecord(value) ||
-    !hasOnlyKeys(value, ["sessionId", "relPath", "threadId", "body"]) ||
+    !hasOnlyKeys(value, [
+      "sessionId",
+      "relPath",
+      "operationId",
+      "threadId",
+      "body",
+    ]) ||
     !validString(value.sessionId, MAX_SESSION_OR_PATH_LENGTH) ||
     !validString(value.relPath, MAX_SESSION_OR_PATH_LENGTH) ||
+    !validString(value.operationId, MAX_ANCHOR_OR_ID_LENGTH) ||
     !validString(value.threadId, MAX_ANCHOR_OR_ID_LENGTH) ||
     typeof value.body !== "string"
   ) {
@@ -216,6 +248,7 @@ function parseReplyPayload(value: unknown): ReplyPayload | null {
   return {
     sessionId: value.sessionId,
     relPath: value.relPath,
+    operationId: value.operationId,
     threadId: value.threadId,
     body,
   };
@@ -336,7 +369,8 @@ export async function handleDiagramCommentCreate(
       payload.anchorId,
       payload.body,
       payload.anchorQuote,
-      payload.anchorOccurrence
+      payload.anchorOccurrence,
+      { operationId: payload.operationId }
     )
   );
 }
@@ -350,7 +384,12 @@ export async function handleDiagramCommentResolve(
   const context = requestContext(deps, payload);
   if (!context.valid) return context.response;
   return containStoreError(() =>
-    deps.resolveComment(context.worktreeReal, context.relPath, payload.threadId)
+    deps.resolveComment(
+      context.worktreeReal,
+      context.relPath,
+      payload.threadId,
+      { operationId: payload.operationId }
+    )
   );
 }
 
@@ -363,9 +402,13 @@ export async function handleDiagramCommentReply(
   const context = requestContext(deps, payload);
   if (!context.valid) return context.response;
   return containStoreError(() =>
-    deps.replyComment(context.worktreeReal, context.relPath, payload.threadId, {
-      body: payload.body,
-    })
+    deps.replyComment(
+      context.worktreeReal,
+      context.relPath,
+      payload.threadId,
+      { body: payload.body },
+      { operationId: payload.operationId }
+    )
   );
 }
 
@@ -378,7 +421,12 @@ export async function handleDiagramCommentDelete(
   const context = requestContext(deps, payload);
   if (!context.valid) return context.response;
   return containStoreError(() =>
-    deps.deleteComment(context.worktreeReal, context.relPath, payload.threadId)
+    deps.deleteComment(
+      context.worktreeReal,
+      context.relPath,
+      payload.threadId,
+      { operationId: payload.operationId }
+    )
   );
 }
 
@@ -390,12 +438,22 @@ export async function handleDiagramCommentSend(
   if (payload === null) return badRequest();
   const context = requestContext(deps, payload);
   if (!context.valid) return context.response;
+  // send は sidecar を変えないが tmux への送信という副作用を持つ。ACK
+  // タイムアウト後の再試行で同じコメントを二重に送らないよう、適用済みの
+  // 操作 ID なら現在のコメントだけを返す。
+  const operationLog = deps.operationLog ?? diagramCommentOperationLog;
+  const operationKey = diagramCommentOperationKey(
+    "send",
+    `${context.worktreeReal}\0${context.relPath}`,
+    payload.operationId
+  );
   return containStoreError(async () => {
     const response = await deps.getComments(
       context.worktreeReal,
       context.relPath
     );
     if (!response.ok) return response;
+    if (operationLog.has(operationKey)) return response;
     const thread = response.comments.threads.find(
       candidate => candidate.id === payload.threadId
     );
@@ -422,6 +480,7 @@ export async function handleDiagramCommentSend(
       };
     }
     deps.sendMessage(context.sessionId, message);
+    operationLog.record(operationKey);
     return response;
   });
 }

--- a/packages/server/src/lib/diagram-comments.test.ts
+++ b/packages/server/src/lib/diagram-comments.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { diagramCommentOperationLog } from "./diagram-comment-operation-log.js";
 import {
   appendDiagramCommentMessage,
   createDiagramComment,
@@ -1338,4 +1339,296 @@ describe("comment mutations", () => {
         .filter(name => name.includes(".tmp"))
     ).toEqual([]);
   });
+});
+
+describe("comment mutations: operationId による冪等化 (#306)", () => {
+  const relPath = ".claude/diagrams/order-flow.diagram.html";
+
+  beforeEach(() => {
+    diagramCommentOperationLog.clear();
+  });
+
+  async function createOnce(operationId: string, body = "本文") {
+    const created = await createDiagramComment(
+      worktree,
+      relPath,
+      "s1-p1",
+      body,
+      undefined,
+      undefined,
+      { operationId }
+    );
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error("create expected to succeed");
+    const threadId = created.comments.threads.at(-1)?.id;
+    if (!threadId) throw new Error("thread expected");
+    return { created, threadId };
+  }
+
+  it("同じ operationId の create 再送は thread を増やさず現在の sidecar を返す", async () => {
+    writeDoc();
+
+    const first = await createOnce("op-create");
+    const again = await createDiagramComment(
+      worktree,
+      relPath,
+      "s1-p1",
+      "本文",
+      undefined,
+      undefined,
+      { operationId: "op-create" }
+    );
+
+    expect(again).toEqual(first.created);
+    expect(again.ok && again.comments.threads).toHaveLength(1);
+  });
+
+  it("別の operationId の create は通常どおり thread を増やす", async () => {
+    writeDoc();
+
+    await createOnce("op-create-1");
+    const second = await createDiagramComment(
+      worktree,
+      relPath,
+      "s1-p1",
+      "本文",
+      undefined,
+      undefined,
+      { operationId: "op-create-2" }
+    );
+
+    expect(second.ok && second.comments.threads).toHaveLength(2);
+  });
+
+  it("operationId 無し（MCP 経由など）は冪等化せず毎回適用する", async () => {
+    writeDoc();
+
+    await createDiagramComment(worktree, relPath, "s1-p1", "本文");
+    const second = await createDiagramComment(
+      worktree,
+      relPath,
+      "s1-p1",
+      "本文"
+    );
+
+    expect(second.ok && second.comments.threads).toHaveLength(2);
+  });
+
+  it("同時に届いた同一 operationId の create も 1 件しか適用しない", async () => {
+    writeDoc();
+
+    const results = await Promise.all([
+      createDiagramComment(
+        worktree,
+        relPath,
+        "s1-p1",
+        "本文",
+        undefined,
+        undefined,
+        {
+          operationId: "op-race",
+        }
+      ),
+      createDiagramComment(
+        worktree,
+        relPath,
+        "s1-p1",
+        "本文",
+        undefined,
+        undefined,
+        {
+          operationId: "op-race",
+        }
+      ),
+    ]);
+
+    for (const result of results) {
+      expect(result.ok && result.comments.threads).toHaveLength(1);
+    }
+    const stored = await readDiagramCommentsFile(worktree, relPath);
+    expect(stored.ok && stored.comments.threads).toHaveLength(1);
+  });
+
+  it("同じ operationId の reply 再送はメッセージを増やさない", async () => {
+    writeDoc();
+    const { threadId } = await createOnce("op-create");
+
+    const first = await appendDiagramCommentMessage(
+      worktree,
+      relPath,
+      threadId,
+      { body: "返信" },
+      { operationId: "op-reply" }
+    );
+    const again = await appendDiagramCommentMessage(
+      worktree,
+      relPath,
+      threadId,
+      { body: "返信" },
+      { operationId: "op-reply" }
+    );
+
+    expect(first.ok && first.comments.threads[0]?.messages).toHaveLength(2);
+    expect(again).toEqual(first);
+  });
+
+  it("同じ operationId の delete 再送は THREAD_NOT_FOUND にせず現在の sidecar を返す", async () => {
+    writeDoc();
+    const { threadId } = await createOnce("op-create");
+
+    const first = await deleteDiagramComment(worktree, relPath, threadId, {
+      operationId: "op-delete",
+    });
+    const again = await deleteDiagramComment(worktree, relPath, threadId, {
+      operationId: "op-delete",
+    });
+
+    expect(first).toEqual({
+      ok: true,
+      comments: { version: 1, target, threads: [] },
+    });
+    expect(again).toEqual(first);
+  });
+
+  it("delete 再送は別 operationId なら従来どおり THREAD_NOT_FOUND", async () => {
+    writeDoc();
+    const { threadId } = await createOnce("op-create");
+
+    await deleteDiagramComment(worktree, relPath, threadId, {
+      operationId: "op-delete-1",
+    });
+
+    await expect(
+      deleteDiagramComment(worktree, relPath, threadId, {
+        operationId: "op-delete-2",
+      })
+    ).resolves.toMatchObject({ ok: false, code: "THREAD_NOT_FOUND" });
+  });
+
+  it("resolve 後に thread が消えても同じ operationId の再送は現在の sidecar を返す", async () => {
+    writeDoc();
+    const { threadId } = await createOnce("op-create");
+
+    const resolved = await resolveDiagramComment(worktree, relPath, threadId, {
+      operationId: "op-resolve",
+    });
+    expect(resolved.ok && resolved.comments.threads[0]?.status).toBe(
+      "resolved"
+    );
+    await deleteDiagramComment(worktree, relPath, threadId, {
+      operationId: "op-delete",
+    });
+
+    await expect(
+      resolveDiagramComment(worktree, relPath, threadId, {
+        operationId: "op-resolve",
+      })
+    ).resolves.toEqual({
+      ok: true,
+      comments: { version: 1, target, threads: [] },
+    });
+  });
+
+  it("失敗した操作の operationId は記録されず、再送で改めて適用される", async () => {
+    writeDoc();
+    await createOnce("op-create");
+    vi.spyOn(fs.promises, "rename").mockRejectedValueOnce(
+      Object.assign(new Error("rename failed"), { code: "EIO" })
+    );
+
+    const failed = await createDiagramComment(
+      worktree,
+      relPath,
+      "s1-p2",
+      "second",
+      undefined,
+      undefined,
+      { operationId: "op-retry" }
+    );
+    const retried = await createDiagramComment(
+      worktree,
+      relPath,
+      "s1-p2",
+      "second",
+      undefined,
+      undefined,
+      { operationId: "op-retry" }
+    );
+
+    expect(failed).toMatchObject({ ok: false, code: "IO_ERROR" });
+    expect(retried.ok && retried.comments.threads).toHaveLength(2);
+  });
+
+  it("operationId は図ファイルごとに区別され、別の図の同じ ID に影響しない", async () => {
+    writeDoc();
+    writeDoc("other-flow");
+    const otherRelPath = ".claude/diagrams/other-flow.diagram.html";
+
+    await createOnce("op-shared");
+    const other = await createDiagramComment(
+      worktree,
+      otherRelPath,
+      "s1-p1",
+      "本文",
+      undefined,
+      undefined,
+      { operationId: "op-shared" }
+    );
+
+    expect(other.ok && other.comments.threads).toHaveLength(1);
+    expect(other.ok && other.comments.target).toBe("other-flow.diagram.html");
+  });
+
+  it("operationId は操作種別ごとに区別される", async () => {
+    writeDoc();
+    const { threadId } = await createOnce("op-shared");
+
+    const resolved = await resolveDiagramComment(worktree, relPath, threadId, {
+      operationId: "op-shared",
+    });
+
+    expect(resolved.ok && resolved.comments.threads[0]?.status).toBe(
+      "resolved"
+    );
+  });
+
+  it.each(["", " ", "o".repeat(DIAGRAM_COMMENTS_MAX_ANCHOR_OR_ID_LENGTH + 1)])(
+    "不正な operationId %j は BAD_REQUEST にして適用しない",
+    async operationId => {
+      writeDoc();
+
+      await expect(
+        createDiagramComment(
+          worktree,
+          relPath,
+          "s1-p1",
+          "本文",
+          undefined,
+          undefined,
+          { operationId }
+        )
+      ).resolves.toMatchObject({ ok: false, code: "BAD_REQUEST" });
+      await expect(
+        resolveDiagramComment(worktree, relPath, "th-1", { operationId })
+      ).resolves.toMatchObject({ ok: false, code: "BAD_REQUEST" });
+      await expect(
+        deleteDiagramComment(worktree, relPath, "th-1", { operationId })
+      ).resolves.toMatchObject({ ok: false, code: "BAD_REQUEST" });
+      await expect(
+        appendDiagramCommentMessage(
+          worktree,
+          relPath,
+          "th-1",
+          { body: "返信" },
+          { operationId }
+        )
+      ).resolves.toMatchObject({ ok: false, code: "BAD_REQUEST" });
+      await expect(readDiagramCommentsFile(worktree, relPath)).resolves.toEqual(
+        {
+          ok: true,
+          comments: { version: 1, target, threads: [] },
+        }
+      );
+    }
+  );
 });

--- a/packages/server/src/lib/diagram-comments.ts
+++ b/packages/server/src/lib/diagram-comments.ts
@@ -7,6 +7,10 @@ import type {
   DiagramCommentsResponse,
   DiagramCommentThread,
 } from "@ark/shared";
+import {
+  diagramCommentOperationKey,
+  diagramCommentOperationLog,
+} from "./diagram-comment-operation-log.js";
 import { validateDiagramDocAnchors } from "./diagram-doc-anchors.js";
 import { DIAGRAM_DIR, resolveDiagramPath } from "./diagram-path.js";
 import { readDiagramModel } from "./diagram-reader.js";
@@ -47,7 +51,16 @@ export type DiagramCommentsPathResult =
       error: string;
     };
 
-interface DeleteDiagramCommentOptions {
+/**
+ * mutation の操作 ID。省略時（MCP 経由の Claude の返信など）は冪等化しない。
+ * 指定時は同じ (種別, sidecar, operationId) の再送を再適用せず、現在の
+ * sidecar を返す（Issue #306: ACK タイムアウト後の再試行による重複防止）。
+ */
+export interface DiagramCommentMutationOptions {
+  operationId?: string;
+}
+
+interface DeleteDiagramCommentOptions extends DiagramCommentMutationOptions {
   platform?: NodeJS.Platform;
 }
 
@@ -414,6 +427,77 @@ async function withMutationQueue<T>(
   }
 }
 
+type OperationKind = Parameters<typeof diagramCommentOperationKey>[0];
+
+interface MutationGate {
+  ok: true;
+  commentsAbsPath: string;
+  /** 適用済み判定用の key。操作 ID 無し（MCP 経由など）は null */
+  operationKey: string | null;
+  worktreeReal: string;
+  relPath: string;
+}
+
+/**
+ * 操作 ID を検証し、mutation queue と冪等化に必要な文脈をまとめる。
+ * 検証は queue に入る前に行い、不正値で queue を占有しない。
+ */
+function openMutation(
+  kind: OperationKind,
+  resolved: Extract<DiagramCommentsPathResult, { ok: true }>,
+  worktreeReal: string,
+  relPath: string,
+  operationId: string | undefined
+): MutationGate | DiagramCommentsError {
+  const base = {
+    ok: true as const,
+    commentsAbsPath: resolved.commentsAbsPath,
+    worktreeReal,
+    relPath,
+  };
+  if (operationId === undefined) return { ...base, operationKey: null };
+  const valid = boundedString(
+    operationId,
+    "operationId",
+    DIAGRAM_COMMENTS_MAX_ANCHOR_OR_ID_LENGTH
+  );
+  if (!valid.ok) return { ok: false, code: "BAD_REQUEST", error: valid.error };
+  return {
+    ...base,
+    operationKey: diagramCommentOperationKey(
+      kind,
+      resolved.commentsAbsPath,
+      valid.value
+    ),
+  };
+}
+
+/**
+ * sidecar 単位の mutation queue 内で operation を 1 回だけ適用する。
+ * 適用済みの操作 ID が再送されたら再適用せず、現在の sidecar を読んで返す。
+ * 初回適用が ok で終わったときだけ記録するので、失敗した操作は再試行で
+ * 改めて適用される。queue 内で判定するため、同時に届いた同一操作も
+ * 2 件目は再適用されない。
+ */
+function withIdempotentMutation(
+  gate: MutationGate,
+  operation: () => Promise<DiagramCommentsResponse>
+): Promise<DiagramCommentsResponse> {
+  return withMutationQueue(gate.commentsAbsPath, async () => {
+    if (
+      gate.operationKey !== null &&
+      diagramCommentOperationLog.has(gate.operationKey)
+    ) {
+      return readDiagramCommentsFile(gate.worktreeReal, gate.relPath);
+    }
+    const result = await operation();
+    if (result.ok && gate.operationKey !== null) {
+      diagramCommentOperationLog.record(gate.operationKey);
+    }
+    return result;
+  });
+}
+
 async function readCurrentDiagram(
   worktreeReal: string,
   relPath: string
@@ -520,11 +604,20 @@ export async function createDiagramComment(
   anchorId: string,
   body: string,
   anchorQuote?: string,
-  anchorOccurrence?: number
+  anchorOccurrence?: number,
+  options: DiagramCommentMutationOptions = {}
 ): Promise<DiagramCommentsResponse> {
   const resolved = resolveDiagramCommentsPath(worktreeReal, relPath);
   if (!resolved.ok) return resolved;
-  return withMutationQueue(resolved.commentsAbsPath, async () => {
+  const gate = openMutation(
+    "create",
+    resolved,
+    worktreeReal,
+    relPath,
+    options.operationId
+  );
+  if (!gate.ok) return gate;
+  return withIdempotentMutation(gate, async () => {
     const diagram = await readCurrentDiagram(worktreeReal, relPath);
     if (!diagram.ok) return diagram;
     const anchor = diagram.model.nodes.find(node => node.id === anchorId);
@@ -629,11 +722,20 @@ export async function appendDiagramCommentMessage(
   worktreeReal: string,
   relPath: string,
   threadId: string,
-  input: { body: string; author?: string }
+  input: { body: string; author?: string },
+  options: DiagramCommentMutationOptions = {}
 ): Promise<DiagramCommentsResponse> {
   const resolved = resolveDiagramCommentsPath(worktreeReal, relPath);
   if (!resolved.ok) return resolved;
-  return withMutationQueue(resolved.commentsAbsPath, async () => {
+  const gate = openMutation(
+    "reply",
+    resolved,
+    worktreeReal,
+    relPath,
+    options.operationId
+  );
+  if (!gate.ok) return gate;
+  return withIdempotentMutation(gate, async () => {
     const diagram = await readCurrentDiagram(worktreeReal, relPath);
     if (!diagram.ok) return diagram;
     const current = await readDiagramCommentsFile(worktreeReal, relPath);
@@ -712,11 +814,20 @@ export async function appendDiagramCommentMessage(
 export async function resolveDiagramComment(
   worktreeReal: string,
   relPath: string,
-  threadId: string
+  threadId: string,
+  options: DiagramCommentMutationOptions = {}
 ): Promise<DiagramCommentsResponse> {
   const resolved = resolveDiagramCommentsPath(worktreeReal, relPath);
   if (!resolved.ok) return resolved;
-  return withMutationQueue(resolved.commentsAbsPath, async () => {
+  const gate = openMutation(
+    "resolve",
+    resolved,
+    worktreeReal,
+    relPath,
+    options.operationId
+  );
+  if (!gate.ok) return gate;
+  return withIdempotentMutation(gate, async () => {
     const diagram = await readCurrentDiagram(worktreeReal, relPath);
     if (!diagram.ok) return diagram;
     const current = await readDiagramCommentsFile(worktreeReal, relPath);
@@ -813,7 +924,15 @@ export async function deleteDiagramComment(
         "この環境では symlink を安全に検証できないためコメントを削除できません",
     };
   }
-  return withMutationQueue(resolved.commentsAbsPath, async () => {
+  const gate = openMutation(
+    "delete",
+    resolved,
+    worktreeReal,
+    relPath,
+    options.operationId
+  );
+  if (!gate.ok) return gate;
+  return withIdempotentMutation(gate, async () => {
     const diagram = await readCurrentDiagram(worktreeReal, relPath);
     if (!diagram.ok) return diagram;
     const current = await readDiagramCommentsFile(worktreeReal, relPath);

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -708,6 +708,35 @@ describe("SessionOrchestrator - プロファイル切替", () => {
     });
   });
 
+  describe("sendMessage", () => {
+    it("tmux への投入後に status 更新が失敗しても throw せずログへ残す (#306)", () => {
+      mockedTmux.getSession.mockReturnValue(makeTmuxSession());
+      mockedDb.updateSessionStatus.mockImplementationOnce(() => {
+        throw new Error("db locked");
+      });
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      expect(() => orchestrator.sendMessage("sess-id-1", "本文")).not.toThrow();
+
+      expect(mockedTmux.sendKeys).toHaveBeenCalledWith("sess-id-1", "本文");
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("db locked")
+      );
+      errorSpy.mockRestore();
+    });
+
+    it("tmux への投入自体の失敗はそのまま throw する", () => {
+      mockedTmux.sendKeys.mockImplementationOnce(() => {
+        throw new Error("Session not found");
+      });
+
+      expect(() => orchestrator.sendMessage("sess-id-1", "本文")).toThrow(
+        "Session not found"
+      );
+      expect(mockedDb.updateSessionStatus).not.toHaveBeenCalled();
+    });
+  });
+
   describe("stopSession", () => {
     it("fire-and-forget teardown の失敗をログへ残す", async () => {
       const contextSessionId = "e".repeat(32);

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -935,9 +935,18 @@ export class SessionOrchestrator extends EventEmitter {
   sendMessage(sessionId: string, message: string): void {
     tmuxManager.sendKeys(sessionId, message);
 
-    const session = tmuxManager.getSession(sessionId);
-    if (session) {
-      db.updateSessionStatus(sessionId, "active");
+    // ここから先は tmux への投入が完了している。status 更新の失敗で throw すると
+    // 呼び出し側（図解コメントの send 等）が「未送信」と誤認して再送し、同じ
+    // メッセージが二重に届くため、付随処理の失敗はログに留める。
+    try {
+      const session = tmuxManager.getSession(sessionId);
+      if (session) {
+        db.updateSessionStatus(sessionId, "active");
+      }
+    } catch (error) {
+      console.error(
+        `[SessionOrchestrator] sendMessage 後の status 更新に失敗 (${sessionId}): ${getErrorMessage(error)}`
+      );
     }
   }
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -292,16 +292,34 @@ export interface DiagramCommentsFile {
   threads: DiagramCommentThread[];
 }
 
-export interface DiagramCommentDeleteRequest {
+/**
+ * mutation の同一性を示す操作 ID。ACK タイムアウト後の再試行で同じ値を送ると、
+ * サーバーは適用済みの操作を再適用せず現在の sidecar を返す（冪等）。
+ * クライアントが生成する 1〜256 文字の任意文字列。
+ */
+export interface DiagramCommentOperation {
+  operationId: string;
+}
+
+export interface DiagramCommentThreadRequest extends DiagramCommentOperation {
   sessionId: string;
   relPath: string;
   threadId: string;
 }
 
-export interface DiagramCommentReplyRequest {
+export interface DiagramCommentCreateRequest extends DiagramCommentOperation {
   sessionId: string;
   relPath: string;
-  threadId: string;
+  anchorId: string;
+  anchorQuote?: string;
+  anchorOccurrence?: number;
+  body: string;
+}
+
+export type DiagramCommentDeleteRequest = DiagramCommentThreadRequest;
+
+export interface DiagramCommentReplyRequest
+  extends DiagramCommentThreadRequest {
   body: string;
 }
 
@@ -601,16 +619,12 @@ export interface ClientToServerEvents {
     callback: (response: DiagramCommentsResponse) => void
   ) => void;
 
-  /** 文書ブロックまたはそのテキスト選択範囲へ単発コメントを作成する */
+  /**
+   * 文書ブロックまたはそのテキスト選択範囲へ単発コメントを作成する。
+   * mutation 系は operationId を必須とし、同じ ID の再送は再適用しない
+   */
   "diagram:comment:create": (
-    data: {
-      sessionId: string;
-      relPath: string;
-      anchorId: string;
-      anchorQuote?: string;
-      anchorOccurrence?: number;
-      body: string;
-    },
+    data: DiagramCommentCreateRequest,
     callback: (response: DiagramCommentsResponse) => void
   ) => void;
 
@@ -622,7 +636,7 @@ export interface ClientToServerEvents {
 
   /** 文書コメントを解決済みにする */
   "diagram:comment:resolve": (
-    data: { sessionId: string; relPath: string; threadId: string },
+    data: DiagramCommentThreadRequest,
     callback: (response: DiagramCommentsResponse) => void
   ) => void;
 
@@ -632,9 +646,9 @@ export interface ClientToServerEvents {
     callback: (response: DiagramCommentsResponse) => void
   ) => void;
 
-  /** 文書コメントを会話セッションへ送る */
+  /** 文書コメントを会話セッションへ送る（同じ operationId の再送は二重送信しない） */
   "diagram:comment:send": (
-    data: { sessionId: string; relPath: string; threadId: string },
+    data: DiagramCommentThreadRequest,
     callback: (response: DiagramCommentsResponse) => void
   ) => void;
 

--- a/packages/web/src/components/DiagramPane.test.ts
+++ b/packages/web/src/components/DiagramPane.test.ts
@@ -77,12 +77,14 @@ describe("forwardDiagramCommentPortRequest", () => {
     {
       type: "ark:diagram-comment-reply",
       requestId: "req-reply",
+      operationId: "op-reply",
       threadId: "th-1",
       body: "返信本文",
     },
     {
       type: "ark:diagram-comment-create",
       requestId: "req-create",
+      operationId: "op-create",
       anchorId: "s1",
       anchorQuote: "選択した本文",
       anchorOccurrence: 1,
@@ -91,16 +93,19 @@ describe("forwardDiagramCommentPortRequest", () => {
     {
       type: "ark:diagram-comment-resolve",
       requestId: "req-resolve",
+      operationId: "op-resolve",
       threadId: "th-1",
     },
     {
       type: "ark:diagram-comment-delete",
       requestId: "req-delete",
+      operationId: "op-delete",
       threadId: "th-1",
     },
     {
       type: "ark:diagram-comment-send",
       requestId: "req-send",
+      operationId: "op-send",
       threadId: "th-1",
     },
   ];
@@ -138,9 +143,11 @@ describe("forwardDiagramCommentPortRequest", () => {
     }
 
     expect(deps.getDiagramComments).toHaveBeenCalledWith("session-1", REL_PATH);
+    // operationId は iframe 由来の値をそのまま透過させる（#306）
     expect(deps.createDiagramComment).toHaveBeenCalledWith(
       "session-1",
       REL_PATH,
+      "op-create",
       "s1",
       "本文",
       "選択した本文",
@@ -149,22 +156,26 @@ describe("forwardDiagramCommentPortRequest", () => {
     expect(deps.replyDiagramComment).toHaveBeenCalledWith(
       "session-1",
       REL_PATH,
+      "op-reply",
       "th-1",
       "返信本文"
     );
     expect(deps.resolveDiagramComment).toHaveBeenCalledWith(
       "session-1",
       REL_PATH,
+      "op-resolve",
       "th-1"
     );
     expect(deps.deleteDiagramComment).toHaveBeenCalledWith(
       "session-1",
       REL_PATH,
+      "op-delete",
       "th-1"
     );
     expect(deps.sendDiagramComment).toHaveBeenCalledWith(
       "session-1",
       REL_PATH,
+      "op-send",
       "th-1"
     );
     expect(deps.reply.mock.calls.map(call => call[0].requestId)).toEqual([

--- a/packages/web/src/components/DiagramPane.test.ts
+++ b/packages/web/src/components/DiagramPane.test.ts
@@ -5,6 +5,7 @@ import type {
   DiagramCommentPortParse,
   DiagramCommentPortRequest,
 } from "../lib/diagram-comment-bridge";
+import { parseDiagramCommentPortRequest } from "../lib/diagram-comment-bridge";
 import {
   applyDiagramPinchZoom,
   DIAGRAM_ZOOM_MAX,
@@ -286,6 +287,29 @@ describe("replyToInvalidDiagramCommentPortRequest", () => {
     ).toBe(false);
     expect(reply).not.toHaveBeenCalled();
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("operationId を持たない古いタブへ BAD_REQUEST の理由を返して画面にも表示する", () => {
+    const parsed = parseDiagramCommentPortRequest({
+      type: "ark:diagram-comment-create",
+      requestId: "req-old-tab",
+      anchorId: "s1",
+      body: "本文",
+    });
+    const reply = vi.fn();
+    const onError = vi.fn();
+
+    expect(
+      replyToInvalidDiagramCommentPortRequest(parsed, reply, onError)
+    ).toBe(true);
+    expect(reply).toHaveBeenCalledWith({
+      type: "ark:diagram-comments-result",
+      requestId: "req-old-tab",
+      ok: false,
+      code: "BAD_REQUEST",
+      error: "操作 ID（operationId）が不正です",
+    });
+    expect(onError).toHaveBeenCalledWith("操作 ID（operationId）が不正です");
   });
 });
 

--- a/packages/web/src/components/DiagramPane.tsx
+++ b/packages/web/src/components/DiagramPane.tsx
@@ -56,6 +56,7 @@ export interface DiagramPaneProps {
   createDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     anchorId: string,
     body: string,
     anchorQuote?: string,
@@ -64,22 +65,26 @@ export interface DiagramPaneProps {
   resolveDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   replyDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string,
     body: string
   ) => Promise<DiagramCommentsResponse>;
   deleteDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   sendDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   /** 未接続時は null。null の間は診断購読をスキップする */
@@ -274,6 +279,7 @@ interface DiagramCommentForwardDeps {
   createDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     anchorId: string,
     body: string,
     anchorQuote?: string,
@@ -282,22 +288,26 @@ interface DiagramCommentForwardDeps {
   resolveDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   replyDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string,
     body: string
   ) => Promise<DiagramCommentsResponse>;
   deleteDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   sendDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   isCurrent: () => boolean;
@@ -360,6 +370,7 @@ export async function forwardDiagramCommentPortRequest(
         response = await deps.createDiagramComment(
           deps.sessionId,
           deps.relPath,
+          request.operationId,
           request.anchorId,
           request.body,
           request.anchorQuote,
@@ -369,12 +380,14 @@ export async function forwardDiagramCommentPortRequest(
         response = await deps.resolveDiagramComment(
           deps.sessionId,
           deps.relPath,
+          request.operationId,
           request.threadId
         );
       } else if (request.type === "ark:diagram-comment-reply") {
         response = await deps.replyDiagramComment(
           deps.sessionId,
           deps.relPath,
+          request.operationId,
           request.threadId,
           request.body
         );
@@ -382,12 +395,14 @@ export async function forwardDiagramCommentPortRequest(
         response = await deps.deleteDiagramComment(
           deps.sessionId,
           deps.relPath,
+          request.operationId,
           request.threadId
         );
       } else {
         response = await deps.sendDiagramComment(
           deps.sessionId,
           deps.relPath,
+          request.operationId,
           request.threadId
         );
       }

--- a/packages/web/src/components/MobileLayout.tsx
+++ b/packages/web/src/components/MobileLayout.tsx
@@ -110,6 +110,7 @@ interface MobileLayoutProps {
   createDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     anchorId: string,
     body: string,
     anchorQuote?: string,
@@ -118,22 +119,26 @@ interface MobileLayoutProps {
   resolveDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   replyDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string,
     body: string
   ) => Promise<DiagramCommentsResponse>;
   deleteDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   sendDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   /** Socket.IO 接続状態 */

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -57,6 +57,7 @@ interface SplitViewPaneProps {
   createDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     anchorId: string,
     body: string,
     anchorQuote?: string,
@@ -65,22 +66,26 @@ interface SplitViewPaneProps {
   resolveDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   replyDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string,
     body: string
   ) => Promise<DiagramCommentsResponse>;
   deleteDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   sendDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   session: ManagedSession;

--- a/packages/web/src/hooks/useSocket.ts
+++ b/packages/web/src/hooks/useSocket.ts
@@ -105,6 +105,7 @@ interface UseSocketReturn {
   createDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     anchorId: string,
     body: string,
     anchorQuote?: string,
@@ -113,22 +114,26 @@ interface UseSocketReturn {
   resolveDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   replyDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string,
     body: string
   ) => Promise<DiagramCommentsResponse>;
   deleteDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   sendDiagramComment: (
     sessionId: string,
     relPath: string,
+    operationId: string,
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
 
@@ -1163,10 +1168,13 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
     []
   );
 
+  // mutation の operationId は iframe（comment layer）が生成し、ここでは
+  // 透過的に transport へ渡す。再試行で同じ値が届けばサーバー側で冪等化される
   const createDiagramComment = useCallback(
     (
       sessionId: string,
       relPath: string,
+      operationId: string,
       anchorId: string,
       body: string,
       anchorQuote?: string,
@@ -1176,6 +1184,7 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
         socketRef.current,
         sessionId,
         relPath,
+        operationId,
         anchorId,
         body,
         anchorQuote,
@@ -1185,22 +1194,35 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   );
 
   const resolveDiagramComment = useCallback(
-    (sessionId: string, relPath: string, threadId: string) =>
+    (
+      sessionId: string,
+      relPath: string,
+      operationId: string,
+      threadId: string
+    ) =>
       requestDiagramCommentResolve(
         socketRef.current,
         sessionId,
         relPath,
+        operationId,
         threadId
       ),
     []
   );
 
   const replyDiagramComment = useCallback(
-    (sessionId: string, relPath: string, threadId: string, body: string) =>
+    (
+      sessionId: string,
+      relPath: string,
+      operationId: string,
+      threadId: string,
+      body: string
+    ) =>
       requestDiagramCommentReply(
         socketRef.current,
         sessionId,
         relPath,
+        operationId,
         threadId,
         body
       ),
@@ -1208,22 +1230,34 @@ export function useSocket(options: UseSocketOptions = {}): UseSocketReturn {
   );
 
   const deleteDiagramComment = useCallback(
-    (sessionId: string, relPath: string, threadId: string) =>
+    (
+      sessionId: string,
+      relPath: string,
+      operationId: string,
+      threadId: string
+    ) =>
       requestDiagramCommentDelete(
         socketRef.current,
         sessionId,
         relPath,
+        operationId,
         threadId
       ),
     []
   );
 
   const sendDiagramComment = useCallback(
-    (sessionId: string, relPath: string, threadId: string) =>
+    (
+      sessionId: string,
+      relPath: string,
+      operationId: string,
+      threadId: string
+    ) =>
       requestDiagramCommentSend(
         socketRef.current,
         sessionId,
         relPath,
+        operationId,
         threadId
       ),
     []

--- a/packages/web/src/lib/diagram-comment-bridge.test.ts
+++ b/packages/web/src/lib/diagram-comment-bridge.test.ts
@@ -11,12 +11,14 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-reply",
         requestId: "req-reply",
+        operationId: "op-1",
         threadId: "th-1",
         body: "返信本文",
       },
       {
         type: "ark:diagram-comment-reply",
         requestId: "req-reply",
+        operationId: "op-1",
         threadId: "th-1",
         body: "返信本文",
       },
@@ -29,6 +31,7 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-create",
         requestId: "req-create",
+        operationId: "op-1",
         anchorId: "s1-p1",
         anchorQuote: "選択した本文",
         anchorOccurrence: 1,
@@ -37,6 +40,7 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-create",
         requestId: "req-create",
+        operationId: "op-1",
         anchorId: "s1-p1",
         anchorQuote: "選択した本文",
         anchorOccurrence: 1,
@@ -47,6 +51,7 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-create",
         requestId: "req-create-first",
+        operationId: "op-1",
         anchorId: "s1-p1",
         anchorQuote: "先頭の一致",
         body: "本文",
@@ -54,6 +59,7 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-create",
         requestId: "req-create-first",
+        operationId: "op-1",
         anchorId: "s1-p1",
         anchorQuote: "先頭の一致",
         body: "本文",
@@ -63,11 +69,13 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-resolve",
         requestId: "req-resolve",
+        operationId: "op-1",
         threadId: "th-1",
       },
       {
         type: "ark:diagram-comment-resolve",
         requestId: "req-resolve",
+        operationId: "op-1",
         threadId: "th-1",
       },
     ],
@@ -75,11 +83,13 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-delete",
         requestId: "req-delete",
+        operationId: "op-1",
         threadId: "th-1",
       },
       {
         type: "ark:diagram-comment-delete",
         requestId: "req-delete",
+        operationId: "op-1",
         threadId: "th-1",
       },
     ],
@@ -87,11 +97,13 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-send",
         requestId: "req-send",
+        operationId: "op-1",
         threadId: "th-1",
       },
       {
         type: "ark:diagram-comment-send",
         requestId: "req-send",
+        operationId: "op-1",
         threadId: "th-1",
       },
     ],
@@ -107,6 +119,7 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-create",
         requestId: "req-anchor",
+        operationId: "op-1",
         anchorId: "",
         body: "本文",
       },
@@ -116,6 +129,7 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-create",
         requestId: "req-body",
+        operationId: "op-1",
         anchorId: "s1",
         body: "\n\t",
       },
@@ -125,6 +139,7 @@ describe("parseDiagramCommentPortRequest", () => {
       {
         type: "ark:diagram-comment-create",
         requestId: "req-quote",
+        operationId: "op-1",
         anchorId: "s1",
         anchorQuote: "q".repeat(1001),
         body: "本文",
@@ -147,6 +162,7 @@ describe("parseDiagramCommentPortRequest", () => {
       parseDiagramCommentPortRequest({
         type: "ark:diagram-comment-create",
         requestId: "req-author",
+        operationId: "op-1",
         anchorId: "s1",
         author: "Reviewer",
         body: "本文",
@@ -167,6 +183,7 @@ describe("parseDiagramCommentPortRequest", () => {
       parseDiagramCommentPortRequest({
         type: "ark:diagram-comment-reply",
         requestId: "req-reply-invalid",
+        operationId: "op-1",
         ...fields,
       })
     ).toMatchObject({
@@ -184,12 +201,14 @@ describe("parseDiagramCommentPortRequest", () => {
     {
       type: "ark:diagram-comment-create",
       requestId: "req",
+      operationId: "op-1",
       anchorId: "a".repeat(257),
       body: "本文",
     },
     {
       type: "ark:diagram-comment-create",
       requestId: "req",
+      operationId: "op-1",
       anchorId: "s1",
       anchorOccurrence: 0,
       body: "本文",
@@ -197,6 +216,7 @@ describe("parseDiagramCommentPortRequest", () => {
     {
       type: "ark:diagram-comment-create",
       requestId: "req",
+      operationId: "op-1",
       anchorId: "s1",
       anchorQuote: "本文",
       anchorOccurrence: -1,
@@ -205,6 +225,7 @@ describe("parseDiagramCommentPortRequest", () => {
     {
       type: "ark:diagram-comment-create",
       requestId: "req",
+      operationId: "op-1",
       anchorId: "s1",
       anchorQuote: "本文",
       anchorOccurrence: 0,
@@ -214,34 +235,40 @@ describe("parseDiagramCommentPortRequest", () => {
     {
       type: "ark:diagram-comment-create",
       requestId: "req",
+      operationId: "op-1",
       anchorId: "s1",
       body: "b".repeat(4001),
     },
     {
       type: "ark:diagram-comment-resolve",
       requestId: "req",
+      operationId: "op-1",
       threadId: null,
     },
     {
       type: "ark:diagram-comment-resolve",
       requestId: "req",
+      operationId: "op-1",
       threadId: "t".repeat(257),
     },
     {
       type: "ark:diagram-comment-delete",
       requestId: "req",
+      operationId: "op-1",
       threadId: "th-1",
       body: "余計な値",
     },
     {
       type: "ark:diagram-comment-send",
       requestId: "req",
+      operationId: "op-1",
       threadId: "th-1",
       body: "クライアントから文面を送らない",
     },
     {
       type: "ark:diagram-comment-send",
       requestId: "req",
+      operationId: "op-1",
       threadId: " ",
     },
   ])("その他の検証失敗 %j も invalid として返す", input => {
@@ -249,6 +276,52 @@ describe("parseDiagramCommentPortRequest", () => {
       kind: "invalid",
       requestId: "req",
       error: expect.any(String),
+    });
+  });
+
+  it.each([
+    "ark:diagram-comment-create",
+    "ark:diagram-comment-reply",
+    "ark:diagram-comment-resolve",
+    "ark:diagram-comment-delete",
+    "ark:diagram-comment-send",
+  ] as const)(
+    "%s の operationId 欠落・不正を requestId 付き invalid にする (#306)",
+    type => {
+      const fields =
+        type === "ark:diagram-comment-create"
+          ? { anchorId: "s1", body: "本文" }
+          : type === "ark:diagram-comment-reply"
+            ? { threadId: "th-1", body: "本文" }
+            : { threadId: "th-1" };
+      for (const operationId of [undefined, "", " ", "o".repeat(257), 1]) {
+        const input: Record<string, unknown> = {
+          type,
+          requestId: "req-op",
+          ...fields,
+        };
+        if (operationId !== undefined) input.operationId = operationId;
+
+        expect(parseDiagramCommentPortRequest(input)).toMatchObject({
+          kind: "invalid",
+          requestId: "req-op",
+          error: expect.stringContaining("operationId"),
+        });
+      }
+    }
+  );
+
+  it("load は operationId を受け付けない（読み取りは冪等化不要）", () => {
+    expect(
+      parseDiagramCommentPortRequest({
+        type: "ark:diagram-comments-load",
+        requestId: "req-load",
+        operationId: "op-1",
+      })
+    ).toMatchObject({
+      kind: "invalid",
+      requestId: "req-load",
+      error: expect.stringContaining("operationId"),
     });
   });
 

--- a/packages/web/src/lib/diagram-comment-bridge.ts
+++ b/packages/web/src/lib/diagram-comment-bridge.ts
@@ -1,16 +1,23 @@
 import type { DiagramCommentsFile, DiagramCommentsResponse } from "@ark/shared";
 
+/**
+ * requestId は port ↔ DiagramPane の 1 往復を相関させる ID（再試行で変わる）。
+ * operationId はユーザー操作の同一性を示す ID で、iframe がタイムアウト後の
+ * 再試行でも同じ値を使う。socket まで透過的に渡し、サーバーが冪等化に使う。
+ */
 export type DiagramCommentPortRequest =
   | { type: "ark:diagram-comments-load"; requestId: string }
   | {
       type: "ark:diagram-comment-reply";
       requestId: string;
+      operationId: string;
       threadId: string;
       body: string;
     }
   | {
       type: "ark:diagram-comment-create";
       requestId: string;
+      operationId: string;
       anchorId: string;
       anchorQuote?: string;
       anchorOccurrence?: number;
@@ -19,16 +26,19 @@ export type DiagramCommentPortRequest =
   | {
       type: "ark:diagram-comment-resolve";
       requestId: string;
+      operationId: string;
       threadId: string;
     }
   | {
       type: "ark:diagram-comment-delete";
       requestId: string;
+      operationId: string;
       threadId: string;
     }
   | {
       type: "ark:diagram-comment-send";
       requestId: string;
+      operationId: string;
       threadId: string;
     };
 
@@ -128,10 +138,16 @@ export function parseDiagramCommentPortRequest(
     };
   }
 
+  // mutation は operationId を必須とする（サーバー側の冪等化に使う）
+  if (!validString(value.operationId, 256)) {
+    return invalid("操作 ID（operationId）が不正です");
+  }
+
   if (value.type === "ark:diagram-comment-create") {
     const allowedKeys = [
       "type",
       "requestId",
+      "operationId",
       "anchorId",
       "anchorQuote",
       "anchorOccurrence",
@@ -169,6 +185,7 @@ export function parseDiagramCommentPortRequest(
     > = {
       type: value.type,
       requestId: value.requestId,
+      operationId: value.operationId,
       anchorId: value.anchorId,
       body: value.body,
     };
@@ -182,7 +199,13 @@ export function parseDiagramCommentPortRequest(
   }
 
   if (value.type === "ark:diagram-comment-reply") {
-    const allowedKeys = ["type", "requestId", "threadId", "body"];
+    const allowedKeys = [
+      "type",
+      "requestId",
+      "operationId",
+      "threadId",
+      "body",
+    ];
     const unexpected = unknownKeys(value, allowedKeys);
     if (unexpected.length > 0) {
       return invalid(
@@ -200,13 +223,19 @@ export function parseDiagramCommentPortRequest(
       request: {
         type: value.type,
         requestId: value.requestId,
+        operationId: value.operationId,
         threadId: value.threadId,
         body: value.body,
       },
     };
   }
 
-  const unexpected = unknownKeys(value, ["type", "requestId", "threadId"]);
+  const unexpected = unknownKeys(value, [
+    "type",
+    "requestId",
+    "operationId",
+    "threadId",
+  ]);
   if (unexpected.length > 0) {
     const action =
       value.type === "ark:diagram-comment-send"
@@ -226,6 +255,7 @@ export function parseDiagramCommentPortRequest(
     request: {
       type: value.type,
       requestId: value.requestId,
+      operationId: value.operationId,
       threadId: value.threadId,
     },
   };

--- a/packages/web/src/lib/diagram-comment-transport.test.ts
+++ b/packages/web/src/lib/diagram-comment-transport.test.ts
@@ -1,6 +1,8 @@
 import type { DiagramCommentsResponse } from "@ark/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  DIAGRAM_COMMENT_ACK_TIMEOUT_MS,
+  DIAGRAM_COMMENT_REQUEST_ATTEMPTS,
   requestDiagramCommentCreate,
   requestDiagramCommentDelete,
   requestDiagramCommentReply,
@@ -44,6 +46,7 @@ it("reply は threadId と本文を送る", async () => {
     fake.socket,
     "session-1",
     ".claude/diagrams/a.diagram.html",
+    "op-1",
     "th-1",
     "返信本文"
   );
@@ -53,6 +56,7 @@ it("reply は threadId と本文を送る", async () => {
     {
       sessionId: "session-1",
       relPath: ".claude/diagrams/a.diagram.html",
+      operationId: "op-1",
       threadId: "th-1",
       body: "返信本文",
     },
@@ -86,6 +90,7 @@ describe("diagram comment transport", () => {
       fake.socket,
       "session-1",
       "sample.diagram.html",
+      "op-1",
       "s1",
       "本文",
       "選択した本文",
@@ -102,6 +107,7 @@ describe("diagram comment transport", () => {
       {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         anchorId: "s1",
         anchorQuote: "選択した本文",
         anchorOccurrence: 1,
@@ -119,6 +125,7 @@ describe("diagram comment transport", () => {
       fake.socket,
       "session-1",
       "sample.diagram.html",
+      "op-1",
       "th-1"
     );
 
@@ -127,6 +134,7 @@ describe("diagram comment transport", () => {
       {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "th-1",
       },
       expect.any(Function)
@@ -141,6 +149,7 @@ describe("diagram comment transport", () => {
       fake.socket,
       "session-1",
       "sample.diagram.html",
+      "op-1",
       "th-1"
     );
 
@@ -149,6 +158,7 @@ describe("diagram comment transport", () => {
       {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "th-1",
       },
       expect.any(Function)
@@ -163,6 +173,7 @@ describe("diagram comment transport", () => {
       fake.socket,
       "session-1",
       "sample.diagram.html",
+      "op-1",
       "th-1"
     );
 
@@ -171,6 +182,7 @@ describe("diagram comment transport", () => {
       {
         sessionId: "session-1",
         relPath: "sample.diagram.html",
+        operationId: "op-1",
         threadId: "th-1",
       },
       expect.any(Function)
@@ -180,19 +192,39 @@ describe("diagram comment transport", () => {
   });
 
   it.each([
-    ["get", requestDiagramCommentsGet],
-    ["resolve", requestDiagramCommentResolve],
+    [
+      "get",
+      (socket: ReturnType<typeof makeSocket>["socket"]) =>
+        requestDiagramCommentsGet(socket, "session-1", "sample.diagram.html"),
+    ],
+    [
+      "resolve",
+      (socket: ReturnType<typeof makeSocket>["socket"]) =>
+        requestDiagramCommentResolve(
+          socket,
+          "session-1",
+          "sample.diagram.html",
+          "op-1",
+          "th-1"
+        ),
+    ],
   ] as const)(
     "未接続の %s は emit せず reject する",
     async (_name, request) => {
       const fake = makeSocket(false);
 
-      await expect(
-        request(fake.socket, "session-1", "sample.diagram.html", "th-1")
-      ).rejects.toThrow("ソケットが切断されています");
+      await expect(request(fake.socket)).rejects.toThrow(
+        "ソケットが切断されています"
+      );
       expect(fake.socket.emit).not.toHaveBeenCalled();
     }
   );
+
+  it("合計の待ち時間は 10 秒で、iframe 側の 15 秒 watchdog より短い", () => {
+    expect(
+      DIAGRAM_COMMENT_ACK_TIMEOUT_MS * DIAGRAM_COMMENT_REQUEST_ATTEMPTS
+    ).toBe(10_000);
+  });
 
   it("10秒 timeout 後の late ACK を無視する", async () => {
     vi.useFakeTimers();
@@ -209,5 +241,107 @@ describe("diagram comment transport", () => {
     await vi.advanceTimersByTimeAsync(10_000);
     await rejection;
     expect(() => fake.reply(response)).not.toThrow();
+  });
+
+  it("ACK が戻らなければ同じ operationId の payload をそのまま再送する (#306)", async () => {
+    vi.useFakeTimers();
+    const fake = makeSocket();
+    const pending = requestDiagramCommentCreate(
+      fake.socket,
+      "session-1",
+      "sample.diagram.html",
+      "op-retry",
+      "s1",
+      "本文"
+    );
+
+    await vi.advanceTimersByTimeAsync(DIAGRAM_COMMENT_ACK_TIMEOUT_MS - 1);
+    expect(fake.socket.emit).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fake.socket.emit).toHaveBeenCalledTimes(
+      DIAGRAM_COMMENT_REQUEST_ATTEMPTS
+    );
+    const payloads = fake.socket.emit.mock.calls.map(call => call[1]);
+    expect(payloads[1]).toEqual(payloads[0]);
+    expect(payloads[0]).toMatchObject({ operationId: "op-retry" });
+
+    fake.reply(response);
+    await expect(pending).resolves.toEqual(response);
+  });
+
+  it("再送後に届いた初回の late ACK を採用し、2 回目の ACK は無視する", async () => {
+    vi.useFakeTimers();
+    const acks: ((value: DiagramCommentsResponse) => void)[] = [];
+    const socket = {
+      connected: true,
+      emit: vi.fn(
+        (
+          _event: string,
+          _payload: unknown,
+          callback: (value: DiagramCommentsResponse) => void
+        ) => {
+          acks.push(callback);
+        }
+      ),
+    };
+    const pending = requestDiagramCommentResolve(
+      socket,
+      "session-1",
+      "sample.diagram.html",
+      "op-1",
+      "th-1"
+    );
+    await vi.advanceTimersByTimeAsync(DIAGRAM_COMMENT_ACK_TIMEOUT_MS);
+    expect(acks).toHaveLength(2);
+
+    const late: DiagramCommentsResponse = {
+      ok: false,
+      code: "THREAD_NOT_FOUND",
+      error: "late",
+    };
+    acks[0]?.(late);
+    acks[1]?.(response);
+
+    await expect(pending).resolves.toEqual(late);
+  });
+
+  it("ACK 前に応答があれば再送しない", async () => {
+    vi.useFakeTimers();
+    const fake = makeSocket();
+    const pending = requestDiagramCommentDelete(
+      fake.socket,
+      "session-1",
+      "sample.diagram.html",
+      "op-1",
+      "th-1"
+    );
+    fake.reply(response);
+    await expect(pending).resolves.toEqual(response);
+
+    await vi.advanceTimersByTimeAsync(
+      DIAGRAM_COMMENT_ACK_TIMEOUT_MS * DIAGRAM_COMMENT_REQUEST_ATTEMPTS
+    );
+    expect(fake.socket.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it("再送時点で切断していれば再送せず reject する", async () => {
+    vi.useFakeTimers();
+    const fake = makeSocket();
+    const pending = requestDiagramCommentSend(
+      fake.socket,
+      "session-1",
+      "sample.diagram.html",
+      "op-1",
+      "th-1"
+    );
+    const rejection = expect(pending).rejects.toThrow(
+      "ソケットが切断されています"
+    );
+    fake.socket.connected = false;
+
+    await vi.advanceTimersByTimeAsync(DIAGRAM_COMMENT_ACK_TIMEOUT_MS);
+    await rejection;
+    expect(fake.socket.emit).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/lib/diagram-comment-transport.ts
+++ b/packages/web/src/lib/diagram-comment-transport.ts
@@ -7,6 +7,17 @@ import type { Socket } from "socket.io-client";
 
 type DiagramCommentSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
 
+/** 1 回の emit が ACK を待つ時間 */
+export const DIAGRAM_COMMENT_ACK_TIMEOUT_MS = 5_000;
+/**
+ * ACK が戻らなかったときの試行回数（初回を含む）。
+ * mutation は operationId でサーバー側が冪等化されているため、同じ payload を
+ * そのまま再送しても二重適用にならない。get は読み取りなので元から安全。
+ * 合計の待ち時間は ACK_TIMEOUT × ATTEMPTS = 10 秒で、iframe 側の
+ * 15 秒 watchdog より短い。
+ */
+export const DIAGRAM_COMMENT_REQUEST_ATTEMPTS = 2;
+
 function requestDiagramComments(
   socket: DiagramCommentSocket | null,
   emit: (
@@ -20,17 +31,38 @@ function requestDiagramComments(
       return;
     }
     let settled = false;
-    const timeoutId = globalThis.setTimeout(() => {
+    let attempt = 0;
+    let timeoutId: ReturnType<typeof globalThis.setTimeout> | null = null;
+    const settle = (response: DiagramCommentsResponse): void => {
+      // どの試行の ACK でも最初の 1 件だけ採用し、遅れて届いた分は無視する
       if (settled) return;
       settled = true;
-      reject(new Error("コメント処理がタイムアウトしました"));
-    }, 10_000);
-    emit(socket, response => {
-      if (settled) return;
-      settled = true;
-      globalThis.clearTimeout(timeoutId);
+      if (timeoutId !== null) globalThis.clearTimeout(timeoutId);
       resolve(response);
-    });
+    };
+    const fail = (error: Error): void => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+    const attemptOnce = (): void => {
+      attempt += 1;
+      timeoutId = globalThis.setTimeout(() => {
+        if (settled) return;
+        if (attempt >= DIAGRAM_COMMENT_REQUEST_ATTEMPTS) {
+          fail(new Error("コメント処理がタイムアウトしました"));
+          return;
+        }
+        if (!socket.connected) {
+          fail(new Error("ソケットが切断されています"));
+          return;
+        }
+        // 同じ payload（同じ operationId）で再送する
+        attemptOnce();
+      }, DIAGRAM_COMMENT_ACK_TIMEOUT_MS);
+      emit(socket, settle);
+    };
+    attemptOnce();
   });
 }
 
@@ -48,20 +80,22 @@ export function requestDiagramCommentCreate(
   socket: DiagramCommentSocket | null,
   sessionId: string,
   relPath: string,
+  operationId: string,
   anchorId: string,
   body: string,
   anchorQuote?: string,
   anchorOccurrence?: number
 ): Promise<DiagramCommentsResponse> {
+  const payload = {
+    sessionId,
+    relPath,
+    operationId,
+    anchorId,
+    body,
+    ...(anchorQuote === undefined ? {} : { anchorQuote }),
+    ...(anchorOccurrence === undefined ? {} : { anchorOccurrence }),
+  };
   return requestDiagramComments(socket, (activeSocket, callback) => {
-    const payload = {
-      sessionId,
-      relPath,
-      anchorId,
-      body,
-      ...(anchorQuote === undefined ? {} : { anchorQuote }),
-      ...(anchorOccurrence === undefined ? {} : { anchorOccurrence }),
-    };
     activeSocket.emit("diagram:comment:create", payload, callback);
   });
 }
@@ -70,12 +104,13 @@ export function requestDiagramCommentResolve(
   socket: DiagramCommentSocket | null,
   sessionId: string,
   relPath: string,
+  operationId: string,
   threadId: string
 ): Promise<DiagramCommentsResponse> {
   return requestDiagramComments(socket, (activeSocket, callback) => {
     activeSocket.emit(
       "diagram:comment:resolve",
-      { sessionId, relPath, threadId },
+      { sessionId, relPath, operationId, threadId },
       callback
     );
   });
@@ -85,13 +120,14 @@ export function requestDiagramCommentReply(
   socket: DiagramCommentSocket | null,
   sessionId: string,
   relPath: string,
+  operationId: string,
   threadId: string,
   body: string
 ): Promise<DiagramCommentsResponse> {
   return requestDiagramComments(socket, (activeSocket, callback) => {
     activeSocket.emit(
       "diagram:comment:reply",
-      { sessionId, relPath, threadId, body },
+      { sessionId, relPath, operationId, threadId, body },
       callback
     );
   });
@@ -101,12 +137,13 @@ export function requestDiagramCommentDelete(
   socket: DiagramCommentSocket | null,
   sessionId: string,
   relPath: string,
+  operationId: string,
   threadId: string
 ): Promise<DiagramCommentsResponse> {
   return requestDiagramComments(socket, (activeSocket, callback) => {
     activeSocket.emit(
       "diagram:comment:delete",
-      { sessionId, relPath, threadId },
+      { sessionId, relPath, operationId, threadId },
       callback
     );
   });
@@ -116,12 +153,13 @@ export function requestDiagramCommentSend(
   socket: DiagramCommentSocket | null,
   sessionId: string,
   relPath: string,
+  operationId: string,
   threadId: string
 ): Promise<DiagramCommentsResponse> {
   return requestDiagramComments(socket, (activeSocket, callback) => {
     activeSocket.emit(
       "diagram:comment:send",
-      { sessionId, relPath, threadId },
+      { sessionId, relPath, operationId, threadId },
       callback
     );
   });


### PR DESCRIPTION
図解コメントの mutation に操作 ID を導入し、ACK タイムアウト後の再試行を冪等にする。

Closes #306

## 問題

transport の 10 秒 ACK タイムアウトはサーバー側の処理を取り消さない。サーバーが sidecar へ書き込んだ後に ACK が遅延すると、クライアントはエラーを表示し、ユーザーの再試行で**同じ thread が 2 件できる**。resolve / delete でも同様に `THREAD_NOT_FOUND` の誤表示につながる。

## 設計

- クライアント生成の `operationId` を mutation payload（create / reply / resolve / delete / send）に必須で載せる
- **ID は iframe のコメント層が「ユーザー操作」単位で生成する。** タイムアウト後にユーザーが UI で同じ操作をやり直しても同じ値を送る（成功時に破棄）
- transport は ACK が戻らなければ同じ payload を 1 回再送する
- サーバーは `(種別, sidecar, operationId)` をキーにプロセス内 LRU で適用済みを記録し、同じ ID の再送は再適用せず現在の sidecar を返す
- **サーバー再起動をまたぐ再試行は冪等化の対象外**（ACK タイムアウトの窓は 10 秒で、Issue が「要検討」とした sidecar 永続化は不要と判断）

### `send` 経路の同型の穴

`SessionOrchestrator.sendMessage` は tmux 投入後の DB status 更新失敗を throw していた。これを handler が失敗扱いすると ID を記録せず再送し、**同じメッセージが二重に届く**。status 更新の失敗はログに留める形に変えた。

## 変更範囲

21 ファイル。Issue の対応案 4 ファイルより広いのは、ID を iframe → bridge → DiagramPane → useSocket → transport と**透過的に引き回す**ためで、codex のレビューで「不自然なスコープ拡大ではない」と判定された。`CLAUDE.md` に設計の記録を追加。

## 互換性

`operationId` を必須にしたため、旧クライアントからの payload は `BAD_REQUEST` になる。Ark はサーバーと Web を同時配布しローリング更新は無いため受け入れる。古いタブが残った場合の `BAD_REQUEST` 理由は iframe と親画面の両方に表示される（回帰テストあり）。

## 検証

実装は Claude Code セッション、レビューは codex（実装者 ≠ レビュアー）。

### 統合テスト（レビュー指摘で追加）

実 transport と実 handler・sidecar store を接続し、テスト用 socket で**最初の ACK だけを破棄**する。タイムアウト後に同一 payload が再送され、create の thread が 1 件、delete 後が 0 件であることを確認。

変異テスト: LRU の記録を無効化すると 2/2 が失敗する（supervisor が独立に再現）。

```
変異なし            exit=0  2 passed
LRU 記録を無効化     exit=1  2 failed  → 検出
復元後              exit=0  2 passed
```

### 全体

```
pnpm check   exit 0
pnpm test    exit 0   69 files / 1131 tests
pnpm build   exit 0
```

## 見送った改善

同じ `operationId` で**内容の異なる** payload を衝突として拒否する案は、payload の正規化とハッシュ保存が要り変更範囲が広がるため見送った。現実装は「適用済み」として現在の sidecar を返す。

## 補足: #367 の測定に使った

この Issue は復唱の効果測定（#367）の題材として、復唱あり / なしの 2 セッションで並行実行した。本 PR は**復唱あり**側の成果物で、盲検評価で採用された。詳細は #367 に記録する。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 図解コメントの作成・返信・解決・削除・送信で、再試行時の二重適用を防止。
  * 通信確認が遅延した場合、コメント操作を自動で再送信。
  * コメント操作のイベントと入力検証を強化。

* **バグ修正**
  * 再送によるコメントの重複作成や、削除・送信処理の重複実行を防止。
  * メッセージ送信後のセッション状態更新に失敗しても、送信自体は成功として扱うよう改善。

* **ドキュメント**
  * 図解コメント操作の再試行仕様とイベント一覧を追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->