### PR TITLE
fix(server): tmux-manager の読み取り系で tmux の失敗と「値なし」を型で区別する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,26 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 - 「前回開いたときから何が変わったか」の差分可視化と、複数エージェントの同時編集の
   競合（last-write-wins）は本機能の範囲外
 
+### tmux 読み取りの結果型（TmuxReadResult）
+
+`TmuxManager` の読み取り系（`getEnv` / `getPaneEnv` / `getBuffer` / `capturePane` /
+`capturePaneVisible`）は `string | null` ではなく `TmuxReadResult<string>`
+（`tmux-read-result.ts`）を返す。以前は **tmux コマンドの失敗**と**値が無いこと**を
+同じ `null` に畳んでいたため、セッション消滅・復元失敗の原因が事後に追えなかった（#393）。
+
+- `{ ok: true, value }` または `{ ok: false, failure }`。`failure.kind` は
+  `no-session`（管理外 ID）/ `tmux-failed`（非 0 終了・起動失敗・timeout。`status` /
+  `signal` / `code` / `stderr` を持つ）/ `not-set` / `no-buffer` / `invalid-pane-pid` /
+  `proc-error` / `unsupported-platform`
+- 呼び出し側は `not-set` と `unsupported-platform` だけを「想定内の値なし」として
+  静かに扱い、それ以外は `describeTmuxReadFailure` でログに理由を残す
+- 1 秒間隔の polling 経路（`getAllPreviews` / bridge-collector）は
+  `TmuxReadFailureReporter` で同じ失敗を 1 度だけ出し、回復時も 1 行残す
+- `getEnv` は `show-environment -t <session>` の一覧から自前で探す（変数名指定だと
+  未設定時も exit 1 になり tmux 失敗と区別できない）。`getBuffer` は `show-buffer` の
+  前に `list-buffers` で有無を見る（同じ理由）
+- 書き込み系（`sendKeys` 等）は従来どおり throw
+
 ### セッション永続化
 
 - **tmuxセッション**: サーバー再起動後も維持される（`cleanup()`でttydのみ停止、tmuxは残す）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,8 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
   `no-session`（管理外 ID）/ `tmux-failed`（非 0 終了・起動失敗・timeout。`status` /
   `signal` / `code` / `stderr` を持つ）/ `not-set` / `no-buffer` / `invalid-pane-pid` /
   `proc-error` / `unsupported-platform`
-- 呼び出し側は `not-set` と `unsupported-platform` だけを「想定内の値なし」として
-  静かに扱い、それ以外は `describeTmuxReadFailure` でログに理由を残す
+- 呼び出し側は `not-set` / `unsupported-platform` / `no-buffer` を「想定内の値なし」として
+  静かに扱い（`no-buffer` は `session:copy` が「バッファが空です」を返す）、それ以外は `describeTmuxReadFailure` でログに理由を残す
 - 1 秒間隔の polling 経路（`getAllPreviews` / bridge-collector）は
   `TmuxReadFailureReporter` で同じ失敗を 1 度だけ出し、回復時も 1 行残す
 - `getEnv` は `show-environment -t <session>` の一覧から自前で探す（変数名指定だと

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -122,6 +122,7 @@ import { listSlashCommands } from "./lib/slash-command-scanner.js";
 import { SPA_FALLBACK_ROUTE_PATTERN } from "./lib/spa-fallback.js";
 import { detectMultiProfileSupported } from "./lib/system.js";
 import { tmuxManager } from "./lib/tmux-manager.js";
+import { describeTmuxReadFailure } from "./lib/tmux-read-result.js";
 import { TunnelManager } from "./lib/tunnel.js";
 import { UsageCollector } from "./lib/usage-collector.js";
 
