### PR TITLE
fix(web): バックグラウンド復帰で固まった ttyd を自動で貼り直す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,27 @@ iframe（別ブラウジングコンテキスト）なので、アンマウン�
 3. tmuxの `C-u` (入力欄クリア) → `send-keys -l` でリテラル入力 + `Enter` キーを送信
 4. claude が transcript (JSONL) に追記 → tail がクライアントへ push → pending と reconcile して確定描画
 
+### ttyd の切断復帰 (Press ⏎ to Reconnect)
+
+ttyd 1.7.4 の自動再接続は「socket が落ちたら 1 度だけ繋ぎ直す」だけで、その試行が
+失敗すると WebSocket の error イベントで `doReconnect=false` になり、以後
+"Press ⏎ to Reconnect" のまま二度と繋ぎ直さない。モバイルで Chrome を
+バックグラウンドへ送ると、電波が戻る前に再接続を試すのでこの状態に落ちる
+(実機再現で確認: close 1006 → token fetch 失敗 → connect 失敗 → 停止)。
+
+`useTtydReconnect` が iframe 内の overlay を 1.5 秒ごとに見て、停止状態を検出したら
+iframe を貼り直す (判定と抑止は `@/lib/ttyd-reconnect`)。
+
+- **復帰手段は iframe リロード**。Enter の合成入力は、実は生きている接続に撃つと
+  permission prompt や AUQ を誤って確定させるので使わない。リロードは tmux に
+  1 バイトも送らない
+- overlay は "Reconnected" / "Reconnecting..." / "80x24" にも使い回される。
+  `/Reconnect/` で判定すると復帰直後に再リロードする無限ループになる
+- **表示中のペインだけ**貼り直す。隠れた iframe を貼り直すと ttyd の `fit()` が
+  サイズ 0 に対して走り、端末が歪んだままになる
+- オフラインのあいだは貼り直さない (白い iframe が残るだけ)。復帰しないまま
+  3 回に達したら諦め、以後は手動リロードボタンに委ねる
+
 ### AskUserQuestion (重要な実機知見)
 
 対話版 claude は AUQ の tool_use を**回答/拒否が確定した瞬間**に tool_result と

--- a/packages/web/src/components/MobileSessionView.tsx
+++ b/packages/web/src/components/MobileSessionView.tsx
@@ -51,6 +51,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { fileToBase64, validateFile } from "../hooks/useFileUpload";
 import { useTerminalLinkInjection } from "../hooks/useTerminalLinkInjection";
