### PR TITLE
fix(context): 復元されたセッションの worktree も legacy settings を掃除する

### DIFF
--- a/packages/server/src/lib/legacy-context-settings-cleanup.test.ts
+++ b/packages/server/src/lib/legacy-context-settings-cleanup.test.ts
@@ -176,6 +176,31 @@ describe("cleanupLegacyContextSettings", () => {
     expect(fs.readFileSync(settingsPath, "utf-8")).toBe(afterFirst);
   });
 
+  it("空文字や相対パスでは呼び出し元の cwd を掃除しない", () => {
+    // worktreePath は pane_current_path を取れないと空文字で復元される。
+    // そのまま渡すとサーバーの cwd を掃除してしまう。
+    const cwdSettings = path.join(
+      process.cwd(),
+      ".claude",
+      "settings.local.json"
+    );
+    const before = fs.existsSync(cwdSettings)
+      ? fs.readFileSync(cwdSettings, "utf-8")
+      : null;
+
+    for (const bad of ["", ".", "./somewhere", "relative/path"]) {
+      expect(cleanupLegacyContextSettings(bad)).toMatchObject({
+        changed: false,
+        removedHooks: 0,
+      });
+    }
+
+    const after = fs.existsSync(cwdSettings)
+      ? fs.readFileSync(cwdSettings, "utf-8")
+      : null;
+    expect(after).toBe(before);
+  });
+
   it("settings が無ければ何もしない", () => {
     expect(cleanupLegacyContextSettings(worktree).changed).toBe(false);
     expect(fs.existsSync(settingsPath)).toBe(false);

--- a/packages/server/src/lib/legacy-context-settings-cleanup.ts
+++ b/packages/server/src/lib/legacy-context-settings-cleanup.ts
@@ -57,6 +57,9 @@ function referencesLegacyContext(entry: unknown): boolean {
 export function cleanupLegacyContextSettings(
   worktreePath: string
 ): LegacyContextCleanupResult {
+  // 空文字や相対パスを受けると、呼び出し元プロセスの cwd を掃除してしまう。
+  // 掃除は「この worktree の設定を戻す」操作なので、絶対パス以外は扱わない。
+  if (!worktreePath || !path.isAbsolute(worktreePath)) return NOOP;
   const settingsPath = path.join(
     worktreePath,
     ".claude",

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -225,6 +225,18 @@ describe("SessionOrchestrator - プロファイル切替", () => {
   // ============================================================
 
   describe("startSession (既存セッション再利用)", () => {
+    it("worktreePath が空で復元されたセッションでは掃除しない", () => {
+      // 空のまま渡すとサーバーの cwd (= Ark 自身の repo) を掃除してしまう。
+      mockedTmux.getAllSessions.mockReturnValue([
+        makeTmuxSession({ worktreePath: "" }),
+      ]);
+      mockedCleanup.mockClear();
+
+      new SessionOrchestrator();
+
+      expect(mockedCleanup).not.toHaveBeenCalled();
+    });
+
     it("サーバー再起動で復元されたセッションの worktree も掃除する", async () => {
       // 復元は startSession を通らない。ここで掃除しないと、
       // 再起動で戻ってきた worktree だけ旧設定が残り続ける。

--- a/packages/server/src/lib/session-orchestrator.test.ts
+++ b/packages/server/src/lib/session-orchestrator.test.ts
@@ -225,6 +225,21 @@ describe("SessionOrchestrator - プロファイル切替", () => {
   // ============================================================
 
   describe("startSession (既存セッション再利用)", () => {
+    it("サーバー再起動で復元されたセッションの worktree も掃除する", async () => {
+      // 復元は startSession を通らない。ここで掃除しないと、
+      // 再起動で戻ってきた worktree だけ旧設定が残り続ける。
+      // worktree が実在しないと孤児として扱われ、掃除の前に continue される。
+      const restored = os.tmpdir();
+      mockedTmux.getAllSessions.mockReturnValue([
+        makeTmuxSession({ worktreePath: restored }),
+      ]);
+      mockedCleanup.mockClear();
+
+      new SessionOrchestrator();
+
+      expect(mockedCleanup).toHaveBeenCalledWith(restored);
+    });
+
     it("既存セッションを再利用する経路でも legacy settings を掃除する", async () => {
       // 早期 return より前で掃除しないと、旧 hook が repo に残り続ける（#401 の指摘）。
       const orchestrator = new SessionOrchestrator();

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -309,6 +309,11 @@ export class SessionOrchestrator extends EventEmitter {
         continue;
       }
 
+      // 撤去済み ark/context が注入したままの hook / deny を取り除く (#367 の移行)。
+      // 復元はセッション起動を通らないため、ここでも掃除しないと
+      // サーバー再起動で戻ってきた worktree だけ旧設定が残り続ける。
+      cleanupLegacyContextSettings(tmuxSession.worktreePath);
+
       // DBにセッション情報があればstatusを尊重（idle等の永続化された状態を維持）
       // repoPathの不整合はttyd起動完了時のtoManagedSession()が修正するので
       // ここで二度execFileSyncを走らせない

--- a/packages/server/src/lib/session-orchestrator.ts
+++ b/packages/server/src/lib/session-orchestrator.ts
@@ -312,7 +312,12 @@ export class SessionOrchestrator extends EventEmitter {
       // 撤去済み ark/context が注入したままの hook / deny を取り除く (#367 の移行)。
       // 復元はセッション起動を通らないため、ここでも掃除しないと
       // サーバー再起動で戻ってきた worktree だけ旧設定が残り続ける。
-      cleanupLegacyContextSettings(tmuxSession.worktreePath);
+      //
+      // worktreePath は pane_current_path を取れないと空文字で復元される。
+      // 空のまま渡すとサーバーの cwd (= Ark 自身の repo) を掃除してしまうため弾く。
+      if (tmuxSession.worktreePath) {
+        cleanupLegacyContextSettings(tmuxSession.worktreePath);
+      }
 
       // DBにセッション情報があればstatusを尊重（idle等の永続化された状態を維持）
       // repoPathの不整合はttyd起動完了時のtoManagedSession()が修正するので


### PR DESCRIPTION
#401 の deploy 後に実機で確認して見つけた抜け。

## 問題

`cleanupLegacyContextSettings()` は `startSession()` / `restartSession()` からしか呼ばれておらず、
**サーバー再起動時の `restoreExistingSessions()` を通らない**。

結果、再起動で復元された worktree は旧 `ark/context` の hook と `TodoWrite` 拒否が
**残り続ける**。新しくセッションを起動しない限り解消しない。

deploy 後にこのリポジトリを確認したところ、実際にこの状態だった。

```
deny:  ['TodoWrite', 'TaskCreate', 'TaskUpdate']
hooks: ['PostToolBatch', 'PostToolUseFailure']   ← 削除済みスクリプトを指す
```

CodeRabbit が指摘した `startSession()` の早期 return と同じ形で、
**「実装済みなのに一部の経路で発火しない」**という #367 で 10 件数えた型そのもの。

## 変更

復元ループ内、孤児 worktree の判定を通過した直後に掃除を呼ぶ。
worktree が実在しない場合は孤児として先に `continue` するため掃除は走らない
（対象が無いので正しい）。

## 検証

- 回帰テスト 1 件（復元経路で掃除が呼ばれること）
- 変異テスト（復元ループの掃除を外す）で 1 件が落ちる
- `pnpm check` / `pnpm test`（73 files / 1196 tests） / `pnpm build` すべて exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * サーバー再起動後に復元された既存の作業環境で、古い設定が自動的にクリーンアップされるようになりました。
  * セッション復元後も、不要な設定が残ることによる動作上の問題を防止します。

* **テスト**
  * サーバー再起動時の設定クリーンアップが正しく実行されることを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->