@@ -472,9 +473,18 @@ export async function startServer(
     // 直前の会話文脈は AUQ 解決まで JSONL に書かれないため、hook 受信の
     // この瞬間 (質問ボックス描画前後) の tmux 画面を verbatim で添付する。
     // 解釈はしない (auq-screen-context.ts の原則境界コメント参照)
-    const screen = buildAuqScreenContext(
-      tmuxManager.capturePane(session.id, AUQ_SCREEN_CAPTURE_LINES)
+    // capture に失敗しても AUQ カード自体は出す (画面添付だけ欠ける)。
+    // 「値が無い」のではなく tmux が失敗したことを、理由付きで残す (#393)
+    const captured = tmuxManager.capturePane(
+      session.id,
+      AUQ_SCREEN_CAPTURE_LINES
     );
+    if (!captured.ok) {
+      console.warn(
+        `[AuqHook] ${session.id}: 直前の画面を取得できません (${describeTmuxReadFailure(captured.failure)})`
+      );
+    }
+    const screen = buildAuqScreenContext(captured.ok ? captured.value : null);
     const entry = auqHookBridge.setPending(
       session.id,
       body.tool_input.questions,
@@ -2206,11 +2216,30 @@ export async function startServer(
     // コピー: tmuxバッファの内容をクライアントに返す（コールバックパターン）
     socket.on("session:copy", (sessionId, callback) => {
       try {
-        const text = tmuxManager.getBuffer(sessionId);
-        if (text) {
-          callback({ text });
-        } else {
-          callback({ error: "バッファが空です" });
+        const result = tmuxManager.getBuffer(sessionId);
+        if (result.ok) {
+          callback(
+            result.value
+              ? { text: result.value }
+              : { error: "バッファが空です" }
+          );
+          return;
+        }
+        // 「バッファが無い」と tmux の失敗を区別して返す (#393)
+        switch (result.failure.kind) {
+          case "no-buffer":
+            callback({ error: "バッファが空です" });
+            break;
+          case "no-session":
+            callback({ error: "セッションが見つかりません" });
+            break;
+          default:
+            console.warn(
+              `[Copy] ${sessionId}: ${describeTmuxReadFailure(result.failure)}`
+            );
+            callback({
+              error: `tmux バッファを取得できません: ${describeTmuxReadFailure(result.failure)}`,
+            });
         }
       } catch (error) {
         callback({ error: String(error) });

--- a/packages/server/src/lib/bridge-collector.test.ts
+++ b/packages/server/src/lib/bridge-collector.test.ts
@@ -81,7 +81,7 @@ describe("bridge-collector - tmux 読み取り失敗 (#393)", () => {
     warnSpy.mockRestore();
   });
 
-  it("collectBridgeSessions: capture-pane 失敗でもセッションは READY で残り、理由は 1 度だけ警告する", () => {
+  it("collectBridgeSessions: capture-pane 失敗は ERR で残り、理由は 1 度だけ警告する", () => {
     mockedTmux.capturePaneVisible.mockReturnValue(
       tmuxFailed("can't find pane: ark-sess-1")
     );
@@ -90,7 +90,7 @@ describe("bridge-collector - tmux 読み取り失敗 (#393)", () => {
     const second = collectBridgeSessions();
 
     expect(first).toHaveLength(1);
-    expect(first[0]?.status).toBe("READY");
+    expect(first[0]?.status).toBe("ERR");
     expect(first[0]?.previewText).toBe("");
     expect(second).toHaveLength(1);
     const matching = warnSpy.mock.calls.filter(([msg]) =>
@@ -99,7 +99,7 @@ describe("bridge-collector - tmux 読み取り失敗 (#393)", () => {
     expect(matching).toHaveLength(1);
   });
 
-  it("collectGridSnapshots: capture-pane 失敗でも snapshot は返り、理由は 1 度だけ警告する", () => {
+  it("collectGridSnapshots: capture-pane 失敗は ERR の snapshot で返り、理由は 1 度だけ警告する", () => {
     mockedTmux.capturePaneVisible.mockReturnValue(
       tmuxFailed("no server running")
     );
@@ -108,7 +108,7 @@ describe("bridge-collector - tmux 読み取り失敗 (#393)", () => {
     const second = collectGridSnapshots();
 
     expect(first).toHaveLength(1);
-    expect(first[0]?.status).toBe("READY");
+    expect(first[0]?.status).toBe("ERR");
     expect(second).toHaveLength(1);
     const matching = warnSpy.mock.calls.filter(([msg]) =>
       String(msg).includes("no server running")

--- a/packages/server/src/lib/bridge-collector.test.ts
+++ b/packages/server/src/lib/bridge-collector.test.ts
@@ -1,0 +1,148 @@
+/**
+ * bridge-collector の tmux 読み取り失敗の扱い (#393)
+ *
+ * collectBridgeSessions / collectGridSnapshots / collectStreamLines は 1 秒前後の
+ * polling で呼ばれる。capture-pane が失敗したとき、失敗理由 (stderr) が 1 度だけ
+ * ログに残り、毎 tick 繰り返さないこと、および成功時と同じ形で結果が組み立て
+ * られることを検証する。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  spawnSync: vi.fn(() => ({ status: 0, stdout: "%0\n", stderr: "" })),
+}));
+
+vi.mock("./database.js", () => ({
+  db: { getSetting: vi.fn(() => null) },
+}));
+
+vi.mock("./session-orchestrator.js", () => ({
+  sessionOrchestrator: { getAllSessions: vi.fn(() => []) },
+}));
+
+vi.mock("./tmux-manager.js", () => ({
+  tmuxManager: {
+    capturePane: vi.fn(),
+    capturePaneVisible: vi.fn(),
+  },
+}));
+
+import {
+  collectBridgeSessions,
+  collectGridSnapshots,
+  collectStreamLines,
+} from "./bridge-collector.js";
+import { sessionOrchestrator } from "./session-orchestrator.js";
+import { tmuxManager } from "./tmux-manager.js";
+
+const mockedOrchestrator = vi.mocked(sessionOrchestrator);
+const mockedTmux = vi.mocked(tmuxManager);
+
+const tmuxFailed = (stderr: string) => ({
+  ok: false as const,
+  failure: {
+    kind: "tmux-failed" as const,
+    command: "capture-pane",
+    status: 1,
+    signal: null,
+    stderr,
+  },
+});
+
+const managedSession = {
+  id: "sess-1",
+  worktreeId: "wt-1",
+  worktreePath: "/repo/wt",
+  repoPath: "/repo",
+  status: "active",
+  createdAt: new Date("2026-08-22T00:00:00Z"),
+  tmuxSessionName: "ark-sess-1",
+  ttydPort: null,
+  ttydUrl: null,
+  profileId: null,
+  profileConfigDir: null,
+  staleProfile: false,
+  lastDiagramPath: null,
+};
+
+describe("bridge-collector - tmux 読み取り失敗 (#393)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedOrchestrator.getAllSessions.mockReturnValue([
+      managedSession as never,
+    ]);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("collectBridgeSessions: capture-pane 失敗でもセッションは READY で残り、理由は 1 度だけ警告する", () => {
+    mockedTmux.capturePaneVisible.mockReturnValue(
+      tmuxFailed("can't find pane: ark-sess-1")
+    );
+
+    const first = collectBridgeSessions();
+    const second = collectBridgeSessions();
+
+    expect(first).toHaveLength(1);
+    expect(first[0]?.status).toBe("READY");
+    expect(first[0]?.previewText).toBe("");
+    expect(second).toHaveLength(1);
+    const matching = warnSpy.mock.calls.filter(([msg]) =>
+      String(msg).includes("can't find pane: ark-sess-1")
+    );
+    expect(matching).toHaveLength(1);
+  });
+
+  it("collectGridSnapshots: capture-pane 失敗でも snapshot は返り、理由は 1 度だけ警告する", () => {
+    mockedTmux.capturePaneVisible.mockReturnValue(
+      tmuxFailed("no server running")
+    );
+
+    const first = collectGridSnapshots();
+    const second = collectGridSnapshots();
+
+    expect(first).toHaveLength(1);
+    expect(first[0]?.status).toBe("READY");
+    expect(second).toHaveLength(1);
+    const matching = warnSpy.mock.calls.filter(([msg]) =>
+      String(msg).includes("no server running")
+    );
+    expect(matching).toHaveLength(1);
+  });
+
+  it("collectStreamLines: capture-pane 失敗なら空配列を返し、理由は 1 度だけ警告する", () => {
+    mockedTmux.capturePane.mockReturnValue(tmuxFailed("server exited"));
+
+    expect(collectStreamLines("sess-1")).toEqual([]);
+    expect(collectStreamLines("sess-1")).toEqual([]);
+
+    const matching = warnSpy.mock.calls.filter(([msg]) =>
+      String(msg).includes("server exited")
+    );
+    expect(matching).toHaveLength(1);
+  });
+
+  it("成功時は画面テキストを解析して返す", () => {
+    // reporter はモジュール単位で状態を持つため、前のテストで失敗した id を
+    // 使うと「回復」行が出る。失敗歴の無い id で警告ゼロを検証する
+    mockedOrchestrator.getAllSessions.mockReturnValue([
+      { ...managedSession, id: "sess-ok" } as never,
+    ]);
+    mockedTmux.capturePaneVisible.mockReturnValue({
+      ok: true,
+      value: "⏺ Bash(ls)\n  ⎿ ok\n❯ ",
+    });
+
+    const sessions = collectBridgeSessions();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]?.previewText).not.toBe("");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/server/src/lib/bridge-collector.ts
+++ b/packages/server/src/lib/bridge-collector.ts
@@ -22,6 +22,16 @@ import { stripAnsi } from "./ansi.js";
 import { db } from "./database.js";
 import { sessionOrchestrator } from "./session-orchestrator.js";
 import { tmuxManager } from "./tmux-manager.js";
+import { TmuxReadFailureReporter } from "./tmux-read-result.js";
+
+/**
+ * capture-pane 失敗の重複抑制ロガー (#393)。
+ *
+ * 3 つの collector は 1〜1.5 秒間隔の polling で呼ばれるため、tmux が死んだ /
+ * セッションが消えた理由 (stderr) を残しつつ、同じ失敗を毎 tick 出さない。
+ * 収集経路ごとに key を分け、回復時も 1 行残す。
+ */
+const captureFailures = new TmuxReadFailureReporter("[Bridge]");
 
 /** capture-pane を独自フォーマットでパースした結果 */
 interface PaneAnalysis {
@@ -59,7 +69,9 @@ export function collectBridgeSessions(): BridgeSession[] {
   for (const ms of filtered) {
     // 可視範囲のみ取得 (scrollback を含めると /clear 後でも過去ログが残り、
     // READY 判定や preview 表示が壊れる)
-    const raw = tmuxManager.capturePaneVisible(ms.id);
+    const captured = tmuxManager.capturePaneVisible(ms.id);
+    captureFailures.report(`sessions:${ms.id}`, captured);
+    const raw = captured.ok ? captured.value : null;
     const analysis = raw ? analyzePane(raw) : EMPTY_ANALYSIS;
     const paneId = lookupPaneId(ms.tmuxSessionName);
     const previewText = raw ? extractPreviewText(raw, 12) : "";
@@ -132,9 +144,10 @@ export function collectStreamLines(
   sessionId: string,
   maxLines = 20
 ): BridgeStreamLine[] {
-  const raw = tmuxManager.capturePane(sessionId, 400);
-  if (!raw) return [];
-  const analysis = analyzePane(raw);
+  const captured = tmuxManager.capturePane(sessionId, 400);
+  captureFailures.report(`stream:${sessionId}`, captured);
+  if (!captured.ok || !captured.value) return [];
+  const analysis = analyzePane(captured.value);
   return analysis.streamLines.slice(-maxLines);
 }
 
@@ -166,7 +179,9 @@ export function collectGridSnapshots(maxLines = 12): SessionGridSnapshot[] {
   const result: SessionGridSnapshot[] = [];
   for (const ms of filtered) {
     // 可視範囲のみ取得 (collectBridgeSessions と統一)
-    const raw = tmuxManager.capturePaneVisible(ms.id);
+    const captured = tmuxManager.capturePaneVisible(ms.id);
+    captureFailures.report(`grid:${ms.id}`, captured);
+    const raw = captured.ok ? captured.value : null;
     const analysis = raw ? analyzePane(raw) : EMPTY_ANALYSIS;
     const previewText = raw ? extractPreviewText(raw, maxLines) : "";
     // collectBridgeSessions と同じ READY 判定を適用

--- a/packages/server/src/lib/bridge-collector.ts
+++ b/packages/server/src/lib/bridge-collector.ts
@@ -78,6 +78,9 @@ export function collectBridgeSessions(): BridgeSession[] {
     let status: BridgeSessionStatus;
     if (ms.status === "stopped") {
       status = "STOP";
+    } else if (!captured.ok) {
+      // tmux 停止・セッション消失などの取得失敗を、空画面の READY と区別する。
+      status = "ERR";
     } else if (analysis.status === "IDLE" && previewText.trim().length === 0) {
       // /clear 直後・起動直後など、画面に意味あるテキストがない場合は READY (グレー)
       status = "READY";
@@ -188,6 +191,9 @@ export function collectGridSnapshots(maxLines = 12): SessionGridSnapshot[] {
     let status: BridgeSessionStatus;
     if (ms.status === "stopped") {
       status = "STOP";
+    } else if (!captured.ok) {
+      // tmux 停止・セッション消失などの取得失敗を、空画面の READY と区別する。
+      status = "ERR";
     } else if (analysis.status === "IDLE" && previewText.trim().length === 0) {
       status = "READY";
     } else {

--- a/packages/server/src/lib/session-orchestrator-context.integration.test.ts
+++ b/packages/server/src/lib/session-orchestrator-context.integration.test.ts
@@ -165,7 +165,9 @@ describe("SessionOrchestrator + real Ark context harness", () => {
     expect(fs.existsSync(settingsPath)).toBe(true);
 
     mockedTmux.getEnv.mockImplementation((_sessionId, name) =>
-      contextEnv?.[name] ? contextEnv[name] : null
+      contextEnv?.[name]
+        ? { ok: true, value: contextEnv[name] }
+        : { ok: false, failure: { kind: "not-set" } }
     );
     orchestrator.stopSession(managed.id);
 

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -33,10 +33,11 @@ vi.mock("./tmux-manager.js", async () => {
     sendKeys = vi.fn();
     sendSpecialKey = vi.fn();
     capturePane = vi.fn();
+    capturePaneVisible = vi.fn();
     setClaudeMcpConfigPath = vi.fn();
-    // restoreExistingSessions → detectEnvProfile が参照する (env 無し = null 相当)
-    getEnv = vi.fn(() => undefined);
-    getPaneEnv = vi.fn(() => undefined);
+    // restoreExistingSessions → detectEnvProfile が参照する (env 無し = not-set)
+    getEnv = vi.fn(() => ({ ok: false, failure: { kind: "not-set" } }));
+    getPaneEnv = vi.fn(() => ({ ok: false, failure: { kind: "not-set" } }));
   }
   const tmuxManager = new TmuxManagerStub();
   // 複数の SessionOrchestrator インスタンス（各testで生成）が listener を追加するため
@@ -459,7 +460,7 @@ describe("SessionOrchestrator - プロファイル切替", () => {
       const oldContextId = "b".repeat(32);
       const newContextId = "c".repeat(32);
       mockedTmux.getSession.mockReturnValue(oldSession);
-      mockedTmux.getEnv.mockReturnValue(oldContextId);
+      mockedTmux.getEnv.mockReturnValue({ ok: true, value: oldContextId });
       mockedDb.getSessionByWorktreePath.mockReturnValue({
         id: "sess-id-1",
         worktreeId: "wt-1",
@@ -741,7 +742,7 @@ describe("SessionOrchestrator - プロファイル切替", () => {
     it("fire-and-forget teardown の失敗をログへ残す", async () => {
       const contextSessionId = "e".repeat(32);
       mockedTmux.getSession.mockReturnValue(makeTmuxSession());
-      mockedTmux.getEnv.mockReturnValue(contextSessionId);
+      mockedTmux.getEnv.mockReturnValue({ ok: true, value: contextSessionId });
       mockedContext.teardownSession.mockRejectedValueOnce(
         new Error("teardown timeout")
       );
@@ -905,7 +906,7 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
     // stopSession は tmuxManager.getSession() から worktreePath を得る
     mockedTmux.getSession.mockReturnValue(makeTmuxSession());
     const contextSessionId = "d".repeat(32);
-    mockedTmux.getEnv.mockReturnValue(contextSessionId);
+    mockedTmux.getEnv.mockReturnValue({ ok: true, value: contextSessionId });
 
     orchestrator.stopSession(managed.id);
 
@@ -1054,5 +1055,200 @@ describe("SessionOrchestrator - board MCP 注入 (Task 4)", () => {
     // 失敗時は registerBoardToken に到達しないため、後始末でファイルが消える
     // (createSession 失敗時点では registry.register も未実行)
     expect(fs.existsSync(cfgPath)).toBe(false);
+  });
+});
+
+/**
+ * tmux 読み取り失敗の区別 (#393)
+ *
+ * 以前は tmux 失敗と「値なし」が同じ null だったため、復元・再起動・停止の分岐が
+ * 黙って「値なし」側へ進んでいた。ここでは tmux-failed のとき理由 (stderr) が
+ * ログに残り、not-set / unsupported-platform は正常な「値なし」として静かに
+ * 扱われることを検証する。
+ */
+describe("SessionOrchestrator - tmux 読み取り失敗の区別 (#393)", () => {
+  const tmuxFailed = (command: string, stderr: string) => ({
+    ok: false as const,
+    failure: {
+      kind: "tmux-failed" as const,
+      command,
+      status: 1,
+      signal: null,
+      stderr,
+    },
+  });
+  const notSet = { ok: false as const, failure: { kind: "not-set" as const } };
+  const unsupported = {
+    ok: false as const,
+    failure: { kind: "unsupported-platform" as const, platform: "darwin" },
+  };
+  const okValue = (value: string) => ({ ok: true as const, value });
+
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedTmux.getAllSessions.mockReturnValue([]);
+    mockedTmux.getSessionByWorktree.mockReturnValue(undefined);
+    mockedTmux.getSession.mockReturnValue(undefined);
+    mockedTmux.getEnv.mockReturnValue(notSet);
+    mockedTmux.getPaneEnv.mockReturnValue(notSet);
+    mockedTtyd.getInstance.mockReturnValue(undefined);
+    mockedDb.getRepoProfileLink.mockReturnValue(null);
+    mockedDb.getWorktreeProfileLink.mockReturnValue(null);
+    mockedDb.getProfile.mockReturnValue(null);
+    mockedDb.getSessionByWorktreePath.mockReturnValue(null);
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe("復元時の CLAUDE_CONFIG_DIR 検出 (detectEnvProfile)", () => {
+    // 復元対象の worktree は実在する必要がある (orphan 判定を通すため)
+    const worktreePath = os.tmpdir();
+
+    it("session env が tmux-failed でも pane environ へフォールバックし、理由を警告に残す", () => {
+      mockedTmux.getAllSessions.mockReturnValue([
+        makeTmuxSession({ worktreePath }) as never,
+      ]);
+      mockedTmux.getEnv.mockReturnValue(
+        tmuxFailed("show-environment", "no such session: ark-sess1")
+      );
+      mockedTmux.getPaneEnv.mockReturnValue(okValue("/home/u/.claude-work"));
+
+      const orchestrator = new SessionOrchestrator();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no such session: ark-sess1")
+      );
+      const managed = orchestrator
+        .getAllSessions()
+        .find(s => s.id === "sess-id-1");
+      expect(managed?.profileConfigDir).toBe("/home/u/.claude-work");
+    });
+
+    it("not-set / unsupported-platform は正常な「値なし」なので警告せず profile 無しで復元する", () => {
+      mockedTmux.getAllSessions.mockReturnValue([
+        makeTmuxSession({ worktreePath }) as never,
+      ]);
+      mockedTmux.getEnv.mockReturnValue(notSet);
+      mockedTmux.getPaneEnv.mockReturnValue(unsupported);
+
+      const orchestrator = new SessionOrchestrator();
+
+      expect(warnSpy).not.toHaveBeenCalled();
+      const managed = orchestrator
+        .getAllSessions()
+        .find(s => s.id === "sess-id-1");
+      expect(managed?.profileConfigDir).toBeNull();
+    });
+
+    it("session env と pane environ の両方が失敗したら両方の理由を警告に残す", () => {
+      mockedTmux.getAllSessions.mockReturnValue([
+        makeTmuxSession({ worktreePath }) as never,
+      ]);
+      mockedTmux.getEnv.mockReturnValue(
+        tmuxFailed("show-environment", "no server running")
+      );
+      mockedTmux.getPaneEnv.mockReturnValue({
+        ok: false,
+        failure: {
+          kind: "proc-error",
+          code: "EACCES",
+          message: "permission denied",
+        },
+      });
+
+      new SessionOrchestrator();
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no server running")
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("EACCES"));
+    });
+  });
+
+  describe("restartSession", () => {
+    it("ARK_SESSION_ID が tmux-failed なら旧 context の teardown を飛ばし、理由を警告に残す", async () => {
+      const orchestrator = new SessionOrchestrator();
+      mockedTmux.getSession.mockReturnValue(makeTmuxSession());
+      mockedTmux.getEnv.mockReturnValue(
+        tmuxFailed("show-environment", "no such session: ark-sess1")
+      );
+      mockedTmux.createSession.mockResolvedValue(
+        makeTmuxSession({ id: "sess-id-2", tmuxSessionName: "ark-sess2" })
+      );
+      mockedTtyd.startInstance.mockResolvedValue({
+        sessionId: "sess-id-2",
+        port: 7682,
+        tmuxSessionName: "ark-sess2",
+        basePath: "/ttyd/sess-id-2",
+      } as never);
+
+      await orchestrator.restartSession("sess-id-1");
+
+      expect(mockedContext.teardownSession).not.toHaveBeenCalled();
+      expect(mockedContext.initializeSession).toHaveBeenCalledWith(
+        "/path/to/work",
+        undefined
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no such session: ark-sess1")
+      );
+    });
+
+    it("ARK_SESSION_ID が not-set なら警告せず新規 context で再起動する", async () => {
+      const orchestrator = new SessionOrchestrator();
+      mockedTmux.getSession.mockReturnValue(makeTmuxSession());
+      mockedTmux.getEnv.mockReturnValue(notSet);
+      mockedTmux.createSession.mockResolvedValue(
+        makeTmuxSession({ id: "sess-id-2", tmuxSessionName: "ark-sess2" })
+      );
+
+      await orchestrator.restartSession("sess-id-1");
+
+      expect(mockedContext.teardownSession).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("stopSession", () => {
+    it("ARK_SESSION_ID が tmux-failed なら teardown を飛ばし、理由を警告に残す", () => {
+      const orchestrator = new SessionOrchestrator();
+      mockedTmux.getSession.mockReturnValue(makeTmuxSession());
+      mockedTmux.getEnv.mockReturnValue(
+        tmuxFailed("show-environment", "no server running")
+      );
+
+      orchestrator.stopSession("sess-id-1");
+
+      expect(mockedTmux.killSession).toHaveBeenCalledWith("sess-id-1");
+      expect(mockedContext.teardownSession).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("no server running")
+      );
+    });
+  });
+
+  describe("getAllPreviews", () => {
+    it("capture-pane が失敗したセッションは理由を 1 度だけ警告し、プレビューから除外する", () => {
+      const orchestrator = new SessionOrchestrator();
+      mockedTmux.getAllSessions.mockReturnValue([
+        makeTmuxSession({ worktreePath: os.tmpdir() }) as never,
+      ]);
+      mockedTmux.capturePaneVisible.mockReturnValue(
+        tmuxFailed("capture-pane", "can't find pane: ark-sess1")
+      );
+
+      expect(orchestrator.getAllPreviews()).toEqual([]);
+      expect(orchestrator.getAllPreviews()).toEqual([]);
+
+      const matching = warnSpy.mock.calls.filter(([msg]) =>
+        String(msg).includes("can't find pane: ark-sess1")
+      );
+      expect(matching).toHaveLength(1);
+    });
   });
 });

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -1212,6 +1212,35 @@ describe("SessionOrchestrator - tmux 読み取り失敗の区別 (#393)", () => 
       expect(mockedContext.teardownSession).not.toHaveBeenCalled();
       expect(warnSpy).not.toHaveBeenCalled();
     });
+
+    it.each([
+      ["空値", ""],
+      ["不正値", "not-a-session-id"],
+    ])(
+      "ARK_SESSION_ID が%sなら破損を警告し、teardown と restart ID への利用を避ける",
+      async (_label, invalidContextId) => {
+        const orchestrator = new SessionOrchestrator();
+        mockedTmux.getSession.mockReturnValue(makeTmuxSession());
+        mockedTmux.getEnv.mockReturnValue({
+          ok: true,
+          value: invalidContextId,
+        });
+        mockedTmux.createSession.mockResolvedValue(
+          makeTmuxSession({ id: "sess-id-2", tmuxSessionName: "ark-sess2" })
+        );
+
+        await orchestrator.restartSession("sess-id-1");
+
+        expect(mockedContext.teardownSession).not.toHaveBeenCalled();
+        expect(mockedContext.initializeSession).toHaveBeenCalledWith(
+          "/path/to/work",
+          undefined
+        );
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("ARK_SESSION_ID が破損しています")
+        );
+      }
+    );
   });
 
   describe("stopSession", () => {

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -27,7 +27,25 @@ import { analyzeBridgeStatus } from "./bridge-collector.js";
 import { db } from "./database.js";
 import { getErrorMessage } from "./errors.js";
 import { type TmuxSession, tmuxManager } from "./tmux-manager.js";
+import {
+  describeTmuxReadFailure,
+  TmuxReadFailureReporter,
+  type TmuxReadResult,
+} from "./tmux-read-result.js";
 import { ttydManager } from "./ttyd-manager.js";
+
+/**
+ * tmux 読み取りが「値なし」として正常に扱える失敗かどうか。
+ * not-set (変数が無い) と unsupported-platform (macOS で /proc が無い) は
+ * 想定内の「値なし」であり、ログに残すべき異常ではない。
+ */
+function isExpectedAbsence(result: TmuxReadResult<unknown>): boolean {
+  return (
+    !result.ok &&
+    (result.failure.kind === "not-set" ||
+      result.failure.kind === "unsupported-platform")
+  );
+}
 
 export type { ManagedSession };
 
@@ -54,6 +72,15 @@ export class SessionOrchestrator extends EventEmitter {
     string,
     { id: string; configDir: string } | null
   >();
+
+  /**
+   * getAllPreviews (1 秒間隔 polling) での capture-pane 失敗を、同じ内容なら
+   * 1 度だけログに残すための reporter。tmux が死んだ・セッションが消えた
+   * 原因を事後に追えるようにしつつ、毎 tick のログ洪水を避ける。
+   */
+  private readonly previewCaptureFailures = new TmuxReadFailureReporter(
+    "[Preview]"
+  );
 
   /**
    * board_open MCP (BoardMcpServer / BoardSessionRegistry) への依存。
@@ -413,14 +440,50 @@ export class SessionOrchestrator extends EventEmitter {
     id: string;
     tmuxSessionName: string;
   }): { id: string; configDir: string } | null {
-    const envConfigDir =
-      tmuxManager.getEnv(tmuxSession.id, "CLAUDE_CONFIG_DIR") ??
-      tmuxManager.getPaneEnv(tmuxSession.id, "CLAUDE_CONFIG_DIR");
-    if (!envConfigDir) return null;
+    // tmux の失敗 (サーバー停止・セッション不在) と「変数が無い」を区別する。
+    // 失敗なら理由を残したうえで次の情報源へフォールバックする (#393)
+    const fromSessionEnv = tmuxManager.getEnv(
+      tmuxSession.id,
+      "CLAUDE_CONFIG_DIR"
+    );
+    if (!fromSessionEnv.ok && !isExpectedAbsence(fromSessionEnv)) {
+      console.warn(
+        `[Orchestrator] ${tmuxSession.tmuxSessionName}: CLAUDE_CONFIG_DIR を tmux session env から読めません (${describeTmuxReadFailure(fromSessionEnv.failure)})。pane environ へフォールバックします`
+      );
+    }
+    const fromPaneEnv = fromSessionEnv.ok
+      ? fromSessionEnv
+      : tmuxManager.getPaneEnv(tmuxSession.id, "CLAUDE_CONFIG_DIR");
+    if (!fromPaneEnv.ok && !isExpectedAbsence(fromPaneEnv)) {
+      console.warn(
+        `[Orchestrator] ${tmuxSession.tmuxSessionName}: CLAUDE_CONFIG_DIR を pane environ から読めません (${describeTmuxReadFailure(fromPaneEnv.failure)})。プロファイル無しで復元します`
+      );
+    }
+    if (!fromPaneEnv.ok || !fromPaneEnv.value) return null;
+    const envConfigDir = fromPaneEnv.value;
     console.log(
       `[Orchestrator] Restored profile from env: ${tmuxSession.tmuxSessionName} -> ${envConfigDir}`
     );
     return { id: "__env__", configDir: envConfigDir };
+  }
+
+  /**
+   * ark context harness の session ID (ARK_SESSION_ID) を tmux env から読む。
+   * tmux の失敗は「未設定」と区別して警告に残す。teardown を飛ばした理由が
+   * 事後に追えないと、context owner の残留と tmux の異常を切り分けられない (#393)。
+   */
+  private readContextSessionId(
+    sessionId: string,
+    purpose: string
+  ): string | undefined {
+    const result = tmuxManager.getEnv(sessionId, "ARK_SESSION_ID");
+    if (result.ok) return result.value;
+    if (!isExpectedAbsence(result)) {
+      console.warn(
+        `[Orchestrator] ${purpose} ${sessionId}: ARK_SESSION_ID を tmux env から読めないため旧 context を teardown せずに進めます (${describeTmuxReadFailure(result.failure)})`
+      );
+    }
+    return undefined;
   }
 
   /**
@@ -780,13 +843,16 @@ export class SessionOrchestrator extends EventEmitter {
 
     // context owner を旧セッションから解放してから新セッションを init する。
     // tmux env はサーバー再起動後も残るため、永続化を追加せず session ID を復元できる。
-    const oldContextSessionId = tmuxManager.getEnv(sessionId, "ARK_SESSION_ID");
+    const oldContextSessionId = this.readContextSessionId(
+      sessionId,
+      "restartSession"
+    );
     if (oldContextSessionId) {
       await this.teardownArkContext(worktreePath, oldContextSessionId);
     }
     const contextEnv = await arkContextHarness.initializeSession(
       worktreePath,
-      oldContextSessionId ?? undefined
+      oldContextSessionId
     );
     const sessionEnv =
       env || contextEnv ? { ...(env ?? {}), ...(contextEnv ?? {}) } : undefined;
@@ -864,6 +930,7 @@ export class SessionOrchestrator extends EventEmitter {
     }
     this.sessionProfiles.set(newTmux.id, snapshot);
     this.sessionProfiles.delete(sessionId);
+    this.previewCaptureFailures.forget(sessionId);
     this.repoPathCache.delete(worktreePath);
     if (boardPrep) {
       this.registerBoardToken(
@@ -974,8 +1041,8 @@ export class SessionOrchestrator extends EventEmitter {
       dbSession?.repoPath ||
       (worktreePath ? this.deriveRepoPath(worktreePath) : undefined);
     const contextSessionId = tmuxSession
-      ? tmuxManager.getEnv(sessionId, "ARK_SESSION_ID")
-      : null;
+      ? this.readContextSessionId(sessionId, "stopSession")
+      : undefined;
 
     ttydManager.stopInstance(sessionId);
     tmuxManager.killSession(sessionId);
@@ -984,6 +1051,7 @@ export class SessionOrchestrator extends EventEmitter {
     }
     db.deleteSession(sessionId);
     this.sessionProfiles.delete(sessionId);
+    this.previewCaptureFailures.forget(sessionId);
     this.unregisterBoardToken(sessionId);
     if (worktreePath) {
       this.repoPathCache.delete(worktreePath);
@@ -1068,6 +1136,7 @@ export class SessionOrchestrator extends EventEmitter {
           db.deleteSession(dbSession.id);
         }
         this.sessionProfiles.delete(s.id);
+        this.previewCaptureFailures.forget(s.id);
         this.repoPathCache.delete(s.worktreePath);
         this.emit("session:stopped", s.id);
       }
@@ -1121,8 +1190,11 @@ export class SessionOrchestrator extends EventEmitter {
     for (const session of allSessions) {
       // 可視範囲のみ取得 (scrollback 込みだと /clear 後にも過去ログが残り、
       // BridgeSessionStatus の READY 判定や preview 表示が壊れる)
-      const raw = tmuxManager.capturePaneVisible(session.id);
-      if (raw === null) continue;
+      const captured = tmuxManager.capturePaneVisible(session.id);
+      // 失敗は同内容なら 1 度だけ警告し (回復時も 1 行)、プレビューから除外する
+      this.previewCaptureFailures.report(session.id, captured);
+      if (!captured.ok) continue;
+      const raw = captured.value;
       // Bridge dashboard / サイドバードット / RepoGridView で共通利用する状態判定。
       // 既存の text/activityText/status (legacy SessionStatus) と同じ raw から
       // 派生させて、tmux capture を1回で済ませる

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -477,7 +477,15 @@ export class SessionOrchestrator extends EventEmitter {
     purpose: string
   ): string | undefined {
     const result = tmuxManager.getEnv(sessionId, "ARK_SESSION_ID");
-    if (result.ok) return result.value;
+    if (result.ok) {
+      if (/^[0-9a-f]{32}$/.test(result.value)) return result.value;
+      const reason =
+        result.value === "" ? "空値です" : "32 桁の hex ではありません";
+      console.warn(
+        `[Orchestrator] ${purpose} ${sessionId}: tmux env の ARK_SESSION_ID が破損しています (${reason})。旧 context を teardown せずに進めます`
+      );
+      return undefined;
+    }
     if (!isExpectedAbsence(result)) {
       console.warn(
         `[Orchestrator] ${purpose} ${sessionId}: ARK_SESSION_ID を tmux env から読めないため旧 context を teardown せずに進めます (${describeTmuxReadFailure(result.failure)})`

--- a/packages/server/src/lib/tmux-manager.test.ts
+++ b/packages/server/src/lib/tmux-manager.test.ts
@@ -884,6 +884,17 @@ describe("TmuxManager - 読み取り系メソッドの失敗分類 (#393)", () =
       });
     });
 
+    it("名前付きバッファだけが存在して show-buffer が no buffers なら no-buffer", () => {
+      mockTmux({
+        "list-buffers": () => textResult({ stdout: "named-buffer\n" }),
+        "show-buffer": () => textResult({ status: 1, stderr: "no buffers\n" }),
+      });
+      expect(manager.getBuffer(sessionId)).toEqual({
+        ok: false,
+        failure: { kind: "no-buffer" },
+      });
+    });
+
     it("バッファがあれば末尾改行を落として返す", () => {
       mockTmux({
         "list-buffers": () => textResult({ stdout: "buffer0\n" }),

--- a/packages/server/src/lib/tmux-manager.test.ts
+++ b/packages/server/src/lib/tmux-manager.test.ts
@@ -4,7 +4,7 @@
  * spawnSync / execSync をモックして、tmuxへ渡す引数を直接検証する。
  */
 
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // child_process全体をモック化（top-level mockはhoistされる）
 vi.mock("node:child_process", () => ({
@@ -27,6 +27,7 @@ vi.mock("./system.js", () => ({
 }));
 
 import { execSync, spawnSync } from "node:child_process";
+import fs from "node:fs";
 import { resolveClaudePath } from "./system.js";
 import { TmuxManager } from "./tmux-manager.js";
 
@@ -566,6 +567,382 @@ describe("TmuxManager - 入力系メソッド", () => {
       expect(() =>
         manager.sendSpecialKey(sessionId, "DangerousKey" as never)
       ).toThrow();
+    });
+  });
+});
+
+/**
+ * 読み取り系メソッドの失敗分類 (#393)
+ *
+ * 以前は tmux コマンドの失敗と「値が無い」を同じ null に畳んでいたため、
+ * セッション消滅・復元失敗の原因を事後に追えなかった。ここでは spawnSync を
+ * 失敗させたとき、失敗要因が型 (failure.kind) で区別され、tmux の stderr /
+ * exit status / errno が結果に残ることを検証する。
+ */
+describe("TmuxManager - 読み取り系メソッドの失敗分類 (#393)", () => {
+  let manager: TmuxManager;
+  let sessionId: string;
+  let tmuxSessionName: string;
+
+  /** encoding: "utf-8" 指定時の spawnSync 戻り値 (stdout/stderr は string) */
+  const textResult = (over: {
+    status?: number | null;
+    signal?: NodeJS.Signals | null;
+    stdout?: string;
+    stderr?: string;
+    error?: Error;
+  }) => ({
+    pid: 1234,
+    output: [null, over.stdout ?? "", over.stderr ?? ""],
+    stdout: over.stdout ?? "",
+    stderr: over.stderr ?? "",
+    // null は「signal で終了 / 起動失敗」を表す正当な値なので ?? で潰さない
+    status: over.status === undefined ? 0 : over.status,
+    signal: over.signal ?? null,
+    error: over.error,
+  });
+
+  /** 指定の tmux サブコマンドだけ差し替え、他は成功扱いにする */
+  function mockTmux(
+    handlers: Record<string, (args: string[]) => ReturnType<typeof textResult>>
+  ) {
+    mockedSpawnSync.mockImplementation((_cmd, args) => {
+      const list = Array.isArray(args) ? (args as string[]) : [];
+      const handler = handlers[list[0] ?? ""];
+      return (handler ? handler(list) : textResult({})) as never;
+    });
+  }
+
+  function callsOf(sub: string): string[][] {
+    return mockedSpawnSync.mock.calls
+      .map(call => call[1])
+      .filter((args): args is string[] => Array.isArray(args))
+      .filter(args => args[0] === sub);
+  }
+
+  beforeEach(async () => {
+    mockedSpawnSync.mockReset();
+    mockedExecSync.mockReset();
+    mockedSpawnSync.mockReturnValue(successResult as never);
+    manager = new TmuxManager();
+    const session = await manager.createSession("/wt");
+    sessionId = session.id;
+    tmuxSessionName = session.tmuxSessionName;
+    mockedSpawnSync.mockClear();
+  });
+
+  describe("getEnv", () => {
+    it("不明なセッション ID は no-session (tmux を呼ばない)", () => {
+      const result = manager.getEnv("unknown", "FOO");
+      expect(result).toEqual({ ok: false, failure: { kind: "no-session" } });
+      expect(mockedSpawnSync).not.toHaveBeenCalled();
+    });
+
+    it("session env 一覧 (show-environment -t <session>) から値を取り出す", () => {
+      mockTmux({
+        "show-environment": () =>
+          textResult({ stdout: "-DISPLAY\nFOO=bar=baz\nOTHER=1\n" }),
+      });
+      expect(manager.getEnv(sessionId, "FOO")).toEqual({
+        ok: true,
+        value: "bar=baz",
+      });
+      expect(callsOf("show-environment")).toEqual([
+        ["show-environment", "-t", tmuxSessionName],
+      ]);
+    });
+
+    it("一覧に変数が無ければ not-set", () => {
+      mockTmux({
+        "show-environment": () => textResult({ stdout: "OTHER=1\n" }),
+      });
+      expect(manager.getEnv(sessionId, "FOO")).toEqual({
+        ok: false,
+        failure: { kind: "not-set" },
+      });
+    });
+
+    it("unset マーカー (-NAME) は not-set", () => {
+      mockTmux({
+        "show-environment": () => textResult({ stdout: "-FOO\nFOOBAR=1\n" }),
+      });
+      expect(manager.getEnv(sessionId, "FOO")).toEqual({
+        ok: false,
+        failure: { kind: "not-set" },
+      });
+    });
+
+    it("前方一致する別名 (FOOBAR) を FOO と誤認しない", () => {
+      mockTmux({
+        "show-environment": () => textResult({ stdout: "FOOBAR=1\n" }),
+      });
+      expect(manager.getEnv(sessionId, "FOO")).toEqual({
+        ok: false,
+        failure: { kind: "not-set" },
+      });
+    });
+
+    it("空文字の値は not-set ではなく ok (値が空) として返す", () => {
+      mockTmux({
+        "show-environment": () => textResult({ stdout: "FOO=\n" }),
+      });
+      expect(manager.getEnv(sessionId, "FOO")).toEqual({ ok: true, value: "" });
+    });
+
+    it("tmux が非 0 で終了したら tmux-failed で status と stderr を残す", () => {
+      mockTmux({
+        "show-environment": () =>
+          textResult({ status: 1, stderr: "no such session: ark-x\n" }),
+      });
+      expect(manager.getEnv(sessionId, "FOO")).toEqual({
+        ok: false,
+        failure: {
+          kind: "tmux-failed",
+          command: "show-environment",
+          status: 1,
+          signal: null,
+          stderr: "no such session: ark-x",
+        },
+      });
+    });
+
+    it("tmux の起動自体に失敗 (spawnSync error) したら errno code と message を残す", () => {
+      const error = Object.assign(new Error("spawnSync tmux ENOENT"), {
+        code: "ENOENT",
+      });
+      mockTmux({
+        "show-environment": () => textResult({ status: null, error }),
+      });
+      const result = manager.getEnv(sessionId, "FOO");
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("unreachable");
+      expect(result.failure).toMatchObject({
+        kind: "tmux-failed",
+        command: "show-environment",
+        status: null,
+        code: "ENOENT",
+        message: "spawnSync tmux ENOENT",
+      });
+    });
+
+    it("timeout で kill された場合は signal と ETIMEDOUT を残す", () => {
+      const error = Object.assign(new Error("spawnSync tmux ETIMEDOUT"), {
+        code: "ETIMEDOUT",
+      });
+      mockTmux({
+        "show-environment": () =>
+          textResult({ status: null, signal: "SIGTERM", error }),
+      });
+      const result = manager.getEnv(sessionId, "FOO");
+      if (result.ok) throw new Error("unreachable");
+      expect(result.failure).toMatchObject({
+        kind: "tmux-failed",
+        signal: "SIGTERM",
+        code: "ETIMEDOUT",
+      });
+      // ハング時にイベントループごと止まらないよう timeout を付けて呼ぶ
+      const opts = callsOf("show-environment").length
+        ? (mockedSpawnSync.mock.calls.find(
+            ([, args]) => Array.isArray(args) && args[0] === "show-environment"
+          )?.[2] as { timeout?: number } | undefined)
+        : undefined;
+      expect(opts?.timeout).toBeGreaterThan(0);
+    });
+  });
+
+  describe("getPaneEnv", () => {
+    const originalPlatform = process.platform;
+    const setPlatform = (value: string) =>
+      Object.defineProperty(process, "platform", { value, configurable: true });
+
+    afterEach(() => {
+      setPlatform(originalPlatform);
+      vi.restoreAllMocks();
+    });
+
+    it("不明なセッション ID は no-session", () => {
+      expect(manager.getPaneEnv("unknown", "FOO")).toEqual({
+        ok: false,
+        failure: { kind: "no-session" },
+      });
+    });
+
+    it("Linux 以外では /proc を読まずに unsupported-platform", () => {
+      setPlatform("darwin");
+      expect(manager.getPaneEnv(sessionId, "FOO")).toEqual({
+        ok: false,
+        failure: { kind: "unsupported-platform", platform: "darwin" },
+      });
+      expect(mockedSpawnSync).not.toHaveBeenCalled();
+    });
+
+    it("list-panes が失敗したら tmux-failed", () => {
+      setPlatform("linux");
+      mockTmux({
+        "list-panes": () =>
+          textResult({ status: 1, stderr: "can't find session: ark-x" }),
+      });
+      expect(manager.getPaneEnv(sessionId, "FOO")).toMatchObject({
+        ok: false,
+        failure: {
+          kind: "tmux-failed",
+          command: "list-panes",
+          status: 1,
+          stderr: "can't find session: ark-x",
+        },
+      });
+    });
+
+    it("pane_pid が数値でなければ invalid-pane-pid", () => {
+      setPlatform("linux");
+      mockTmux({ "list-panes": () => textResult({ stdout: "abc\n" }) });
+      expect(manager.getPaneEnv(sessionId, "FOO")).toEqual({
+        ok: false,
+        failure: { kind: "invalid-pane-pid", raw: "abc" },
+      });
+    });
+
+    it("/proc/<pid>/environ が読めなければ proc-error (errno 付き)", () => {
+      setPlatform("linux");
+      mockTmux({ "list-panes": () => textResult({ stdout: "4242\n" }) });
+      vi.spyOn(fs, "readFileSync").mockImplementation(() => {
+        throw Object.assign(new Error("EACCES: permission denied"), {
+          code: "EACCES",
+        });
+      });
+      expect(manager.getPaneEnv(sessionId, "FOO")).toEqual({
+        ok: false,
+        failure: {
+          kind: "proc-error",
+          code: "EACCES",
+          message: "EACCES: permission denied",
+        },
+      });
+      expect(fs.readFileSync).toHaveBeenCalledWith(
+        "/proc/4242/environ",
+        "utf-8"
+      );
+    });
+
+    it("environ に変数があれば ok、無ければ not-set", () => {
+      setPlatform("linux");
+      mockTmux({ "list-panes": () => textResult({ stdout: "4242\n" }) });
+      vi.spyOn(fs, "readFileSync").mockReturnValue(
+        "PATH=/bin\0FOO=/home/u/.claude-work\0"
+      );
+      expect(manager.getPaneEnv(sessionId, "FOO")).toEqual({
+        ok: true,
+        value: "/home/u/.claude-work",
+      });
+      expect(manager.getPaneEnv(sessionId, "BAR")).toEqual({
+        ok: false,
+        failure: { kind: "not-set" },
+      });
+    });
+  });
+
+  describe("getBuffer", () => {
+    it("不明なセッション ID は no-session", () => {
+      expect(manager.getBuffer("unknown")).toEqual({
+        ok: false,
+        failure: { kind: "no-session" },
+      });
+    });
+
+    it("バッファが 1 つも無い場合は tmux-failed ではなく no-buffer", () => {
+      mockTmux({ "list-buffers": () => textResult({ stdout: "" }) });
+      expect(manager.getBuffer(sessionId)).toEqual({
+        ok: false,
+        failure: { kind: "no-buffer" },
+      });
+      expect(callsOf("show-buffer")).toHaveLength(0);
+    });
+
+    it("list-buffers が失敗したら tmux-failed", () => {
+      mockTmux({
+        "list-buffers": () =>
+          textResult({ status: 1, stderr: "no server running" }),
+      });
+      expect(manager.getBuffer(sessionId)).toMatchObject({
+        ok: false,
+        failure: {
+          kind: "tmux-failed",
+          command: "list-buffers",
+          stderr: "no server running",
+        },
+      });
+    });
+
+    it("show-buffer が失敗したら tmux-failed (command=show-buffer)", () => {
+      mockTmux({
+        "list-buffers": () => textResult({ stdout: "buffer0\n" }),
+        "show-buffer": () => textResult({ status: 1, stderr: "boom" }),
+      });
+      expect(manager.getBuffer(sessionId)).toMatchObject({
+        ok: false,
+        failure: { kind: "tmux-failed", command: "show-buffer" },
+      });
+    });
+
+    it("バッファがあれば末尾改行を落として返す", () => {
+      mockTmux({
+        "list-buffers": () => textResult({ stdout: "buffer0\n" }),
+        "show-buffer": () => textResult({ stdout: "copied text\n" }),
+      });
+      expect(manager.getBuffer(sessionId)).toEqual({
+        ok: true,
+        value: "copied text",
+      });
+    });
+  });
+
+  describe("capturePane / capturePaneVisible", () => {
+    it("不明なセッション ID は no-session", () => {
+      expect(manager.capturePane("unknown")).toEqual({
+        ok: false,
+        failure: { kind: "no-session" },
+      });
+      expect(manager.capturePaneVisible("unknown")).toEqual({
+        ok: false,
+        failure: { kind: "no-session" },
+      });
+    });
+
+    it("capture-pane が失敗したら tmux-failed に stderr を残す", () => {
+      mockTmux({
+        "capture-pane": () =>
+          textResult({ status: 1, stderr: "can't find pane: ark-x" }),
+      });
+      const expected = {
+        ok: false,
+        failure: {
+          kind: "tmux-failed",
+          command: "capture-pane",
+          status: 1,
+          stderr: "can't find pane: ark-x",
+        },
+      };
+      expect(manager.capturePane(sessionId, 50)).toMatchObject(expected);
+      expect(manager.capturePaneVisible(sessionId)).toMatchObject(expected);
+    });
+
+    it("成功時は画面テキストを返し、空画面は失敗ではなく空文字", () => {
+      mockTmux({
+        "capture-pane": args =>
+          textResult({ stdout: args.includes("-S") ? "scrollback\n" : "" }),
+      });
+      expect(manager.capturePane(sessionId, 50)).toEqual({
+        ok: true,
+        value: "scrollback",
+      });
+      expect(manager.capturePaneVisible(sessionId)).toEqual({
+        ok: true,
+        value: "",
+      });
+      expect(callsOf("capture-pane")).toEqual([
+        ["capture-pane", "-t", tmuxSessionName, "-p", "-S", "-50"],
+        ["capture-pane", "-t", tmuxSessionName, "-p"],
+      ]);
     });
   });
 });

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -776,7 +776,14 @@ export class TmuxManager extends EventEmitter {
       return { ok: false, failure: { kind: "no-buffer" } };
     }
     const shown = runTmux(["show-buffer"]);
-    if (!shown.ok) return shown;
+    if (!shown.ok) {
+      // show-buffer (引数なし) は最新の自動バッファだけを対象にするため、
+      // 名前付きバッファしか無い場合や一覧取得後に消えた場合も no buffers になる。
+      if (shown.failure.stderr === "no buffers") {
+        return { ok: false, failure: { kind: "no-buffer" } };
+      }
+      return shown;
+    }
     return { ok: true, value: shown.stdout.trimEnd() };
   }
 

--- a/packages/server/src/lib/tmux-manager.ts
+++ b/packages/server/src/lib/tmux-manager.ts
@@ -11,20 +11,110 @@ import fs from "node:fs";
 import path from "node:path";
 import type { SpecialKey } from "@ark/shared";
 import { nanoid } from "nanoid";
+import { errnoCode, errnoMessage } from "./errors.js";
 import { resolveClaudePath, resolveTmuxPath } from "./system.js";
+import {
+  describeTmuxReadFailure,
+  type TmuxReadFailure,
+  type TmuxReadResult,
+} from "./tmux-read-result.js";
 
 // tmux 絶対パス (pm2/systemd で PATH に tmux が無くても動作させるため)。
 // 解決不能なら "tmux" にフォールバック (PATH依存)。
 const TMUX_BINARY_PATH = resolveTmuxPath() ?? "tmux";
 
 /**
- * セッション作成/破棄系の tmux コマンドの打ち切り時間 (ms)。
+ * セッション作成/破棄系および読み取り系の tmux コマンドの打ち切り時間 (ms)。
  * spawnSync は同期呼び出しでハングするとイベントループごと停止し、
  * JS 側のタイムアウト (Promise.race 等) では救えない。timeout で子プロセスを
  * kill させ error → throw に変換することで、restartSession の in-flight guard
- * が finally で確実に解放される (通常の tmux コマンドは数十 ms で完了する)
+ * が finally で確実に解放される (通常の tmux コマンドは数十 ms で完了する)。
+ * 読み取り系では timeout は `tmux-failed` (code=ETIMEDOUT, signal=SIGTERM) として
+ * 結果に残る。
  */
 const TMUX_CMD_TIMEOUT_MS = 10_000;
+
+type TmuxCommandFailure = Extract<TmuxReadFailure, { kind: "tmux-failed" }>;
+
+type TmuxCommandResult =
+  | { ok: true; stdout: string }
+  | { ok: false; failure: TmuxCommandFailure };
+
+/**
+ * 読み取り系の tmux コマンドを実行し、失敗要因を型で返す。
+ *
+ * spawnSync は通常 throw せず `result.error` (ENOENT / ETIMEDOUT 等) と
+ * `status` / `signal` で失敗を表すため、それらをまとめて `tmux-failed` に詰める。
+ * stdout は encoding 指定で string になるが、テストのモックが Buffer を返す
+ * 場合もあるので String() で正規化する。
+ */
+function runTmux(args: string[]): TmuxCommandResult {
+  const command = args[0] ?? "";
+  try {
+    const result = spawnSync(TMUX_BINARY_PATH, args, {
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+      timeout: TMUX_CMD_TIMEOUT_MS,
+    });
+    const stderr = String(result.stderr ?? "").trim();
+    if (result.error || result.status !== 0) {
+      return {
+        ok: false,
+        failure: {
+          kind: "tmux-failed",
+          command,
+          status: result.status ?? null,
+          signal: result.signal ?? null,
+          stderr,
+          ...(result.error
+            ? {
+                code: errnoCode(result.error),
+                message: errnoMessage(result.error),
+              }
+            : {}),
+        },
+      };
+    }
+    return { ok: true, stdout: String(result.stdout ?? "") };
+  } catch (e) {
+    // spawnSync が throw するのは引数不正等の例外的なケース。握り潰さず残す
+    return {
+      ok: false,
+      failure: {
+        kind: "tmux-failed",
+        command,
+        status: null,
+        signal: null,
+        stderr: "",
+        code: errnoCode(e),
+        message: errnoMessage(e),
+      },
+    };
+  }
+}
+
+const NO_SESSION: TmuxReadResult<never> = {
+  ok: false,
+  failure: { kind: "no-session" },
+};
+const NOT_SET: TmuxReadResult<never> = {
+  ok: false,
+  failure: { kind: "not-set" },
+};
+
+/**
+ * `tmux show-environment -t <session>` の一覧出力から変数の値を取り出す。
+ * 出力形式は 1 行 1 変数で `NAME=value` または `-NAME` (unset マーカー)。
+ * 変数名を指定した `show-environment NAME` は未設定時に exit 1 となり
+ * tmux 失敗と区別できないため、一覧を取って自前で探す。
+ */
+function findEnvValue(listing: string, name: string): string | null {
+  for (const line of listing.split("\n")) {
+    if (line === `-${name}`) return null;
+    if (line.startsWith(`${name}=`)) return line.slice(name.length + 1);
+  }
+  return null;
+}
 
 /**
  * POSIX shell の single-quote 文字列にエスケープする。
@@ -216,14 +306,17 @@ export class TmuxManager extends EventEmitter {
    */
   private discoverExistingSessions(): void {
     try {
-      const result = spawnSync(
-        TMUX_BINARY_PATH,
-        ["list-sessions", "-F", "#{session_name}"],
-        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-      );
-      if (result.status !== 0) return;
-      const output = result.stdout ?? "";
-      const sessionNames = output.trim().split("\n").filter(Boolean);
+      const result = runTmux(["list-sessions", "-F", "#{session_name}"]);
+      if (!result.ok) {
+        // サーバー未起動 ("no server running on ...") は正常な初回起動だが、
+        // socket の権限エラー等でも同じ分岐に入る。セッションが「全消滅した」
+        // ように見えたとき事後に切り分けられるよう、理由を必ず残す
+        console.log(
+          `[TmuxManager] 既存セッションを検出できません: ${describeTmuxReadFailure(result.failure)}`
+        );
+        return;
+      }
+      const sessionNames = result.stdout.trim().split("\n").filter(Boolean);
 
       for (const name of sessionNames) {
         if (name.startsWith(this.SESSION_PREFIX)) {
@@ -245,11 +338,18 @@ export class TmuxManager extends EventEmitter {
           }
           const id = name.replace(this.SESSION_PREFIX, "");
           const cwd = this.getTmuxSessionCwd(name);
+          if (!cwd.ok) {
+            // worktreePath が空のまま復元されると orphan 判定も DB 照合も
+            // 効かず黙って進むため、理由をログに残す
+            console.warn(
+              `[TmuxManager] ${name}: pane_current_path を取得できません (${describeTmuxReadFailure(cwd.failure)})。worktreePath を空で復元します`
+            );
+          }
 
           this.sessions.set(id, {
             id,
             tmuxSessionName: name,
-            worktreePath: cwd || "",
+            worktreePath: cwd.ok ? cwd.value : "",
             createdAt: new Date(),
             lastActivity: new Date(),
             status: "running",
@@ -277,18 +377,16 @@ export class TmuxManager extends EventEmitter {
   /**
    * tmuxセッションの作業ディレクトリを取得
    */
-  private getTmuxSessionCwd(sessionName: string): string | null {
-    try {
-      const result = spawnSync(
-        TMUX_BINARY_PATH,
-        ["display-message", "-p", "-t", sessionName, "#{pane_current_path}"],
-        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-      );
-      if (result.status !== 0) return null;
-      return (result.stdout ?? "").trim();
-    } catch {
-      return null;
-    }
+  private getTmuxSessionCwd(sessionName: string): TmuxReadResult<string> {
+    const result = runTmux([
+      "display-message",
+      "-p",
+      "-t",
+      sessionName,
+      "#{pane_current_path}",
+    ]);
+    if (!result.ok) return result;
+    return { ok: true, value: result.stdout.trim() };
   }
 
   /**
@@ -589,108 +687,120 @@ export class TmuxManager extends EventEmitter {
   }
 
   /**
-   * 指定セッションの tmux 環境変数を取得する。未定義/未取得は null。
+   * 指定セッションの tmux 環境変数を取得する。
    *
-   * `tmux show-environment -t <session> <NAME>` を使用。変数名指定は
-   * 該当変数が無い場合に exit code 非 0 になるので、ステータスのみ判定する。
+   * `tmux show-environment -t <session>` で session env の一覧を取り、自前で
+   * 変数を探す (findEnvValue 参照)。失敗要因は型で区別する:
+   *   - no-session: TmuxManager が管理していない ID
+   *   - tmux-failed: tmux が失敗 (セッション不在 / サーバー停止 / 起動失敗 / timeout)
+   *   - not-set: tmux は成功したが変数が無い (または `-NAME` で unset)
    */
-  getEnv(sessionId: string, name: string): string | null {
+  getEnv(sessionId: string, name: string): TmuxReadResult<string> {
     const session = this.sessions.get(sessionId);
-    if (!session) return null;
-    try {
-      const result = spawnSync(
-        TMUX_BINARY_PATH,
-        ["show-environment", "-t", session.tmuxSessionName, name],
-        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-      );
-      if (result.status !== 0) return null;
-      const line = (result.stdout ?? "").trim();
-      // 出力形式: `NAME=value` または `-NAME` (unset)
-      if (line.startsWith("-")) return null;
-      const eq = line.indexOf("=");
-      if (eq < 0) return null;
-      return line.slice(eq + 1);
-    } catch {
-      return null;
-    }
+    if (!session) return NO_SESSION;
+    const result = runTmux(["show-environment", "-t", session.tmuxSessionName]);
+    if (!result.ok) return result;
+    const value = findEnvValue(result.stdout, name);
+    return value === null ? NOT_SET : { ok: true, value };
   }
 
   /**
    * pane のシェルプロセスの環境変数を /proc/<pane_pid>/environ から読む。
-   * Linux 限定 (/proc が無い環境では null)。
+   * Linux 限定 (/proc が無い環境では `unsupported-platform`)。
    *
    * tmux session env (`show-environment`) に変数が無くても、tmux サーバー
    * プロセスの env を継承してシェル/claude に変数が渡っているケースがある
    * (旧コードで起動されたセッションの CLAUDE_CONFIG_DIR 継承等)。
    * 「claude が実際にどの env で動いているか」の事実はプロセス environ が
    * 唯一の情報源なので、復元時のプロファイル補完フォールバックに使う。
+   *
+   * 失敗要因: no-session / unsupported-platform / tmux-failed (list-panes) /
+   * invalid-pane-pid / proc-error (/proc 読み取り失敗) / not-set
    */
-  getPaneEnv(sessionId: string, name: string): string | null {
+  getPaneEnv(sessionId: string, name: string): TmuxReadResult<string> {
     const session = this.sessions.get(sessionId);
-    if (!session) return null;
-    try {
-      const result = spawnSync(
-        TMUX_BINARY_PATH,
-        ["list-panes", "-t", session.tmuxSessionName, "-F", "#{pane_pid}"],
-        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-      );
-      if (result.status !== 0) return null;
-      const pid = Number.parseInt(
-        (result.stdout ?? "").trim().split("\n")[0] ?? "",
-        10
-      );
-      if (!Number.isFinite(pid) || pid <= 0) return null;
-      const environ = fs.readFileSync(`/proc/${pid}/environ`, "utf-8");
-      for (const entry of environ.split("\0")) {
-        if (entry.startsWith(`${name}=`)) return entry.slice(name.length + 1);
-      }
-      return null;
-    } catch {
-      return null;
+    if (!session) return NO_SESSION;
+    if (process.platform !== "linux") {
+      return {
+        ok: false,
+        failure: { kind: "unsupported-platform", platform: process.platform },
+      };
     }
+    const result = runTmux([
+      "list-panes",
+      "-t",
+      session.tmuxSessionName,
+      "-F",
+      "#{pane_pid}",
+    ]);
+    if (!result.ok) return result;
+    const raw = result.stdout.trim().split("\n")[0] ?? "";
+    const pid = Number.parseInt(raw, 10);
+    if (!Number.isInteger(pid) || pid <= 0) {
+      return { ok: false, failure: { kind: "invalid-pane-pid", raw } };
+    }
+    let environ: string;
+    try {
+      environ = fs.readFileSync(`/proc/${pid}/environ`, "utf-8");
+    } catch (e) {
+      return {
+        ok: false,
+        failure: {
+          kind: "proc-error",
+          code: errnoCode(e),
+          message: errnoMessage(e),
+        },
+      };
+    }
+    for (const entry of environ.split("\0")) {
+      if (entry.startsWith(`${name}=`)) {
+        return { ok: true, value: entry.slice(name.length + 1) };
+      }
+    }
+    return NOT_SET;
   }
 
   /**
    * tmuxのペーストバッファの内容を取得
+   *
+   * `show-buffer` はバッファが無いときも exit 1 ("no buffers") になり tmux 失敗と
+   * 区別できないため、先に `list-buffers` (空でも exit 0) で有無を確認する。
+   * 失敗要因: no-session / tmux-failed / no-buffer
    */
-  getBuffer(sessionId: string): string | null {
+  getBuffer(sessionId: string): TmuxReadResult<string> {
     const session = this.sessions.get(sessionId);
-    if (!session) return null;
-    const result = spawnSync(TMUX_BINARY_PATH, ["show-buffer"], {
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    });
-    if (result.status !== 0) return null;
-    return (result.stdout ?? "").trimEnd();
+    if (!session) return NO_SESSION;
+    const list = runTmux(["list-buffers", "-F", "#{buffer_name}"]);
+    if (!list.ok) return list;
+    if (list.stdout.trim() === "") {
+      return { ok: false, failure: { kind: "no-buffer" } };
+    }
+    const shown = runTmux(["show-buffer"]);
+    if (!shown.ok) return shown;
+    return { ok: true, value: shown.stdout.trimEnd() };
   }
 
   /**
    * tmux capture-paneでターミナルの現在の表示内容を取得する
    * @param sessionId セッションID
    * @param lines 取得する行数（デフォルト: 100）
+   *
+   * 失敗要因: no-session / tmux-failed。空画面は失敗ではなく `value: ""`
    */
-  capturePane(sessionId: string, lines = 100): string | null {
+  capturePane(sessionId: string, lines = 100): TmuxReadResult<string> {
     const session = this.sessions.get(sessionId);
-    if (!session) return null;
-    try {
-      // -p: stdoutに出力、-S: 開始行（負数で過去の行）
-      const result = spawnSync(
-        TMUX_BINARY_PATH,
-        [
-          "capture-pane",
-          "-t",
-          session.tmuxSessionName,
-          "-p",
-          "-S",
-          `-${lines}`,
-        ],
-        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-      );
-      if (result.status !== 0) return null;
-      return (result.stdout ?? "").trimEnd();
-    } catch {
-      return null;
-    }
+    if (!session) return NO_SESSION;
+    // -p: stdoutに出力、-S: 開始行（負数で過去の行）
+    const result = runTmux([
+      "capture-pane",
+      "-t",
+      session.tmuxSessionName,
+      "-p",
+      "-S",
+      `-${lines}`,
+    ]);
+    if (!result.ok) return result;
+    return { ok: true, value: result.stdout.trimEnd() };
   }
 
   /**
@@ -698,21 +808,20 @@ export class TmuxManager extends EventEmitter {
    *
    * `capturePane` は -S -N で scrollback を含むが、こちらは引数なしで visible 範囲のみ。
    * 用途: /clear 後に「現状の見え方」を取りたい場合、scrollback を含まないことが必要。
+   *
+   * 失敗要因: no-session / tmux-failed。空画面は失敗ではなく `value: ""`
    */
-  capturePaneVisible(sessionId: string): string | null {
+  capturePaneVisible(sessionId: string): TmuxReadResult<string> {
     const session = this.sessions.get(sessionId);
-    if (!session) return null;
-    try {
-      const result = spawnSync(
-        TMUX_BINARY_PATH,
-        ["capture-pane", "-t", session.tmuxSessionName, "-p"],
-        { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }
-      );
-      if (result.status !== 0) return null;
-      return (result.stdout ?? "").trimEnd();
-    } catch {
-      return null;
-    }
+    if (!session) return NO_SESSION;
+    const result = runTmux([
+      "capture-pane",
+      "-t",
+      session.tmuxSessionName,
+      "-p",
+    ]);
+    if (!result.ok) return result;
+    return { ok: true, value: result.stdout.trimEnd() };
   }
 
   /**

--- a/packages/server/src/lib/tmux-read-result.test.ts
+++ b/packages/server/src/lib/tmux-read-result.test.ts
@@ -1,0 +1,134 @@
+/**
+ * tmux 読み取り結果の失敗分類 (#393)
+ *
+ * describeTmuxReadFailure が失敗要因ごとに原因を特定できる 1 行を返すこと、
+ * TmuxReadFailureReporter が polling 経路で同じ失敗を毎 tick 出力しないことを検証する。
+ */
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  describeTmuxReadFailure,
+  type TmuxReadFailure,
+  TmuxReadFailureReporter,
+  type TmuxReadResult,
+} from "./tmux-read-result.js";
+
+const tmuxFailed = (over: Partial<TmuxReadFailure> = {}): TmuxReadFailure => ({
+  kind: "tmux-failed",
+  command: "capture-pane",
+  status: 1,
+  signal: null,
+  stderr: "can't find pane: ark-x",
+  ...over,
+});
+
+describe("describeTmuxReadFailure", () => {
+  it("tmux-failed はコマンド名 / status / stderr を含む (事後に原因を追えること)", () => {
+    const text = describeTmuxReadFailure(tmuxFailed());
+    expect(text).toContain("capture-pane");
+    expect(text).toContain("status=1");
+    expect(text).toContain("can't find pane: ark-x");
+  });
+
+  it("tmux-failed で spawn 自体が失敗した場合は errno code と message を含む", () => {
+    const text = describeTmuxReadFailure(
+      tmuxFailed({
+        status: null,
+        code: "ENOENT",
+        stderr: "",
+        message: "spawnSync tmux ENOENT",
+      })
+    );
+    expect(text).toContain("code=ENOENT");
+    expect(text).toContain("spawnSync tmux ENOENT");
+  });
+
+  it("tmux-failed で timeout により signal で落ちた場合は signal を含む", () => {
+    const text = describeTmuxReadFailure(
+      tmuxFailed({ status: null, signal: "SIGTERM", code: "ETIMEDOUT" })
+    );
+    expect(text).toContain("signal=SIGTERM");
+    expect(text).toContain("code=ETIMEDOUT");
+  });
+
+  it("失敗要因ごとに異なる説明を返す", () => {
+    const kinds: TmuxReadFailure[] = [
+      { kind: "no-session" },
+      { kind: "not-set" },
+      { kind: "no-buffer" },
+      { kind: "invalid-pane-pid", raw: "abc" },
+      { kind: "proc-error", code: "EACCES", message: "permission denied" },
+      { kind: "unsupported-platform", platform: "darwin" },
+      tmuxFailed(),
+    ];
+    const texts = kinds.map(describeTmuxReadFailure);
+    expect(new Set(texts).size).toBe(kinds.length);
+    expect(texts[3]).toContain('"abc"');
+    expect(texts[4]).toContain("EACCES");
+    expect(texts[5]).toContain("darwin");
+  });
+});
+
+describe("TmuxReadFailureReporter", () => {
+  const fail = (f: TmuxReadFailure): TmuxReadResult<string> => ({
+    ok: false,
+    failure: f,
+  });
+  const ok: TmuxReadResult<string> = { ok: true, value: "x" };
+
+  it("同じ key の同じ失敗は 1 回しか出力しない", () => {
+    const log = vi.fn();
+    const reporter = new TmuxReadFailureReporter("[Preview]", log);
+    reporter.report("s1", fail(tmuxFailed()));
+    reporter.report("s1", fail(tmuxFailed()));
+    reporter.report("s1", fail(tmuxFailed()));
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log.mock.calls[0]?.[0]).toContain("[Preview]");
+    expect(log.mock.calls[0]?.[0]).toContain("s1");
+    expect(log.mock.calls[0]?.[0]).toContain("can't find pane: ark-x");
+  });
+
+  it("失敗内容が変わったら再度出力する", () => {
+    const log = vi.fn();
+    const reporter = new TmuxReadFailureReporter("[Preview]", log);
+    reporter.report("s1", fail(tmuxFailed()));
+    reporter.report("s1", fail(tmuxFailed({ stderr: "server exited" })));
+    expect(log).toHaveBeenCalledTimes(2);
+    expect(log.mock.calls[1]?.[0]).toContain("server exited");
+  });
+
+  it("key が異なれば独立に出力する", () => {
+    const log = vi.fn();
+    const reporter = new TmuxReadFailureReporter("[Preview]", log);
+    reporter.report("s1", fail(tmuxFailed()));
+    reporter.report("s2", fail(tmuxFailed()));
+    expect(log).toHaveBeenCalledTimes(2);
+  });
+
+  it("成功に戻ったら回復を 1 行出し、その後の同じ失敗は再び出力する", () => {
+    const log = vi.fn();
+    const reporter = new TmuxReadFailureReporter("[Preview]", log);
+    reporter.report("s1", fail(tmuxFailed()));
+    reporter.report("s1", ok);
+    reporter.report("s1", ok);
+    reporter.report("s1", fail(tmuxFailed()));
+    expect(log).toHaveBeenCalledTimes(3);
+    expect(log.mock.calls[1]?.[0]).toMatch(/回復/);
+  });
+
+  it("一度も失敗していない key の成功は何も出力しない", () => {
+    const log = vi.fn();
+    const reporter = new TmuxReadFailureReporter("[Preview]", log);
+    reporter.report("s1", ok);
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("forget した key は記録が消え、次の同じ失敗を再び出力する", () => {
+    const log = vi.fn();
+    const reporter = new TmuxReadFailureReporter("[Preview]", log);
+    reporter.report("s1", fail(tmuxFailed()));
+    reporter.forget("s1");
+    reporter.report("s1", fail(tmuxFailed()));
+    expect(log).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/server/src/lib/tmux-read-result.ts
+++ b/packages/server/src/lib/tmux-read-result.ts
@@ -1,0 +1,111 @@
+/**
+ * tmux 読み取り系の結果型 (#393)
+ *
+ * 以前は `TmuxManager` の読み取り系メソッド (getEnv / getPaneEnv / getBuffer /
+ * capturePane / capturePaneVisible) が **tmux コマンドの失敗** と **値が無いこと**
+ * を同じ `null` に畳んでいた。そのためセッションが消えた・復元できない・env が
+ * 読めないとき、「tmux サーバーが死んでいた」のか「変数が未設定だった」のかが
+ * 事後に一切追えず、復元の分岐を誤ったまま黙って進んでいた。
+ *
+ * `managed-worktree.ts` と同じ方式で失敗要因を型で区別して返し、呼び出し側が
+ * ログ・メッセージに tmux の exit status / stderr / errno まで載せられるようにする。
+ */
+
+export type TmuxReadFailure =
+  /** TmuxManager がそのセッション ID を管理していない (未登録 / kill 済み) */
+  | { kind: "no-session" }
+  /**
+   * tmux コマンド自体が失敗した。非 0 終了 (セッション不在・サーバー停止等) と、
+   * プロセス起動失敗 (ENOENT) / timeout (ETIMEDOUT + signal) の両方を含む。
+   * どちらかは `status` / `code` / `signal` で判別できる
+   */
+  | {
+      kind: "tmux-failed";
+      /** tmux サブコマンド名 (例: "capture-pane") */
+      command: string;
+      status: number | null;
+      signal: NodeJS.Signals | null;
+      /** stderr (trim 済み)。tmux の "no such session: x" 等がそのまま入る */
+      stderr: string;
+      /** spawnSync が error を返した場合の errno code (ENOENT / ETIMEDOUT 等) */
+      code?: string;
+      /** spawnSync が error を返した場合の message */
+      message?: string;
+    }
+  /** tmux は成功したが、要求した環境変数が設定されていない */
+  | { kind: "not-set" }
+  /** tmux は成功したが、ペーストバッファが 1 つも無い */
+  | { kind: "no-buffer" }
+  /** `list-panes -F #{pane_pid}` の出力が pid として解釈できない */
+  | { kind: "invalid-pane-pid"; raw: string }
+  /** `/proc/<pid>/environ` の読み取りに失敗した (ENOENT / EACCES 等) */
+  | { kind: "proc-error"; code: string; message: string }
+  /** pane environ の読み取りは /proc のある Linux 限定 */
+  | { kind: "unsupported-platform"; platform: string };
+
+export type TmuxReadResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; failure: TmuxReadFailure };
+
+/** 失敗要因を人間が読める 1 行に落とす (ログ・エラーメッセージ用) */
+export function describeTmuxReadFailure(failure: TmuxReadFailure): string {
+  switch (failure.kind) {
+    case "no-session":
+      return "TmuxManager が管理していないセッション ID です";
+    case "tmux-failed": {
+      const parts = [`status=${failure.status ?? "null"}`];
+      if (failure.signal) parts.push(`signal=${failure.signal}`);
+      if (failure.code) parts.push(`code=${failure.code}`);
+      const detail = failure.stderr || failure.message || "";
+      return `tmux ${failure.command} が失敗しました (${parts.join(", ")})${
+        detail ? `: ${detail}` : ""
+      }`;
+    }
+    case "not-set":
+      return "変数が未設定です";
+    case "no-buffer":
+      return "tmux ペーストバッファがありません";
+    case "invalid-pane-pid":
+      return `pane_pid を解釈できません: ${JSON.stringify(failure.raw)}`;
+    case "proc-error":
+      return `/proc の読み取りに失敗しました (${failure.code}): ${failure.message}`;
+    case "unsupported-platform":
+      return `pane environ の読み取りは Linux 限定です (platform=${failure.platform})`;
+  }
+}
+
+/**
+ * polling 経路 (1 秒間隔の preview / bridge 収集) で同じ失敗を毎 tick 出力しない
+ * ための状態付きロガー。
+ *
+ * key (通常は sessionId) ごとに直前の失敗の説明文を覚え、内容が変わったときだけ
+ * 出力する。成功に戻ったら回復を 1 行出して記録を消す (時系列の再構成に使う)。
+ */
+export class TmuxReadFailureReporter {
+  private readonly last = new Map<string, string>();
+
+  constructor(
+    private readonly prefix: string,
+    private readonly log: (message: string) => void = (message: string) =>
+      console.warn(message)
+  ) {}
+
+  /** 結果を観測する。失敗なら必要に応じて出力し、成功なら回復を出力する */
+  report(key: string, result: TmuxReadResult<unknown>): void {
+    if (result.ok) {
+      if (this.last.delete(key)) {
+        this.log(`${this.prefix} ${key}: tmux の読み取りが回復しました`);
+      }
+      return;
+    }
+    const text = describeTmuxReadFailure(result.failure);
+    if (this.last.get(key) === text) return;
+    this.last.set(key, text);
+    this.log(`${this.prefix} ${key}: ${text}`);
+  }
+
+  /** セッション削除時などに記録を消す */
+  forget(key: string): void {
+    this.last.delete(key);
+  }
+}


### PR DESCRIPTION
`tmux-manager.ts` の読み取り系メソッドが、tmux コマンドの失敗と「値が無い」を同じ `null` に畳んでいた問題を直す。

Closes #393

## 問題

`getEnv` / `getPaneEnv` / `getBuffer` / `capturePane` / `capturePaneVisible` が `string | null` を返し、
セッション不在・tmux 失敗・変数未設定・値が空、を区別しない。呼び出し側は `null` を「値なし」として扱うため、
**tmux が死んでいても同じ分岐に入り、セッション消滅の原因が事後に追えない**。

`managed-worktree.ts` で同じ構造を既に直した前例があり、`tmux-manager.ts` はその対象外だった。

## 変更

`tmux-read-result.ts` を新設し、`managed-worktree.ts` と同じ方式で失敗要因を型で区別する。

```ts
{ ok: true; value: string } | { ok: false; reason: "no-session" | "tmux-failed" | "not-set" | ...; detail? }
```

- `isExpectedAbsence`: `not-set` / `unsupported-platform` は想定内として警告しない。`tmux-failed` だけ警告する
- timeout / errno / stderr を `detail` に保持し、重複抑制ロガーで同じ警告を連発しない
- 呼び出し側 9 箇所（`session-orchestrator` / `index.ts` / `bridge-collector`）を共通 helper 経由に集約

### 再起動経路

`session-orchestrator` の再起動・停止で `ARK_SESSION_ID` を読めないとき、**teardown を飛ばす理由を警告に残す**。
tmux が死んでいるのに「旧セッションなし」と誤認して黙って進む経路を塞いだ。

`ARK_SESSION_ID` は 32 桁 hex という既存契約で検証し、空・不正値は破損状態として警告する。

## レビューで見つかった欠陥（修正済み）

実装は Claude Code セッション、レビューは codex（実装者 ≠ レビュアー）。**必須 3 件**が見つかり反映した。

1. **`bridge-collector` が capture 失敗を `READY` に畳んでいた。** tmux 停止が UI 上「待機中」に見える。
   Issue の「失敗と値なしの混同」が直したつもりの実装に残っていた。`ERR` を返すよう修正し、
   誤った `READY` を固定していたテストの期待値も直した
2. **`getBuffer` の `no-buffer` 判定が tmux の実装と合っていなかった。** `list-buffers` は名前付きバッファも
   列挙するが `show-buffer` は自動バッファだけを探す（`cmd-list-buffers.c` / `paste.c`）。名前付きだけの場合に
   想定内が `tmux-failed` になっていた。stderr の `no buffers` で分類するよう修正
3. **`readContextSessionId` が値を検証していなかった。** `ARK_SESSION_ID=` の空値で警告なしに teardown を
   飛ばしていた。32 桁 hex で検証し、空・不正値は警告する

## 検証

変異テストで検出力を確認した（レビュー側が独立に再現）。

```
32 桁 hex 検証を無効化    → 2 failed / 36
ERR を READY に戻す       → Bridge テスト 2 件が失敗（codex 報告）
tmux-failed を not-set に畳む → 3 件が失敗（codex 報告）
```

```
pnpm check   exit 0
pnpm test    exit 0   72 files / 1202 tests
pnpm build   exit 0
```

## 範囲外

- `getEnv` の改行を含む値への対応（現行用途は `CLAUDE_CONFIG_DIR` / `ARK_SESSION_ID` に限定）
- `sendKeys` 等の書き込み系（既に throw している）
- 114 箇所ある「理由を捨てる catch」の全件対応

## 補足: #367 の測定に使った（n=3）

復唱あり / なしの 2 セッションで並行実行し、盲検評価した。**今回は復唱なし側を採用**。
両群とも Issue に書かなかった根（再起動経路の teardown スキップ）に到達しており、差は
`isExpectedAbsence` の線引きという設計の細部だった。詳細は #367 に記録する。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - tmuxの読み取り失敗を、セッション不存在・未設定・タイムアウトなどの原因別に扱えるようになりました。
  - セッション一覧やプレビューで、取得失敗時に空画面を誤表示せず、安全に除外・フォールバックします。
  - `session:copy` が、バッファ未設定・セッション不存在・実行エラーを区別して通知します。
  - 同じ障害の警告が繰り返し表示されないようになり、復旧時には通知されます。
  - 質問画面のキャプチャに失敗しても、質問カードの配信を継続します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->