### PR TITLE
docs(deploy): pnpm 11 要件と mise が古い場合の回避を手順に書く

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,11 @@ mainブランチをpullした後は、以下の手順で **順番通りに** ビ
 #    毎日の bump-claude-code ワークフローによる同梱 @anthropic-ai/claude-code の
 #    更新は install で初めて node_modules に反映される。省略すると稼働中の Ark が
 #    旧バージョンの claude を配り続ける
+#
+#    pnpm 11 が要る (.mise.toml / packageManager が 11 系を指す)。mise が古いと
+#    `no asset found: pnpm-linux-arm64` で pnpm 自体が入らず、この行が失敗する。
+#    その場合は `mise self-update` するか、corepack 経由に切り替える:
+#      corepack pnpm install --frozen-lockfile
 pnpm install --frozen-lockfile
 
 # 2. ビルド


### PR DESCRIPTION
#423 で pnpm を 11 系に上げた結果、CLAUDE.md のデプロイ手順 1 が **この機械では失敗する**。手順にその回避を書く。

## 何が起きるか

```
$ pnpm --version
mise pnpm@11.24.0      [1/2] install
mise ERROR Failed to install aqua:pnpm/pnpm@11.24.0: no asset found: pnpm-linux-arm64
```

merged main のワークツリーで実測。手元の mise (2026.3.15) は aqua レジストリが古く、pnpm 11 の配布物名（`pnpm-linux-arm64.tar.gz`）に追従していない。pnpm が解決できないので `pnpm install --frozen-lockfile` がそもそも走らない。

CI では起きない（`jdx/mise-action@v4` が最新 mise を入れる。#423 の CI は pnpm 11.24.0 で緑）。

## 回避（どちらも実測で通る）

- `mise self-update`
- `corepack pnpm install --frozen-lockfile`（`packageManager` の pin をそのまま使う）

デプロイ手順のコメントに両方書いた。