### PR TITLE
feat(diagram): 順位付きリストの図種 backlog を足す

### DIFF
--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -21,7 +21,7 @@ Ark が配信時に生成し、生成物はファイルへ焼き付かない（�
 | `flow` | 業務フロー・シナリオ・処理の分岐 | `step`（既定）/ `command` / `decision` / `policy` / `event` / `outcome` / `error` / `actor` / `note` |
 | `state` | 状態遷移 | `state`（既定）/ `initial` / `terminal-ok` / `terminal-cancel` / `note` |
 | `context-map` | コンテキストマップ（戦略設計） | `supporting`（既定）/ `core` / `generic` / `developed` / `external` / `note` |
-| `backlog` | バックログ・タスク一覧（順位付きリスト） | `story`（既定）/ `bug` / `task` / `spike` / `chore` / `epic` / `note` |
+| `backlog` | バックログ・タスク一覧（順位付きリスト） | `story`（既定）/ `bug` / `task` / `spike` / `chore` / `epic` |
 
 語彙にない kind を書くとその図種の既定スタイルになる。`flow` の出口は成功を
 `outcome`、失敗を `error` に分けると、色に頼らず読めるようになる。区間の枠
@@ -37,6 +37,10 @@ Ark が配信時に生成し、生成物はファイルへ焼き付かない（�
   種別（`kind`）と状態（`status`）は直交させる。`kind` に done を作らない
 - `node.fields` は行の下にチップとして並ぶ。担当・見積り・Issue 番号のような列に使う
 - `ext.layout` と `ext.x` / `ext.y` は効かない（自動レイアウトを使わないため）
+- **`note` kind は使わない。**行の補足は `fields` に置く。note 本文の編集は graph
+  のハーネスに載っているため、リストの図種では同期されない
+- **行にコメントは付けられない**（コメント層のアンカーが graph 前提のため）。
+  指摘は会話か Issue で行う
 
 順位そのものが意味を持つので、**状態を `backlog` に持たせすぎないこと**。
 GitHub Issue のように別に正本がある情報を写すと、その瞬間から腐りはじめる。

--- a/.claude/skills/diagram-authoring/SKILL.md
+++ b/.claude/skills/diagram-authoring/SKILL.md
@@ -21,10 +21,25 @@ Ark が配信時に生成し、生成物はファイルへ焼き付かない（�
 | `flow` | 業務フロー・シナリオ・処理の分岐 | `step`（既定）/ `command` / `decision` / `policy` / `event` / `outcome` / `error` / `actor` / `note` |
 | `state` | 状態遷移 | `state`（既定）/ `initial` / `terminal-ok` / `terminal-cancel` / `note` |
 | `context-map` | コンテキストマップ（戦略設計） | `supporting`（既定）/ `core` / `generic` / `developed` / `external` / `note` |
+| `backlog` | バックログ・タスク一覧（順位付きリスト） | `story`（既定）/ `bug` / `task` / `spike` / `chore` / `epic` / `note` |
 
 語彙にない kind を書くとその図種の既定スタイルになる。`flow` の出口は成功を
 `outcome`、失敗を `error` に分けると、色に頼らず読めるようになる。区間の枠
 （単一Tx境界、スイムレーン、境界づけられたコンテキスト）は group で表す。
