### PR TITLE
fix(server): セッション削除時の worktree 消滅を全クライアントへ broadcast する

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1707,7 +1707,10 @@ export async function startServer(
                 .replace(/[/+=]/g, "");
               await deleteWorktree(result.repoPath, result.worktreePath);
               managedWorktreeCache.delete(result.worktreePath);
-              socket.emit("worktree:deleted", {
+              // worktree の消滅は全クライアント共通の事実なので、削除を要求した
+              // socket だけでなく io で broadcast する。socket.emit だと他タブの
+              // サイドバーに消えた worktree が残る（worktree:delete 経路と非対称）。
+              io.emit("worktree:deleted", {
                 repoPath: result.repoPath,
                 worktreeId: deletedWorktreeId,
               });
@@ -1724,7 +1727,7 @@ export async function startServer(
 
             try {
               const worktrees = await listWorktrees(result.repoPath);
-              socket.emit("worktree:list", {
+              io.emit("worktree:list", {
                 repoPath: result.repoPath,
                 worktrees,
               });

--- a/packages/server/src/worktree-broadcast.test.ts
+++ b/packages/server/src/worktree-broadcast.test.ts
@@ -3,10 +3,10 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 /**
- * worktree:created / worktree:deleted は「worktree が生まれた／消えた」という
- * 全クライアント共通の事実で、ServerToClientEvents の型コメントでも io.emit で
- * broadcast する契約になっている。socket.emit で書くと要求元のタブだけが更新され、
- * 他タブのサイドバーに消えた worktree が残る（session:stop 経路で実際に起きた）。
+ * worktree の生成・削除は全クライアント共通の事実なので、通知は io.emit で
+ * broadcast する（ServerToClientEvents の型コメントにも明記されている）。
+ * socket.emit で書くと要求元のタブだけが更新され、他タブのサイドバーに
+ * 消えた worktree が残る（session:stop 経路で実際に起きた）。
  *
  * index.ts の socket ハンドラは巨大で単体テストの取り出しができないため、
  * ソース走査で emit の種別だけを固定する。
@@ -15,6 +15,31 @@ const source = readFileSync(
   fileURLToPath(new URL("./index.ts", import.meta.url)),
   "utf-8"
 );
+
+/**
+ * `socket.on("<event>", ...)` の登録から次の登録までを切り出す。
+ * ハンドラは全て 4 スペース字下げで登録されており、引数を次行に置く
+ * 複数行形式（worktree:create）もあるので空白を潰して名前を照合する。
+ */
+function handlerSource(event: string): string {
+  const marker = "\n    socket.on(";
+  const starts: number[] = [];
+  for (
+    let i = source.indexOf(marker);
+    i !== -1;
+    i = source.indexOf(marker, i + 1)
+  ) {
+    starts.push(i + 1);
+  }
+  const index = starts.findIndex(start =>
+    source
+      .slice(start, start + 200)
+      .replace(/\s+/g, "")
+      .startsWith(`socket.on("${event}"`)
+  );
+  if (index === -1) throw new Error(`ハンドラが見つからない: ${event}`);
+  return source.slice(starts[index], starts[index + 1] ?? source.length);
+}
 
 describe("worktree ライフサイクルイベントの配信範囲", () => {
   for (const event of ["worktree:created", "worktree:deleted"] as const) {
@@ -27,6 +52,22 @@ describe("worktree ライフサイクルイベントの配信範囲", () => {
 
       expect(emitters.length).toBeGreaterThan(0);
       expect(emitters).toEqual(emitters.map(() => "io"));
+    });
+  }
+
+  // worktree を作成／削除したハンドラが返す worktree:list も全タブへ届ける。
+  // repo:select / worktree:list のリクエスト応答は「要求元へのスナップショット」
+  // なので socket.emit のままで正しく、ここでは対象にしない。
+  for (const event of [
+    "worktree:create",
+    "worktree:delete",
+    "session:stop",
+  ] as const) {
+    it(`${event} ハンドラの worktree:list は io.emit で broadcast する`, () => {
+      const handler = handlerSource(event);
+
+      expect(handler).toContain('io.emit("worktree:list"');
+      expect(handler).not.toContain('socket.emit("worktree:list"');
     });
   }
 });

--- a/packages/server/src/worktree-broadcast.test.ts
+++ b/packages/server/src/worktree-broadcast.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * worktree:created / worktree:deleted は「worktree が生まれた／消えた」という
+ * 全クライアント共通の事実で、ServerToClientEvents の型コメントでも io.emit で
+ * broadcast する契約になっている。socket.emit で書くと要求元のタブだけが更新され、
+ * 他タブのサイドバーに消えた worktree が残る（session:stop 経路で実際に起きた）。
+ *
+ * index.ts の socket ハンドラは巨大で単体テストの取り出しができないため、
+ * ソース走査で emit の種別だけを固定する。
+ */
+const source = readFileSync(
+  fileURLToPath(new URL("./index.ts", import.meta.url)),
+  "utf-8"
+);
+
+describe("worktree ライフサイクルイベントの配信範囲", () => {
+  for (const event of ["worktree:created", "worktree:deleted"] as const) {
+    it(`${event} は io.emit で broadcast する`, () => {
+      const emitters = [
+        ...source.matchAll(
+          new RegExp(String.raw`(\w+)\.emit\("${event}"`, "g")
+        ),
+      ].map(m => m[1]);
+
+      expect(emitters.length).toBeGreaterThan(0);
+      expect(emitters).toEqual(emitters.map(() => "io"));
+    });
+  }
+});


### PR DESCRIPTION
## 症状

worktree の削除が**タブ間でリアルタイムに反映されない**。

セッションを削除したタブでは worktree がサイドバーから消えるが、別タブでは
**セッション行だけが消えて worktree が残り続ける**（リロードするまで消えない）。

## 原因

`session:stop` ハンドラは worktree を削除したあと、`worktree:deleted` /
`worktree:list` を **`socket.emit`（要求元のソケットのみ）** で送っていた。

一方 `session:stopped` は orchestrator のイベントを各ソケットが自前で転送する
（`packages/server/src/index.ts` の `forwardedEvents`）ため、全タブに届く。
この非対称が「セッションだけ消えて worktree は残る」という中途半端な症状になっていた。

`worktree:delete` ハンドラ（サイドバーの Worktree 直接削除）は同じイベントを
`io.emit` しており、`ServerToClientEvents` の型コメントにも

> worktree:created / worktree:deleted は io.emit で全クライアントにブロードキャストされる

と書かれている。`session:stop` 経路だけがこの契約から外れていた。

## 変更

- `session:stop` 内の `worktree:deleted` / `worktree:list` を `io.emit` に変更
  - 同ハンドラの `session:error` は要求元への応答なので `socket.emit` のまま
  - `worktree:list` の**リクエスト応答**（`repo:select` / `worktree:list` 受信時）は
    別クライアントの repo スナップショットを押し付けることになるため触っていない
- 契約をソース走査で固定する回帰テストを追加（`worktree-broadcast.test.ts`）

## 検証

隔離環境（別 `ARK_DATA_DIR` / `PORT=4099`、本番 pm2 インスタンスと分離）で
socket クライアントを 2 本つなぎ、A から `session:stop` を送って B の受信を観測した。

| | A（削除した側） | B（別タブ） |
|---|---|---|
| 修正前 | `session:stopped` / `worktree:deleted` / `worktree:list` | `session:stopped` のみ |
| 修正後 | 同上 | `session:stopped` / `worktree:deleted` / 削除反映済み `worktree:list` |

回帰テストも修正前のソースに対して RED になることを確認済み
（`worktree:deleted` の emitter が `["io","socket"]` になる）。

`pnpm check` / `pnpm test`（75 files / 1222 tests）ともに green。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ワークツリーの削除時、削除通知と最新の一覧情報が接続中のすべての画面に即時反映されるようになりました。
  * 複数の画面で同時に作業している場合でも、ワークツリーの状態を一貫して確認できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->