### PR TITLE
feat(web): PC の左ペインをターミナル ⇄ 会話で切り替えられるようにする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,20 +8,29 @@
 
 ## アーキテクチャ
 
-### PC: ttyd ターミナル方式 / モバイル: チャットビュー (JSONL tail) 併用
+### ttyd ターミナル方式 / チャットビュー (JSONL tail) 併用
 
-PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`SplitViewPane` の
-左ペインに常時表示）。右ペインは図解タブが開かれたときだけ意味を持ち、
-上部バーのトグルで開閉する（中身は `DiagramPane`。詳細は下記「セッションボード」）。
-チャット形式で会話を描画する `SplitChatPane`（JSONL transcript を tail）は
-モバイル専用（`MobileSessionView` の🖥/💬トグルで ttyd 表示と切替）。
+PC・モバイルとも、ttyd の生ターミナル（`TerminalPane`）と、チャット形式で会話を
+描画する `SplitChatPane`（JSONL transcript を tail）を切り替えて使う。
+
+- **PC**: `SplitViewPane` の左ペインを上部バーの🖥/💬トグルで切り替える（既定は端末）。
+  右ペインは図解で、上部バー右端のトグルで開閉する（中身は `DiagramPane`。
+  詳細は下記「セッションボード」）。左ペインの選択・右ペインの幅と開閉は localStorage
+  に永続化する
+- **モバイル**: `MobileSessionView` の🖥/💬/📐トグルで 1 画面ずつ切り替える（既定は会話）
+
+左ペインは端末・会話の両方をマウントしたまま `display` で切り替える。ttyd は
+iframe（別ブラウジングコンテキスト）なので、アンマウントすると再接続になるため。
+その代わり「見えていないペイン」も生きているので、JSONL 購読と window レベルの
+ファイル D&D は表示中の 1 枚だけに絞る（`split-view-left-mode.ts`）。
+
 エンジンは PC・モバイル共通で tmux 上の対話版 claude
 (プラン枠課金を維持。Agent SDK / claude -p は使わない)。
 
 ```text
-表示: <configDir>/projects/<encoded-cwd>/*.jsonl → JsonlTailManager → Socket.IO → チャット描画（モバイル専用）
+表示: <configDir>/projects/<encoded-cwd>/*.jsonl → JsonlTailManager → Socket.IO → チャット描画
 入力: チャット入力欄 / ターミナル入力欄 → Socket.IO → tmux send-keys → claude CLI
-補助: tmux(セッション) ←→ ttyd(WebSocket) ←→ iframe (PC は常時表示 / モバイルはトグル)
+補助: tmux(セッション) ←→ ttyd(WebSocket) ←→ iframe (どちらもトグルで表示切替)
 ```
 
 **情報源分離の原則 (チャット UI v3 の核心)**: 会話内容は 100% JSONL transcript
@@ -33,7 +42,7 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 
 1. **tmux**: Claude CLIプロセスをdetachedセッションで管理。サーバー再起動後もセッションが永続化される
 2. **JsonlTailManager**: worktree 毎の JSONL を fs.watch + 1 秒 polling で tail し、新規行を購読 socket に push。/clear のファイル切替は onReset → 空 snapshot で追従
-3. **ttyd**: tmuxセッションにWebターミナルアクセスを提供（PC は常時表示、モバイルは🖥/💬トグルで表示切替）
+3. **ttyd**: tmuxセッションにWebターミナルアクセスを提供（PC は左ペイン、モバイルは全画面。どちらも🖥/💬トグルで会話ビューと切替）
 4. **SessionOrchestrator**: tmuxとttydを統合管理し、セッションのライフサイクルを制御する
 
 ### メッセージ送信の流れ