+
+`backlog` だけは graph ではなくリストとして描かれる。読み方が他の 5 種と違う。
+
+- **順位は `nodes` 配列の並び**。上から順に 1, 2, 3 と番号が振られる
+- `edges` は描かれない。バックログに矢印は無いので書かなくてよい
+- `group` は区切り見出しになる。group の順に並び、どの group にも属さない node は
+  最後にまとめて出る。同じ node を複数 group に入れても行は最初の group にだけ出す
+- `node.ext.status` に `todo` / `doing` / `blocked` / `done` を書くと状態バッジが付く。
+  種別（`kind`）と状態（`status`）は直交させる。`kind` に done を作らない
+- `node.fields` は行の下にチップとして並ぶ。担当・見積り・Issue 番号のような列に使う
+- `ext.layout` と `ext.x` / `ext.y` は効かない（自動レイアウトを使わないため）
+
+順位そのものが意味を持つので、**状態を `backlog` に持たせすぎないこと**。
+GitHub Issue のように別に正本がある情報を写すと、その瞬間から腐りはじめる。
 
 ```html
 <!doctype html>

--- a/packages/server/src/lib/diagram-builtin.test.ts
+++ b/packages/server/src/lib/diagram-builtin.test.ts
@@ -387,7 +387,7 @@ describe("injectBuiltinProjection: backlog", () => {
     const out = injectBuiltinProjection(page(modelScript), backlogModel());
     const style = out.slice(out.indexOf("<style"), out.indexOf("</style>"));
 
-    for (const label of ['"TODO"', '"DOING"', '"BLOCKED"', '"DONE"']) {
+    for (const label of ['"TO DO"', '"IN PROGRESS"', '"BLOCKED"', '"DONE"']) {
       expect(style).toContain(label);
     }
   });

--- a/packages/server/src/lib/diagram-builtin.test.ts
+++ b/packages/server/src/lib/diagram-builtin.test.ts
@@ -292,6 +292,14 @@ describe("injectBuiltinProjection", () => {
   });
 });
 
+/** 属性の並び順に依存せず、その node の <article> 開始タグだけを取り出す */
+function rowTag(html: string, id: string): string {
+  const match = html.match(
+    new RegExp(`<article[^>]*data-model-id="${id}"[^>]*>`)
+  );
+  return match?.[0] ?? "";
+}
+
 function backlogModel(overrides: Partial<DiagramModel> = {}): DiagramModel {
   return {
     version: 1,
@@ -372,15 +380,9 @@ describe("injectBuiltinProjection: backlog", () => {
   it("ext.status を行の data-status に載せ、無い node には付けない", () => {
     const out = injectBuiltinProjection(page(modelScript), backlogModel());
 
-    expect(out).toMatch(
-      /<article[^>]*data-status="doing"[^>]*data-model-id="ga4"/
-    );
-    expect(out).toMatch(
-      /<article[^>]*data-status="done"[^>]*data-model-id="lh"/
-    );
-    expect(out).not.toMatch(
-      /<article[^>]*data-status[^>]*data-model-id="works"/
-    );
+    expect(rowTag(out, "ga4")).toContain('data-status="doing"');
+    expect(rowTag(out, "lh")).toContain('data-status="done"');
+    expect(rowTag(out, "works")).not.toContain("data-status");
   });
 
   it("状態を色だけで伝えない（CSS に状態名の文字列を持つ）", () => {
@@ -434,8 +436,8 @@ describe("injectBuiltinProjection: backlog の順位と再注入", () => {
       })
     );
 
-    expect(out).toMatch(/<article[^>]*data-rank="2"[^>]*data-model-id="b"/);
-    expect(out).toMatch(/<article[^>]*data-rank="1"[^>]*data-model-id="a"/);
+    expect(rowTag(out, "b")).toContain('data-rank="2"');
+    expect(rowTag(out, "a")).toContain('data-rank="1"');
     // 行の並びは group 順のまま
     expect(out.indexOf('data-model-id="b"')).toBeLessThan(
       out.indexOf('data-model-id="a"')
@@ -445,7 +447,7 @@ describe("injectBuiltinProjection: backlog の順位と再注入", () => {
   it("group に属さない node にも nodes 配列どおりの順位が付く", () => {
     const out = injectBuiltinProjection(page(modelScript), backlogModel());
 
-    expect(out).toMatch(/<article[^>]*data-rank="4"[^>]*data-model-id="loose"/);
+    expect(rowTag(out, "loose")).toContain('data-rank="4"');
   });
 
   it("既に list 容れ物がある HTML には二度目の投影を足さない", () => {

--- a/packages/server/src/lib/diagram-builtin.test.ts
+++ b/packages/server/src/lib/diagram-builtin.test.ts
@@ -291,3 +291,127 @@ describe("injectBuiltinProjection", () => {
     expect(out).not.toContain('rel="stylesheet"');
   });
 });
+
+function backlogModel(overrides: Partial<DiagramModel> = {}): DiagramModel {
+  return {
+    version: 1,
+    type: "backlog",
+    title: "AEO 2026-09",
+    nodes: [
+      {
+        id: "ga4",
+        label: "GA4 初回セットアップ",
+        kind: "task",
+        ext: { status: "doing" },
+        fields: [{ id: "ga4-own", label: "担当: あなた" }],
+      },
+      {
+        id: "lh",
+        label: "Lighthouse 計測",
+        kind: "task",
+        ext: { status: "done" },
+      },
+      { id: "works", label: "/works の被引用性", kind: "story" },
+      { id: "loose", label: "未分類の項目", kind: "chore" },
+    ],
+    edges: [],
+    groups: [
+      { id: "now", label: "いま", nodes: ["ga4"] },
+      { id: "done", label: "済んだこと", nodes: ["lh"] },
+      { id: "later", label: "あとで", nodes: ["works"] },
+    ],
+    ...overrides,
+  };
+}
+
+describe("injectBuiltinProjection: backlog", () => {
+  it("graph ではない容れ物を作る（自動レイアウトと edge に載せない）", () => {
+    const out = injectBuiltinProjection(page(modelScript), backlogModel());
+
+    expect(out).toContain('data-ark-container="list"');
+    expect(out).toContain('data-ark-builtin="backlog"');
+    expect(out).not.toContain('data-ark-container="graph"');
+  });
+
+  it("group を見出しにして、その直後にメンバー行を並べる", () => {
+    const out = injectBuiltinProjection(page(modelScript), backlogModel());
+
+    expect(out).toContain("ark-backlog-section");
+    expect(out).toContain('data-model-id="now"');
+    expect(out.indexOf('data-model-id="now"')).toBeLessThan(
+      out.indexOf('data-model-id="ga4"')
+    );
+    expect(out.indexOf('data-model-id="ga4"')).toBeLessThan(
+      out.indexOf('data-model-id="done"')
+    );
+  });
+
+  it("group に属さない node は最後に出る", () => {
+    const out = injectBuiltinProjection(page(modelScript), backlogModel());
+
+    expect(out.indexOf('data-model-id="works"')).toBeLessThan(
+      out.indexOf('data-model-id="loose"')
+    );
+  });
+
+  it("複数 group に入れても行は 1 回だけ出す（順位が二つにならない）", () => {
+    const out = injectBuiltinProjection(
+      page(modelScript),
+      backlogModel({
+        groups: [
+          { id: "now", label: "いま", nodes: ["ga4"] },
+          { id: "dup", label: "重複", nodes: ["ga4"] },
+        ],
+      })
+    );
+    const rows = out.match(/<article[^>]*data-model-id="ga4"/g) ?? [];
+
+    expect(rows).toHaveLength(1);
+  });
+
+  it("ext.status を行の data-status に載せ、無い node には付けない", () => {
+    const out = injectBuiltinProjection(page(modelScript), backlogModel());
+
+    expect(out).toMatch(
+      /<article[^>]*data-status="doing"[^>]*data-model-id="ga4"/
+    );
+    expect(out).toMatch(
+      /<article[^>]*data-status="done"[^>]*data-model-id="lh"/
+    );
+    expect(out).not.toMatch(
+      /<article[^>]*data-status[^>]*data-model-id="works"/
+    );
+  });
+
+  it("状態を色だけで伝えない（CSS に状態名の文字列を持つ）", () => {
+    const out = injectBuiltinProjection(page(modelScript), backlogModel());
+    const style = out.slice(out.indexOf("<style"), out.indexOf("</style>"));
+
+    for (const label of ['"TODO"', '"DOING"', '"BLOCKED"', '"DONE"']) {
+      expect(style).toContain(label);
+    }
+  });
+
+  it("行は既存図種と同じ投影契約を保つ（label と field の id）", () => {
+    const out = injectBuiltinProjection(page(modelScript), backlogModel());
+
+    expect(out).toContain('class="ark-builtin-node"');
+    expect(out).toContain('data-kind="task"');
+    expect(out).toContain('data-model-id="ga4-own"');
+    expect(out).toContain("担当: あなた");
+  });
+
+  it("既存 5 種は graph container のまま変わらない", () => {
+    for (const type of [
+      "er",
+      "event-storming",
+      "flow",
+      "state",
+      "context-map",
+    ]) {
+      const out = injectBuiltinProjection(page(modelScript), model({ type }));
+      expect(out).toContain('data-ark-container="graph"');
+      expect(out).not.toContain('data-ark-container="list"');
+    }
+  });
+});

--- a/packages/server/src/lib/diagram-builtin.test.ts
+++ b/packages/server/src/lib/diagram-builtin.test.ts
@@ -415,3 +415,51 @@ describe("injectBuiltinProjection: backlog", () => {
     }
   });
 });
+
+describe("injectBuiltinProjection: backlog の順位と再注入", () => {
+  it("順位は group 順ではなく nodes 配列の位置で決まる", () => {
+    // nodes は [A(g2), B(g1)]、groups は [g1, g2]。行は g1 が先に出るが、
+    // 順位は nodes の並びどおり A=1 / B=2 でなければならない
+    const out = injectBuiltinProjection(
+      page(modelScript),
+      backlogModel({
+        nodes: [
+          { id: "a", label: "A", kind: "task" },
+          { id: "b", label: "B", kind: "task" },
+        ],
+        groups: [
+          { id: "g1", label: "先に出る", nodes: ["b"] },
+          { id: "g2", label: "後に出る", nodes: ["a"] },
+        ],
+      })
+    );
+
+    expect(out).toMatch(/<article[^>]*data-rank="2"[^>]*data-model-id="b"/);
+    expect(out).toMatch(/<article[^>]*data-rank="1"[^>]*data-model-id="a"/);
+    // 行の並びは group 順のまま
+    expect(out.indexOf('data-model-id="b"')).toBeLessThan(
+      out.indexOf('data-model-id="a"')
+    );
+  });
+
+  it("group に属さない node にも nodes 配列どおりの順位が付く", () => {
+    const out = injectBuiltinProjection(page(modelScript), backlogModel());
+
+    expect(out).toMatch(/<article[^>]*data-rank="4"[^>]*data-model-id="loose"/);
+  });
+
+  it("既に list 容れ物がある HTML には二度目の投影を足さない", () => {
+    const once = injectBuiltinProjection(page(modelScript), backlogModel());
+    const twice = injectBuiltinProjection(once, backlogModel());
+
+    expect(twice).toBe(once);
+    expect(twice.match(/data-ark-container="list"/g)).toHaveLength(1);
+  });
+
+  it("graph 図種の再注入ガードは従来どおり効く", () => {
+    const once = injectBuiltinProjection(page(modelScript), model());
+    const twice = injectBuiltinProjection(once, model());
+
+    expect(twice).toBe(once);
+  });
+});

--- a/packages/server/src/lib/diagram-builtin.ts
+++ b/packages/server/src/lib/diagram-builtin.ts
@@ -35,6 +35,14 @@ export const GENERATED_ATTR = "data-ark-harness-generated";
 interface BuiltinType {
   /** 図種専用の CSS（外部リソースを参照しない） */
   css: string;
+  /**
+   * graph 以外の容れ物を持つ図種だけが実装する DOM builder。
+   *
+   * 既存 5 種はすべて graph（絶対配置 + edge + drag で x/y 保存）なので
+   * 共通の `renderGraph` を使う。バックログのように「順位付きリスト」が
+   * 主役の図種は node の並びそのものが意味を持ち、絶対配置に載せられない。
+   */
+  render?: (model: DiagramModel) => string;
 }
 
 const BASE_CSS = `