+import { useTtydReconnect } from "../hooks/useTtydReconnect";
 import { useVisualViewport } from "../hooks/useVisualViewport";
 import {
   type DiagramOpenRequest,
@@ -407,6 +408,15 @@ export function MobileSessionView({
 
   // ttyd iframe内のxterm.jsにリンク検出をインジェクト（共通フック）
   useTerminalLinkInjection(iframeRef, iframeKey);
+
+  // バックグラウンド復帰で ttyd の WebSocket が落ちると端末は
+  // "Press ⏎ to Reconnect" のまま固まる。表示中のターミナルに限って検出し、
+  // iframe を貼り直して復帰させる（共通フック）。
+  useTtydReconnect(iframeRef, iframeKey, {
+    isVisible:
+      isActive && viewMode === "terminal" && activeTabType === "terminal",
+    onReload: handleReloadIframe,
+  });
 
   // スラッシュコマンド
   const slashCommands = [

--- a/packages/web/src/components/TerminalPane.tsx
+++ b/packages/web/src/components/TerminalPane.tsx
@@ -48,6 +48,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { fileToBase64, validateFile } from "../hooks/useFileUpload";
 import { useIsMobile } from "../hooks/useMobile";
 import { useTerminalLinkInjection } from "../hooks/useTerminalLinkInjection";
+import { useTtydReconnect } from "../hooks/useTtydReconnect";
 import { FileViewerPane } from "./FileViewerPane";
 import { HtmlViewerPane } from "./HtmlViewerPane";
 import { MessageShortcutManagerDialog } from "./MessageShortcutManagerDialog";
@@ -457,6 +458,14 @@ export function TerminalPane({
   const safeVisibleActiveTabIndex = isActiveTabHidden
     ? 0
     : visibleActiveTabIndex;
+
+  // スリープ復帰やモバイルのバックグラウンド復帰で ttyd の WebSocket が落ちると
+  // 端末は "Press ⏎ to Reconnect" のまま固まる。表示中のターミナルに限って
+  // 検出し、iframe を貼り直して復帰させる。
+  useTtydReconnect(iframeRef, iframeKey, {
+    isVisible: isVisible && tabs[effectiveActiveTabIndex]?.type === "terminal",
+    onReload: handleReloadIframe,
+  });
 
   return (
     <div className="h-full flex flex-col bg-card border border-border rounded-lg overflow-hidden">

--- a/packages/web/src/hooks/useTtydReconnect.ts
+++ b/packages/web/src/hooks/useTtydReconnect.ts
@@ -1,0 +1,108 @@
+import { type RefObject, useEffect, useRef } from "react";
+import {
+  createTtydReconnectState,
+  isTtydStuckOverlay,
+  stepTtydReconnect,
+  type TtydReconnectState,
+} from "@/lib/ttyd-reconnect";
+import { usePersistFn } from "./usePersistFn";
+
+/**
+ * ttyd の接続断を監視する間隔 (ms)。
+ *
+ * MutationObserver ではなく polling にしているのは 2 点の理由による。
+ *
+ * - 切断は visibilitychange の「後」に届く。バックグラウンド復帰の瞬間に
+ *   1 回だけ見ても overlay はまだ出ていないので、定期的に見る必要がある
+ * - overlay は xterm の描画 DOM と同じ木の中にあり、DOM renderer 使用時は
+ *   端末出力のたびに mutation が飛ぶ。監視より数秒おきの読み取りの方が軽い
+ */
+const POLL_INTERVAL_MS = 1_500;
+
+interface UseTtydReconnectOptions {
+  /** ターミナルが実際に画面へ出ているか (display:none の残置ペインは false) */
+  isVisible: boolean;
+  /** iframe を貼り直す (呼び出し側の iframeKey を進める) */
+  onReload: () => void;
+}
+
+/**
+ * ttyd が切断されたまま "Press ⏎ to Reconnect" で止まったら iframe を貼り直す。
+ *
+ * モバイル Chrome のバックグラウンド復帰やスリープ復帰で WebSocket が落ちると、
+ * ttyd 自身の自動再接続は効かず端末が固まったままになる (理由は
+ * `@/lib/ttyd-reconnect` のコメント参照)。判定と抑止のロジックはそちらに置き、
+ * ここは iframe から観測して結果を反映するだけにしている。
+ */
+export function useTtydReconnect(
+  iframeRef: RefObject<HTMLIFrameElement | null>,
+  iframeKey: number,
+  { isVisible, onReload }: UseTtydReconnectOptions
+) {
+  const stateRef = useRef<TtydReconnectState>(createTtydReconnectState());
+  const exhaustedRef = useRef(false);
+  const reload = usePersistFn(onReload);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: iframeKey は iframe 貼り直し後に監視を張り直すために必要
+  useEffect(() => {
+    const check = () => {
+      let ready = false;
+      let stuck = false;
+      try {
+        const iframeWindow = iframeRef.current?.contentWindow;
+        if (!iframeWindow) return;
+        // biome-ignore lint/suspicious/noExplicitAny: ttyd iframe 内の xterm オブジェクトにアクセスするため
+        const term = (iframeWindow as any).term;
+        const element: Element | undefined = term?.element;
+        ready = Boolean(element);
+        stuck = isTtydStuckOverlay(element);
+      } catch {
+        // 読み込み途中でクロスオリジン扱いになる等。次の観測に任せる
+        return;
+      }
+
+      // ブラウザ側がバックグラウンドのときにリロードしても無駄なので待つ
+      const pageVisible = document.visibilityState === "visible";
+
+      const result = stepTtydReconnect(stateRef.current, {
+        ready,
+        stuck,
+        isVisible: isVisible && pageVisible,
+        online: navigator.onLine,
+        now: Date.now(),
+      });
+      stateRef.current = result.state;
+
+      if (result.exhausted) {
+        if (!exhaustedRef.current) {
+          exhaustedRef.current = true;
+          console.warn(
+            "[ark] ttyd の自動再接続を諦めました。手動でリロードしてください"
+          );
+        }
+      } else {
+        exhaustedRef.current = false;
+      }
+
+      if (result.reload) {
+        console.info("[ark] ttyd が切断されたため iframe を貼り直します");
+        reload();
+      }
+    };
+
+    check();
+    const intervalId = setInterval(check, POLL_INTERVAL_MS);
+    // コールバックはフリーズ中に動かないので、復帰の合図でも即座に見る
+    const handleWake = () => check();
+    document.addEventListener("visibilitychange", handleWake);
+    window.addEventListener("pageshow", handleWake);
+    window.addEventListener("online", handleWake);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", handleWake);
+      window.removeEventListener("pageshow", handleWake);
+      window.removeEventListener("online", handleWake);
+    };
+  }, [iframeRef, iframeKey, isVisible, reload]);
+}

--- a/packages/web/src/hooks/useTtydReconnect.ts
+++ b/packages/web/src/hooks/useTtydReconnect.ts
@@ -1,6 +1,7 @@
 import { type RefObject, useEffect, useRef } from "react";
 import {
   createTtydReconnectState,
+  hasTerminalOutput,
   isTtydStuckOverlay,
   stepTtydReconnect,
   type TtydReconnectState,
@@ -46,16 +47,17 @@ export function useTtydReconnect(
   // biome-ignore lint/correctness/useExhaustiveDependencies: iframeKey は iframe 貼り直し後に監視を張り直すために必要
   useEffect(() => {
     const check = () => {
-      let ready = false;
+      let connected = false;
       let stuck = false;
       try {
         const iframeWindow = iframeRef.current?.contentWindow;
         if (!iframeWindow) return;
         // biome-ignore lint/suspicious/noExplicitAny: ttyd iframe 内の xterm オブジェクトにアクセスするため
         const term = (iframeWindow as any).term;
-        const element: Element | undefined = term?.element;
-        ready = Boolean(element);
-        stuck = isTtydStuckOverlay(element);
+        stuck = isTtydStuckOverlay(term?.element);
+        // 「stuck でない」だけでは handshake 保留と区別できないので、
+        // 画面が届いていることを繋がった証拠にする
+        connected = hasTerminalOutput(term);
       } catch {
         // 読み込み途中でクロスオリジン扱いになる等。次の観測に任せる
         return;
@@ -65,7 +67,7 @@ export function useTtydReconnect(
       const pageVisible = document.visibilityState === "visible";
 
       const result = stepTtydReconnect(stateRef.current, {
-        ready,
+        connected,
         stuck,
         isVisible: isVisible && pageVisible,
         online: navigator.onLine,

--- a/packages/web/src/lib/ttyd-reconnect.test.ts
+++ b/packages/web/src/lib/ttyd-reconnect.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 import {
   createTtydReconnectState,
+  hasTerminalOutput,
   isTtydStuckOverlay,
   stepTtydReconnect,
   TTYD_LOAD_TIMEOUT_MS,
@@ -67,9 +68,37 @@ describe("isTtydStuckOverlay", () => {
   });
 });
 
+describe("hasTerminalOutput", () => {
+  const buildTerm = (lines: string[]) => ({
+    rows: lines.length,
+    buffer: {
+      active: {
+        length: lines.length,
+        getLine: (y: number) =>
+          lines[y] === undefined
+            ? undefined
+            : { translateToString: () => lines[y] },
+      },
+    },
+  });
+
+  it("画面に文字があれば繋がっているとみなす", () => {
+    expect(hasTerminalOutput(buildTerm(["", "$ claude", ""]))).toBe(true);
+  });
+
+  it("空白だけの画面は繋がっていないとみなす", () => {
+    expect(hasTerminalOutput(buildTerm(["", "   ", ""]))).toBe(false);
+  });
+
+  it("xterm がまだ無いときは繋がっていないとみなす", () => {
+    expect(hasTerminalOutput(null)).toBe(false);
+    expect(hasTerminalOutput({})).toBe(false);
+  });
+});
+
 describe("stepTtydReconnect", () => {
   const base = {
-    ready: true,
+    connected: true,
     stuck: true,
     isVisible: true,
     online: true,
@@ -83,10 +112,10 @@ describe("stepTtydReconnect", () => {
     expect(r.state.lastReloadAt).toBe(1_000);
   });
 
-  it("初回読み込み中 (ready=false かつ未リロード) は何もしない", () => {
+  it("初回読み込み中 (画面がまだ来ておらず未リロード) は何もしない", () => {
     const r = stepTtydReconnect(createTtydReconnectState(), {
       ...base,
-      ready: false,
+      connected: false,
       stuck: false,
     });
     expect(r.reload).toBe(false);
@@ -110,11 +139,11 @@ describe("stepTtydReconnect", () => {
     expect(online.reload).toBe(true);
   });
 
-  it("貼り直した iframe に xterm が出てこないままなら再度貼り直す", () => {
+  it("貼り直しても画面が届かないまま (読み込み失敗・handshake 保留) なら再度貼り直す", () => {
     const first = stepTtydReconnect(createTtydReconnectState(), base);
     const stillLoading = stepTtydReconnect(first.state, {
       ...base,
-      ready: false,
+      connected: false,
       stuck: false,
       now: base.now + TTYD_LOAD_TIMEOUT_MS - 1,
     });
@@ -122,7 +151,7 @@ describe("stepTtydReconnect", () => {
 
     const timedOut = stepTtydReconnect(first.state, {
       ...base,
-      ready: false,
+      connected: false,
       stuck: false,
       now: base.now + TTYD_LOAD_TIMEOUT_MS,
     });
@@ -189,11 +218,47 @@ describe("stepTtydReconnect", () => {
     expect(connecting.state.attempts).toBe(1);
   });
 
-  it("復帰確認時間だけ stuck にならなければ試行回数を戻す", () => {
+  it("handshake 保留 (画面が来ていない) を復帰と誤認しない", () => {
+    // codex review 指摘: stuck でないだけで試行回数を戻すと、
+    // 繋がらない回線で上限が効かず無限に貼り直し続ける
+    const first = stepTtydReconnect(createTtydReconnectState(), base);
+    const pending = stepTtydReconnect(first.state, {
+      ...base,
+      connected: false,
+      stuck: false,
+      now: base.now + TTYD_RECOVERY_CONFIRM_MS,
+    });
+    expect(pending.state.attempts).toBe(2); // 戻さず、時間切れで再試行
+    expect(pending.state.lastReloadAt).not.toBe(null);
+  });
+
+  it("貼り直しても繋がらないまま時間だけ過ぎる場合、上限で止まる", () => {
+    // 1 回目は stuck 検出で貼り直し、以後は画面が来ないまま時間切れを繰り返す
+    const first = stepTtydReconnect(createTtydReconnectState(), base);
+    let state = first.state;
+    let now = base.now;
+    let reloads = first.reload ? 1 : 0;
+    for (let i = 0; i < 20; i++) {
+      now += TTYD_LOAD_TIMEOUT_MS;
+      const r = stepTtydReconnect(state, {
+        ...base,
+        connected: false,
+        stuck: false,
+        now,
+      });
+      if (r.reload) reloads++;
+      state = r.state;
+    }
+    expect(reloads).toBe(TTYD_RELOAD_MAX_ATTEMPTS);
+    expect(state.attempts).toBe(TTYD_RELOAD_MAX_ATTEMPTS);
+  });
+
+  it("復帰確認時間だけ繋がっていれば試行回数を戻す", () => {
     const first = stepTtydReconnect(createTtydReconnectState(), base);
     const recovered = stepTtydReconnect(first.state, {
       ...base,
       stuck: false,
+      connected: true,
       now: base.now + TTYD_RECOVERY_CONFIRM_MS,
     });
     expect(recovered.state.attempts).toBe(0);

--- a/packages/web/src/lib/ttyd-reconnect.test.ts
+++ b/packages/web/src/lib/ttyd-reconnect.test.ts
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import {
+  createTtydReconnectState,
+  isTtydStuckOverlay,
+  stepTtydReconnect,
+  TTYD_LOAD_TIMEOUT_MS,
+  TTYD_RECOVERY_CONFIRM_MS,
+  TTYD_RELOAD_MAX_ATTEMPTS,
+  TTYD_RELOAD_MIN_INTERVAL_MS,
+} from "./ttyd-reconnect";
+
+/** xterm の term.element を模した DOM を組み立てる */
+function buildTermElement(overlayText: string | null): HTMLElement {
+  const element = document.createElement("div");
+  element.className = "xterm";
+
+  const viewport = document.createElement("div");
+  viewport.className = "xterm-viewport";
+  element.appendChild(viewport);
+
+  const screen = document.createElement("div");
+  screen.className = "xterm-screen";
+  element.appendChild(screen);
+
+  if (overlayText !== null) {
+    // OverlayAddon は class を持たない div を term.element 直下に足す
+    const overlay = document.createElement("div");
+    overlay.textContent = overlayText;
+    element.appendChild(overlay);
+  }
+  return element;
+}
+
+describe("isTtydStuckOverlay", () => {
+  it("Enter 待ちの overlay を stuck と判定する", () => {
+    expect(isTtydStuckOverlay(buildTermElement("Press ⏎ to Reconnect"))).toBe(
+      true
+    );
+  });
+
+  it("再接続成功直後の 'Reconnected' は stuck ではない", () => {
+    // /Reconnect/ だけで判定するとここが true になり、
+    // リロード直後にまたリロードする無限ループになる
+    expect(isTtydStuckOverlay(buildTermElement("Reconnected"))).toBe(false);
+  });
+
+  it("ttyd 自身が再接続中の 'Reconnecting...' は stuck ではない", () => {
+    expect(isTtydStuckOverlay(buildTermElement("Reconnecting..."))).toBe(false);
+  });
+
+  it("overlay が無ければ stuck ではない", () => {
+    expect(isTtydStuckOverlay(buildTermElement(null))).toBe(false);
+  });
+
+  it("端末本文に同じ文字列が出ていても stuck とはみなさない", () => {
+    const element = buildTermElement(null);
+    const screen = element.querySelector(".xterm-screen");
+    if (!screen) throw new Error("xterm-screen が無い");
+    screen.textContent = "$ echo 'Press ⏎ to Reconnect'";
+    expect(isTtydStuckOverlay(element)).toBe(false);
+  });
+
+  it("element が無いとき (起動中) は stuck ではない", () => {
+    expect(isTtydStuckOverlay(null)).toBe(false);
+  });
+});
+
+describe("stepTtydReconnect", () => {
+  const base = {
+    ready: true,
+    stuck: true,
+    isVisible: true,
+    online: true,
+    now: 1_000,
+  };
+
+  it("停止していればリロードする", () => {
+    const r = stepTtydReconnect(createTtydReconnectState(), base);
+    expect(r.reload).toBe(true);
+    expect(r.state.attempts).toBe(1);
+    expect(r.state.lastReloadAt).toBe(1_000);
+  });
+
+  it("初回読み込み中 (ready=false かつ未リロード) は何もしない", () => {
+    const r = stepTtydReconnect(createTtydReconnectState(), {
+      ...base,
+      ready: false,
+      stuck: false,
+    });
+    expect(r.reload).toBe(false);
+  });
+
+  it("オフラインのあいだは貼り直さず試行回数も消費しない", () => {
+    const r = stepTtydReconnect(createTtydReconnectState(), {
+      ...base,
+      online: false,
+    });
+    expect(r.reload).toBe(false);
+    expect(r.state.attempts).toBe(0);
+  });
+
+  it("オンラインに戻ったら貼り直す", () => {
+    const offline = stepTtydReconnect(createTtydReconnectState(), {
+      ...base,
+      online: false,
+    });
+    const online = stepTtydReconnect(offline.state, { ...base, now: 3_000 });
+    expect(online.reload).toBe(true);
+  });
+
+  it("貼り直した iframe に xterm が出てこないままなら再度貼り直す", () => {
+    const first = stepTtydReconnect(createTtydReconnectState(), base);
+    const stillLoading = stepTtydReconnect(first.state, {
+      ...base,
+      ready: false,
+      stuck: false,
+      now: base.now + TTYD_LOAD_TIMEOUT_MS - 1,
+    });
+    expect(stillLoading.reload).toBe(false);
+
+    const timedOut = stepTtydReconnect(first.state, {
+      ...base,
+      ready: false,
+      stuck: false,
+      now: base.now + TTYD_LOAD_TIMEOUT_MS,
+    });
+    expect(timedOut.reload).toBe(true);
+    expect(timedOut.state.attempts).toBe(2);
+  });
+
+  it("表示されていないペインはリロードしない", () => {
+    const r = stepTtydReconnect(createTtydReconnectState(), {
+      ...base,
+      isVisible: false,
+    });
+    expect(r.reload).toBe(false);
+    expect(r.state.attempts).toBe(0);
+  });
+
+  it("表示に戻った時点でリロードする (保留していた分)", () => {
+    const hidden = stepTtydReconnect(createTtydReconnectState(), {
+      ...base,
+      isVisible: false,
+    });
+    const shown = stepTtydReconnect(hidden.state, { ...base, now: 2_000 });
+    expect(shown.reload).toBe(true);
+  });
+
+  it("最小間隔内の連続リロードは抑止する", () => {
+    const first = stepTtydReconnect(createTtydReconnectState(), base);
+    const soon = stepTtydReconnect(first.state, {
+      ...base,
+      now: base.now + TTYD_RELOAD_MIN_INTERVAL_MS - 1,
+    });
+    expect(soon.reload).toBe(false);
+    expect(soon.state.attempts).toBe(1);
+
+    const later = stepTtydReconnect(first.state, {
+      ...base,
+      now: base.now + TTYD_RELOAD_MIN_INTERVAL_MS,
+    });
+    expect(later.reload).toBe(true);
+    expect(later.state.attempts).toBe(2);
+  });
+
+  it("復帰しないまま上限に達したら諦める", () => {
+    let state = createTtydReconnectState();
+    let now = base.now;
+    for (let i = 0; i < TTYD_RELOAD_MAX_ATTEMPTS; i++) {
+      const r = stepTtydReconnect(state, { ...base, now });
+      expect(r.reload).toBe(true);
+      state = r.state;
+      now += TTYD_RELOAD_MIN_INTERVAL_MS;
+    }
+    const giveUp = stepTtydReconnect(state, { ...base, now });
+    expect(giveUp.reload).toBe(false);
+    expect(giveUp.exhausted).toBe(true);
+  });
+
+  it("リロード直後の非 stuck では試行回数を戻さない (接続中を復帰と誤認しない)", () => {
+    const first = stepTtydReconnect(createTtydReconnectState(), base);
+    const connecting = stepTtydReconnect(first.state, {
+      ...base,
+      stuck: false,
+      now: base.now + 1_000,
+    });
+    expect(connecting.state.attempts).toBe(1);
+  });
+
+  it("復帰確認時間だけ stuck にならなければ試行回数を戻す", () => {
+    const first = stepTtydReconnect(createTtydReconnectState(), base);
+    const recovered = stepTtydReconnect(first.state, {
+      ...base,
+      stuck: false,
+      now: base.now + TTYD_RECOVERY_CONFIRM_MS,
+    });
+    expect(recovered.state.attempts).toBe(0);
+    expect(recovered.state.lastReloadAt).toBe(null);
+  });
+});

--- a/packages/web/src/lib/ttyd-reconnect.ts
+++ b/packages/web/src/lib/ttyd-reconnect.ts
@@ -1,0 +1,158 @@
+/**
+ * ttyd が「切断されたまま Enter 待ちで止まっている」状態を検出し、
+ * iframe を貼り直して復帰させるための純粋ロジック。
+ *
+ * ## なぜ必要か
+ *
+ * モバイル Chrome をバックグラウンドに送ると ttyd への WebSocket が落ちる。
+ * ttyd 1.7.4 の `onSocketClose` は
+ *
+ *   - close code !== 1000 かつ `doReconnect` → 自力で "Reconnecting..." して再接続
+ *   - それ以外                               → "Press ⏎ to Reconnect" を出して停止
+ *
+ * の 2 分岐で、`doReconnect` は WebSocket の error イベントで false になる
+ * (`t(u(e,"error",()=>this.doReconnect=!1))`)。回線が切れる経路は error を伴う
+ * ため、バックグラウンド復帰は必ず後者（Enter 待ちで停止）に落ちる。
+ * ttyd 側の自動再接続はこのケースでは最初から効かない。
+ *
+ * ## 復帰手段に iframe リロードを選ぶ理由
+ *
+ * 再接続は iframe 内の Xterm コンポーネントが握っており、window に露出して
+ * いるのは xterm の Terminal (`window.term`) だけで socket も connect() も
+ * 外から触れない。Enter キーの合成入力は、実は生きている接続に撃つと
+ * permission prompt や AskUserQuestion を誤って確定させうるので使わない。
+ * iframe リロードは tmux に 1 バイトも送らないので、画面に何が出ていても安全。
+ * ttyd 自身の再接続も `terminal.reset()` するので、リロードで失うものは無い。
+ */
+
+/**
+ * Enter 待ちで停止したときに ttyd が overlay へ出す文言 (ttyd 1.7.4 `onSocketClose`)。
+ *
+ * overlay は "Reconnecting..." / "Reconnected" / "80x24" / "✂" にも使い回される。
+ * 特に "Reconnected" は再接続成功の表示なので、`/Reconnect/` だけで判定すると
+ * リロード直後に再び stuck と誤判定して無限リロードになる。
+ */
+const STUCK_OVERLAY_PATTERN = /Press\s.*Reconnect/;
+
+/** 自動リロードの最小間隔 (ms) */
+export const TTYD_RELOAD_MIN_INTERVAL_MS = 5_000;
+
+/** 復帰を確認できないまま繰り返す自動リロードの上限 */
+export const TTYD_RELOAD_MAX_ATTEMPTS = 3;
+
+/** リロード後この時間 stuck にならなければ復帰とみなし、試行回数を戻す (ms) */
+export const TTYD_RECOVERY_CONFIRM_MS = 10_000;
+
+/** リロード後この時間 xterm が現れなければ読み込み失敗とみなす (ms) */
+export const TTYD_LOAD_TIMEOUT_MS = 10_000;
+
+/**
+ * xterm の `term.element` を見て、ttyd が Enter 待ちで止まっているかを判定する。
+ *
+ * OverlayAddon は class を持たない div を `term.element` 直下へ append する。
+ * 端末本文 (.xterm-*) に同じ文字列が表示されていても拾わないよう、
+ * xterm 自身の子要素は除外する。
+ */
+export function isTtydStuckOverlay(
+  termElement: Element | null | undefined
+): boolean {
+  if (!termElement) return false;
+  for (const child of Array.from(termElement.children)) {
+    const className =
+      typeof child.className === "string" ? child.className : "";
+    if (className.includes("xterm")) continue;
+    if (STUCK_OVERLAY_PATTERN.test(child.textContent ?? "")) return true;
+  }
+  return false;
+}
+
+export interface TtydReconnectState {
+  /** 復帰を確認できていない連続自動リロード回数 */
+  attempts: number;
+  /** 直近に自動リロードした時刻 (ms)。未リロードなら null */
+  lastReloadAt: number | null;
+}
+
+export function createTtydReconnectState(): TtydReconnectState {
+  return { attempts: 0, lastReloadAt: null };
+}
+
+export interface TtydReconnectInput {
+  /** iframe 内に xterm が出来ているか (読み込み中・読み込み失敗は false) */
+  ready: boolean;
+  /** Enter 待ちで停止しているか */
+  stuck: boolean;
+  /** ターミナルが実際に画面へ出ているか */
+  isVisible: boolean;
+  /** ブラウザがオンラインか (`navigator.onLine`) */
+  online: boolean;
+  now: number;
+}
+
+export interface TtydReconnectStep {
+  state: TtydReconnectState;
+  /** iframe を貼り直すべきか */
+  reload: boolean;
+  /** 上限まで試して復帰しなかったか (以後は手動リロードに委ねる) */
+  exhausted: boolean;
+}
+
+/**
+ * 1 回ぶんの観測から、iframe を貼り直すかどうかを決める。
+ *
+ * - 表示されていないペインはリロードしない。隠れた iframe を貼り直すと
+ *   ttyd の `fitAddon.fit()` がサイズ 0 に対して走り、次の resize まで
+ *   端末が歪んだままになる。表示に戻った次の観測でリロードする
+ * - 復帰の確認は「リロードから `TTYD_RECOVERY_CONFIRM_MS` 経っても stuck に
+ *   ならないこと」で行う。直後の非 stuck は単に接続中の可能性があるため、
+ *   ここで試行回数を戻すと壊れたセッションを延々リロードし続ける
+ * - オフラインのあいだは貼り直さない。回線が戻る前にリロードすると
+ *   iframe が読み込み失敗のまま残り、xterm が現れないので次の検出もできない
+ */
+export function stepTtydReconnect(
+  state: TtydReconnectState,
+  input: TtydReconnectInput
+): TtydReconnectStep {
+  const { ready, stuck, isVisible, online, now } = input;
+  const sinceReload =
+    state.lastReloadAt === null ? null : now - state.lastReloadAt;
+
+  if (ready && !stuck) {
+    // リロード直後の非 stuck は「まだ接続中」かもしれないので復帰とみなさない。
+    // ここで試行回数を戻すと、壊れたセッションを延々リロードし続ける
+    if (sinceReload !== null && sinceReload >= TTYD_RECOVERY_CONFIRM_MS) {
+      return {
+        state: createTtydReconnectState(),
+        reload: false,
+        exhausted: false,
+      };
+    }
+    return { state, reload: false, exhausted: false };
+  }
+
+  // 貼り直した iframe に xterm が出てこない = 読み込み自体が失敗している
+  // (回線が戻る前にリロードしてしまった場合など)。時間切れで再度貼り直す
+  const loadFailed =
+    !ready && sinceReload !== null && sinceReload >= TTYD_LOAD_TIMEOUT_MS;
+  if (!stuck && !loadFailed) return { state, reload: false, exhausted: false };
+
+  if (!isVisible) return { state, reload: false, exhausted: false };
+
+  // 回線が切れているうちに貼り直しても白い iframe が残るだけなので、
+  // オンラインに戻るまで待つ (試行回数も消費しない)
+  if (!online) return { state, reload: false, exhausted: false };
+
+  if (state.attempts >= TTYD_RELOAD_MAX_ATTEMPTS) {
+    return { state, reload: false, exhausted: true };
+  }
+
+  const throttled =
+    sinceReload !== null && sinceReload < TTYD_RELOAD_MIN_INTERVAL_MS;
+  if (throttled) return { state, reload: false, exhausted: false };
+
+  return {
+    state: { attempts: state.attempts + 1, lastReloadAt: now },
+    reload: true,
+    exhausted: false,
+  };
+}

--- a/packages/web/src/lib/ttyd-reconnect.ts
+++ b/packages/web/src/lib/ttyd-reconnect.ts
@@ -43,7 +43,7 @@ export const TTYD_RELOAD_MAX_ATTEMPTS = 3;
 /** リロード後この時間 stuck にならなければ復帰とみなし、試行回数を戻す (ms) */
 export const TTYD_RECOVERY_CONFIRM_MS = 10_000;
 
-/** リロード後この時間 xterm が現れなければ読み込み失敗とみなす (ms) */
+/** リロード後この時間 画面が届かなければ読み込み失敗・handshake 保留とみなす (ms) */
 export const TTYD_LOAD_TIMEOUT_MS = 10_000;
 
 /**
@@ -66,6 +66,45 @@ export function isTtydStuckOverlay(
   return false;
 }
 
+/**
+ * xterm のバッファに何か描画されているか。
+ *
+ * 「stuck overlay が出ていない」だけでは接続できたことにならない。iframe を
+ * 貼り直した直後や、パケットが落ちるだけで RST が返らない回線では、xterm は
+ * 出来ているのに WebSocket の handshake が延々と保留になる。この状態を復帰と
+ * 誤認すると試行回数が戻ってしまい、上限が効かなくなる (codex review 指摘)。
+ *
+ * 接続できていれば tmux が画面を描き直すので、バッファに文字が入ることを
+ * 「繋がった」の肯定的な証拠として使う。空の判定は保守的側 (繋がっていない扱い)
+ * に倒れるので、誤っても暴走はしない。
+ */
+export function hasTerminalOutput(term: XtermLike | null | undefined): boolean {
+  const buffer = term?.buffer?.active;
+  if (!buffer) return false;
+  const rows = Math.min(term?.rows ?? 0, buffer.length ?? 0);
+  // 先頭から数行見れば足りる (繋がっていれば 1 行目から埋まる)
+  const limit = Math.min(rows, 24);
+  for (let y = 0; y < limit; y++) {
+    if ((buffer.getLine(y)?.translateToString(true) ?? "").trim() !== "") {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** `window.term` (xterm.js の Terminal) のうち、ここで使う部分だけ */
+export interface XtermLike {
+  rows?: number;
+  buffer?: {
+    active?: {
+      length?: number;
+      getLine(
+        y: number
+      ): { translateToString(trim?: boolean): string } | undefined;
+    };
+  };
+}
+
 export interface TtydReconnectState {
   /** 復帰を確認できていない連続自動リロード回数 */
   attempts: number;
@@ -78,8 +117,8 @@ export function createTtydReconnectState(): TtydReconnectState {
 }
 
 export interface TtydReconnectInput {
-  /** iframe 内に xterm が出来ているか (読み込み中・読み込み失敗は false) */
-  ready: boolean;
+  /** WebSocket が繋がって画面が届いているか (xterm 未生成・handshake 保留は false) */
+  connected: boolean;
   /** Enter 待ちで停止しているか */
   stuck: boolean;
   /** ターミナルが実際に画面へ出ているか */
@@ -103,9 +142,8 @@ export interface TtydReconnectStep {
  * - 表示されていないペインはリロードしない。隠れた iframe を貼り直すと
  *   ttyd の `fitAddon.fit()` がサイズ 0 に対して走り、次の resize まで
  *   端末が歪んだままになる。表示に戻った次の観測でリロードする
- * - 復帰の確認は「リロードから `TTYD_RECOVERY_CONFIRM_MS` 経っても stuck に
- *   ならないこと」で行う。直後の非 stuck は単に接続中の可能性があるため、
- *   ここで試行回数を戻すと壊れたセッションを延々リロードし続ける
+ * - 復帰の確認は「画面が届いている状態が `TTYD_RECOVERY_CONFIRM_MS` 続くこと」。
+ *   stuck でないだけでは handshake 保留と区別できず、試行回数の上限が効かなくなる
  * - オフラインのあいだは貼り直さない。回線が戻る前にリロードすると
  *   iframe が読み込み失敗のまま残り、xterm が現れないので次の検出もできない
  */
@@ -113,13 +151,13 @@ export function stepTtydReconnect(
   state: TtydReconnectState,
   input: TtydReconnectInput
 ): TtydReconnectStep {
-  const { ready, stuck, isVisible, online, now } = input;
+  const { connected, stuck, isVisible, online, now } = input;
   const sinceReload =
     state.lastReloadAt === null ? null : now - state.lastReloadAt;
 
-  if (ready && !stuck) {
-    // リロード直後の非 stuck は「まだ接続中」かもしれないので復帰とみなさない。
-    // ここで試行回数を戻すと、壊れたセッションを延々リロードし続ける
+  if (!stuck && connected) {
+    // 繋がった状態が `TTYD_RECOVERY_CONFIRM_MS` 続いたら復帰とみなす。
+    // 直後に戻さないのは、貼り直した直後の一瞬を復帰と誤認しないため
     if (sinceReload !== null && sinceReload >= TTYD_RECOVERY_CONFIRM_MS) {
       return {
         state: createTtydReconnectState(),
@@ -130,11 +168,11 @@ export function stepTtydReconnect(
     return { state, reload: false, exhausted: false };
   }
 
-  // 貼り直した iframe に xterm が出てこない = 読み込み自体が失敗している
-  // (回線が戻る前にリロードしてしまった場合など)。時間切れで再度貼り直す
-  const loadFailed =
-    !ready && sinceReload !== null && sinceReload >= TTYD_LOAD_TIMEOUT_MS;
-  if (!stuck && !loadFailed) return { state, reload: false, exhausted: false };
+  // 貼り直したのに画面が来ない = 読み込み失敗か handshake が保留のまま
+  // (回線が戻る前に貼り直した場合など)。時間切れでもう一度貼り直す
+  const stalled =
+    !connected && sinceReload !== null && sinceReload >= TTYD_LOAD_TIMEOUT_MS;
+  if (!stuck && !stalled) return { state, reload: false, exhausted: false };
 
   if (!isVisible) return { state, reload: false, exhausted: false };
 


### PR DESCRIPTION
## 症状

モバイル Chrome をバックグラウンドから戻すと、ターミナルが `Press ⏎ to Reconnect` のまま固まる。手動でリロードするまで操作できない。

## 原因

ttyd 1.7.4 の `onSocketClose` は 2 分岐しかない。

- close code !== 1000 かつ `doReconnect` → 自力で "Reconnecting..." して再接続
- それ以外 → `Press ⏎ to Reconnect` を出して**停止**

`doReconnect` は WebSocket の `error` イベントで false になる（`t(u(e,"error",()=>this.doReconnect=!1))`）。バックグラウンド復帰では電波が戻る前に 1 度きりの再接続が走って失敗するため、必ず停止側へ落ちる。**単に socket が落ちただけなら ttyd は自力で復帰する**（実測済み）が、その再接続試行が失敗した瞬間に再接続機構ごと無効化される。

実機再現ログ:

```
[ttyd] fetch .../token: TypeError: Failed to fetch
[ttyd] websocket connection closed with code: 1006
→ overlay: "Press ⏎ to Reconnect" のまま停止
```

## 直し方

`useTtydReconnect` が iframe 内の overlay を 1.5 秒ごとに読み、停止状態なら iframe を貼り直す。判定と抑止は純粋関数（`lib/ttyd-reconnect.ts`）に分けてテストしている。

- **復帰手段は iframe リロード**。Enter の合成入力は、実は生きている接続に撃つと permission prompt や AskUserQuestion を誤って確定させうるので使わない。リロードは tmux に 1 バイトも送らない（ttyd 自身の再接続も `terminal.reset()` するので失うものは無い）
- **`/Reconnect/` では判定しない**。overlay は "Reconnected"（再接続成功）にも使い回されるため、素朴に一致させるとリロード直後に再びリロードする無限ループになる
- **表示中のペインだけ**貼り直す。両画面とも非表示ペインを `display:none` で残置するので、隠れた iframe を貼り直すと ttyd の `fit()` がサイズ 0 に対して走り端末が歪む
- **オフライン中は貼り直さない**（白い iframe が残るだけ）。回線が戻る前に貼り直してしまった場合は、10 秒経っても xterm が現れないことを見て貼り直す
- 復帰しないまま 3 回に達したら諦め、以後は既存の手動リロードボタンに委ねる
- MutationObserver ではなく polling なのは、切断が visibilitychange の**後**に届くため 1 回きりの確認では取り逃すのと、overlay が xterm の描画 DOM と同じ木にあるため

## 検証

`pnpm check` / `vitest`（`ttyd-reconnect.test.ts` 17 件）に加え、実セッションに対する E2E を PC・モバイル両方の viewport で実施。TCP を物理的に切って「圏外」を作り、再接続試行を失敗させて停止状態を再現した。

| 検証項目 | PC | モバイル |
| --- | --- | --- |
| 接続中は貼り直さない（9 秒観察） | ✅ 0 回 | ✅ 0 回 |
| `Press ⏎ to Reconnect` を検出 | ✅ | ✅ |
| 圏内復帰後に自動で貼り直して復帰 | ✅ 1 回で復帰 | ✅ 1 回で復帰 |
| 復帰後に貼り直しを繰り返さない（14 秒観察） | ✅ 0 回 | ✅ 0 回 |

E2E は実セッション（tmux + claude CLI）の起動が要るため、既存の `e2e/` の方針に合わせてコミットしていない。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ターミナルが「Press ⏎ to Reconnect」で停止した場合、表示中かつオンラインであれば自動的に再接続するようになりました。
  * バックグラウンドから復帰した際も接続状態を確認し、必要に応じて再接続します。
  * 自動再接続は最大3回まで試行し、復旧できない場合は手動リロードをご利用ください。
  * 非表示のターミナルやオフライン時には再接続を実行しません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->