@@ -131,9 +140,9 @@ PC のデフォルト UI は ttyd の生ターミナル（`TerminalPane`。`Spli
 | リポジトリスキャン     | 指定パス配下のGitリポジトリを探索（fd/findコマンド使用）                    |
 | Git Worktree管理       | 一覧表示、作成、削除                                                        |
 | セッション管理         | tmux + ttydベースの起動、停止、復元、状態管理                               |
-| チャットビュー (モバイル専用) | JSONL tail ベースの会話描画 + pending reconcile + AskUserQuestion カード + slash 補完 + busy/AWAITING 表示（`MobileSessionView` の🖥/💬トグルで ttyd 表示と切替） |
+| チャットビュー           | JSONL tail ベースの会話描画 + pending reconcile + AskUserQuestion カード + slash 補完 + busy/AWAITING 表示（PC は `SplitViewPane` の左ペイン、モバイルは `MobileSessionView`。どちらも🖥/💬トグルで ttyd 表示と切替） |
 | セッションボード       | worktree の `.claude/diagrams/*.diagram.html`（意味モデル + HTML 投影）を表示する図解ペイン（右ペインタブ・PC のみ）。Claude が MCP ツール `board_open` で開き、ファイル更新を検知して自動再読込する |
-| Webターミナル          | ttyd iframeによるフルターミナル体験（PC はデフォルト表示、モバイルは🖥/💬トグルでチャットビューと切替） |
+| Webターミナル          | ttyd iframeによるフルターミナル体験（PC は左ペインの既定、モバイルは🖥/💬トグルでチャットビューと切替） |
 | マルチペインビュー     | 複数セッションの同時表示（1列 / 2x2グリッド切り替え）                       |
 | モバイル対応           | セッション一覧/詳細の画面遷移、Quick Keys、スクロールモード、キーボード対応 |
 | 特殊キー送信           | Enter, Ctrl+C, Ctrl+D, y, n, S-Tab, Escape, スクロール等                    |

--- a/packages/server/src/lib/usage-collector.ts
+++ b/packages/server/src/lib/usage-collector.ts
@@ -20,12 +20,7 @@ import { EventEmitter } from "node:events";
 import { mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type {
-  Profile,
-  UsageEntry,
-  UsageProgress,
-  UsageReport,
-} from "@ark/shared";
+import type { Profile, UsageEntry, UsageReport } from "@ark/shared";
 import { stripAnsi } from "./ansi.js";
 import { resolveClaudePath, resolveTmuxPath } from "./system.js";
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -50,6 +50,7 @@
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
     "autoprefixer": "^10.5.4",
+    "jsdom": "^30.0.1",
     "postcss": "^8.5.26",
     "tailwindcss": "^4.3.3",
     "tw-animate-css": "^1.4.0",

--- a/packages/web/src/components/SplitViewLeftModeToggle.tsx
+++ b/packages/web/src/components/SplitViewLeftModeToggle.tsx
@@ -1,0 +1,53 @@
+/**
+ * PC 左ペインの表示モード切替（端末 / 会話）。
+ *
+ * SplitViewPane 上部バーの左端に置く。右端の 📐（右ペイン開閉）とは
+ * 独立した状態で、両方を同時に選べる（例: 会話 + 図の左右 2 ペイン）。
+ */
+
+import type { SplitViewLeftMode } from "../lib/split-view-left-mode";
+
+export const SPLIT_VIEW_LEFT_MODES: ReadonlyArray<{
+  value: SplitViewLeftMode;
+  icon: string;
+  label: string;
+}> = [
+  { value: "terminal", icon: "🖥", label: "端末" },
+  { value: "chat", icon: "💬", label: "会話" },
+];
+
+interface SplitViewLeftModeToggleProps {
+  value: SplitViewLeftMode;
+  onChange: (mode: SplitViewLeftMode) => void;
+}
+
+export function SplitViewLeftModeToggle({
+  value,
+  onChange,
+}: SplitViewLeftModeToggleProps) {
+  return (
+    <fieldset className="flex items-center rounded-md border-0 bg-muted p-0.5 shrink-0">
+      <legend className="sr-only">左ペインの表示</legend>
+      {SPLIT_VIEW_LEFT_MODES.map(option => {
+        const selected = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            aria-label={option.label}
+            aria-pressed={selected}
+            onClick={() => onChange(option.value)}
+            className={`flex items-center gap-0.5 rounded px-1.5 py-1 text-[11px] font-medium transition-colors ${
+              selected
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <span aria-hidden="true">{option.icon}</span>
+            <span>{option.label}</span>
+          </button>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/packages/web/src/components/SplitViewPane.test.tsx
+++ b/packages/web/src/components/SplitViewPane.test.tsx
@@ -1,0 +1,113 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import {
+  normalizeSplitViewLeftMode,
+  readSavedSplitViewLeftMode,
+  SPLIT_VIEW_LEFT_MODE_VALUES,
+  shouldAcceptTerminalFileDrop,
+  shouldSubscribeChat,
+  writeSavedSplitViewLeftMode,
+} from "../lib/split-view-left-mode";
+import {
+  SPLIT_VIEW_LEFT_MODES,
+  SplitViewLeftModeToggle,
+} from "./SplitViewLeftModeToggle";
+
+describe("PC 左ペインの表示モード", () => {
+  it("terminal / chat を正規化し、不正値は terminal へ戻す", () => {
+    expect(SPLIT_VIEW_LEFT_MODES.map(option => option.value)).toEqual([
+      "terminal",
+      "chat",
+    ]);
+    expect(normalizeSplitViewLeftMode("terminal")).toBe("terminal");
+    expect(normalizeSplitViewLeftMode("chat")).toBe("chat");
+    // モバイル側の値（board）は PC の左ペインには無い
+    expect(normalizeSplitViewLeftMode("board")).toBe("terminal");
+    expect(normalizeSplitViewLeftMode(null)).toBe("terminal");
+    expect(normalizeSplitViewLeftMode(undefined)).toBe("terminal");
+  });
+
+  it("chat を永続化し、保存値から復元する", () => {
+    const writer = { setItem: vi.fn() };
+
+    writeSavedSplitViewLeftMode("chat", writer);
+
+    expect(writer.setItem).toHaveBeenCalledWith("ark-split-left-mode", "chat");
+    expect(readSavedSplitViewLeftMode({ getItem: () => "chat" })).toBe("chat");
+  });
+
+  it("保存が無いユーザーは従来どおりターミナルで開く", () => {
+    expect(readSavedSplitViewLeftMode({ getItem: () => null })).toBe(
+      "terminal"
+    );
+  });
+
+  it("localStorage が使えなくても既定へ落ちて切替を壊さない", () => {
+    const throwingReader = {
+      getItem: () => {
+        throw new Error("storage disabled");
+      },
+    };
+    const throwingWriter = {
+      setItem: () => {
+        throw new Error("storage disabled");
+      },
+    };
+
+    expect(readSavedSplitViewLeftMode(throwingReader)).toBe("terminal");
+    expect(() =>
+      writeSavedSplitViewLeftMode("chat", throwingWriter)
+    ).not.toThrow();
+  });
+
+  it("会話ビューの JSONL 購読は選択中セッションの会話モード 1 枚だけ", () => {
+    // 全セッションぶんの SplitViewPane が常時マウントされ、さらに左ペインは
+    // 端末・会話の両方をマウントしたままなので、両方の条件で絞らないと
+    // セッション数ぶんの tail が走る
+    expect(shouldSubscribeChat(true, "chat")).toBe(true);
+    expect(shouldSubscribeChat(true, "terminal")).toBe(false);
+    expect(shouldSubscribeChat(false, "chat")).toBe(false);
+    expect(shouldSubscribeChat(false, "terminal")).toBe(false);
+  });
+
+  it("端末の window D&D も表示中の 1 枚だけが受け取る", () => {
+    // 会話モードでチャット欄へ落としたファイルが裏の端末ペインへ二重に
+    // 入らないこと（window リスナーは display:none でも発火する）
+    expect(shouldAcceptTerminalFileDrop(true, "terminal")).toBe(true);
+    expect(shouldAcceptTerminalFileDrop(true, "chat")).toBe(false);
+    expect(shouldAcceptTerminalFileDrop(false, "terminal")).toBe(false);
+    expect(shouldAcceptTerminalFileDrop(false, "chat")).toBe(false);
+  });
+
+  it("選択中セッションではどちらか一方だけが「表示中」になる", () => {
+    // 2 つの述語は左ペインの排他な 2 モードに 1 対 1 で対応する。
+    // 同時 true（二重動作）も、選択中なのに同時 false（どちらのペインも
+    // 動いていない）も、モードを増やしたときに壊れる形なのでここで縛る
+    // モードを増やしたら自動でこの検査の対象になるよう、定義から回す
+    for (const mode of SPLIT_VIEW_LEFT_MODE_VALUES) {
+      expect(shouldSubscribeChat(true, mode)).toBe(
+        !shouldAcceptTerminalFileDrop(true, mode)
+      );
+      // 非選択セッションはどちらのペインも見えていない
+      expect(shouldSubscribeChat(false, mode)).toBe(false);
+      expect(shouldAcceptTerminalFileDrop(false, mode)).toBe(false);
+    }
+  });
+
+  it("トグルは選択中のモードだけを aria-pressed で示す", () => {
+    const html = renderToStaticMarkup(
+      createElement(SplitViewLeftModeToggle, {
+        value: "chat",
+        onChange: () => {},
+      })
+    );
+
+    expect(html).toContain('aria-label="会話"');
+    expect(html).toContain('aria-label="端末"');
+    expect(html.match(/aria-pressed="true"/g)).toHaveLength(1);
+    // 会話が選択されている＝会話ボタンだけが pressed
+    const chatButton = html.slice(html.indexOf('aria-label="会話"'));
+    expect(chatButton.slice(0, 120)).toContain('aria-pressed="true"');
+  });
+});

--- a/packages/web/src/components/SplitViewPane.test.tsx
+++ b/packages/web/src/components/SplitViewPane.test.tsx
@@ -1,113 +1,310 @@
-import { createElement } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it, vi } from "vitest";
+// @vitest-environment jsdom
+
+import type { BridgeSessionStatus, ManagedSession } from "@ark/shared";
+import { act, type ComponentProps, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   normalizeSplitViewLeftMode,
   readSavedSplitViewLeftMode,
-  SPLIT_VIEW_LEFT_MODE_VALUES,
-  shouldAcceptTerminalFileDrop,
-  shouldSubscribeChat,
+  STORAGE_KEY_SPLIT_LEFT_MODE,
   writeSavedSplitViewLeftMode,
 } from "../lib/split-view-left-mode";
-import {
-  SPLIT_VIEW_LEFT_MODES,
-  SplitViewLeftModeToggle,
-} from "./SplitViewLeftModeToggle";
+import { SplitViewPane } from "./SplitViewPane";
+
+interface ObservedChatProps {
+  session: ManagedSession;
+  isActive: boolean;
+  bridgeStatus?: BridgeSessionStatus;
+  awaitingText?: string;
+}
+
+const testDoubles = vi.hoisted(() => ({
+  splitChatPane: vi.fn(),
+}));
+
+vi.mock("./SplitChatPane", () => ({
+  SplitChatPane: (props: ObservedChatProps) => {
+    testDoubles.splitChatPane(props);
+    return <div data-testid={`chat-${props.session.id}`} />;
+  },
+}));
+
+vi.mock("./DiagramPane", () => ({
+  DiagramPane: () => <div data-testid="diagram-pane" />,
+}));
+
+vi.mock("../hooks/useMobile", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("../hooks/useTerminalLinkInjection", () => ({
+  useTerminalLinkInjection: () => undefined,
+}));
+
+const mountedRoots: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+function mount(element: ReactElement): HTMLDivElement {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  act(() => root.render(element));
+  mountedRoots.push({ root, container });
+  return container;
+}
+
+function makeSession(id: string): ManagedSession {
+  return {
+    id,
+    worktreeId: `worktree-${id}`,
+    worktreePath: `/worktrees/${id}`,
+    status: "active",
+    createdAt: new Date("2026-08-23T00:00:00Z"),
+    tmuxSessionName: `tmux-${id}`,
+    ttydPort: 4100,
+    ttydUrl: `/ttyd/${id}/`,
+  };
+}
+
+const notCalled = async (): Promise<never> => {
+  throw new Error("このテストでは呼ばれない関数です");
+};
+
+function makePaneProps(
+  session: ManagedSession,
+  isActive: boolean
+): ComponentProps<typeof SplitViewPane> {
+  return {
+    socket: null,
+    isConnected: true,
+    diagramCommentsUpdate: null,
+    listDiagrams: async () => [],
+    deleteDiagram: notCalled,
+    getDiagramComments: notCalled,
+    createDiagramComment: notCalled,
+    resolveDiagramComment: notCalled,
+    replyDiagramComment: notCalled,
+    deleteDiagramComment: notCalled,
+    sendDiagramComment: notCalled,
+    session,
+    isActive,
+    worktree: undefined,
+    tabs: [{ type: "terminal", id: `terminal-${session.id}` }],
+    activeTabIndex: 0,
+    onTabSelect: vi.fn(),
+    onTabClose: vi.fn(),
+    onSelectDiagram: vi.fn(),
+    onSendMessage: vi.fn(),
+    onSendKey: vi.fn(),
+    onDeleteSession: vi.fn(),
+    onUploadFile: vi.fn(async data => ({
+      path: `/uploads/${data.originalFilename ?? "file"}`,
+      filename: data.originalFilename ?? "file",
+    })),
+    messageShortcuts: [],
+    onCreateShortcut: vi.fn(),
+    onUpdateShortcut: vi.fn(),
+    onDeleteShortcut: vi.fn(),
+  };
+}
+
+function paneSection(
+  session: ManagedSession,
+  isActive: boolean,
+  overrides: Partial<ComponentProps<typeof SplitViewPane>> = {}
+): ReactElement {
+  return (
+    <section key={session.id} data-testid={`pane-${session.id}`}>
+      <SplitViewPane {...makePaneProps(session, isActive)} {...overrides} />
+    </section>
+  );
+}
+
+function renderSessions(
+  activeSessionId: string,
+  sessions: ManagedSession[],
+  overrides: Partial<ComponentProps<typeof SplitViewPane>> = {}
+): ReactElement {
+  return (
+    <>
+      {sessions.map(session =>
+        paneSection(session, session.id === activeSessionId, overrides)
+      )}
+    </>
+  );
+}
+
+function clickButton(scope: ParentNode, label: string): void {
+  const button = scope.querySelector<HTMLButtonElement>(
+    `button[aria-label="${label}"]`
+  );
+  expect(button).not.toBeNull();
+  act(() => button?.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+}
+
+function dispatchFileDrop(filename: string): void {
+  const event = new Event("drop", {
+    bubbles: true,
+    cancelable: true,
+  });
+  Object.defineProperty(event, "dataTransfer", {
+    value: {
+      types: ["Files"],
+      files: [new File(["review"], filename, { type: "text/plain" })],
+    },
+  });
+  window.dispatchEvent(event);
+}
+
+function latestChatProps(sessionId: string): ObservedChatProps {
+  const calls = testDoubles.splitChatPane.mock.calls
+    .map(([props]) => props as ObservedChatProps)
+    .filter(props => props.session.id === sessionId);
+  const latest = calls.at(-1);
+  expect(latest).toBeDefined();
+  return latest as ObservedChatProps;
+}
+
+function textContent(scope: ParentNode): string {
+  return scope.textContent ?? "";
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  localStorage.clear();
+  testDoubles.splitChatPane.mockClear();
+});
+
+afterEach(() => {
+  for (const { root, container } of mountedRoots.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+  vi.restoreAllMocks();
+});
 
 describe("PC 左ペインの表示モード", () => {
-  it("terminal / chat を正規化し、不正値は terminal へ戻す", () => {
-    expect(SPLIT_VIEW_LEFT_MODES.map(option => option.value)).toEqual([
-      "terminal",
-      "chat",
-    ]);
+  it("保存値を正規化し、localStorage が使えなくても既定へ戻る", () => {
     expect(normalizeSplitViewLeftMode("terminal")).toBe("terminal");
     expect(normalizeSplitViewLeftMode("chat")).toBe("chat");
-    // モバイル側の値（board）は PC の左ペインには無い
     expect(normalizeSplitViewLeftMode("board")).toBe("terminal");
-    expect(normalizeSplitViewLeftMode(null)).toBe("terminal");
-    expect(normalizeSplitViewLeftMode(undefined)).toBe("terminal");
-  });
-
-  it("chat を永続化し、保存値から復元する", () => {
-    const writer = { setItem: vi.fn() };
-
-    writeSavedSplitViewLeftMode("chat", writer);
-
-    expect(writer.setItem).toHaveBeenCalledWith("ark-split-left-mode", "chat");
-    expect(readSavedSplitViewLeftMode({ getItem: () => "chat" })).toBe("chat");
-  });
-
-  it("保存が無いユーザーは従来どおりターミナルで開く", () => {
     expect(readSavedSplitViewLeftMode({ getItem: () => null })).toBe(
       "terminal"
     );
-  });
-
-  it("localStorage が使えなくても既定へ落ちて切替を壊さない", () => {
-    const throwingReader = {
-      getItem: () => {
-        throw new Error("storage disabled");
-      },
-    };
-    const throwingWriter = {
-      setItem: () => {
-        throw new Error("storage disabled");
-      },
-    };
-
-    expect(readSavedSplitViewLeftMode(throwingReader)).toBe("terminal");
+    expect(
+      readSavedSplitViewLeftMode({
+        getItem: () => {
+          throw new Error("storage disabled");
+        },
+      })
+    ).toBe("terminal");
     expect(() =>
-      writeSavedSplitViewLeftMode("chat", throwingWriter)
+      writeSavedSplitViewLeftMode("chat", {
+        setItem: () => {
+          throw new Error("storage disabled");
+        },
+      })
     ).not.toThrow();
   });
 
-  it("会話ビューの JSONL 購読は選択中セッションの会話モード 1 枚だけ", () => {
-    // 全セッションぶんの SplitViewPane が常時マウントされ、さらに左ペインは
-    // 端末・会話の両方をマウントしたままなので、両方の条件で絞らないと
-    // セッション数ぶんの tail が走る
-    expect(shouldSubscribeChat(true, "chat")).toBe(true);
-    expect(shouldSubscribeChat(true, "terminal")).toBe(false);
-    expect(shouldSubscribeChat(false, "chat")).toBe(false);
-    expect(shouldSubscribeChat(false, "terminal")).toBe(false);
-  });
+  it("SplitViewPane から会話ビューへ bridgeStatus / awaitingText を渡す", () => {
+    localStorage.setItem(STORAGE_KEY_SPLIT_LEFT_MODE, "chat");
+    const session = makeSession("wiring");
 
-  it("端末の window D&D も表示中の 1 枚だけが受け取る", () => {
-    // 会話モードでチャット欄へ落としたファイルが裏の端末ペインへ二重に
-    // 入らないこと（window リスナーは display:none でも発火する）
-    expect(shouldAcceptTerminalFileDrop(true, "terminal")).toBe(true);
-    expect(shouldAcceptTerminalFileDrop(true, "chat")).toBe(false);
-    expect(shouldAcceptTerminalFileDrop(false, "terminal")).toBe(false);
-    expect(shouldAcceptTerminalFileDrop(false, "chat")).toBe(false);
-  });
-
-  it("選択中セッションではどちらか一方だけが「表示中」になる", () => {
-    // 2 つの述語は左ペインの排他な 2 モードに 1 対 1 で対応する。
-    // 同時 true（二重動作）も、選択中なのに同時 false（どちらのペインも
-    // 動いていない）も、モードを増やしたときに壊れる形なのでここで縛る
-    // モードを増やしたら自動でこの検査の対象になるよう、定義から回す
-    for (const mode of SPLIT_VIEW_LEFT_MODE_VALUES) {
-      expect(shouldSubscribeChat(true, mode)).toBe(
-        !shouldAcceptTerminalFileDrop(true, mode)
-      );
-      // 非選択セッションはどちらのペインも見えていない
-      expect(shouldSubscribeChat(false, mode)).toBe(false);
-      expect(shouldAcceptTerminalFileDrop(false, mode)).toBe(false);
-    }
-  });
-
-  it("トグルは選択中のモードだけを aria-pressed で示す", () => {
-    const html = renderToStaticMarkup(
-      createElement(SplitViewLeftModeToggle, {
-        value: "chat",
-        onChange: () => {},
+    mount(
+      paneSection(session, true, {
+        bridgeStatus: "AWAITING",
+        awaitingText: "レビューを続けますか？",
       })
     );
 
-    expect(html).toContain('aria-label="会話"');
-    expect(html).toContain('aria-label="端末"');
-    expect(html.match(/aria-pressed="true"/g)).toHaveLength(1);
-    // 会話が選択されている＝会話ボタンだけが pressed
-    const chatButton = html.slice(html.indexOf('aria-label="会話"'));
-    expect(chatButton.slice(0, 120)).toContain('aria-pressed="true"');
+    expect(latestChatProps(session.id)).toMatchObject({
+      isActive: true,
+      bridgeStatus: "AWAITING",
+      awaitingText: "レビューを続けますか？",
+    });
+  });
+
+  it("トグル操作で状態と localStorage が変わり、全セッションで共有される", () => {
+    const sessions = [makeSession("a"), makeSession("b")];
+    const container = mount(renderSessions("a", sessions));
+    const paneA = container.querySelector('[data-testid="pane-a"]');
+    const paneB = container.querySelector('[data-testid="pane-b"]');
+    expect(paneA).not.toBeNull();
+    expect(paneB).not.toBeNull();
+
+    clickButton(paneA as ParentNode, "会話");
+
+    expect(localStorage.getItem(STORAGE_KEY_SPLIT_LEFT_MODE)).toBe("chat");
+    for (const pane of [paneA, paneB]) {
+      expect(
+        pane
+          ?.querySelector('button[aria-label="会話"]')
+          ?.getAttribute("aria-pressed")
+      ).toBe("true");
+    }
+    expect(
+      paneA?.querySelector('[data-testid="chat-a"]')?.parentElement?.className
+    ).toBe("h-full");
+    expect(
+      paneB?.querySelector('[data-testid="chat-b"]')?.parentElement?.className
+    ).toBe("h-full");
+  });
+
+  it("active session と left mode に応じて会話購読と端末 D&D を一枚だけ有効にする", async () => {
+    const sessions = [makeSession("a"), makeSession("b")];
+    const container = mount(renderSessions("a", sessions));
+    const root = mountedRoots.at(-1)?.root;
+    expect(root).toBeDefined();
+
+    expect(latestChatProps("a").isActive).toBe(false);
+    expect(latestChatProps("b").isActive).toBe(false);
+
+    await act(async () => {
+      dispatchFileDrop("active-a.txt");
+      await new Promise(resolve => setTimeout(resolve, 10));
+    });
+    expect(
+      textContent(
+        container.querySelector('[data-testid="pane-a"]') as ParentNode
+      )
+    ).toContain("ファイルを送信（1件）");
+    expect(
+      textContent(
+        container.querySelector('[data-testid="pane-b"]') as ParentNode
+      )
+    ).not.toContain("ファイルを送信（1件）");
+
+    act(() => root?.render(renderSessions("b", sessions)));
+    expect(latestChatProps("a").isActive).toBe(false);
+    expect(latestChatProps("b").isActive).toBe(false);
+
+    clickButton(container, "会話");
+    expect(latestChatProps("a").isActive).toBe(false);
+    expect(latestChatProps("b").isActive).toBe(true);
+  });
+
+  it("display:none の TerminalPane は window drop を処理しない", async () => {
+    localStorage.setItem(STORAGE_KEY_SPLIT_LEFT_MODE, "chat");
+    const session = makeSession("hidden-terminal");
+    const container = mount(paneSection(session, true));
+    const readSpy = vi.spyOn(FileReader.prototype, "readAsDataURL");
+
+    await act(async () => {
+      dispatchFileDrop("must-not-be-read.txt");
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(readSpy).not.toHaveBeenCalled();
+    expect(textContent(container)).not.toContain("ファイルを送信（1件）");
+
+    // 陽性対照: 同じペインを端末表示に戻せば、同じ window drop が処理される。
+    clickButton(container, "端末");
+    await act(async () => {
+      dispatchFileDrop("visible-terminal.txt");
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    expect(textContent(container)).toContain("ファイルを送信（1件）");
   });
 });

--- a/packages/web/src/components/SplitViewPane.test.tsx
+++ b/packages/web/src/components/SplitViewPane.test.tsx
@@ -171,6 +171,29 @@ function hasTerminalUploadPreview(scope: ParentNode): boolean {
   );
 }
 
+async function waitForTerminalUploadPreview(scope: ParentNode): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!hasTerminalUploadPreview(scope)) {
+    if (Date.now() >= deadline) {
+      throw new Error(
+        "terminal upload preview did not appear within 5 seconds"
+      );
+    }
+    await act(
+      () =>
+        new Promise<void>(resolve => {
+          const channel = new MessageChannel();
+          channel.port1.onmessage = () => {
+            channel.port1.close();
+            channel.port2.close();
+            resolve();
+          };
+          channel.port2.postMessage(undefined);
+        })
+    );
+  }
+}
+
 beforeEach(() => {
   globalThis.IS_REACT_ACT_ENVIRONMENT = true;
   localStorage.clear();
@@ -285,10 +308,10 @@ describe("PC 左ペインの表示モード", () => {
     expect(latestChatProps("a").isActive).toBe(false);
     expect(latestChatProps("b").isActive).toBe(false);
 
-    await act(async () => {
-      dispatchFileDrop("active-a.txt");
-      await new Promise(resolve => setTimeout(resolve, 10));
-    });
+    act(() => dispatchFileDrop("active-a.txt"));
+    await waitForTerminalUploadPreview(
+      container.querySelector('[data-testid="pane-a"]') as ParentNode
+    );
     expect(
       hasTerminalUploadPreview(
         container.querySelector('[data-testid="pane-a"]') as ParentNode
@@ -315,21 +338,16 @@ describe("PC 左ペインの表示モード", () => {
     const container = mount(paneSection(session, true));
     const readSpy = vi.spyOn(FileReader.prototype, "readAsDataURL");
 
-    await act(async () => {
-      dispatchFileDrop("must-not-be-read.txt");
-      await new Promise(resolve => setTimeout(resolve, 0));
-    });
+    act(() => dispatchFileDrop("must-not-be-read.txt"));
 
     expect(readSpy).not.toHaveBeenCalled();
     expect(hasTerminalUploadPreview(container)).toBe(false);
 
     // 陽性対照: 同じペインを端末表示に戻せば、同じ window drop が処理される。
     clickButton(container, "端末");
-    await act(async () => {
-      dispatchFileDrop("visible-terminal.txt");
-      await new Promise(resolve => setTimeout(resolve, 0));
-    });
+    act(() => dispatchFileDrop("visible-terminal.txt"));
     expect(readSpy).toHaveBeenCalledTimes(1);
+    await waitForTerminalUploadPreview(container);
     expect(hasTerminalUploadPreview(container)).toBe(true);
   });
 });

--- a/packages/web/src/components/SplitViewPane.test.tsx
+++ b/packages/web/src/components/SplitViewPane.test.tsx
@@ -165,8 +165,10 @@ function latestChatProps(sessionId: string): ObservedChatProps {
   return latest as ObservedChatProps;
 }
 
-function textContent(scope: ParentNode): string {
-  return scope.textContent ?? "";
+function hasTerminalUploadPreview(scope: ParentNode): boolean {
+  return (
+    scope.querySelector('[data-testid="terminal-upload-preview"]') !== null
+  );
 }
 
 beforeEach(() => {
@@ -251,6 +253,29 @@ describe("PC 左ペインの表示モード", () => {
     ).toBe("h-full");
   });
 
+  it("localStorage 書き込み失敗時も全セッションへ選択モードを通知する", () => {
+    const sessions = [makeSession("storage-a"), makeSession("storage-b")];
+    const container = mount(renderSessions("storage-a", sessions));
+    const paneA = container.querySelector('[data-testid="pane-storage-a"]');
+    const paneB = container.querySelector('[data-testid="pane-storage-b"]');
+    expect(paneA).not.toBeNull();
+    expect(paneB).not.toBeNull();
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("storage disabled");
+    });
+
+    clickButton(paneA as ParentNode, "会話");
+
+    expect(localStorage.getItem(STORAGE_KEY_SPLIT_LEFT_MODE)).toBeNull();
+    for (const pane of [paneA, paneB]) {
+      expect(
+        pane
+          ?.querySelector('button[aria-label="会話"]')
+          ?.getAttribute("aria-pressed")
+      ).toBe("true");
+    }
+  });
+
   it("active session と left mode に応じて会話購読と端末 D&D を一枚だけ有効にする", async () => {
     const sessions = [makeSession("a"), makeSession("b")];
     const container = mount(renderSessions("a", sessions));
@@ -265,15 +290,15 @@ describe("PC 左ペインの表示モード", () => {
       await new Promise(resolve => setTimeout(resolve, 10));
     });
     expect(
-      textContent(
+      hasTerminalUploadPreview(
         container.querySelector('[data-testid="pane-a"]') as ParentNode
       )
-    ).toContain("ファイルを送信（1件）");
+    ).toBe(true);
     expect(
-      textContent(
+      hasTerminalUploadPreview(
         container.querySelector('[data-testid="pane-b"]') as ParentNode
       )
-    ).not.toContain("ファイルを送信（1件）");
+    ).toBe(false);
 
     act(() => root?.render(renderSessions("b", sessions)));
     expect(latestChatProps("a").isActive).toBe(false);
@@ -296,7 +321,7 @@ describe("PC 左ペインの表示モード", () => {
     });
 
     expect(readSpy).not.toHaveBeenCalled();
-    expect(textContent(container)).not.toContain("ファイルを送信（1件）");
+    expect(hasTerminalUploadPreview(container)).toBe(false);
 
     // 陽性対照: 同じペインを端末表示に戻せば、同じ window drop が処理される。
     clickButton(container, "端末");
@@ -305,6 +330,6 @@ describe("PC 左ペインの表示モード", () => {
       await new Promise(resolve => setTimeout(resolve, 0));
     });
     expect(readSpy).toHaveBeenCalledTimes(1);
-    expect(textContent(container)).toContain("ファイルを送信（1件）");
+    expect(hasTerminalUploadPreview(container)).toBe(true);
   });
 });

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -35,7 +35,9 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
 import {
   readSavedSplitViewLeftMode,
+  SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT,
   type SplitViewLeftMode,
+  STORAGE_KEY_SPLIT_LEFT_MODE,
   shouldAcceptTerminalFileDrop,
   shouldSubscribeChat,
   writeSavedSplitViewLeftMode,
@@ -169,12 +171,28 @@ export function SplitViewPane(props: SplitViewPaneProps) {
   const [showBoard, setShowBoard] = useState<boolean>(() =>
     readSavedShowBoard()
   );
-  // 左ペインのモード。showBoard / boardWidth と同じく、保存値の読み出しは
-  // マウント時の初期化のみ。既にマウント済みの他セッションのペインは、
-  // こちらで切り替えても追随しない（右ペインの開閉と同じ挙動）
+  // 左ペインのモード。選択は PC 全体で共有し、常時マウント済みの別セッション
+  // および別ブラウザタブからの変更にも追随する。
   const [leftMode, setLeftMode] = useState<SplitViewLeftMode>(
     readSavedSplitViewLeftMode
   );
+
+  useEffect(() => {
+    const syncFromStorage = () => setLeftMode(readSavedSplitViewLeftMode());
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY_SPLIT_LEFT_MODE) syncFromStorage();
+    };
+
+    window.addEventListener(SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT, syncFromStorage);
+    window.addEventListener("storage", handleStorage);
+    return () => {
+      window.removeEventListener(
+        SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT,
+        syncFromStorage
+      );
+      window.removeEventListener("storage", handleStorage);
+    };
+  }, []);
 
   const handleLeftModeChange = useCallback((next: SplitViewLeftMode) => {
     writeSavedSplitViewLeftMode(next);

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -34,9 +34,11 @@ import type {
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
 import {
+  normalizeSplitViewLeftMode,
   readSavedSplitViewLeftMode,
   SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT,
   type SplitViewLeftMode,
+  type SplitViewLeftModeChangeDetail,
   STORAGE_KEY_SPLIT_LEFT_MODE,
   shouldAcceptTerminalFileDrop,
   shouldSubscribeChat,
@@ -178,17 +180,26 @@ export function SplitViewPane(props: SplitViewPaneProps) {
   );
 
   useEffect(() => {
-    const syncFromStorage = () => setLeftMode(readSavedSplitViewLeftMode());
+    const handleLeftModeChange = (event: Event) => {
+      const { mode } = (event as CustomEvent<SplitViewLeftModeChangeDetail>)
+        .detail;
+      setLeftMode(mode);
+    };
     const handleStorage = (event: StorageEvent) => {
-      if (event.key === STORAGE_KEY_SPLIT_LEFT_MODE) syncFromStorage();
+      if (event.key === STORAGE_KEY_SPLIT_LEFT_MODE) {
+        setLeftMode(normalizeSplitViewLeftMode(event.newValue));
+      }
     };
 
-    window.addEventListener(SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT, syncFromStorage);
+    window.addEventListener(
+      SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT,
+      handleLeftModeChange
+    );
     window.addEventListener("storage", handleStorage);
     return () => {
       window.removeEventListener(
         SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT,
-        syncFromStorage
+        handleLeftModeChange
       );
       window.removeEventListener("storage", handleStorage);
     };

--- a/packages/web/src/components/SplitViewPane.tsx
+++ b/packages/web/src/components/SplitViewPane.tsx
@@ -1,19 +1,26 @@
 /**
- * SplitViewPane - PC 用セッションビュー（ターミナル + 右ペインの左右2ペイン）
+ * SplitViewPane - PC 用セッションビュー（左ペイン + 右ペインの左右2ペイン）
  *
- * 左ペイン = TerminalPane（ttyd + file/html タブ）を常時表示、
+ * 左ペインは上部バーのトグルで「端末（TerminalPane = ttyd + file/html タブ）」と
+ * 「会話（SplitChatPane = JSONL tail のチャットビュー）」を切り替える。
  * 右ペインは図が未選択でも上部バーのトグルで開閉できる。
  * 中身は DiagramPane（B-0a の図ペイン）。
- * 会話ビュー（SplitChatPane）は使わない — チャット内容を確認したい場合は
- * ttyd の生ターミナル（左ペイン）を直接見る。
  *
  * - diagram は TerminalPane のタブ機構から外れ、右ペイン専属になった
  *   （タブ自体は sessionTabs 上には残るが、非表示のまま「開いている印」として使う）
  * - 図（openDiagramTab）の activation id が変わると showBoard を自動 true にする
- * - 右ペイン幅 / 開閉状態は localStorage に永続化
+ * - 左ペインのモード / 右ペイン幅 / 右ペイン開閉状態は localStorage に永続化
+ * - 左ペインは端末・会話の両方をマウントしたまま display 切替する。ttyd は
+ *   iframe（別ブラウジングコンテキスト）なので、アンマウントすると再接続に
+ *   なってしまう（.claude/rules/frontend-codegen.md）
+ * - 会話ビューには showTerminal / onToggleTerminal を渡さない。渡すとチャット
+ *   ヘッダにもう 1 つ 🖥 トグルが出て、上部バーの切替と二重になる。AUQ カードや
+ *   AWAITING バナーの「ターミナルへ」導線も同 props 由来で消えるが、
+ *   切替は 1 行上の上部バーにあり、モバイル（MobileSessionView）とも揃う
  */
 
 import type {
+  BridgeSessionStatus,
   ClientToServerEvents,
   DiagramCommentsResponse,
   DiagramDeleteResponse,
@@ -26,7 +33,16 @@ import type {
 } from "@ark/shared";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Socket } from "socket.io-client";
+import {
+  readSavedSplitViewLeftMode,
+  type SplitViewLeftMode,
+  shouldAcceptTerminalFileDrop,
+  shouldSubscribeChat,
+  writeSavedSplitViewLeftMode,
+} from "../lib/split-view-left-mode";
 import { DiagramPane } from "./DiagramPane";
+import { SplitChatPane } from "./SplitChatPane";
+import { SplitViewLeftModeToggle } from "./SplitViewLeftModeToggle";
 import { TerminalPane, type ViewerTab } from "./TerminalPane";
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
@@ -89,6 +105,16 @@ interface SplitViewPaneProps {
     threadId: string
   ) => Promise<DiagramCommentsResponse>;
   session: ManagedSession;
+  /**
+   * このセッションが現在選択中か。SplitViewPane は Dashboard で全セッション
+   * ぶんが常時マウントされる（非選択は `hidden`）ため、会話ビューの JSONL
+   * 購読はこれと左ペインのモードの両方で絞る（shouldSubscribeChat）
+   */
+  isActive: boolean;
+  /** session:previews 由来のセッション状態（会話ビューの busy / AWAITING 表示） */
+  bridgeStatus?: BridgeSessionStatus;
+  /** AWAITING 時の確認 UI 生テキスト（会話ビューのバナー表示） */
+  awaitingText?: string;
   worktree: Worktree | undefined;
   repoName?: string;
   tabs: ViewerTab[];
@@ -143,6 +169,17 @@ export function SplitViewPane(props: SplitViewPaneProps) {
   const [showBoard, setShowBoard] = useState<boolean>(() =>
     readSavedShowBoard()
   );
+  // 左ペインのモード。showBoard / boardWidth と同じく、保存値の読み出しは
+  // マウント時の初期化のみ。既にマウント済みの他セッションのペインは、
+  // こちらで切り替えても追随しない（右ペインの開閉と同じ挙動）
+  const [leftMode, setLeftMode] = useState<SplitViewLeftMode>(
+    readSavedSplitViewLeftMode
+  );
+
+  const handleLeftModeChange = useCallback((next: SplitViewLeftMode) => {
+    writeSavedSplitViewLeftMode(next);
+    setLeftMode(next);
+  }, []);
 
   // 現在図は session ごとに最大1件。diagram タブは左タブバーから除外され、
   // ここでのみ参照する。
@@ -243,8 +280,12 @@ export function SplitViewPane(props: SplitViewPaneProps) {
 
   return (
     <div className="h-full flex flex-col">
-      {/* 上部バー: 右ペイン開閉トグル */}
-      <div className="h-8 shrink-0 border-b border-border bg-sidebar flex items-center justify-end px-2">
+      {/* 上部バー: 左は左ペイン切替（端末 / 会話）、右は右ペイン開閉トグル */}
+      <div className="h-8 shrink-0 border-b border-border bg-sidebar flex items-center justify-between px-2">
+        <SplitViewLeftModeToggle
+          value={leftMode}
+          onChange={handleLeftModeChange}
+        />
         <button
           type="button"
           onClick={handleToggleBoard}
@@ -261,7 +302,7 @@ export function SplitViewPane(props: SplitViewPaneProps) {
       </div>
 
       <div ref={containerRef} className="flex-1 min-h-0 flex relative">
-        {/* 左ペイン: ターミナル（常時表示）
+        {/* 左ペイン: 端末 / 会話（上部バーで切替。両方マウントしたまま display 切替）
             リサイズ中は pointer-events-none にする。ターミナルは ttyd の iframe
             （別ブラウジングコンテキスト）で、分割線を左へドラッグしてカーソルが
             この上に乗ると mousemove / mouseup を iframe が飲み込み、window の
@@ -273,24 +314,43 @@ export function SplitViewPane(props: SplitViewPaneProps) {
             isDragging ? "pointer-events-none" : ""
           }`}
         >
-          <TerminalPane
-            session={props.session}
-            worktree={props.worktree}
-            repoName={props.repoName}
-            tabs={props.tabs}
-            activeTabIndex={props.activeTabIndex}
-            onTabSelect={props.onTabSelect}
-            onTabClose={props.onTabClose}
-            onSendMessage={props.onSendMessage}
-            onSendKey={props.onSendKey}
-            onDeleteSession={props.onDeleteSession}
-            onUploadFile={props.onUploadFile}
-            onCopyBuffer={props.onCopyBuffer}
-            messageShortcuts={props.messageShortcuts}
-            onCreateShortcut={props.onCreateShortcut}
-            onUpdateShortcut={props.onUpdateShortcut}
-            onDeleteShortcut={props.onDeleteShortcut}
-          />
+          {/* 端末: ttyd の再接続を避けるため hidden で残置する */}
+          <div className={leftMode === "terminal" ? "h-full" : "hidden"}>
+            <TerminalPane
+              session={props.session}
+              worktree={props.worktree}
+              repoName={props.repoName}
+              isVisible={shouldAcceptTerminalFileDrop(props.isActive, leftMode)}
+              tabs={props.tabs}
+              activeTabIndex={props.activeTabIndex}
+              onTabSelect={props.onTabSelect}
+              onTabClose={props.onTabClose}
+              onSendMessage={props.onSendMessage}
+              onSendKey={props.onSendKey}
+              onDeleteSession={props.onDeleteSession}
+              onUploadFile={props.onUploadFile}
+              onCopyBuffer={props.onCopyBuffer}
+              messageShortcuts={props.messageShortcuts}
+              onCreateShortcut={props.onCreateShortcut}
+              onUpdateShortcut={props.onUpdateShortcut}
+              onDeleteShortcut={props.onDeleteShortcut}
+            />
+          </div>
+
+          {/* 会話: JSONL tail のチャットビュー。入力欄 / AUQ カード / slash 補完 /
+              ファイルアップロード / busy・AWAITING 表示を内包する */}
+          <div className={leftMode === "chat" ? "h-full" : "hidden"}>
+            <SplitChatPane
+              socket={props.socket}
+              session={props.session}
+              isActive={shouldSubscribeChat(props.isActive, leftMode)}
+              bridgeStatus={props.bridgeStatus}
+              awaitingText={props.awaitingText}
+              onSendMessage={props.onSendMessage}
+              onSendKey={props.onSendKey}
+              onUploadFile={props.onUploadFile}
+            />
+          </div>
         </div>
 
         {/* リサイザ・右ペイン */}

--- a/packages/web/src/components/TerminalPane.tsx
+++ b/packages/web/src/components/TerminalPane.tsx
@@ -636,7 +636,10 @@ export function TerminalPane({
         })()}
       {/* 添付ファイル プレビューダイアログ（画像/非画像共通） */}
       {pendingFiles.length > 0 && (
-        <div className="absolute inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+        <div
+          className="absolute inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+          data-testid="terminal-upload-preview"
+        >
           <div className="bg-card border border-border rounded-lg p-4 max-w-md w-full">
             <h3 className="text-sm font-semibold mb-3">
               ファイルを送信（{pendingFiles.length}件）

--- a/packages/web/src/components/TerminalPane.tsx
+++ b/packages/web/src/components/TerminalPane.tsx
@@ -99,6 +99,17 @@ interface TerminalPaneProps {
   session: ManagedSession;
   worktree: Worktree | undefined;
   repoName?: string;
+  /**
+   * このペインが実際に画面へ出ているか（既定 true）。
+   *
+   * ファイル D&D は ttyd iframe がドラッグイベントを親に届けないため
+   * window レベルで受けている。TerminalPane は全セッションぶんが常時
+   * マウントされ、さらに左ペインが会話モードのときも `display:none` で
+   * 残置されるので、無条件に window で受けると「見えていないペイン」にも
+   * ドロップが入り、あとで開いたときに身に覚えのない送信プレビューが出る。
+   * 表示中の 1 枚だけが受け取るようにこれで絞る。
+   */
+  isVisible?: boolean;
   onSendMessage: (message: string) => void;
   onSendKey: (key: SpecialKey) => void;
   /** セッション削除（停止 + メイン以外のWorktree削除） */
@@ -127,6 +138,7 @@ export function TerminalPane({
   session,
   worktree,
   repoName,
+  isVisible = true,
   onSendMessage,
   onSendKey,
   onDeleteSession,
@@ -352,8 +364,10 @@ export function TerminalPane({
   // ttyd iframe はクロスフレーム分離でドラッグイベントを親に届けないため、
   // window レベルのリスナーで検知して全画面オーバーレイを表示する
   // onUploadFile が未定義（アップロード非対応）の場合はリスナーを登録しない
+  // 非表示のペイン（他セッション / 左ペインが会話モード）でも登録しない。
+  // window リスナーは表示状態と無関係に発火するため（isVisible の項参照）
   useEffect(() => {
-    if (!onUploadFile) return;
+    if (!onUploadFile || !isVisible) return;
     let dragCounter = 0;
 
     const handleDragEnter = (e: DragEvent) => {
@@ -393,7 +407,7 @@ export function TerminalPane({
       window.removeEventListener("dragleave", handleDragLeave);
       window.removeEventListener("drop", handleDrop);
     };
-  }, [onUploadFile, handleFilesSelected]);
+  }, [onUploadFile, isVisible, handleFilesSelected]);
 
   // ファイル選択/D&D後のtextarea自動挿入は廃止（プレビューダイアログ経由に統一）
 

--- a/packages/web/src/lib/split-view-left-mode.ts
+++ b/packages/web/src/lib/split-view-left-mode.ts
@@ -24,6 +24,10 @@ interface LeftModeStorageWriter {
 
 export const STORAGE_KEY_SPLIT_LEFT_MODE = "ark-split-left-mode";
 
+/** 同じタブ内で、常時マウント済みの全 SplitViewPane へ変更を伝える。 */
+export const SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT =
+  "ark:split-view-left-mode-change";
+
 export function normalizeSplitViewLeftMode(value: unknown): SplitViewLeftMode {
   return SPLIT_VIEW_LEFT_MODE_VALUES.includes(value as SplitViewLeftMode)
     ? (value as SplitViewLeftMode)
@@ -50,6 +54,12 @@ export function writeSavedSplitViewLeftMode(
   try {
     const target = storage ?? window.localStorage;
     target.setItem(STORAGE_KEY_SPLIT_LEFT_MODE, mode);
+    // storage イベントは同じ window には発火しない。Dashboard で常時
+    // マウントされている別セッションにも即座に反映するため、通常の
+    // localStorage 書き込み時だけ同一タブ向けイベントを補う。
+    if (storage === undefined) {
+      window.dispatchEvent(new Event(SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT));
+    }
   } catch {
     // Storage unavailable (SSR / private mode / quota) must not break switching.
   }

--- a/packages/web/src/lib/split-view-left-mode.ts
+++ b/packages/web/src/lib/split-view-left-mode.ts
@@ -1,0 +1,88 @@
+/**
+ * PC（SplitViewPane）の左ペイン表示モードと、その永続化。
+ *
+ * 左ペインは「端末（ttyd）」と「会話（SplitChatPane）」の 2 値で切り替える。
+ * 図（board）は右ペイン側の独立した開閉状態（`ark-split-show-board`）が担うため、
+ * ここには含めない。モバイルの `mobile-session-view-mode.ts` と形は似ているが、
+ * 取りうる値も保存キーも別物なので独立したモジュールとして持つ。
+ *
+ * 既定は "terminal"。従来の PC は常にターミナルだったため、未保存の
+ * ユーザーには従来どおりの見え方を返す。
+ */
+
+export const SPLIT_VIEW_LEFT_MODE_VALUES = ["terminal", "chat"] as const;
+
+export type SplitViewLeftMode = (typeof SPLIT_VIEW_LEFT_MODE_VALUES)[number];
+
+interface LeftModeStorageReader {
+  getItem(key: string): string | null;
+}
+
+interface LeftModeStorageWriter {
+  setItem(key: string, value: string): void;
+}
+
+export const STORAGE_KEY_SPLIT_LEFT_MODE = "ark-split-left-mode";
+
+export function normalizeSplitViewLeftMode(value: unknown): SplitViewLeftMode {
+  return SPLIT_VIEW_LEFT_MODE_VALUES.includes(value as SplitViewLeftMode)
+    ? (value as SplitViewLeftMode)
+    : "terminal";
+}
+
+export function readSavedSplitViewLeftMode(
+  storage?: LeftModeStorageReader
+): SplitViewLeftMode {
+  try {
+    const source = storage ?? window.localStorage;
+    return normalizeSplitViewLeftMode(
+      source.getItem(STORAGE_KEY_SPLIT_LEFT_MODE)
+    );
+  } catch {
+    return "terminal";
+  }
+}
+
+export function writeSavedSplitViewLeftMode(
+  mode: SplitViewLeftMode,
+  storage?: LeftModeStorageWriter
+): void {
+  try {
+    const target = storage ?? window.localStorage;
+    target.setItem(STORAGE_KEY_SPLIT_LEFT_MODE, mode);
+  } catch {
+    // Storage unavailable (SSR / private mode / quota) must not break switching.
+  }
+}
+
+/**
+ * 会話ビューが JSONL を購読してよいか。
+ *
+ * SplitViewPane は Dashboard で全セッションぶんが常時マウントされる
+ * （選択中でないものは `hidden` で存在し続ける）。さらに左ペインは
+ * 端末・会話の両方をマウントしたまま display 切替する。したがって
+ * 「選択中のセッション」かつ「会話モード」の 1 枚だけが購読しないと、
+ * セッション数ぶんの JSONL tail が常時走ってしまう。
+ */
+export function shouldSubscribeChat(
+  isSelectedSession: boolean,
+  mode: SplitViewLeftMode
+): boolean {
+  return isSelectedSession && mode === "chat";
+}
+
+/**
+ * 端末ペインが window レベルのファイル D&D を受け取ってよいか。
+ *
+ * TerminalPane の D&D は ttyd iframe を跨ぐため window で受けており、
+ * 表示状態と無関係に発火する。上と同じ理由でマウント枚数ぶん多重に効くので、
+ * 実際に見えている 1 枚だけに絞る。絞らないと、会話モードでチャット欄へ
+ * 落としたファイルが裏の端末ペインにも入り、端末へ戻したときに
+ * 身に覚えのない送信プレビューが出る。
+ */
+export function shouldAcceptTerminalFileDrop(
+  isSelectedSession: boolean,
+  mode: SplitViewLeftMode
+): boolean {
+  return isSelectedSession && mode === "terminal";
+}

--- a/packages/web/src/lib/split-view-left-mode.ts
+++ b/packages/web/src/lib/split-view-left-mode.ts
@@ -14,6 +14,10 @@ export const SPLIT_VIEW_LEFT_MODE_VALUES = ["terminal", "chat"] as const;
 
 export type SplitViewLeftMode = (typeof SPLIT_VIEW_LEFT_MODE_VALUES)[number];
 
+export interface SplitViewLeftModeChangeDetail {
+  mode: SplitViewLeftMode;
+}
+
 interface LeftModeStorageReader {
   getItem(key: string): string | null;
 }
@@ -51,15 +55,21 @@ export function writeSavedSplitViewLeftMode(
   mode: SplitViewLeftMode,
   storage?: LeftModeStorageWriter
 ): void {
+  // storage イベントは同じ window には発火しない。Dashboard で常時
+  // マウントされている別セッションにも、Storage の成否にかかわらず
+  // 選択値を直接反映できるよう、書き込みより先に同一タブへ通知する。
+  if (storage === undefined && typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent<SplitViewLeftModeChangeDetail>(
+        SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT,
+        { detail: { mode } }
+      )
+    );
+  }
+
   try {
     const target = storage ?? window.localStorage;
     target.setItem(STORAGE_KEY_SPLIT_LEFT_MODE, mode);
-    // storage イベントは同じ window には発火しない。Dashboard で常時
-    // マウントされている別セッションにも即座に反映するため、通常の
-    // localStorage 書き込み時だけ同一タブ向けイベントを補う。
-    if (storage === undefined) {
-      window.dispatchEvent(new Event(SPLIT_VIEW_LEFT_MODE_CHANGE_EVENT));
-    }
   } catch {
     // Storage unavailable (SSR / private mode / quota) must not break switching.
   }

--- a/packages/web/src/pages/Dashboard.test.tsx
+++ b/packages/web/src/pages/Dashboard.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+
+import type { ManagedSession } from "@ark/shared";
+import { act, type ReactElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Dashboard from "./Dashboard";
+
+const testDoubles = vi.hoisted(() => ({
+  getSetting: vi.fn(),
+  setSetting: vi.fn(),
+  splitChatPane: vi.fn(),
+  socketState: {} as Record<string, unknown>,
+}));
+
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: {},
+    isLoading: false,
+    getSetting: testDoubles.getSetting,
+    setSetting: testDoubles.setSetting,
+  }),
+}));
+
+vi.mock("@/hooks/useSocket", () => ({
+  useSocket: () => testDoubles.socketState,
+}));
+
+vi.mock("@/hooks/useMobile", () => ({
+  useIsMobile: () => false,
+}));
+
+vi.mock("@/hooks/useBridgeSnapshot", () => ({
+  useBridgeSnapshot: () => null,
+}));
+
+vi.mock("@/hooks/useSessionNotifications", () => ({
+  useSessionNotifications: () => ({
+    supported: false,
+    permission: "denied",
+    requestPermission: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useViewerTabs", () => ({
+  useViewerTabs: () => ({
+    getTabsForSession: (sessionId: string) => [
+      { type: "terminal", id: `terminal-${sessionId}` },
+    ],
+    getActiveTabForSession: () => 0,
+    handleTabSelect: vi.fn(),
+    handleTabClose: vi.fn(),
+    openDiagramTab: vi.fn(),
+    clearDiagramTab: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/SplitChatPane", () => ({
+  SplitChatPane: (props: Record<string, unknown>) => {
+    testDoubles.splitChatPane(props);
+    return <div data-testid="dashboard-chat" />;
+  },
+}));
+
+vi.mock("@/components/TerminalPane", () => ({
+  TerminalPane: () => <div data-testid="dashboard-terminal" />,
+}));
+
+vi.mock("@/components/DiagramPane", () => ({
+  DiagramPane: () => null,
+}));
+
+vi.mock("@/components/SidebarMainLayout", () => ({
+  SidebarMainLayout: ({ main }: { main: ReactNode }) => <>{main}</>,
+}));
+
+vi.mock("@/components/AboutDialog", () => ({ AboutDialog: () => null }));
+vi.mock("@/components/BrowserPane", () => ({ BrowserPane: () => null }));
+vi.mock("@/components/CreateWorktreeDialog", () => ({
+  CreateWorktreeDialog: () => null,
+}));
+vi.mock("@/components/NotificationPermissionButton", () => ({
+  NotificationPermissionButton: () => null,
+}));
+vi.mock("@/components/ProfileManagerDialog", () => ({
+  ProfileManagerDialog: () => null,
+}));
+vi.mock("@/components/RepoGridView", () => ({ RepoGridView: () => null }));
+vi.mock("@/components/RepoSelectDialog", () => ({
+  RepoSelectDialog: () => null,
+}));
+vi.mock("@/components/SessionSidebar", () => ({
+  SessionSidebar: () => null,
+}));
+vi.mock("@/components/UpdateBanner", () => ({ UpdateBanner: () => null }));
+
+vi.mock("@/components/MobileLayout", () => ({
+  MobileLayout: () => null,
+  normalizeMobileTab: (value: unknown) => value,
+  normalizeSessionId: (value: unknown) => value,
+  normalizeSessionSubView: (value: unknown) => value,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: () => null,
+  DialogContent: () => null,
+  DialogDescription: () => null,
+  DialogFooter: () => null,
+  DialogHeader: () => null,
+  DialogTitle: () => null,
+}));
+
+vi.mock("@/components/ui/button", () => ({ Button: () => null }));
+vi.mock("@/components/ui/input", () => ({ Input: () => null }));
+vi.mock("@/components/ui/label", () => ({ Label: () => null }));
+vi.mock("@/components/ui/select", () => ({
+  Select: () => null,
+  SelectContent: () => null,
+  SelectItem: () => null,
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+}));
+
+let mountedRoot: { root: Root; container: HTMLDivElement } | null = null;
+
+function makeSession(): ManagedSession {
+  return {
+    id: "dashboard-session",
+    worktreeId: "dashboard-worktree",
+    worktreePath: "/worktrees/dashboard",
+    status: "active",
+    createdAt: new Date("2026-08-23T00:00:00Z"),
+    tmuxSessionName: "tmux-dashboard",
+    ttydPort: 4100,
+    ttydUrl: "/ttyd/dashboard-session/",
+  };
+}
+
+function socketState(session: ManagedSession): Record<string, unknown> {
+  const fn = vi.fn();
+  return {
+    socket: null,
+    isConnected: true,
+    error: null,
+    diagramCommentsUpdate: null,
+    allowedRepos: [],
+    repoList: [],
+    repoPath: null,
+    selectRepo: fn,
+    removeRepo: fn,
+    scannedRepos: [],
+    isScanning: false,
+    scanRepos: fn,
+    listDirectory: fn,
+    listDiagrams: async () => [],
+    deleteDiagram: fn,
+    getDiagramComments: fn,
+    createDiagramComment: fn,
+    replyDiagramComment: fn,
+    resolveDiagramComment: fn,
+    deleteDiagramComment: fn,
+    sendDiagramComment: fn,
+    worktrees: [],
+    createWorktree: fn,
+    deleteWorktree: fn,
+    sessions: new Map([[session.id, session]]),
+    sessionsLoaded: true,
+    startSession: fn,
+    stopSession: fn,
+    sendMessage: fn,
+    sendKey: fn,
+    tunnelUrl: null,
+    tunnelToken: null,
+    tunnelLoading: false,
+    tunnelJustStarted: false,
+    startTunnel: fn,
+    stopTunnel: fn,
+    clearTunnelJustStarted: fn,
+    listeningPorts: [],
+    uploadFile: fn,
+    copyBuffer: undefined,
+    deletedWorktreeId: null,
+    clearDeletedWorktreeId: fn,
+    sessionPreviews: new Map(),
+    sessionActivityTexts: new Map(),
+    sessionAwaitingTexts: new Map([
+      [session.id, "Dashboard から届く AWAITING テキスト"],
+    ]),
+    gridSnapshots: new Map(),
+    subscribeGrid: fn,
+    unsubscribeGrid: fn,
+    sessionStatuses: new Map([[session.id, "AWAITING"]]),
+    sessionStatusSignals: [],
+    sessionAuqSignals: [],
+    readFile: fn,
+    fileContent: null,
+    browserSessions: new Map(),
+    startBrowser: fn,
+    navigateBrowser: fn,
+    profiles: [],
+    repoProfileLinks: new Map(),
+    worktreeProfileLinks: new Map(),
+    capabilities: { multiProfileSupported: false },
+    createProfile: fn,
+    updateProfile: fn,
+    deleteProfile: fn,
+    setRepoProfile: fn,
+    setWorktreeProfile: fn,
+    worktreeDisplayNames: new Map(),
+    setWorktreeDisplayName: fn,
+    restartSessionWithProfile: fn,
+    messageShortcuts: [],
+    createShortcut: fn,
+    updateShortcut: fn,
+    deleteShortcut: fn,
+  };
+}
+
+function mount(element: ReactElement): void {
+  const container = document.createElement("div");
+  document.body.append(container);
+  const root = createRoot(container);
+  act(() => root.render(element));
+  mountedRoot = { root, container };
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  localStorage.clear();
+  localStorage.setItem("ark-split-left-mode", "chat");
+  testDoubles.splitChatPane.mockClear();
+  testDoubles.setSetting.mockClear();
+
+  const session = makeSession();
+  testDoubles.socketState = socketState(session);
+  testDoubles.getSetting.mockImplementation((key: string, fallback: unknown) =>
+    key === "selectedSessionId" ? session.id : fallback
+  );
+});
+
+afterEach(() => {
+  if (mountedRoot) {
+    act(() => mountedRoot?.root.unmount());
+    mountedRoot.container.remove();
+    mountedRoot = null;
+  }
+});
+
+describe("Dashboard の会話ビュー配線", () => {
+  it("Dashboard → SplitViewPane → SplitChatPane へ preview 状態を渡す", () => {
+    mount(<Dashboard />);
+
+    const observed = testDoubles.splitChatPane.mock.calls
+      .map(([props]) => props as Record<string, unknown>)
+      .at(-1);
+    expect(observed).toMatchObject({
+      isActive: true,
+      bridgeStatus: "AWAITING",
+      awaitingText: "Dashboard から届く AWAITING テキスト",
+    });
+  });
+});

--- a/packages/web/src/pages/Dashboard.tsx
+++ b/packages/web/src/pages/Dashboard.tsx
@@ -858,6 +858,11 @@ export default function Dashboard() {
                       <SplitViewPane
                         socket={socket}
                         isConnected={isConnected}
+                        // 会話ビュー（左ペイン）用。全セッションぶんが常時
+                        // マウントされるため、JSONL 購読は isActive で絞る
+                        isActive={isActive}
+                        bridgeStatus={sessionStatuses.get(session.id)}
+                        awaitingText={sessionAwaitingTexts.get(session.id)}
                         diagramCommentsUpdate={diagramCommentsUpdate}
                         listDiagrams={listDiagrams}
                         deleteDiagram={deleteDiagram}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.10(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/desktop:
     dependencies:
@@ -141,7 +141,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
+        version: 4.1.10(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
 
   packages/shared: {}
 
@@ -262,6 +262,9 @@ importers:
       autoprefixer:
         specifier: ^10.5.4
         version: 10.5.4(postcss@8.5.26)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       postcss:
         specifier: ^8.5.26
         version: 8.5.26
@@ -335,6 +338,14 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
   '@biomejs/biome@2.5.8':
     resolution: {integrity: sha512-aeAeeJB9fSDc7Gq+2GqpQxA0qBj6gj1k2R6L1cYqGePKP/baIq1WX8y6B+D+nRsO5ViQL22K/8IwbqERW0q1nw==}
     engines: {node: '>=14.21.3'}
@@ -395,8 +406,48 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@chevrotain/types@11.1.2':
     resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
+
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
@@ -584,6 +635,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.8.0':
     resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
@@ -1777,6 +1837,9 @@ packages:
     resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -2040,6 +2103,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -2204,6 +2271,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
@@ -2219,6 +2290,9 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -2371,6 +2445,10 @@ packages:
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -2683,6 +2761,10 @@ packages:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -2812,6 +2894,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -2855,6 +2940,15 @@ packages:
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -3092,6 +3186,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
@@ -3172,6 +3270,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.1:
     resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
@@ -3507,6 +3608,9 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3829,6 +3933,10 @@ packages:
     resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -4040,6 +4148,9 @@ packages:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
@@ -4085,6 +4196,13 @@ packages:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
@@ -4095,6 +4213,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4153,6 +4279,10 @@ packages:
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -4340,6 +4470,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   wait-on@8.0.5:
     resolution: {integrity: sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==}
     engines: {node: '>=12.0.0'}
@@ -4347,6 +4481,22 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
 
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
@@ -4396,9 +4546,16 @@ packages:
       utf-8-validate:
         optional: true
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xmlhttprequest-ssl@2.1.2:
     resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
@@ -4500,6 +4657,21 @@ snapshots:
       '@anthropic-ai/claude-code-win32-arm64': 2.1.239
       '@anthropic-ai/claude-code-win32-x64': 2.1.239
 
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
   '@biomejs/biome@2.5.8':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.5.8
@@ -4537,7 +4709,35 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@chevrotain/types@11.1.2': {}
+
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@develar/schema-utils@2.6.5':
     dependencies:
@@ -4692,6 +4892,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.2':
     optional: true
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.8.0':
     dependencies:
@@ -5930,6 +6132,10 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -6230,6 +6436,11 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
@@ -6418,6 +6629,13 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   dayjs@1.11.21: {}
 
   debug@4.4.3:
@@ -6425,6 +6643,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -6639,6 +6859,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -7044,6 +7266,12 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
@@ -7170,6 +7398,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-unicode-supported@0.1.0: {}
@@ -7211,6 +7441,32 @@ snapshots:
   js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-buffer@3.0.1: {}
 
@@ -7381,6 +7637,8 @@ snapshots:
   lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.5.2: {}
 
   lru-cache@6.0.0:
     dependencies:
@@ -7581,6 +7839,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.1: {}
 
@@ -8021,6 +8281,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-data-parser@0.1.0: {}
@@ -8383,6 +8647,10 @@ snapshots:
 
   sax@1.6.1: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver-compare@1.0.0:
@@ -8646,6 +8914,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@3.6.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.3.3):
@@ -8696,6 +8966,12 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
   tmp-promise@3.0.3:
     dependencies:
       tmp: 0.2.7
@@ -8703,6 +8979,14 @@ snapshots:
   tmp@0.2.7: {}
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -8748,6 +9032,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici-types@8.3.0: {}
+
+  undici@8.10.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -8887,7 +9173,7 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.12
 
-  vitest@4.1.10(@types/node@24.13.3)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
+  vitest@4.1.10(@types/node@24.13.3)(jsdom@30.0.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12))
@@ -8911,8 +9197,13 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   wait-on@8.0.5:
     dependencies:
@@ -8928,6 +9219,26 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-module@2.0.1: {}
 
@@ -8973,7 +9284,11 @@ snapshots:
 
   ws@8.21.3: {}
 
+  xml-name-validator@5.0.0: {}
+
   xmlbuilder@15.1.1: {}
+
+  xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.1.2: {}
 


### PR DESCRIPTION
PC の左ペインをターミナル ⇄ 会話で切り替えられるようにし、選択を永続化する。

Closes #395

## 背景

PC はかつて会話ビュー（`SplitChatPane`）をデフォルト UI にしていたが、`445b617` で
「会話廃止・ターミナル/ボード左右 2 ペイン」に再構成された。**外した理由は記録に残っていない。**

実際に使うと ttyd では長い会話の振り返り・発言のコピー・AUQ カードでの回答がしづらい。
モバイルは 🖥/💬 で切り替えられ、`SplitChatPane` は 1,496 行で健在。**PC だけがこの UI を失っていた。**

## 変更

- 左ペインをターミナル ⇄ 会話でトグル（`SplitLeftModeToggle`）
- 選択は `localStorage`（`ark-split-left-mode`）に永続化。右ペイン幅・開閉と同じ扱い
- **セッション間で共有**する。同一 window はカスタムイベント、別タブは `storage` イベントで同期
- 会話ビューはモバイルと同等（入力欄 / AUQ / slash 補完 / アップロード / busy・AWAITING）

`SplitChatPane` は変更していない。モバイルで動いているものをそのまま使う。

### 配線の穴を塞いだ

`SplitChatPane` が必要とする `bridgeStatus` / `awaitingText` が `SplitViewPane` に届いていなかった。
`Dashboard` のセッション別 Map から供給する経路を通した。

### 切替が生む副作用への対処

`TerminalPane` に `isVisible` を追加した。

ファイル D&D は ttyd iframe がドラッグイベントを親に届けないため **window レベルで受けている**。
`TerminalPane` は全セッションぶんが常時マウントされ、左ペインが会話モードのときも `display:none` で
残るため、無条件だと**見えていないペインにもドロップが入り、後で開いたときに身に覚えのない
送信プレビューが出る**。`display:none` は effect を解除しないので、明示的に止める必要がある。

レビューで「従来から非選択セッションの全 `TerminalPane` が window D&D を受け得た問題も
同時に直す」と評価された。

## 検証

実装は Claude Code セッション、レビューは codex（実装者 ≠ レビュアー）。

初回のレビューで「実装ロジックは妥当だが、**テストが核心を保証していない**」と判定され、
検出力のあるテストを追加した。

```
配線            Dashboard → SplitViewPane → SplitChatPane まで実 render で検証
isActive/isVisible  2 セッションで active と left mode の組み合わせを検証
トグル→永続化    ボタン押下 → 表示 → 両セッションのモード → 保存値
D&D 抑止        window に dataTransfer.files 付き drop を送り、
                非表示時は FileReader.readAsDataURL が呼ばれないこと（表示時の陽性対照つき）
```

変異テストで検出力を確認（レビュー側が独立に再現）。

```
isVisible を無視させる → 2 failed / 5  → 検出
配線を削る             → 配線テスト 2 件が失敗（codex 報告）
localStorage 書き込み削除 → 永続化テストが失敗（codex 報告）
```

```
pnpm check   exit 0
pnpm test    exit 0   74 files / 1208 tests
pnpm build   exit 0
```

## 仕様判断

`leftMode` は当初セッションごとにマウント時 1 回だけ読んでいたため、セッション A で会話に
変えても既にマウント済みの B は端末のままだった。**「最後の選択を PC 全体で共有する」を仕様**とした。
右ペイン幅・開閉と同じ扱いにするのが Issue の意図と判断した。

## 補足: #367 の測定に使った（n=4）

復唱あり / なしの 2 セッションで並行実行し、盲検評価した。**本 PR は復唱なし側の成果物**で、
`TerminalPane` の副作用に気づいた点が決め手になった。詳細は #367 に記録する。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * PCでもチャットビューを利用できるようになりました。
  * 左ペイン上部の切り替えボタンから、Webターミナルとチャットビューを選択できます。
  * 選択した表示モードは保存され、複数の画面で同期されます。

* **改善**
  * ターミナルとチャットの切り替え時も状態を維持します。
  * 非表示のターミナルではファイルのドラッグ＆ドロップを受け付けないよう改善しました。
  * ttyd、チャットビュー、Webターミナルの対応範囲と既定表示に関する案内を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->