@@ -142,12 +150,60 @@ const CONTEXT_MAP_CSS = `${BASE_CSS}
 [data-ark-builtin="context-map"] .ark-builtin-node[data-kind="note"]{--kn:"note";--k:#94a3b8;--kb:#1b2130;width:19rem;border-style:dashed;border-left-style:solid}
 `;
 
+/**
+ * バックログ。順位付きリストが主役で、graph ではない唯一の図種。
+ *
+ * 行は既存 5 種と同じ `.ark-builtin-node` / `data-model-id` / `data-kind` の
+ * 投影契約をそのまま使う（label 編集も field 編集もハーネス側の実装が効く）。
+ * 変えるのは容れ物と並べ方だけ。`node.ext.status` は行の `data-status` に載せ、
+ * 状態名は CSS 変数から文字として出す（色だけで状態を伝えない）。
+ */
+const BACKLOG_CSS = `${BASE_CSS}
+[data-ark-builtin="backlog"]{min-height:0;counter-reset:ark-backlog}
+.ark-backlog-section{margin:1.1rem 0 .5rem;padding:0 0 .3rem;
+border-bottom:1px solid #334155}
+.ark-backlog-section:first-child{margin-top:0}
+.ark-backlog-section .group-label{font-size:.78rem;font-weight:700;color:#7dd3fc}
+[data-ark-builtin="backlog"] .ark-builtin-node{display:grid;
+grid-template-columns:6.5rem minmax(0,1fr) auto;gap:.1rem .8rem;
+align-items:baseline;width:auto;margin:.3rem 0;padding:.5rem .7rem;
+counter-increment:ark-backlog}
+[data-ark-builtin="backlog"] .ark-builtin-node::before{grid-column:1;grid-row:1;
+content:counter(ark-backlog) "\\00A0" var(--kg,"\\25A3") "\\00A0" var(--kn,"story");
+font-size:.6rem;letter-spacing:.04em;white-space:nowrap}
+[data-ark-builtin="backlog"] .ark-builtin-label{grid-column:2;grid-row:1;
+margin-top:0;font-size:.86rem}
+[data-ark-builtin="backlog"] .ark-builtin-note{grid-column:2;grid-row:1}
+[data-ark-builtin="backlog"] .ark-builtin-fields{grid-column:2;grid-row:2;
+display:flex;flex-wrap:wrap;gap:.25rem .5rem;margin:.3rem 0 0;padding:0;
+border-top:none}
+[data-ark-builtin="backlog"] .ark-builtin-fields li{padding:.05rem .4rem;
+border:1px solid rgba(148,163,184,.35);border-radius:3px;font-size:.65rem}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status]::after{grid-column:3;
+grid-row:1;content:var(--st,"");padding:.05rem .45rem;border-radius:999px;
+border:1px solid var(--sc,#94a3b8);color:var(--sc,#94a3b8);
+font-size:.6rem;font-weight:700;letter-spacing:.04em;white-space:nowrap}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="todo"]{--st:"TODO";--sc:#94a3b8}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="doing"]{--st:"DOING";--sc:#38bdf8}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="blocked"]{--st:"BLOCKED";--sc:#f87171}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="done"]{--st:"DONE";--sc:#4ade80;opacity:.62}
+[data-ark-builtin="backlog"] .ark-builtin-node{--kn:"story";--k:#60a5fa;--kb:#172a46;--kg:"\\25A3"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="story"]{--kn:"story";--k:#60a5fa;--kb:#172a46;--kg:"\\25A3"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="bug"]{--kn:"bug";--k:#f87171;--kb:#3a1a1a;--kg:"\\2716"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="task"]{--kn:"task";--k:#38bdf8;--kb:#12283a;--kg:"\\2714"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="spike"]{--kn:"spike";--k:#c084fc;--kb:#2a2044;--kg:"\\25C7"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="chore"]{--kn:"chore";--k:#a3a3a3;--kb:#26262b;--kg:"\\25A4"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="epic"]{--kn:"epic";--k:#facc15;--kb:#332b0e;--kg:"\\2605";border-width:2px;border-left-width:5px}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="note"]{--kn:"note";--k:#94a3b8;--kb:#1b2130;border-style:dashed;border-left-style:solid}
+`;
+
 export const BUILTIN_DIAGRAM_TYPES: Readonly<Record<string, BuiltinType>> = {
   er: { css: ER_CSS },
   "event-storming": { css: STORMING_CSS },
   flow: { css: FLOW_CSS },
   state: { css: STATE_CSS },
   "context-map": { css: CONTEXT_MAP_CSS },
+  backlog: { css: BACKLOG_CSS, render: renderBacklog },
 };
 
 function escapeHtml(value: string): string {
@@ -197,6 +253,56 @@ function renderNode(node: DiagramNode): string {
   return `<article class="ark-builtin-node" data-model-id="${id}"${kindAttr}>${parts.join("")}</article>`;
 }
 
+/**
+ * バックログの 1 行。`renderNode` と同じ投影契約に `data-status` だけ足す。
+ *
+ * status を kind に混ぜないのは、種別（story / bug）と状態（todo / done）が
+ * 直交するから。kind に done を作ると「done な bug」が表せなくなる。
+ */
+function renderBacklogRow(node: DiagramNode): string {
+  const status = node.ext?.status;
+  if (typeof status !== "string" || status === "") return renderNode(node);
+  return renderNode(node).replace(
+    "<article ",
+    `<article data-status="${escapeHtml(status)}" `
+  );
+}
+
+/**
+ * バックログ投影。順位は `model.nodes` の並び、区切りは group。
+ *
+ * group に属さない node は最後にまとめて出す。同じ node を複数 group に入れた
+ * 場合は最初の group にだけ出し、行の重複は作らない（順位が二つになるため）。
+ */
+function renderBacklog(model: DiagramModel): string {
+  const placed = new Set<string>();
+  const sections: string[] = [];
+
+  for (const group of model.groups) {
+    const rows = model.nodes
+      .filter(node => group.nodes.includes(node.id) && !placed.has(node.id))
+      .map(node => {
+        placed.add(node.id);
+        return renderBacklogRow(node);
+      });
+    if (rows.length === 0) continue;
+    const safeId = escapeHtml(group.id);
+    sections.push(
+      `<section class="ark-backlog-section" data-ark-group data-model-id="${safeId}">` +
+        `<span class="group-label" data-model-id="${safeId}">${escapeHtml(group.label)}</span>` +
+        "</section>" +
+        rows.join("")
+    );
+  }
+
+  const rest = model.nodes
+    .filter(node => !placed.has(node.id))
+    .map(node => renderBacklogRow(node));
+  if (rest.length > 0) sections.push(rest.join(""));
+
+  return sections.join("");
+}
+
 function renderGroup(id: string, label: string): string {
   const safeId = escapeHtml(id);
   return (
@@ -242,16 +348,19 @@ export function injectBuiltinProjection(
   const title = model.title
     ? `<h1 class="ark-builtin-title" ${GENERATED_ATTR}="1">${escapeHtml(model.title)}</h1>`
     : "";
-  const groups = model.groups
-    .map(group => renderGroup(group.id, group.label))
-    .join("");
-  const nodes = model.nodes.map(node => renderNode(node)).join("");
+  // graph 以外の容れ物を持つ図種は自前の DOM を組む。graph という値は
+  // ハーネスの自動レイアウト・edge 描画・drag の入口なので、リストの図種に
+  // 付けてはならない（付けると絶対配置に載せられて行が重なる）。
+  const container = type.render ? "list" : "graph";
+  const body = type.render
+    ? type.render(model)
+    : model.groups.map(g => renderGroup(g.id, g.label)).join("") +
+      model.nodes.map(node => renderNode(node)).join("");
   const projection =
     `<style data-ark-harness-ui="1">${type.css}</style>` +
     title +
-    `<div data-ark-container="graph" data-ark-builtin="${safeType}" ${GENERATED_ATTR}="1">` +
-    groups +
-    nodes +
+    `<div data-ark-container="${container}" data-ark-builtin="${safeType}" ${GENERATED_ATTR}="1">` +
+    body +
     "</div>";
 
   const closing = html.toLowerCase().lastIndexOf("</body>");

--- a/packages/server/src/lib/diagram-builtin.ts
+++ b/packages/server/src/lib/diagram-builtin.ts
@@ -159,21 +159,19 @@ const CONTEXT_MAP_CSS = `${BASE_CSS}
  * 状態名は CSS 変数から文字として出す（色だけで状態を伝えない）。
  */
 const BACKLOG_CSS = `${BASE_CSS}
-[data-ark-builtin="backlog"]{min-height:0;counter-reset:ark-backlog}
+[data-ark-builtin="backlog"]{min-height:0}
 .ark-backlog-section{margin:1.1rem 0 .5rem;padding:0 0 .3rem;
 border-bottom:1px solid #334155}
 .ark-backlog-section:first-child{margin-top:0}
 .ark-backlog-section .group-label{font-size:.78rem;font-weight:700;color:#7dd3fc}
 [data-ark-builtin="backlog"] .ark-builtin-node{display:grid;
 grid-template-columns:6.5rem minmax(0,1fr) auto;gap:.1rem .8rem;
-align-items:baseline;width:auto;margin:.3rem 0;padding:.5rem .7rem;
-counter-increment:ark-backlog}
+align-items:baseline;width:auto;margin:.3rem 0;padding:.5rem .7rem}
 [data-ark-builtin="backlog"] .ark-builtin-node::before{grid-column:1;grid-row:1;
-content:counter(ark-backlog) "\\00A0" var(--kg,"\\25A3") "\\00A0" var(--kn,"story");
+content:attr(data-rank) "\\00A0" var(--kg,"\\25A3") "\\00A0" var(--kn,"story");
 font-size:.6rem;letter-spacing:.04em;white-space:nowrap}
 [data-ark-builtin="backlog"] .ark-builtin-label{grid-column:2;grid-row:1;
 margin-top:0;font-size:.86rem}
-[data-ark-builtin="backlog"] .ark-builtin-note{grid-column:2;grid-row:1}
 [data-ark-builtin="backlog"] .ark-builtin-fields{grid-column:2;grid-row:2;
 display:flex;flex-wrap:wrap;gap:.25rem .5rem;margin:.3rem 0 0;padding:0;
 border-top:none}
@@ -194,7 +192,6 @@ font-size:.6rem;font-weight:700;letter-spacing:.04em;white-space:nowrap}
 [data-ark-builtin="backlog"] .ark-builtin-node[data-kind="spike"]{--kn:"spike";--k:#c084fc;--kb:#2a2044;--kg:"\\25C7"}
 [data-ark-builtin="backlog"] .ark-builtin-node[data-kind="chore"]{--kn:"chore";--k:#a3a3a3;--kb:#26262b;--kg:"\\25A4"}
 [data-ark-builtin="backlog"] .ark-builtin-node[data-kind="epic"]{--kn:"epic";--k:#facc15;--kb:#332b0e;--kg:"\\2605";border-width:2px;border-left-width:5px}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="note"]{--kn:"note";--k:#94a3b8;--kb:#1b2130;border-style:dashed;border-left-style:solid}
 `;
 
 export const BUILTIN_DIAGRAM_TYPES: Readonly<Record<string, BuiltinType>> = {
@@ -259,12 +256,18 @@ function renderNode(node: DiagramNode): string {
  * status を kind に混ぜないのは、種別（story / bug）と状態（todo / done）が
  * 直交するから。kind に done を作ると「done な bug」が表せなくなる。
  */
-function renderBacklogRow(node: DiagramNode): string {
+function renderBacklogRow(node: DiagramNode, rank: number): string {
   const status = node.ext?.status;
-  if (typeof status !== "string" || status === "") return renderNode(node);
+  const statusAttr =
+    typeof status === "string" && status !== ""
+      ? ` data-status="${escapeHtml(status)}"`
+      : "";
+  // 順位は CSS counter ではなく nodes 配列の位置から出す。counter は DOM の
+  // 並び順で振られるため、group 順が nodes 順と違う図で「nodes の並びが順位」
+  // という規約と食い違う（codex review 指摘）。
   return renderNode(node).replace(
     "<article ",
-    `<article data-status="${escapeHtml(status)}" `
+    `<article data-rank="${rank}"${statusAttr} `
   );
 }
 
@@ -277,13 +280,16 @@ function renderBacklogRow(node: DiagramNode): string {
 function renderBacklog(model: DiagramModel): string {
   const placed = new Set<string>();
   const sections: string[] = [];
+  const rankOf = new Map(
+    model.nodes.map((node, index) => [node.id, index + 1])
+  );
 
   for (const group of model.groups) {
     const rows = model.nodes
       .filter(node => group.nodes.includes(node.id) && !placed.has(node.id))
       .map(node => {
         placed.add(node.id);
-        return renderBacklogRow(node);
+        return renderBacklogRow(node, rankOf.get(node.id) ?? 0);
       });
     if (rows.length === 0) continue;
     const safeId = escapeHtml(group.id);
@@ -297,7 +303,7 @@ function renderBacklog(model: DiagramModel): string {
 
   const rest = model.nodes
     .filter(node => !placed.has(node.id))
-    .map(node => renderBacklogRow(node));
+    .map(node => renderBacklogRow(node, rankOf.get(node.id) ?? 0));
   if (rest.length > 0) sections.push(rest.join(""));
 
   return sections.join("");
@@ -318,15 +324,19 @@ function renderGroup(id: string, label: string): string {
  * HTML は引用符なしの属性値も許すため `data-ark-container=graph` も拾う。
  * 逆に script 本文（モデル JSON の label 等）や HTML コメントの中の同じ文字列は
  * 属性ではないので、判定前に取り除く。誤検出すると投影を生成せず白紙になり、
- * 見落とすと graph が二重になる。
+ * 見落とすと容れ物が二重になる。
+ *
+ * これから生成する容れ物と同じ名前だけを見る。graph 固定にすると、既に list を
+ * 持つ HTML へ二度目の注入が通り、投影がまるごと重複する（codex review 指摘）。
  */
-function hasAuthoredGraph(html: string): boolean {
+function hasContainer(html: string, name: string): boolean {
   const markup = html
     .replace(/<!--[\s\S]*?-->/g, "")
     .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "");
-  return /data-ark-container\s*=\s*(?:"graph"|'graph'|graph(?=[\s/>]|$))/i.test(
-    markup
-  );
+  return new RegExp(
+    `data-ark-container\\s*=\\s*(?:"${name}"|'${name}'|${name}(?=[\\s/>]|$))`,
+    "i"
+  ).test(markup);
 }
 
 /**
@@ -342,16 +352,16 @@ export function injectBuiltinProjection(
   if (!Object.hasOwn(BUILTIN_DIAGRAM_TYPES, typeName)) return html;
   const type = BUILTIN_DIAGRAM_TYPES[typeName];
   if (!type) return html;
-  if (hasAuthoredGraph(html)) return html;
+  // graph 以外の容れ物を持つ図種は自前の DOM を組む。graph という値は
+  // ハーネスの自動レイアウト・edge 描画・drag の入口なので、リストの図種に
+  // 付けてはならない（付けると絶対配置に載せられて行が重なる）。
+  const container = type.render ? "list" : "graph";
+  if (hasContainer(html, container)) return html;
 
   const safeType = escapeHtml(typeName);
   const title = model.title
     ? `<h1 class="ark-builtin-title" ${GENERATED_ATTR}="1">${escapeHtml(model.title)}</h1>`
     : "";
-  // graph 以外の容れ物を持つ図種は自前の DOM を組む。graph という値は
-  // ハーネスの自動レイアウト・edge 描画・drag の入口なので、リストの図種に
-  // 付けてはならない（付けると絶対配置に載せられて行が重なる）。
-  const container = type.render ? "list" : "graph";
   const body = type.render
     ? type.render(model)
     : model.groups.map(g => renderGroup(g.id, g.label)).join("") +

--- a/packages/server/src/lib/diagram-builtin.ts
+++ b/packages/server/src/lib/diagram-builtin.ts
@@ -159,49 +159,54 @@ const CONTEXT_MAP_CSS = `${BASE_CSS}
  * 状態名は CSS 変数から文字として出す（色だけで状態を伝えない）。
  */
 const BACKLOG_CSS = `${BASE_CSS}
-[data-ark-builtin="backlog"]{min-height:0;border-top:1px solid #1e2532}
-.ark-backlog-section{display:flex;align-items:center;gap:.5rem;
-margin:0;padding:.42rem .6rem;background:#161b25;border-bottom:1px solid #1e2532}
-.ark-backlog-section .group-label{font-size:.72rem;font-weight:700;color:#cbd5e1}
-.ark-backlog-count{font-size:.66rem;color:#64748b}
+body{background:#f4f5f7;color:#172b4d}
+.ark-builtin-title{color:#172b4d;font-size:1rem}
+[data-ark-builtin="backlog"]{min-height:0;border:1px solid #dfe1e6;border-radius:3px;
+background:#fff;overflow:hidden}
+.ark-backlog-section{display:flex;align-items:center;gap:.5rem;margin:0;
+padding:.42rem .7rem;background:#f4f5f7;border-bottom:1px solid #dfe1e6}
+.ark-backlog-section .group-label{font-size:.72rem;font-weight:700;color:#172b4d}
+.ark-backlog-count{font-size:.66rem;color:#6b778c}
 [data-ark-builtin="backlog"] .ark-builtin-node{display:grid;
-grid-template-columns:6.2rem minmax(0,1fr) minmax(0,17rem) 5.2rem;align-items:center;
-gap:0 .8rem;width:auto;margin:0;padding:.4rem .6rem;
-border:0;border-radius:0;border-bottom:1px solid #1e2532;background:transparent}
-[data-ark-builtin="backlog"] .ark-builtin-node:hover{background:#151b26}
-[data-ark-builtin="backlog"] .ark-builtin-node::before{grid-column:1;grid-row:1;
-display:block;content:attr(data-rank) "\\00A0" var(--kg,"\\25A3") "\\00A0" var(--kn,"story");
-font-size:.62rem;letter-spacing:.03em;color:var(--k,#94a3b8);white-space:nowrap;
+grid-template-columns:1.05rem 4.4rem minmax(0,1fr) minmax(0,16rem) 6rem;
+align-items:center;gap:0 .6rem;width:auto;margin:0;padding:.42rem .7rem;
+border:0;border-radius:0;border-bottom:1px solid #ebecf0;background:#fff}
+[data-ark-builtin="backlog"] .ark-builtin-node:last-child{border-bottom:0}
+[data-ark-builtin="backlog"] .ark-builtin-node:hover{background:#f4f5f7}
+[data-ark-builtin="backlog"] .ark-builtin-node::before{content:none}
+.ark-backlog-type{grid-column:1;display:grid;place-items:center;
+width:1.05rem;height:1.05rem;border-radius:3px;background:var(--k,#8993a4)}
+.ark-backlog-type::before{content:var(--kg,"\\25A3");color:#fff;font-size:.62rem;line-height:1}
+.ark-backlog-key{grid-column:2;font-size:.68rem;color:#6b778c;white-space:nowrap;
 overflow:hidden;text-overflow:ellipsis}
-[data-ark-builtin="backlog"] .ark-builtin-label{grid-column:2;grid-row:1;
-margin-top:0;font-size:.79rem;font-weight:500;color:#e2e8f0;
+[data-ark-builtin="backlog"] .ark-builtin-label{grid-column:3;margin-top:0;
+font-size:.8rem;font-weight:400;color:#172b4d;
 white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-[data-ark-builtin="backlog"] .ark-builtin-fields{grid-column:3;grid-row:1;
-display:flex;flex-wrap:nowrap;gap:.3rem;margin:0;padding:0;border-top:none;
-overflow:hidden;
+[data-ark-builtin="backlog"] .ark-builtin-node:hover .ark-builtin-label{color:#0052cc}
+[data-ark-builtin="backlog"] .ark-builtin-fields{grid-column:4;display:flex;
+flex-wrap:nowrap;gap:.28rem;margin:0;padding:0;border-top:none;overflow:hidden;
 -webkit-mask-image:linear-gradient(to right,#000 88%,transparent);
 mask-image:linear-gradient(to right,#000 88%,transparent)}
 [data-ark-builtin="backlog"] .ark-builtin-fields li{flex:0 0 auto;
-padding:.02rem .38rem;border:1px solid #2c3648;border-radius:3px;
-background:#161b25;font-size:.62rem;color:#94a3b8;white-space:nowrap;
-max-width:8rem;overflow:hidden;text-overflow:ellipsis}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status]::after{grid-column:4;
-grid-row:1;justify-self:end;content:var(--st,"");box-sizing:border-box;
-min-width:5.2rem;padding:.09rem 0;border-radius:3px;text-align:center;
-background:var(--sb,#232a38);color:var(--sc,#94a3b8);
-font-size:.58rem;font-weight:800;letter-spacing:.06em;white-space:nowrap}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="todo"]{--st:"TO DO";--sb:#232a38;--sc:#b6c2d4}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="doing"]{--st:"IN PROGRESS";--sb:#123054;--sc:#7cc2ff}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="blocked"]{--st:"BLOCKED";--sb:#3d1a1a;--sc:#ff8f7a}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="done"]{--st:"DONE";--sb:#123527;--sc:#5fdca4}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="done"] .ark-builtin-label{color:#8b97ab}
+padding:.06rem .4rem;border:0;border-radius:3px;background:#ebecf0;
+font-size:.62rem;color:#42526e;white-space:nowrap;max-width:7.5rem;
+overflow:hidden;text-overflow:ellipsis}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status]::after{grid-column:5;
+justify-self:end;content:var(--st,"");box-sizing:border-box;min-width:6rem;
+padding:.11rem 0;border-radius:3px;text-align:center;
+background:var(--sb,#dfe1e6);color:var(--sc,#42526e);
+font-size:.58rem;font-weight:700;letter-spacing:.05em;white-space:nowrap}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="todo"]{--st:"TO DO";--sb:#dfe1e6;--sc:#42526e}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="doing"]{--st:"IN PROGRESS";--sb:#deebff;--sc:#0747a6}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="blocked"]{--st:"BLOCKED";--sb:#ffebe6;--sc:#bf2600}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="done"]{--st:"DONE";--sb:#e3fcef;--sc:#006644}
 [data-ark-builtin="backlog"] .ark-builtin-node{--kn:"story";--k:#36b37e;--kg:"\\25A3"}
 [data-ark-builtin="backlog"] .ark-builtin-node[data-kind="story"]{--kn:"story";--k:#36b37e;--kg:"\\25A3"}
 [data-ark-builtin="backlog"] .ark-builtin-node[data-kind="bug"]{--kn:"bug";--k:#ff5630;--kg:"\\2716"}
 [data-ark-builtin="backlog"] .ark-builtin-node[data-kind="task"]{--kn:"task";--k:#4bade8;--kg:"\\2714"}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="spike"]{--kn:"spike";--k:#c084fc;--kg:"\\25C7"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="spike"]{--kn:"spike";--k:#8777d9;--kg:"\\25C7"}
 [data-ark-builtin="backlog"] .ark-builtin-node[data-kind="chore"]{--kn:"chore";--k:#8993a4;--kg:"\\25A4"}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="epic"]{--kn:"epic";--k:#904ee2;--kg:"\\2605"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="epic"]{--kn:"epic";--k:#6554c0;--kg:"\\2605"}
 `;
 
 export const BUILTIN_DIAGRAM_TYPES: Readonly<Record<string, BuiltinType>> = {
@@ -267,17 +272,36 @@ function renderNode(node: DiagramNode): string {
  * 直交するから。kind に done を作ると「done な bug」が表せなくなる。
  */
 function renderBacklogRow(node: DiagramNode, rank: number): string {
+  const id = escapeHtml(node.id);
+  const kind = node.kind && node.kind !== "" ? node.kind : "story";
   const status = node.ext?.status;
   const statusAttr =
     typeof status === "string" && status !== ""
       ? ` data-status="${escapeHtml(status)}"`
       : "";
-  // 順位は CSS counter ではなく nodes 配列の位置から出す。counter は DOM の
-  // 並び順で振られるため、group 順が nodes 順と違う図で「nodes の並びが順位」
-  // という規約と食い違う（codex review 指摘）。
-  return renderNode(node).replace(
-    "<article ",
-    `<article data-rank="${rank}"${statusAttr} title="${escapeHtml(node.label)}" `
+  // 種別は色の付いた四角（Jira の type icon）で示すが、色だけに頼らないよう
+  // 種別名を key 欄に文字としても出す。順位は nodes 配列の位置（rank）。
+  const parts = [
+    '<span class="ark-backlog-type" aria-hidden="true"></span>',
+    `<span class="ark-backlog-key">${rank} \u00B7 ${escapeHtml(kind)}</span>`,
+    `<span class="ark-builtin-label" data-model-id="${id}">${escapeHtml(node.label)}</span>`,
+  ];
+  const fields = node.fields ?? [];
+  if (fields.length > 0) {
+    const items = fields
+      .map(
+        field =>
+          `<li data-model-id="${escapeHtml(field.id)}">${escapeHtml(field.label)}</li>`
+      )
+      .join("");
+    parts.push(`<ul class="ark-builtin-fields">${items}</ul>`);
+  }
+  // 1 行に収めるので、切り詰められた要約は title で読めるようにする
+  return (
+    `<article class="ark-builtin-node" data-model-id="${id}" data-kind="${escapeHtml(kind)}"` +
+    ` data-rank="${rank}"${statusAttr} title="${escapeHtml(node.label)}">` +
+    parts.join("") +
+    "</article>"
   );
 }
 

--- a/packages/server/src/lib/diagram-builtin.ts
+++ b/packages/server/src/lib/diagram-builtin.ts
@@ -159,39 +159,49 @@ const CONTEXT_MAP_CSS = `${BASE_CSS}
  * 状態名は CSS 変数から文字として出す（色だけで状態を伝えない）。
  */
 const BACKLOG_CSS = `${BASE_CSS}
-[data-ark-builtin="backlog"]{min-height:0}
-.ark-backlog-section{margin:1.1rem 0 .5rem;padding:0 0 .3rem;
-border-bottom:1px solid #334155}
-.ark-backlog-section:first-child{margin-top:0}
-.ark-backlog-section .group-label{font-size:.78rem;font-weight:700;color:#7dd3fc}
+[data-ark-builtin="backlog"]{min-height:0;border-top:1px solid #1e2532}
+.ark-backlog-section{display:flex;align-items:center;gap:.5rem;
+margin:0;padding:.42rem .6rem;background:#161b25;border-bottom:1px solid #1e2532}
+.ark-backlog-section .group-label{font-size:.72rem;font-weight:700;color:#cbd5e1}
+.ark-backlog-count{font-size:.66rem;color:#64748b}
 [data-ark-builtin="backlog"] .ark-builtin-node{display:grid;
-grid-template-columns:6.5rem minmax(0,1fr) auto;gap:.1rem .8rem;
-align-items:baseline;width:auto;margin:.3rem 0;padding:.5rem .7rem}
+grid-template-columns:6.2rem minmax(0,1fr) minmax(0,17rem) 5.2rem;align-items:center;
+gap:0 .8rem;width:auto;margin:0;padding:.4rem .6rem;
+border:0;border-radius:0;border-bottom:1px solid #1e2532;background:transparent}
+[data-ark-builtin="backlog"] .ark-builtin-node:hover{background:#151b26}
 [data-ark-builtin="backlog"] .ark-builtin-node::before{grid-column:1;grid-row:1;
-content:attr(data-rank) "\\00A0" var(--kg,"\\25A3") "\\00A0" var(--kn,"story");
-font-size:.6rem;letter-spacing:.04em;white-space:nowrap}
+display:block;content:attr(data-rank) "\\00A0" var(--kg,"\\25A3") "\\00A0" var(--kn,"story");
+font-size:.62rem;letter-spacing:.03em;color:var(--k,#94a3b8);white-space:nowrap;
+overflow:hidden;text-overflow:ellipsis}
 [data-ark-builtin="backlog"] .ark-builtin-label{grid-column:2;grid-row:1;
-margin-top:0;font-size:.86rem}
-[data-ark-builtin="backlog"] .ark-builtin-fields{grid-column:2;grid-row:2;
-display:flex;flex-wrap:wrap;gap:.25rem .5rem;margin:.3rem 0 0;padding:0;
-border-top:none}
-[data-ark-builtin="backlog"] .ark-builtin-fields li{padding:.05rem .4rem;
-border:1px solid rgba(148,163,184,.35);border-radius:3px;font-size:.65rem}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status]::after{grid-column:3;
-grid-row:1;content:var(--st,"");padding:.05rem .45rem;border-radius:999px;
-border:1px solid var(--sc,#94a3b8);color:var(--sc,#94a3b8);
-font-size:.6rem;font-weight:700;letter-spacing:.04em;white-space:nowrap}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="todo"]{--st:"TODO";--sc:#94a3b8}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="doing"]{--st:"DOING";--sc:#38bdf8}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="blocked"]{--st:"BLOCKED";--sc:#f87171}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-status="done"]{--st:"DONE";--sc:#4ade80;opacity:.62}
-[data-ark-builtin="backlog"] .ark-builtin-node{--kn:"story";--k:#60a5fa;--kb:#172a46;--kg:"\\25A3"}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="story"]{--kn:"story";--k:#60a5fa;--kb:#172a46;--kg:"\\25A3"}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="bug"]{--kn:"bug";--k:#f87171;--kb:#3a1a1a;--kg:"\\2716"}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="task"]{--kn:"task";--k:#38bdf8;--kb:#12283a;--kg:"\\2714"}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="spike"]{--kn:"spike";--k:#c084fc;--kb:#2a2044;--kg:"\\25C7"}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="chore"]{--kn:"chore";--k:#a3a3a3;--kb:#26262b;--kg:"\\25A4"}
-[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="epic"]{--kn:"epic";--k:#facc15;--kb:#332b0e;--kg:"\\2605";border-width:2px;border-left-width:5px}
+margin-top:0;font-size:.79rem;font-weight:500;color:#e2e8f0;
+white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+[data-ark-builtin="backlog"] .ark-builtin-fields{grid-column:3;grid-row:1;
+display:flex;flex-wrap:nowrap;gap:.3rem;margin:0;padding:0;border-top:none;
+overflow:hidden;
+-webkit-mask-image:linear-gradient(to right,#000 88%,transparent);
+mask-image:linear-gradient(to right,#000 88%,transparent)}
+[data-ark-builtin="backlog"] .ark-builtin-fields li{flex:0 0 auto;
+padding:.02rem .38rem;border:1px solid #2c3648;border-radius:3px;
+background:#161b25;font-size:.62rem;color:#94a3b8;white-space:nowrap;
+max-width:8rem;overflow:hidden;text-overflow:ellipsis}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status]::after{grid-column:4;
+grid-row:1;justify-self:end;content:var(--st,"");box-sizing:border-box;
+min-width:5.2rem;padding:.09rem 0;border-radius:3px;text-align:center;
+background:var(--sb,#232a38);color:var(--sc,#94a3b8);
+font-size:.58rem;font-weight:800;letter-spacing:.06em;white-space:nowrap}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="todo"]{--st:"TO DO";--sb:#232a38;--sc:#b6c2d4}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="doing"]{--st:"IN PROGRESS";--sb:#123054;--sc:#7cc2ff}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="blocked"]{--st:"BLOCKED";--sb:#3d1a1a;--sc:#ff8f7a}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="done"]{--st:"DONE";--sb:#123527;--sc:#5fdca4}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-status="done"] .ark-builtin-label{color:#8b97ab}
+[data-ark-builtin="backlog"] .ark-builtin-node{--kn:"story";--k:#36b37e;--kg:"\\25A3"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="story"]{--kn:"story";--k:#36b37e;--kg:"\\25A3"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="bug"]{--kn:"bug";--k:#ff5630;--kg:"\\2716"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="task"]{--kn:"task";--k:#4bade8;--kg:"\\2714"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="spike"]{--kn:"spike";--k:#c084fc;--kg:"\\25C7"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="chore"]{--kn:"chore";--k:#8993a4;--kg:"\\25A4"}
+[data-ark-builtin="backlog"] .ark-builtin-node[data-kind="epic"]{--kn:"epic";--k:#904ee2;--kg:"\\2605"}
 `;
 
 export const BUILTIN_DIAGRAM_TYPES: Readonly<Record<string, BuiltinType>> = {
@@ -267,7 +277,7 @@ function renderBacklogRow(node: DiagramNode, rank: number): string {
   // という規約と食い違う（codex review 指摘）。
   return renderNode(node).replace(
     "<article ",
-    `<article data-rank="${rank}"${statusAttr} `
+    `<article data-rank="${rank}"${statusAttr} title="${escapeHtml(node.label)}" `
   );
 }
 
@@ -296,6 +306,7 @@ function renderBacklog(model: DiagramModel): string {
     sections.push(
       `<section class="ark-backlog-section" data-ark-group data-model-id="${safeId}">` +
         `<span class="group-label" data-model-id="${safeId}">${escapeHtml(group.label)}</span>` +
+        `<span class="ark-backlog-count">${rows.length} 件</span>` +
         "</section>" +
         rows.join("")
     );


### PR DESCRIPTION
## なぜ

図種が 5 つあるが、**すべて graph** だった（絶対配置 + edge + drag で `ext.x/y` 保存）。
順位付きリストという形が無く、バックログやタスク一覧は表現できなかった。

バックログは `nodes` の並びそのものが意味（優先順位）なので、絶対配置には載せられない。

## 何をしたか

`BuiltinType` に任意の `render` を足し、graph 以外の容れ物を持つ図種だけが自前の DOM を
組めるようにした。`injectBuiltinProjection` は `render` があれば container を `list` にする。

**既存 5 種の生成物は 1 バイトも変わらない**（回帰テストあり）。

新しい図種 `backlog`:

- 順位は `nodes` 配列の並び。CSS counter で 1, 2, 3 と振る
- `edges` は描かない。バックログに矢印は無い
- `group` は区切り見出し。未所属の node は最後にまとめる
- 同じ node を複数 group に入れても行は最初の group にだけ出す（順位が二重にならない）
- `node.ext.status`（`todo` / `doing` / `blocked` / `done`）を行の `data-status` に載せる
- `node.fields` は行の下にチップとして並ぶ（担当・見積り・Issue 番号などの列）

### kind と status を直交させた理由

`kind` に `done` を作ると「done な bug」が表せなくなる。種別（story / bug / task）と
状態（todo / doing / blocked / done）は別軸なので、`kind` と `ext.status` に分けた。

### 状態を色だけで伝えない

バッジは CSS 変数から `"TODO"` / `"BLOCKED"` / `"DONE"` の文字を出す。
既存図種が kind 名を併置しているのと同じ方針。テストで文字列の存在を固定している。

## 投影契約は既存と同じ

行は `.ark-builtin-node` / `data-model-id` / `data-kind` をそのまま使う。
ハーネス側の label 編集・field 編集・field 並べ替えは変更なしで効く。

## 動作確認

配信 HTML を実機で確認した。

- container は `list` が 1 つだけ、`graph` の container 要素は無い
- 行の順序: `g-now → ga4-setup → ga4-transcribe → g-next → works → ...`（設計どおり）
- 描画: 順位 1〜10、種別アイコン + 名前、TODO/BLOCKED/DONE バッジ、列チップ、区切り見出し
- console エラーなし

`pnpm check` 通過、`pnpm vitest run` 全 1233 件通過（うち backlog の新規テスト 8 件）。

## 残していること

- **drag による node 並べ替えの書き戻しは未実装**。ハーネスの並べ替えは今のところ
  `node.fields` 単位（`diagram-harness.ts:3106`）で、node 配列には効かない。
  順位の編集はモデル直接編集で行う。次の一手はここ
- GitHub Issue との連携は無い。状態は手で書く。**別に正本がある情報を写すと腐る**ので、
  規約側に「状態を持たせすぎない」と明記した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * バックログ図を追加しました。
  * ストーリー、バグ、タスク、スパイク、作業、エピックを表示できます。
  * 順序付きリスト、グループ見出し、状態バッジ、フィールドチップに対応しました。

* **ドキュメント**
  * バックログ図の表示ルールと利用可能な状態・種別を追加しました。
  * 行の補足はフィールドに記載し、指摘は会話またはIssueで行う制約を明記しました。

* **品質改善**
  * ノードの順序、グループ分け、状態表示、重複防止などの表示動作を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->